### PR TITLE
Backwards compatibility for ListObjects

### DIFF
--- a/components/data_proxy/src/caching/cache.rs
+++ b/components/data_proxy/src/caching/cache.rs
@@ -894,7 +894,7 @@ impl Cache {
         };
 
         self.multi_parts
-            .retain(|_, v| v.first().map_or(true, |e| e.object_id != id));
+            .retain(|_, v| v.first().is_none_or(|e| e.object_id != id));
 
         let object = old.1 .0.read().await;
         for p in self

--- a/components/data_proxy/src/data_backends/s3_backend.rs
+++ b/components/data_proxy/src/data_backends/s3_backend.rs
@@ -25,7 +25,6 @@ use http_body_util::StreamBody;
 use hyper::body::Frame;
 use rand::random;
 use tracing::error;
-use tracing::trace;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]

--- a/components/data_proxy/src/replication/replication_handler.rs
+++ b/components/data_proxy/src/replication/replication_handler.rs
@@ -516,13 +516,12 @@ impl ReplicationHandler {
                                     continue;
                                 } else {
                                     let parent = {
-                                        let mut current_version_id = object_id.clone();
+                                        let mut current_version_id = object_id;
                                         if let Some(version) = &object.versions {
-                                            version.iter().next().map(|v| match v {
-                                                VersionVariant::IsVersion(id) => {
-                                                    current_version_id = id.clone()
+                                            version.iter().next().map(|v| {
+                                                if let VersionVariant::IsVersion(id) = v {
+                                                    current_version_id = *id
                                                 }
-                                                _ => {}
                                             });
                                         }
                                         cache.get_single_parent(&current_version_id).await.map_err(

--- a/components/data_proxy/src/s3_frontend/data_handler.rs
+++ b/components/data_proxy/src/s3_frontend/data_handler.rs
@@ -71,11 +71,12 @@ impl DataHandler {
         let parents = if let Some(levels) = path_level {
             levels
         } else {
-            let mut object_id = object.id.clone();
+            let mut object_id = object.id;
             if let Some(version) = &object.versions {
-                version.iter().next().map(|v| match v {
-                    VersionVariant::IsVersion(id) => object_id = id.clone(),
-                    _ => {}
+                version.iter().next().map(|v| {
+                    if let VersionVariant::IsVersion(id) = v {
+                        object_id = *id
+                    }
                 });
             }
             cache.get_single_parent(&object_id).await.map_err(|e| {
@@ -83,7 +84,7 @@ impl DataHandler {
                 e
             })?
         };
-        if parents.get(0).is_none() {
+        if parents.is_empty() {
             error!(?parents, "No parent found");
             return Err(anyhow!("No parent found"));
         }

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -878,6 +878,7 @@ impl S3 for ArunaS3Service {
             project_name,
             &start_after,
             max_keys,
+            false
         )
         .await
         .map_err(|_| {

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -814,6 +814,125 @@ impl S3 for ArunaS3Service {
 
     #[tracing::instrument(err)]
     #[allow(clippy::blocks_in_conditions)]
+    async fn list_objects(
+        &self,
+        req: S3Request<ListObjectsInput>,
+    ) -> S3Result<S3Response<ListObjectsOutput>> {
+        let CheckAccessResult { headers, .. } = req
+            .extensions
+            .get::<CheckAccessResult>()
+            .cloned()
+            .ok_or_else(|| {
+                error!(error = "No context found");
+                s3_error!(InternalError, "No context found")
+            })?;
+        // Fetch the project name, delimiter and prefix from the request
+        let project_name = &req.input.bucket;
+        let delimiter = req.input.delimiter;
+        let prefix = req.input.prefix.filter(|prefix| !prefix.is_empty());
+
+        // Check if bucket exists as root in cache of paths
+        match self.cache.get_path(project_name.as_str()) {
+            Some(_) => {}
+            None => {
+                error!("No bucket found");
+                return Err(s3_error!(NoSuchBucket, "No bucket found"));
+            }
+        };
+
+        let max_keys = match req.input.max_keys {
+            Some(k) if k < 1000 => k as usize,
+            _ => 1000usize,
+        };
+
+        let start_at = match &req.input.marker {
+            Some(marker) => marker,
+            None => "",
+        };
+
+        let (keys, common_prefixes, next_marker) = list_response(
+            &self.cache,
+            &delimiter,
+            &prefix,
+            project_name,
+            start_at,
+            max_keys,
+            true,
+        )
+        .await
+        .map_err(|_| {
+            error!(error = "Keys not found in ListObjects");
+            s3_error!(NoSuchKey, "Keys not found in ListObjects")
+        })?;
+
+        let common_prefixes = Some(
+            common_prefixes
+                .into_iter()
+                .map(|e| CommonPrefix { prefix: Some(e) })
+                .collect(),
+        );
+        let contents = Some(
+            keys.into_iter()
+                .map(|e| Object {
+                    checksum_algorithm: None,
+                    e_tag: Some(e.etag.to_string()),
+                    key: Some(e.key),
+                    last_modified: e.created_at.map(|t| {
+                        s3s::dto::Timestamp::from(
+                            time::OffsetDateTime::from_unix_timestamp(t.and_utc().timestamp())
+                                .unwrap_or_else(|_| {
+                                    error!(error = "Unable to parse timestamp");
+                                    time::OffsetDateTime::now_utc()
+                                }),
+                        )
+                    }),
+                    owner: None,
+                    size: Some(e.size),
+                    ..Default::default()
+                })
+                .collect(),
+        );
+
+        let result = ListObjectsOutput {
+            common_prefixes,
+            contents,
+            marker: req.input.marker,
+            delimiter,
+            encoding_type: None,
+            is_truncated: Some(next_marker.is_some()),
+            max_keys: Some(max_keys.try_into().map_err(|err| {
+                error!(error = ?err, "Conversion failure");
+                s3_error!(InternalError, "[BACKEND] Conversion failure: {}", err)
+            })?),
+            name: Some(project_name.clone()),
+            next_marker,
+            prefix,
+            ..Default::default()
+        };
+        debug!(?result);
+
+        let mut resp = S3Response::new(result);
+
+        if let Some(headers) = headers {
+            for (k, v) in headers {
+                resp.headers.insert(
+                    HeaderName::from_bytes(k.as_bytes()).map_err(|_| {
+                        error!(error = "Unable to parse header name");
+                        s3_error!(InternalError, "Unable to parse header name")
+                    })?,
+                    HeaderValue::from_str(&v).map_err(|_| {
+                        error!(error = "Unable to parse header value");
+                        s3_error!(InternalError, "Unable to parse header value")
+                    })?,
+                );
+            }
+        }
+
+        Ok(resp)
+    }
+
+    #[tracing::instrument(err)]
+    #[allow(clippy::blocks_in_conditions)]
     async fn list_objects_v2(
         &self,
         req: S3Request<ListObjectsV2Input>,

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -181,7 +181,7 @@ impl S3 for ArunaS3Service {
             })?;
 
         let response = CompleteMultipartUploadOutput {
-            e_tag: Some(format!("-{}", object.id.to_string())),
+            e_tag: Some(format!("-{}", object.id)),
             ..Default::default()
         };
 
@@ -997,7 +997,7 @@ impl S3 for ArunaS3Service {
             project_name,
             &start_after,
             max_keys,
-            false
+            false,
         )
         .await
         .map_err(|_| {

--- a/components/data_proxy/src/s3_frontend/utils/list_objects.rs
+++ b/components/data_proxy/src/s3_frontend/utils/list_objects.rs
@@ -42,6 +42,7 @@ pub async fn list_response(
     bucket_name: &str,
     start_at: &str,
     max_keys: usize,
+    v1: bool, // If true, returns raw path marker instead of continuation token
 ) -> Result<(BTreeSet<Contents>, BTreeSet<String>, Option<String>)> {
     let mut keys: BTreeSet<Contents> = BTreeSet::default();
     let mut common_prefixes: BTreeSet<String> = BTreeSet::default();
@@ -53,7 +54,11 @@ pub async fn list_response(
                 // Breaks with next path to start at after max_keys is reached
                 let num_keys = keys.len() + common_prefixes.len();
                 if num_keys == max_keys {
-                    new_continuation_token = Some(general_purpose::STANDARD_NO_PAD.encode(path));
+                    new_continuation_token = if v1 {
+                        Some(path)
+                    } else {
+                        Some(general_purpose::STANDARD_NO_PAD.encode(path))
+                    };
                     break;
                 }
 
@@ -85,7 +90,11 @@ pub async fn list_response(
                 // Breaks with next path to start at after max_keys is reached
                 let num_keys = keys.len() + common_prefixes.len();
                 if num_keys == max_keys {
-                    new_continuation_token = Some(general_purpose::STANDARD_NO_PAD.encode(path));
+                    new_continuation_token = if v1 {
+                        Some(path)
+                    } else {
+                        Some(general_purpose::STANDARD_NO_PAD.encode(path))
+                    };
                     break;
                 }
 
@@ -111,7 +120,11 @@ pub async fn list_response(
                 // Breaks with next path to start at after max_keys is reached
                 let num_keys = keys.len() + common_prefixes.len();
                 if num_keys == max_keys {
-                    new_continuation_token = Some(general_purpose::STANDARD_NO_PAD.encode(path));
+                    new_continuation_token = if v1 {
+                        Some(path)
+                    } else {
+                        Some(general_purpose::STANDARD_NO_PAD.encode(path))
+                    };
                     break;
                 }
 
@@ -135,7 +148,11 @@ pub async fn list_response(
                 // Breaks with next path to start at after max_keys is reached
                 let num_keys = keys.len() + common_prefixes.len();
                 if num_keys == max_keys {
-                    new_continuation_token = Some(general_purpose::STANDARD_NO_PAD.encode(path));
+                    new_continuation_token = if v1 {
+                        Some(path)
+                    } else {
+                        Some(general_purpose::STANDARD_NO_PAD.encode(path))
+                    };
                     break;
                 }
 


### PR DESCRIPTION
This PR implements support for the legacy S3 `ListObjects` API operation. Note that this function has been superseded by `ListObjectsV2` and is included solely for backwards compatibility with existing systems that may still rely on the original API.

**Important:** This implementation will not receive feature updates or enhancements going forward. New integrations should use `ListObjectsV2` instead, which provides better performance and additional functionality.
