### PR TITLE
fix: Fixed CORS headers in dataproxy, authors in server

### DIFF
--- a/components/data_proxy/src/caching/cache.rs
+++ b/components/data_proxy/src/caching/cache.rs
@@ -776,7 +776,7 @@ impl Cache {
     #[tracing::instrument(level = "trace", skip(self, object))]
     pub async fn insert_temp_resource(&self, object: Object) -> Result<()> {
         // Return Ok if already exists
-        if let Ok((rwlock_object, _)) = self.get_resource(&object.id).await {
+        if let Ok((rwlock_object, _)) = self.get_resource(&object.id) {
             let cache_object = rwlock_object.read().await;
             if *cache_object == object {
                 return Ok(());
@@ -836,7 +836,7 @@ impl Cache {
     pub async fn upsert_object(&self, object: Object) -> Result<()> {
         trace!(?object, "upserting object");
 
-        if let Ok((rwlock_object, _)) = self.get_resource(&object.id).await {
+        if let Ok((rwlock_object, _)) = self.get_resource(&object.id) {
             let cache_object = rwlock_object.read().await;
             if *cache_object == object {
                 return Ok(());
@@ -998,7 +998,7 @@ impl Cache {
 
     #[tracing::instrument(level = "trace", skip(self))]
     #[allow(clippy::type_complexity)]
-    pub async fn get_resource(
+    pub fn get_resource(
         &self,
         resource_id: &DieselUlid,
     ) -> Result<(Arc<RwLock<Object>>, Arc<RwLock<Option<ObjectLocation>>>)> {
@@ -1015,7 +1015,7 @@ impl Cache {
         resource_id: &DieselUlid,
         skip_location: bool,
     ) -> Result<(Object, Option<ObjectLocation>)> {
-        let (obj, loc) = self.get_resource(resource_id).await?;
+        let (obj, loc) = self.get_resource(resource_id)?;
         let obj = obj.read().await.clone();
         let loc = if !skip_location {
             loc.read().await.clone()
@@ -1111,7 +1111,7 @@ impl Cache {
 
     #[tracing::instrument(level = "trace", skip(self))]
     pub async fn get_resource_name(&self, id: &DieselUlid) -> Option<String> {
-        let (res, _) = self.get_resource(id).await.ok()?;
+        let (res, _) = self.get_resource(id).ok()?;
         let res = res.read().await.name.clone();
         Some(res)
     }
@@ -1158,7 +1158,7 @@ impl Cache {
 
     #[tracing::instrument(level = "trace", skip(self, id))]
     pub async fn get_location_cloned(&self, id: &DieselUlid) -> Option<ObjectLocation> {
-        let (_, loc) = self.get_resource(id).await.ok()?;
+        let (_, loc) = self.get_resource(id).ok()?;
         let loc = loc.read().await;
         loc.clone()
     }

--- a/components/data_proxy/src/s3_frontend/s3server.rs
+++ b/components/data_proxy/src/s3_frontend/s3server.rs
@@ -31,7 +31,6 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tracing::error;
 use tracing::info;
-use tracing::trace;
 
 pub struct S3Server {
     s3service: S3Service,
@@ -123,7 +122,6 @@ impl Service<hyper::Request<hyper::body::Incoming>> for WrappingService {
 
     #[tracing::instrument(level = "trace", skip(self, req))]
     fn call(&self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
-        trace!("{:?}", req.headers());
         // Catch OPTIONS requests
         if req.method() == Method::OPTIONS {
             let clone = self.clone();
@@ -187,8 +185,6 @@ impl Service<hyper::Request<hyper::body::Incoming>> for WrappingService {
                     *status = StatusCode::from_u16(206).unwrap();
                 }
 
-                trace!("{:?}", r.headers());
-
                 r.map(Body::from)
             })
         });
@@ -244,10 +240,6 @@ impl WrappingService {
             .headers()
             .get(HOST)
             .ok_or_else(|| s3_error!(InvalidURI, "No authority provided in URI"))?;
-
-        trace!("{:?}", authority);
-        // .authority()
-        // .ok_or_else(|| s3_error!(InvalidURI, "No authority provided in URI"))?;
         let bucket = authority
             .to_str()
             .map_err(|e| {

--- a/components/data_proxy/src/s3_frontend/s3server.rs
+++ b/components/data_proxy/src/s3_frontend/s3server.rs
@@ -6,6 +6,10 @@ use crate::CORS_REGEX;
 use anyhow::Result;
 use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
+use http::header::ACCESS_CONTROL_ALLOW_HEADERS;
+use http::header::ACCESS_CONTROL_ALLOW_METHODS;
+use http::header::ACCESS_CONTROL_ALLOW_ORIGIN;
+use http::header::ORIGIN;
 use http::HeaderValue;
 use http::Method;
 use http::StatusCode;
@@ -13,6 +17,7 @@ use hyper::service::Service;
 use hyper_util::rt::TokioExecutor;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
+use s3s::header::HOST;
 use s3s::s3_error;
 use s3s::service::S3Service;
 use s3s::service::S3ServiceBuilder;
@@ -26,14 +31,19 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tracing::error;
 use tracing::info;
+use tracing::trace;
 
 pub struct S3Server {
     s3service: S3Service,
     address: String,
+    inner_raw: ArunaS3Service,
 }
 
 #[derive(Clone)]
-pub struct WrappingService(SharedS3Service);
+pub struct WrappingService {
+    shared: SharedS3Service,
+    inner: ArunaS3Service,
+}
 
 impl S3Server {
     #[tracing::instrument(level = "trace", skip(address, hostname, backend, cache))]
@@ -51,7 +61,7 @@ impl S3Server {
             })?;
 
         let service = {
-            let mut b = S3ServiceBuilder::new(s3service);
+            let mut b = S3ServiceBuilder::new(s3service.clone());
             b.set_base_domain(hostname);
             b.set_auth(AuthProvider::new(cache).await);
             b.build()
@@ -60,6 +70,7 @@ impl S3Server {
         Ok(Self {
             s3service: service,
             address: address.into(),
+            inner_raw: s3service,
         })
     }
     #[tracing::instrument(level = "trace", skip(self))]
@@ -72,7 +83,10 @@ impl S3Server {
 
         let local_addr = listener.local_addr()?;
 
-        let service = WrappingService(self.s3service.into_shared());
+        let service = WrappingService {
+            shared: self.s3service.into_shared(),
+            inner: self.inner_raw.clone(),
+        };
 
         let connection = ConnBuilder::new(TokioExecutor::new());
 
@@ -109,18 +123,21 @@ impl Service<hyper::Request<hyper::body::Incoming>> for WrappingService {
 
     #[tracing::instrument(level = "trace", skip(self, req))]
     fn call(&self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
+        trace!("{:?}", req.headers());
         // Catch OPTIONS requests
         if req.method() == Method::OPTIONS {
-            let resp = Box::pin(async {
-                hyper::Response::builder()
-                    .header("Access-Control-Allow-Origin", "*")
-                    .header("Access-Control-Allow-Methods", "*")
-                    .header("Access-Control-Allow-Headers", "*")
-                    .body(Body::empty())
-                    .map_err(|_| s3_error!(InvalidRequest, "Invalid OPTIONS request"))
+            let clone = self.clone();
+            return Box::pin(async move {
+                match clone.get_bucket_cors(req).await {
+                    Ok(resp) => Ok(resp),
+                    Err(err) => {
+                        error!("{err}");
+                        hyper::Response::builder()
+                            .body(Body::empty())
+                            .map_err(|_| s3_error!(InvalidRequest, "Invalid OPTIONS request"))
+                    }
+                }
             });
-
-            return resp;
         }
 
         // Check if response gets CORS header pass
@@ -132,7 +149,7 @@ impl Service<hyper::Request<hyper::body::Incoming>> for WrappingService {
             }
         }
 
-        let service = self.0.clone();
+        let service = self.shared.clone();
         let resp = service.call(req);
         let res = resp.map(move |r| {
             r.map(|mut r| {
@@ -151,15 +168,14 @@ impl Service<hyper::Request<hyper::body::Incoming>> for WrappingService {
                 // Add CORS * if request origin matches exception regex
                 if origin_exception {
                     r.headers_mut()
-                        .append("Access-Control-Allow-Origin", HeaderValue::from_static("*"));
-                    r.headers_mut().append(
-                        "Access-Control-Allow-Methods",
-                        HeaderValue::from_static("*"),
-                    );
-                    r.headers_mut().append(
-                        "Access-Control-Allow-Headers",
-                        HeaderValue::from_static("*"),
-                    );
+                        .entry(ACCESS_CONTROL_ALLOW_ORIGIN)
+                        .or_insert(HeaderValue::from_static("*"));
+                    r.headers_mut()
+                        .entry(ACCESS_CONTROL_ALLOW_METHODS)
+                        .or_insert(HeaderValue::from_static("*"));
+                    r.headers_mut()
+                        .entry(ACCESS_CONTROL_ALLOW_HEADERS)
+                        .or_insert(HeaderValue::from_static("*"));
                 }
 
                 // Workaround to return 206 (Partial Content) for range responses
@@ -171,6 +187,8 @@ impl Service<hyper::Request<hyper::body::Incoming>> for WrappingService {
                     *status = StatusCode::from_u16(206).unwrap();
                 }
 
+                trace!("{:?}", r.headers());
+
                 r.map(Body::from)
             })
         });
@@ -181,7 +199,7 @@ impl Service<hyper::Request<hyper::body::Incoming>> for WrappingService {
 impl AsRef<S3Service> for WrappingService {
     #[tracing::instrument(level = "trace", skip(self))]
     fn as_ref(&self) -> &S3Service {
-        self.0.as_ref()
+        self.shared.as_ref()
     }
 }
 
@@ -206,5 +224,105 @@ impl<T, S: Clone> Service<T> for MakeService<S> {
     #[tracing::instrument(level = "trace", skip(self))]
     fn call(&self, _: T) -> Self::Future {
         ready(Ok(self.0.clone()))
+    }
+}
+impl WrappingService {
+    async fn get_bucket_cors(
+        &self,
+        req: hyper::Request<hyper::body::Incoming>,
+    ) -> Result<hyper::Response<Body>, S3Error> {
+        let origin = req
+            .headers()
+            .get(ORIGIN)
+            .ok_or_else(|| s3_error!(InvalidURI, "No authority provided in URI"))?
+            .to_str()
+            .map_err(|e| {
+                error!("{e}");
+                s3_error!(InvalidURI, "Invalid URI encoding")
+            })?;
+        let authority = req
+            .headers()
+            .get(HOST)
+            .ok_or_else(|| s3_error!(InvalidURI, "No authority provided in URI"))?;
+
+        trace!("{:?}", authority);
+        // .authority()
+        // .ok_or_else(|| s3_error!(InvalidURI, "No authority provided in URI"))?;
+        let bucket = authority
+            .to_str()
+            .map_err(|e| {
+                error!("{e}");
+                s3_error!(InvalidURI, "Invalid URI encoding")
+            })?
+            .split(".")
+            .next()
+            .ok_or_else(|| s3_error!(InvalidURI, "No bucket found in URI"))?;
+        let project_id = self
+            .inner
+            .cache
+            .get_path(bucket)
+            .ok_or_else(|| s3_error!(NoSuchBucket, "No bucket found with name {}", bucket))?;
+        let (project, _) = self.inner.cache.get_resource(&project_id).map_err(|e| {
+            error!("{e}");
+            s3_error!(NoSuchBucket, "No bucket found with id {}", project_id)
+        })?;
+        let cors = project
+            .read()
+            .await
+            .key_values
+            .clone()
+            .into_iter()
+            .find(|kv| kv.key == "app.aruna-storage.org/cors")
+            .map(|kv| kv.value)
+            .ok_or_else(|| {
+                s3_error!(
+                    NoSuchBucketPolicy,
+                    "No cors rules for bucket found {}",
+                    bucket
+                )
+            })?;
+        let cors: crate::structs::CORSConfiguration =
+            serde_json::from_str(&cors).map_err(|_| {
+                error!(error = "Unable to deserialize cors from JSON");
+                s3_error!(InvalidObjectState, "Unable to deserialize cors from JSON")
+            })?;
+        let rule = cors
+            .0
+            .iter()
+            .find(|rule| {
+                rule.allowed_origins.contains(&origin.to_string())
+                    || rule.allowed_origins.contains(&"*".to_string())
+            })
+            .ok_or_else(|| s3_error!(NoSuchBucketPolicy, "No cors policy found for bucket"))?;
+        let mut builder = hyper::Response::builder();
+        for origin in rule.allowed_origins.iter() {
+            builder = builder.header(
+                ACCESS_CONTROL_ALLOW_ORIGIN,
+                HeaderValue::from_str(origin).map_err(|e| {
+                    error!("{e}");
+                    s3_error!(InvalidPolicyDocument, "Invalid header name for policy")
+                })?,
+            );
+        }
+        if let Some(headers) = &rule.allowed_headers {
+            builder = builder.header(
+                ACCESS_CONTROL_ALLOW_HEADERS,
+                HeaderValue::from_str(&headers.join(",")).map_err(|e| {
+                    error!("{e}");
+                    s3_error!(InvalidPolicyDocument, "Invalid header name for policy")
+                })?,
+            )
+        }
+        let resp = builder
+            .header(
+                ACCESS_CONTROL_ALLOW_METHODS,
+                HeaderValue::from_str(&rule.allowed_methods.join(",")).map_err(|e| {
+                    error!("{e}");
+                    s3_error!(InvalidPolicyDocument, "Invalid header name for policy")
+                })?,
+            )
+            .body(Body::empty())
+            .map_err(|_| s3_error!(InvalidRequest, "Invalid OPTIONS request"))?;
+        Ok(resp)
     }
 }

--- a/components/server/src/database/dsls/object_dsl.rs
+++ b/components/server/src/database/dsls/object_dsl.rs
@@ -655,6 +655,17 @@ impl Object {
         client.query(&prepared, &[id, &title]).await?;
         Ok(())
     }
+
+    pub async fn update_authors(&self, client: &Client) -> Result<()> {
+        let query = "UPDATE objects
+        SET authors = $2
+        WHERE id = $1 ;";
+
+        let prepared = client.prepare(query).await?;
+
+        client.query(&prepared, &[&self.id, &self.authors]).await?;
+        Ok(())
+    }
     pub async fn update(&self, client: &Client) -> Result<()> {
         let query = "UPDATE objects 
         SET description = $2, key_values = $3, data_class = $4

--- a/components/server/src/database/dsls/object_dsl.rs
+++ b/components/server/src/database/dsls/object_dsl.rs
@@ -648,7 +648,7 @@ impl Object {
     pub async fn update_title(id: &DieselUlid, title: String, client: &Client) -> Result<()> {
         let query = "UPDATE objects
         SET title = $2
-        WHERE id = $1 ;";
+        WHERE id = $1;";
 
         let prepared = client.prepare(query).await?;
 
@@ -659,7 +659,7 @@ impl Object {
     pub async fn update_authors(&self, client: &Client) -> Result<()> {
         let query = "UPDATE objects
         SET authors = $2
-        WHERE id = $1 ;";
+        WHERE id = $1;";
 
         let prepared = client.prepare(query).await?;
 
@@ -669,7 +669,7 @@ impl Object {
     pub async fn update(&self, client: &Client) -> Result<()> {
         let query = "UPDATE objects 
         SET description = $2, key_values = $3, data_class = $4
-        WHERE id = $1 ;";
+        WHERE id = $1;";
 
         let prepared = client.prepare(query).await?;
 

--- a/components/server/src/middlelayer/update_db_handler.rs
+++ b/components/server/src/middlelayer/update_db_handler.rs
@@ -633,7 +633,7 @@ impl DatabaseHandler {
         let transaction_client = transaction.client();
 
         // Update object & Evaluate Rules
-        object.object.update(transaction_client).await?;
+        object.object.update_authors(transaction_client).await?;
         self.evaluate_rules(&vec![object.object.id], transaction_client)
             .await?;
 


### PR DESCRIPTION
Fixed:
- When OPTIONS requests are made, bucket-specific CORS configurations are returned
- Only CORS headers for ORIGIN are returned
- Authors are now also updated in database
- CORS headers are either set or deleted, not both