### PR TITLE
Checksum Integrity Validation

### DIFF
--- a/components/data_proxy/src/caching/cache.rs
+++ b/components/data_proxy/src/caching/cache.rs
@@ -5,6 +5,7 @@ use crate::data_backends::storage_backend::StorageBackend;
 use crate::database::persistence::{delete_parts_by_object_id, delete_parts_by_upload_id};
 use crate::replication::replication_handler::ReplicationMessage;
 use crate::s3_frontend::data_handler::DataHandler;
+use crate::s3_frontend::utils::checksum::ChecksumHandler;
 use crate::structs::{
     AccessKeyPermissions, Bundle, DbPermissionLevel, LocationBinding, ObjectType, TypedId,
     UploadPart, User,
@@ -385,6 +386,7 @@ impl Cache {
                             backend,
                             temp_location,
                             None,
+                            ChecksumHandler::new(None),
                         )
                         .await
                         {
@@ -923,6 +925,32 @@ impl Cache {
                 self.paths.insert(new, *old_entry.value());
             }
         }
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, object_id, hashes))]
+    pub async fn update_object_hashes(
+        &self,
+        object_id: DieselUlid,
+        hashes: HashMap<String, String>,
+    ) -> Result<()> {
+        if let Ok((rwlock_object, _)) = self.get_resource(&object_id) {
+            // Update hashes in cache object
+            let mut cache_object = rwlock_object.write().await;
+            cache_object.hashes.extend(hashes);
+
+            // Write update to persistence if available
+            if let Some(persistence) = self.persistence.read().await.as_ref() {
+                let mut client = persistence.get_client().await?;
+                let transaction = client.transaction().await?;
+                let transaction_client = transaction.client();
+                cache_object.upsert(transaction_client).await?;
+                transaction.commit().await?;
+            }
+        } else {
+            bail!("Object with id {} not found", object_id);
+        }
+
         Ok(())
     }
 

--- a/components/data_proxy/src/caching/cache.rs
+++ b/components/data_proxy/src/caching/cache.rs
@@ -386,7 +386,7 @@ impl Cache {
                             backend,
                             temp_location,
                             None,
-                            ChecksumHandler::new(None),
+                            ChecksumHandler::new(),
                         )
                         .await
                         {

--- a/components/data_proxy/src/caching/cache.rs
+++ b/components/data_proxy/src/caching/cache.rs
@@ -1320,6 +1320,7 @@ impl Cache {
         part_number: u64,
         raw_size: u64,
         final_size: u64,
+        checksums: HashMap<String, String>,
     ) -> Result<()> {
         let part = UploadPart {
             id: DieselUlid::generate(),
@@ -1328,6 +1329,7 @@ impl Cache {
             object_id,
             upload_id: upload_id.clone(),
             raw_size,
+            checksums: Some(checksums),
         };
         if let Some(persistence) = self.persistence.read().await.as_ref() {
             part.upsert(persistence.get_client().await?.client())

--- a/components/data_proxy/src/caching/grpc_query_handler.rs
+++ b/components/data_proxy/src/caching/grpc_query_handler.rs
@@ -688,7 +688,7 @@ impl GrpcQueryHandler {
         let mut req = Request::new(FinishObjectStagingRequest {
             object_id: server_object.id.to_string(),
             content_len,
-            hashes: proxy_object.get_api_safe_hashes(), // Hashes stay the same
+            hashes: proxy_object.get_api_safe_hashes()?, // Hashes stay the same
             completed_parts: vec![],
             upload_id: "".to_string(), // Upload id only needed in requests from users
         });

--- a/components/data_proxy/src/caching/grpc_query_handler.rs
+++ b/components/data_proxy/src/caching/grpc_query_handler.rs
@@ -688,7 +688,7 @@ impl GrpcQueryHandler {
         let mut req = Request::new(FinishObjectStagingRequest {
             object_id: server_object.id.to_string(),
             content_len,
-            hashes: proxy_object.get_hashes(), // Hashes stay the same
+            hashes: proxy_object.get_api_safe_hashes(), // Hashes stay the same
             completed_parts: vec![],
             upload_id: "".to_string(), // Upload id only needed in requests from users
         });

--- a/components/data_proxy/src/caching/grpc_query_handler.rs
+++ b/components/data_proxy/src/caching/grpc_query_handler.rs
@@ -711,8 +711,9 @@ impl GrpcQueryHandler {
                 anyhow!("Object missing in FinishObjectResponse")
             })?;
 
-        // Id of location record should be set to Dataproxy Object id but is set to Server Object id... the fuck?
-        let object = DPObject::try_from(response)?;
+        // Convert Object from response to Dataproxy internal representation and merge hashes
+        let mut object = DPObject::try_from(response)?;
+        object.hashes.extend(proxy_object.hashes);
 
         // Persist Object and Location in cache/database
         self.cache.upsert_object(object.clone()).await?;

--- a/components/data_proxy/src/s3_frontend/data_handler.rs
+++ b/components/data_proxy/src/s3_frontend/data_handler.rs
@@ -236,7 +236,7 @@ impl DataHandler {
 
                 // Fetch hashes
                 let mut hashes = HashMap::new();
-                for (key, rx) in vec![
+                for (key, rx) in [
                     ("sha256", sha_rx),
                     ("md5", md5_rx),
                     ("crc32", crc32_rx),

--- a/components/data_proxy/src/s3_frontend/data_handler.rs
+++ b/components/data_proxy/src/s3_frontend/data_handler.rs
@@ -26,7 +26,7 @@ use pithos_lib::transformers::pithos_comp_enc::PithosTransformer;
 use pithos_lib::transformers::size_probe::SizeProbe;
 use pithos_lib::transformers::zstd_comp::ZstdEnc;
 use pithos_lib::transformers::zstd_decomp::ZstdDec;
-use s3s::dto::{CompleteMultipartUploadOutput, ETag};
+use s3s::dto::{ChecksumType, CompleteMultipartUploadOutput, ETag};
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -370,6 +370,7 @@ impl DataHandler {
                     output.checksum_crc32 = checksum_handler.get_checksum_by_key("sha256");
                 }
             }
+            output.checksum_type = Some(ChecksumType::from_static(ChecksumType::FULL_OBJECT));
         }
 
         Ok(output)

--- a/components/data_proxy/src/s3_frontend/data_handler.rs
+++ b/components/data_proxy/src/s3_frontend/data_handler.rs
@@ -1,6 +1,9 @@
 use crate::caching::cache::Cache;
 use crate::data_backends::storage_backend::StorageBackend;
-use crate::s3_frontend::utils::buffered_s3_sink::BufferedS3Sink;
+use crate::s3_frontend::utils::checksum::{ChecksumHandler, IntegrityChecksum};
+use crate::s3_frontend::utils::{
+    buffered_s3_sink::BufferedS3Sink, crc_transformer::CrcTransformer,
+};
 use crate::structs::Object;
 use crate::structs::ObjectLocation;
 use crate::structs::VersionVariant;
@@ -9,6 +12,8 @@ use anyhow::Result;
 use aruna_rust_api::api::storage::models::v2::Hash;
 use aruna_rust_api::api::storage::models::v2::Hashalgorithm;
 use aruna_rust_api::api::storage::models::v2::Status;
+use crc_fast::CrcAlgorithm;
+use crc_fast::Digest as CrcDigest;
 use diesel_ulid::DieselUlid;
 use md5::{Digest, Md5};
 use pithos_lib::streamreadwrite::GenericStreamReadWriter;
@@ -21,7 +26,9 @@ use pithos_lib::transformers::pithos_comp_enc::PithosTransformer;
 use pithos_lib::transformers::size_probe::SizeProbe;
 use pithos_lib::transformers::zstd_comp::ZstdEnc;
 use pithos_lib::transformers::zstd_decomp::ZstdDec;
+use s3s::dto::{CompleteMultipartUploadOutput, ETag};
 use sha2::Sha256;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::pin;
@@ -45,7 +52,8 @@ impl DataHandler {
         backend: Arc<Box<dyn StorageBackend>>,
         before_location: ObjectLocation,
         path_level: Option<[Option<(DieselUlid, String)>; 4]>,
-    ) -> Result<()> {
+        mut checksum_handler: ChecksumHandler,
+    ) -> Result<CompleteMultipartUploadOutput> {
         let token = if let Some(handler) = cache.auth.read().await.as_ref() {
             let Some(created_by) = object.created_by else {
                 error!("No created_by found");
@@ -157,17 +165,38 @@ impl DataHandler {
                     asr = asr.add_transformer(ZstdDec::new());
                 }
 
-                let (uncompressed_probe, uncompressed_stream) = SizeProbe::new();
+                // [Optional] Checksums
+                let (crc32_t, crc32_rx) = CrcTransformer::new_with_backchannel(
+                    CrcDigest::new(CrcAlgorithm::Crc32IsoHdlc),
+                    false,
+                );
+                let (crc32c_t, crc32c_rx) = CrcTransformer::new_with_backchannel(
+                    CrcDigest::new(CrcAlgorithm::Crc32Iscsi),
+                    false,
+                );
+                let (crc64nvme_t, crc64nvme_rx) = CrcTransformer::new_with_backchannel(
+                    CrcDigest::new(CrcAlgorithm::Crc64Nvme),
+                    false,
+                );
 
-                asr = asr.add_transformer(uncompressed_probe);
+                asr = asr.add_transformer(crc32_t);
+                asr = asr.add_transformer(crc32c_t);
+                asr = asr.add_transformer(crc64nvme_t);
 
-                let (sha_transformer, sha_recv) =
+                // Hashes
+                let (sha_t, sha_rx) =
                     HashingTransformer::new_with_backchannel(Sha256::new(), "sha256".to_string());
-                let (md5_transformer, md5_recv) =
+                let (md5_t, md5_rx) =
                     HashingTransformer::new_with_backchannel(Md5::new(), "md5".to_string());
+                //TODO: HashingTransformer sends hash to Footer which does not support SHA1 ...
+                //let (sha_transformer, sha_recv) = HashingTransformer::new_with_backchannel(Sha1::new(), "sha1".to_string());
 
-                asr = asr.add_transformer(sha_transformer);
-                asr = asr.add_transformer(md5_transformer);
+                asr = asr.add_transformer(sha_t);
+                asr = asr.add_transformer(md5_t);
+
+                // Log uncompressed size
+                let (uncompressed_probe, uncompressed_stream) = SizeProbe::new();
+                asr = asr.add_transformer(uncompressed_probe);
 
                 if new_location_clone.is_pithos() {
                     tx.send(pithos_lib::helpers::notifications::Message::FileContext(
@@ -205,19 +234,31 @@ impl DataHandler {
                     e
                 })?;
 
-                Ok::<(u64, u64, String, String, String), anyhow::Error>((
+                // Fetch hashes
+                let mut hashes = HashMap::new();
+                for (key, rx) in vec![
+                    ("sha256", sha_rx),
+                    ("md5", md5_rx),
+                    ("crc32", crc32_rx),
+                    ("crc32c", crc32c_rx),
+                    ("crc64nvme", crc64nvme_rx),
+                ] {
+                    hashes.insert(
+                        key.into(),
+                        rx.try_recv().inspect_err(|&e| {
+                            error!(error = ?e, msg = e.to_string());
+                        })?,
+                    );
+                }
+
+                Ok::<(u64, u64, HashMap<String, String>, String), anyhow::Error>((
                     disk_size_stream.try_recv().inspect_err(|&e| {
                         error!(error = ?e, msg = e.to_string());
                     })?,
                     uncompressed_stream.try_recv().inspect_err(|&e| {
                         error!(error = ?e, msg = e.to_string());
                     })?,
-                    sha_recv.try_recv().inspect_err(|&e| {
-                        error!(error = ?e, msg = e.to_string());
-                    })?,
-                    md5_recv.try_recv().inspect_err(|&e| {
-                        error!(error = ?e, msg = e.to_string());
-                    })?,
+                    hashes,
                     final_sha_recv.try_recv().inspect_err(|&e| {
                         error!(error = ?e, msg = e.to_string());
                     })?,
@@ -242,7 +283,7 @@ impl DataHandler {
             }
         }
 
-        let (before_size, after_size, sha, md5, final_sha) = aswr_handle
+        let (before_size, after_size, hashes, final_sha) = aswr_handle
             .await
             .map_err(|e| {
                 error!(error = ?e, msg = e.to_string());
@@ -259,20 +300,33 @@ impl DataHandler {
 
         debug!(new_location = ?new_location, "Finished finalizing location");
 
-        let hashes = vec![
-            Hash {
-                alg: Hashalgorithm::Sha256.into(),
-                hash: sha,
-            },
-            Hash {
-                alg: Hashalgorithm::Md5.into(),
-                hash: md5,
-            },
-        ];
+        // Already store hashes in cache/database
+        checksum_handler.calculated_checksums = hashes;
+        cache
+            .update_object_hashes(
+                object.id,
+                checksum_handler.get_calculated_checksums().clone(),
+            )
+            .await?;
 
         if let Some(handler) = cache.aruna_client.read().await.as_ref() {
-            // Set id of new location to object id to satisfy FK constraint
-            // TODO: Update hashes etc.
+            // Send SHA256 and MD5 hashes to Aruna server
+            let hashes = vec![
+                Hash {
+                    alg: Hashalgorithm::Sha256.into(),
+                    hash: checksum_handler
+                        .get_checksum_by_key("sha256")
+                        .ok_or_else(|| anyhow!("SHA256 not found."))?
+                        .clone(),
+                },
+                Hash {
+                    alg: Hashalgorithm::Md5.into(),
+                    hash: checksum_handler
+                        .get_checksum_by_key("md5")
+                        .ok_or_else(|| anyhow!("MD5 not found."))?
+                        .clone(),
+                },
+            ];
 
             handler
                 .set_object_hashes(&object.id, hashes, &token)
@@ -287,10 +341,38 @@ impl DataHandler {
                 .to_string();
             backend.delete_object(before_location).await?;
 
+            // Remove parts from database
             cache.delete_parts_by_upload_id(upload_id).await?;
         }
 
-        Ok(())
+        // Create basic response with Etag
+        let mut output = CompleteMultipartUploadOutput {
+            e_tag: Some(ETag::Strong(format!("-{}", object.id))),
+            ..Default::default()
+        };
+
+        // Add required checksum to response
+        if let Some(required) = &checksum_handler.required_checksum {
+            match required {
+                IntegrityChecksum::CRC32(_) => {
+                    output.checksum_crc32 = checksum_handler.get_checksum_by_key("crc32");
+                }
+                IntegrityChecksum::CRC32C(_) => {
+                    output.checksum_crc32c = checksum_handler.get_checksum_by_key("crc32c");
+                }
+                IntegrityChecksum::CRC64NVME(_) => {
+                    output.checksum_crc64nvme = checksum_handler.get_checksum_by_key("crc64nvme");
+                }
+                IntegrityChecksum::SHA1(_) => {
+                    output.checksum_crc32 = checksum_handler.get_checksum_by_key("sha1");
+                }
+                IntegrityChecksum::SHA256(_) => {
+                    output.checksum_crc32 = checksum_handler.get_checksum_by_key("sha256");
+                }
+            }
+        }
+
+        Ok(output)
     }
 }
 

--- a/components/data_proxy/src/s3_frontend/s3server.rs
+++ b/components/data_proxy/src/s3_frontend/s3server.rs
@@ -201,32 +201,6 @@ impl AsRef<S3Service> for WrappingService {
     }
 }
 
-/*
-impl WrappingService {
-    #[tracing::instrument(level = "trace", skip(self))]
-    #[must_use]
-    pub fn into_make_service(self) -> MakeService<Self> {
-        MakeService(self)
-    }
-}
-
-#[derive(Clone)]
-pub struct MakeService<S>(S);
-
-impl<T, S: Clone> Service<T> for MakeService<S> {
-    type Response = S;
-
-    type Error = Infallible;
-
-    type Future = Ready<Result<Self::Response, Self::Error>>;
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    fn call(&self, _: T) -> Self::Future {
-        ready(Ok(self.0.clone()))
-    }
-}
-*/
-
 impl WrappingService {
     async fn get_cors_headers(
         &self,

--- a/components/data_proxy/src/s3_frontend/s3server.rs
+++ b/components/data_proxy/src/s3_frontend/s3server.rs
@@ -190,7 +190,6 @@ impl Service<Request<Incoming>> for WrappingService {
                 .map_err(|_| s3_error!(InternalError, "Failed to add CORS header"));
             final_response.await
         })
-        //final_response.boxed()
     }
 }
 
@@ -205,7 +204,7 @@ impl WrappingService {
     async fn get_cors_headers(
         &self,
         origin_exception: bool,
-        req: &hyper::Request<hyper::body::Incoming>,
+        req: &Request<Incoming>,
     ) -> Result<hyper::HeaderMap, S3Error> {
         // Return all * if origin exception matches
         if origin_exception {

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -156,7 +156,7 @@ impl S3 for ArunaS3Service {
             })?;
 
         // Init checksum handler
-        let checksum_handler = ChecksumHandler::from_headers(&req.headers)?;
+        let checksum_handler = ChecksumHandler::try_from(&req.headers)?;
 
         let impersonating_token =
             user_state.sign_impersonating_token(self.cache.auth.read().await.as_ref());

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -1989,6 +1989,11 @@ impl S3 for ArunaS3Service {
             )?;
         }
 
+        // Validate optionally provided checksum
+        if !checksum_handler.validate_checksum() {
+            return Err(s3_error!(BadDigest, "Checksum validation failed"));
+        }
+
         let sha_final: String = final_sha_recv.try_recv().map_err(|_| {
             error!(error = "Unable to sha hash final data");
             s3_error!(InternalError, "Unable to sha hash final data")
@@ -2235,6 +2240,11 @@ impl S3 for ArunaS3Service {
                         })?,
                         hex_to_b64,
                     )?;
+                }
+
+                // Validate optionally provided checksum
+                if !checksum_handler.validate_checksum() {
+                    return Err(s3_error!(BadDigest, "Checksum validation failed"));
                 }
 
                 self.cache

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -97,14 +97,14 @@ impl ArunaS3Service {
             ..Default::default()
         };
 
-        // Add demanded checksum
+        // Add optionally required checksum
         if let Some(required) = checksum_handler.required_checksum {
             let empty_checksum = required.get_empty_checksum();
             match required {
                 IntegrityChecksum::CRC32(_) => output.checksum_crc32 = Some(empty_checksum),
                 IntegrityChecksum::CRC32C(_) => output.checksum_crc32c = Some(empty_checksum),
                 IntegrityChecksum::CRC64NVME(_) => output.checksum_crc64nvme = Some(empty_checksum),
-                IntegrityChecksum::SHA1(_) => output.checksum_sha1 = Some(empty_checksum),
+                IntegrityChecksum::_SHA1(_) => output.checksum_sha1 = Some(empty_checksum),
                 IntegrityChecksum::SHA256(_) => output.checksum_sha256 = Some(empty_checksum),
             }
             output.checksum_type = Some(ChecksumType::from_static(ChecksumType::FULL_OBJECT));
@@ -2038,12 +2038,7 @@ impl S3 for ArunaS3Service {
             if let Some(token) = &impersonating_token {
                 if was_init {
                     new_object = handler
-                        .finish_object(
-                            new_object.id,
-                            location.raw_content_len,
-                            proto_hashes.clone(),
-                            token,
-                        )
+                        .finish_object(new_object.id, location.raw_content_len, proto_hashes, token)
                         .await
                         .map_err(|_| {
                             error!(error = "Unable to finish object");

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -2063,6 +2063,7 @@ impl S3 for ArunaS3Service {
                     output.checksum_crc32 = checksum_handler.get_checksum_by_key("sha256");
                 }
             }
+            output.checksum_type = Some(ChecksumType::from_static(ChecksumType::FULL_OBJECT));
         }
         debug!(?output);
 

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -27,9 +27,7 @@ use futures_util::{FutureExt, TryStreamExt};
 use http::HeaderName;
 use http::HeaderValue;
 use md5::{Digest, Md5};
-use pithos_lib::helpers::footer_parser::Footer;
-use pithos_lib::helpers::footer_parser::FooterParser;
-use pithos_lib::helpers::footer_parser::FooterParserState;
+use pithos_lib::helpers::footer_parser::{Footer, FooterParser, FooterParserState};
 use pithos_lib::helpers::notifications::Message as PithosMessage;
 use pithos_lib::streamreadwrite::GenericStreamReadWriter;
 use pithos_lib::transformer::ReadWriter;
@@ -45,24 +43,14 @@ use pithos_lib::transformers::zstd_comp::ZstdEnc;
 use pithos_lib::transformers::zstd_decomp::ZstdDec;
 use s3s::dto::*;
 use s3s::s3_error;
-use s3s::S3Error;
-use s3s::S3Request;
-use s3s::S3Response;
-use s3s::S3Result;
-use s3s::S3;
+use s3s::{S3Error, S3Request, S3Response, S3Result, S3};
 use sha2::Sha256;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::pin;
-use tracing::debug;
-use tracing::error;
-use tracing::info_span;
-use tracing::trace;
-use tracing::warn;
-use tracing::Instrument;
+use tracing::{debug, error, info_span, trace, warn, Instrument};
 
 pub struct ArunaS3Service {
     pub backend: Arc<Box<dyn StorageBackend>>,
@@ -1952,7 +1940,7 @@ impl S3 for ArunaS3Service {
 
         // Fetch calculated hashes
         trace!("fetching hashes");
-        for (key, rx) in vec![
+        for (key, rx) in [
             ("sha256", initial_sha_rx),
             ("md5", md5_rx),
             ("crc32", crc32_rx),
@@ -2206,7 +2194,7 @@ impl S3 for ArunaS3Service {
                 })?;
 
                 // Fetch hashes
-                for (key, rx) in vec![
+                for (key, rx) in [
                     ("md5", md5_rx),
                     ("sha256", sha_rx),
                     ("crc32", crc32_rx),

--- a/components/data_proxy/src/s3_frontend/utils/checksum.rs
+++ b/components/data_proxy/src/s3_frontend/utils/checksum.rs
@@ -514,7 +514,7 @@ mod tests {
         );
 
         // Validation should now succeed
-        assert!(!handler.validate_checksum());
+        assert!(handler.validate_checksum());
     }
 
     #[test]

--- a/components/data_proxy/src/s3_frontend/utils/checksum.rs
+++ b/components/data_proxy/src/s3_frontend/utils/checksum.rs
@@ -210,7 +210,11 @@ pub struct ChecksumHandler {
 }
 
 impl ChecksumHandler {
-    pub fn new(required_checksum: Option<IntegrityChecksum>) -> Self {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn _new_with_checksum(required_checksum: Option<IntegrityChecksum>) -> Self {
         ChecksumHandler {
             required_checksum,
             checksum_type: None,
@@ -220,7 +224,7 @@ impl ChecksumHandler {
     }
 
     pub fn from_headers(headers: &HeaderMap<HeaderValue>) -> Result<Self, S3Error> {
-        Ok(Self::new(eval_required_checksum(headers)?))
+        Ok(Self::try_from(headers)?)
     }
 
     pub fn get_validation_checksum(&self) -> &Option<String> {

--- a/components/data_proxy/src/s3_frontend/utils/checksum.rs
+++ b/components/data_proxy/src/s3_frontend/utils/checksum.rs
@@ -9,6 +9,12 @@ pub const CRC64NVME_HEADER: &str = "x-amz-checksum-crc64nvme";
 pub const SHA1_HEADER: &str = "x-amz-checksum-sha1";
 pub const SHA256_HEADER: &str = "x-amz-checksum-sha256";
 
+pub const CRC32_EMPTY: &str = "AAAAAA==";
+pub const CRC32C_EMPTY: &str = "AAAAAA==";
+pub const CRC64NVME_EMPTY: &str = "AAAAAAAAAAA=";
+pub const SHA1_EMPTY: &str = "2jmj7l5rSw0yVb/vlWAYkK/YBwk=";
+pub const SHA256_EMPTY: &str = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
+
 #[derive(Clone, Debug)]
 pub enum IntegrityChecksum {
     CRC32(Option<String>),
@@ -99,6 +105,17 @@ impl IntegrityChecksum {
             IntegrityChecksum::SHA1(ref mut val) => *val = Some(checksum),
             IntegrityChecksum::SHA256(ref mut val) => *val = Some(checksum),
         }
+    }
+
+    pub fn get_empty_checksum(&self) -> String {
+        match self {
+            IntegrityChecksum::CRC32(_) => CRC32_EMPTY,
+            IntegrityChecksum::CRC32C(_) => CRC32C_EMPTY,
+            IntegrityChecksum::CRC64NVME(_) => CRC64NVME_EMPTY,
+            IntegrityChecksum::SHA1(_) => SHA1_EMPTY,
+            IntegrityChecksum::SHA256(_) => SHA256_EMPTY,
+        }
+        .to_string()
     }
 }
 

--- a/components/data_proxy/src/s3_frontend/utils/checksum.rs
+++ b/components/data_proxy/src/s3_frontend/utils/checksum.rs
@@ -1,4 +1,6 @@
 use aws_sdk_s3::types::ChecksumType;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
 use http::{HeaderMap, HeaderValue};
 use s3s::{s3_error, S3Error};
 use std::collections::HashMap;
@@ -284,6 +286,19 @@ pub fn header_value_to_str(value: &HeaderValue) -> Result<&str, S3Error> {
     value
         .to_str()
         .map_err(|_| s3_error!(InvalidArgument, "invalid header value"))
+}
+
+pub fn hex_to_base64(value: &str) -> Result<String, S3Error> {
+    Ok(BASE64_STANDARD.encode(
+        hex::decode(value)
+            .map_err(|_| s3_error!(InternalError, "Hex to base64 conversion failed"))?,
+    ))
+}
+
+pub fn base64_to_hex(value: &str) -> Result<String, S3Error> {
+    Ok(hex::encode(BASE64_STANDARD.decode(value).map_err(
+        |_| s3_error!(InternalError, "Base64 to hex conversion failed"),
+    )?))
 }
 
 #[cfg(test)]

--- a/components/data_proxy/src/s3_frontend/utils/checksum.rs
+++ b/components/data_proxy/src/s3_frontend/utils/checksum.rs
@@ -191,6 +191,10 @@ impl ChecksumHandler {
         }
     }
 
+    pub fn from_headers(headers: &HeaderMap<HeaderValue>) -> Result<Self, S3Error> {
+        Ok(Self::new(eval_required_checksum(headers)?))
+    }
+
     pub fn get_validation_checksum(&self) -> &Option<String> {
         if let Some(checksum) = &self.required_checksum {
             match checksum {

--- a/components/data_proxy/src/s3_frontend/utils/checksum.rs
+++ b/components/data_proxy/src/s3_frontend/utils/checksum.rs
@@ -529,4 +529,27 @@ mod tests {
         let res = header_value_to_str(&invalid_hv);
         assert!(res.is_err());
     }
+
+    #[test]
+    fn test_hex_and_base64_conversion_success_and_roundtrip() {
+        // Use hex "abcd" => bytes [0xAB, 0xCD] => base64 "q80="
+        let hex = "abcd";
+        let b64 = hex_to_base64(hex).expect("should convert hex to base64");
+        assert_eq!(b64, "q80=");
+
+        // Convert back
+        let hex_back = base64_to_hex(&b64).expect("should convert base64 to hex");
+        assert_eq!(hex_back, "abcd");
+    }
+
+    #[test]
+    fn test_hex_and_base64_conversion_errors() {
+        // Invalid hex should return an error
+        let bad_hex = "zzzz";
+        assert!(hex_to_base64(bad_hex).is_err());
+
+        // Invalid base64 should return an error
+        let bad_b64 = "!!!notbase64";
+        assert!(base64_to_hex(bad_b64).is_err());
+    }
 }

--- a/components/data_proxy/src/s3_frontend/utils/checksum.rs
+++ b/components/data_proxy/src/s3_frontend/utils/checksum.rs
@@ -1,0 +1,454 @@
+use http::{HeaderMap, HeaderValue};
+use s3s::{s3_error, S3Error};
+use std::collections::HashMap;
+use std::fmt::Formatter;
+
+pub const CRC32_HEADER: &str = "x-amz-checksum-crc32";
+pub const CRC32C_HEADER: &str = "x-amz-checksum-crc32c";
+pub const CRC64NVME_HEADER: &str = "x-amz-checksum-crc64nvme";
+pub const SHA1_HEADER: &str = "x-amz-checksum-sha1";
+pub const SHA256_HEADER: &str = "x-amz-checksum-sha256";
+
+#[derive(Clone, Debug)]
+pub enum IntegrityChecksum {
+    CRC32(Option<String>),
+    CRC32C(Option<String>),
+    CRC64NVME(Option<String>),
+    SHA1(Option<String>), // For the sake of completeness. Not supported.
+    SHA256(Option<String>),
+}
+
+impl std::fmt::Display for IntegrityChecksum {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntegrityChecksum::CRC32(_) => write!(f, "crc32"),
+            IntegrityChecksum::CRC32C(_) => write!(f, "crc32c"),
+            IntegrityChecksum::CRC64NVME(_) => write!(f, "crc64nvme"),
+            IntegrityChecksum::SHA1(_) => write!(f, "sha1"),
+            IntegrityChecksum::SHA256(_) => write!(f, "sha256"),
+        }
+    }
+}
+
+impl TryFrom<&HeaderValue> for IntegrityChecksum {
+    type Error = S3Error;
+
+    #[tracing::instrument(level = "trace", skip(value))]
+    fn try_from(value: &HeaderValue) -> Result<Self, Self::Error> {
+        let header_value_str = value
+            .to_str()
+            .map_err(|_| s3_error!(InvalidArgument, "header contains invalid value"))?;
+        match header_value_str {
+            "CRC32" => Ok(IntegrityChecksum::CRC32(None)),
+            "CRC32C" => Ok(IntegrityChecksum::CRC32C(None)),
+            "CRC64NVME" => Ok(IntegrityChecksum::CRC64NVME(None)),
+            "SHA256" => Ok(IntegrityChecksum::SHA256(None)),
+            "SHA1" => Err(s3_error!(
+                NotImplemented,
+                "Sha1 checksum integrity validation is not supported"
+            )),
+            _ => Err(s3_error!(InvalidArgument, "invalid checksum algorithm")),
+        }
+    }
+}
+
+impl TryFrom<(&str, Option<&HeaderValue>)> for IntegrityChecksum {
+    type Error = S3Error;
+
+    fn try_from(value: (&str, Option<&HeaderValue>)) -> Result<Self, Self::Error> {
+        let provided_checksum = match value.1 {
+            None => None,
+            Some(val) => Some(
+                val.to_str()
+                    .map_err(|_| s3_error!(InvalidArgument, "header contains invalid characters"))?
+                    .to_string(),
+            ),
+        };
+
+        match value.0 {
+            "CRC32" => Ok(IntegrityChecksum::CRC32(provided_checksum)),
+            "CRC32C" => Ok(IntegrityChecksum::CRC32C(provided_checksum)),
+            "CRC64NVME" => Ok(IntegrityChecksum::CRC64NVME(provided_checksum)),
+            "SHA256" => Ok(IntegrityChecksum::SHA256(provided_checksum)),
+            "SHA1" => Err(s3_error!(
+                NotImplemented,
+                "Sha1 checksum integrity validation is not supported"
+            )),
+            _ => Err(s3_error!(InvalidArgument, "invalid checksum algorithm")),
+        }
+    }
+}
+
+impl IntegrityChecksum {
+    /// Get the checksum header name for this algorithm
+    pub fn checksum_header_name(&self) -> &str {
+        match self {
+            Self::CRC32(_) => CRC32_HEADER,
+            Self::CRC32C(_) => CRC32C_HEADER,
+            Self::CRC64NVME(_) => CRC64NVME_HEADER,
+            Self::SHA1(_) => SHA1_HEADER,
+            Self::SHA256(_) => SHA256_HEADER,
+        }
+    }
+
+    pub fn set_validation_checksum(&mut self, checksum: String) {
+        match self {
+            IntegrityChecksum::CRC32(ref mut val) => *val = Some(checksum),
+            IntegrityChecksum::CRC32C(ref mut val) => *val = Some(checksum),
+            IntegrityChecksum::CRC64NVME(ref mut val) => *val = Some(checksum),
+            IntegrityChecksum::SHA1(ref mut val) => *val = Some(checksum),
+            IntegrityChecksum::SHA256(ref mut val) => *val = Some(checksum),
+        }
+    }
+}
+
+pub fn eval_required_checksum(
+    headers: &HeaderMap<HeaderValue>,
+) -> Result<Option<IntegrityChecksum>, S3Error> {
+    // Check if "x-amz-sdk-checksum-algorithm" is present
+    if let Some(header_value) = headers.get("x-amz-sdk-checksum-algorithm") {
+        let mut req_checksum = IntegrityChecksum::try_from(header_value)?;
+
+        // Enforce that the corresponding "x-amz-checksum-algorithm" or "x-amz-trailer" is present
+        let checksum_header = req_checksum.checksum_header_name();
+        if let Some(validation_checksum) = headers.get(checksum_header) {
+            let checksum_str = header_value_to_str(validation_checksum)?.to_string();
+            req_checksum.set_validation_checksum(checksum_str);
+        } else if let Some(trailer) = headers.get("x-amz-trailer") {
+            let trailer_header: Vec<&str> = header_value_to_str(trailer)?
+                .split(',')
+                .map(|t| t.trim())
+                .collect();
+
+            if !trailer_header.contains(&checksum_header) {
+                return Err(s3_error!(
+                    MissingSecurityHeader,
+                    "Integrity validation is missing required header"
+                ));
+            }
+        }
+
+        return Ok(Some(req_checksum));
+    }
+
+    // Else check if any standalone "x-amz-checksum-algorithm" is present
+    let checksum = detect_algorithm_from_headers(headers)?;
+    Ok(checksum)
+}
+
+/// Detect algorithm from individual checksum headers
+fn detect_algorithm_from_headers(
+    headers: &HeaderMap<HeaderValue>,
+) -> Result<Option<IntegrityChecksum>, S3Error> {
+    let (algo, header) = if headers.contains_key(CRC32_HEADER) {
+        ("CRC32", CRC32_HEADER)
+    } else if headers.contains_key(CRC32C_HEADER) {
+        ("CRC32C", CRC32C_HEADER)
+    } else if headers.contains_key(CRC64NVME_HEADER) {
+        ("CRC64NVME", CRC64NVME_HEADER)
+    } else if headers.contains_key(SHA1_HEADER) {
+        ("SHA1", SHA1_HEADER)
+    } else if headers.contains_key(SHA256_HEADER) {
+        ("SHA256", SHA256_HEADER)
+    } else {
+        return Ok(None);
+    };
+
+    Ok(Some(IntegrityChecksum::try_from((
+        algo,
+        headers.get(header),
+    ))?))
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ChecksumHandler {
+    pub required_checksum: Option<IntegrityChecksum>,
+    pub calculated_checksums: HashMap<String, String>,
+}
+
+impl ChecksumHandler {
+    pub fn new(required_checksum: Option<IntegrityChecksum>) -> Self {
+        ChecksumHandler {
+            required_checksum,
+            calculated_checksums: HashMap::new(),
+        }
+    }
+
+    pub fn get_validation_checksum(&self) -> &Option<String> {
+        if let Some(checksum) = &self.required_checksum {
+            match checksum {
+                IntegrityChecksum::CRC32(val)
+                | IntegrityChecksum::CRC32C(val)
+                | IntegrityChecksum::CRC64NVME(val)
+                | IntegrityChecksum::SHA1(val)
+                | IntegrityChecksum::SHA256(val) => val,
+            }
+        } else {
+            &None
+        }
+    }
+
+    pub fn add_calculated_checksum(&mut self, key: impl Into<String>, checksum: String) {
+        self.calculated_checksums.insert(key.into(), checksum);
+    }
+
+    pub fn get_calculated_checksum(&self) -> Option<String> {
+        if let Some(algo) = &self.required_checksum {
+            self.calculated_checksums.get(&algo.to_string()).cloned()
+        } else {
+            None
+        }
+    }
+
+    pub fn get_calculated_checksums(&self) -> &HashMap<String, String> {
+        &self.calculated_checksums
+    }
+
+    pub fn get_checksum_by_key(&self, key: &str) -> Option<String> {
+        self.calculated_checksums.get(key).cloned()
+    }
+
+    pub fn upsert_checksum(&mut self, key: &str, checksum: &str) -> Option<String> {
+        self.calculated_checksums
+            .insert(key.to_string(), checksum.to_string())
+    }
+
+    pub fn validate_checksum(&self) -> bool {
+        if let Some(checksum) = &self.required_checksum {
+            let calculated = self
+                .calculated_checksums
+                .get(&checksum.to_string())
+                .cloned();
+            return self.get_validation_checksum().eq(&calculated);
+        }
+
+        // If no checksum is required
+        true
+    }
+}
+
+pub fn header_value_to_str(value: &HeaderValue) -> Result<&str, S3Error> {
+    value
+        .to_str()
+        .map_err(|_| s3_error!(InvalidArgument, "invalid header value"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn test_display_variants() {
+        assert_eq!(IntegrityChecksum::CRC32(None).to_string(), "crc32");
+        assert_eq!(IntegrityChecksum::CRC32C(None).to_string(), "crc32c");
+        assert_eq!(IntegrityChecksum::CRC64NVME(None).to_string(), "crc64nvme");
+        assert_eq!(IntegrityChecksum::SHA1(None).to_string(), "sha1");
+        assert_eq!(IntegrityChecksum::SHA256(None).to_string(), "sha256");
+
+        assert_eq!(
+            IntegrityChecksum::CRC32(Some("lorem".into())).to_string(),
+            "crc32"
+        );
+        assert_eq!(
+            IntegrityChecksum::CRC32C(Some("lorem".into())).to_string(),
+            "crc32c"
+        );
+        assert_eq!(
+            IntegrityChecksum::CRC64NVME(Some("lorem".into())).to_string(),
+            "crc64nvme"
+        );
+        assert_eq!(
+            IntegrityChecksum::SHA1(Some("lorem".into())).to_string(),
+            "sha1"
+        );
+        assert_eq!(
+            IntegrityChecksum::SHA256(Some("lorem".into())).to_string(),
+            "sha256"
+        );
+    }
+
+    #[test]
+    fn test_try_from_headervalue_ok_and_err() {
+        let hv_crc32 = HeaderValue::from_static("CRC32");
+        let res = IntegrityChecksum::try_from(&hv_crc32);
+        assert!(res.is_ok());
+        match res.unwrap() {
+            IntegrityChecksum::CRC32(val) => assert!(val.is_none()),
+            _ => panic!("Expected CRC32 variant"),
+        }
+
+        let hv_invalid = HeaderValue::from_static("INVALID");
+        let res_invalid = IntegrityChecksum::try_from(&hv_invalid);
+        assert!(res_invalid.is_err());
+
+        // SHA1 is explicitly not implemented
+        let hv_sha1 = HeaderValue::from_static("SHA1");
+        let res_sha1 = IntegrityChecksum::try_from(&hv_sha1);
+        assert!(res_sha1.is_err());
+    }
+
+    #[test]
+    fn test_try_from_tuple_ok_and_err() {
+        let v = ("CRC32", Some(&HeaderValue::from_static("abcd")));
+        let res = IntegrityChecksum::try_from(v);
+        assert!(res.is_ok());
+        match res.unwrap() {
+            IntegrityChecksum::CRC32(val) => assert_eq!(val, Some("abcd".to_string())),
+            _ => panic!("Expected CRC32 variant"),
+        }
+
+        let v_none = ("CRC32", None);
+        let res_none = IntegrityChecksum::try_from(v_none);
+        assert!(res_none.is_ok());
+        match res_none.unwrap() {
+            IntegrityChecksum::CRC32(val) => assert!(val.is_none()),
+            _ => panic!("Expected CRC32 variant"),
+        }
+
+        let v_invalid = ("NOT_AN_ALGO", None);
+        assert!(IntegrityChecksum::try_from(v_invalid).is_err());
+    }
+
+    #[test]
+    fn test_checksum_header_name_and_set_validation() {
+        let mut ic = IntegrityChecksum::CRC32(None);
+        assert_eq!(ic.checksum_header_name(), CRC32_HEADER);
+        ic.set_validation_checksum("val1".to_string());
+        match ic {
+            IntegrityChecksum::CRC32(Some(v)) => assert_eq!(v, "val1"),
+            _ => panic!("Expected CRC32(Some)"),
+        }
+
+        let mut ic2 = IntegrityChecksum::SHA256(None);
+        assert_eq!(ic2.checksum_header_name(), SHA256_HEADER);
+        ic2.set_validation_checksum("val2".to_string());
+        match ic2 {
+            IntegrityChecksum::SHA256(Some(v)) => assert_eq!(v, "val2"),
+            _ => panic!("Expected SHA256(Some)"),
+        }
+    }
+
+    #[test]
+    fn test_eval_required_checksum_sdk_with_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-amz-sdk-checksum-algorithm",
+            HeaderValue::from_static("CRC32"),
+        );
+        headers.insert(CRC32_HEADER, HeaderValue::from_static("mycrc"));
+
+        let res = eval_required_checksum(&headers).expect("should parse checksum");
+        assert!(res.is_some());
+        match res.unwrap() {
+            IntegrityChecksum::CRC32(val) => assert_eq!(val, Some("mycrc".to_string())),
+            _ => panic!("Expected CRC32"),
+        }
+    }
+
+    #[test]
+    fn test_eval_required_checksum_sdk_with_trailer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-amz-sdk-checksum-algorithm",
+            HeaderValue::from_static("CRC32"),
+        );
+        headers.insert("x-amz-trailer", HeaderValue::from_static(CRC32_HEADER));
+
+        let res = eval_required_checksum(&headers).expect("should parse checksum from trailer");
+        assert!(res.is_some());
+        match res.unwrap() {
+            IntegrityChecksum::CRC32(val) => assert!(val.is_none()),
+            _ => panic!("Expected CRC32"),
+        }
+    }
+
+    #[test]
+    fn test_eval_required_checksum_sdk_missing_trailer_or_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-amz-sdk-checksum-algorithm",
+            HeaderValue::from_static("CRC32"),
+        );
+        headers.insert(
+            "x-amz-trailer",
+            HeaderValue::from_static("some-other-header"),
+        );
+
+        let res = eval_required_checksum(&headers);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_detect_algorithm_from_headers_via_eval() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CRC32_HEADER, HeaderValue::from_static("detected"));
+        let res = eval_required_checksum(&headers).expect("should detect algorithm");
+        assert!(res.is_some());
+        match res.unwrap() {
+            IntegrityChecksum::CRC32(val) => assert_eq!(val, Some("detected".to_string())),
+            _ => panic!("Expected CRC32"),
+        }
+    }
+
+    #[test]
+    fn test_checksum_handler_operations() {
+        // No required checksum
+        let handler = ChecksumHandler::new(None);
+        assert!(handler.get_validation_checksum().is_none());
+        assert!(handler.get_calculated_checksum().is_none());
+        assert!(handler.validate_checksum()); // no required checksum => true
+
+        // With required checksum
+        let required = IntegrityChecksum::CRC32(None);
+        let mut handler = ChecksumHandler::new(Some(required));
+        // set validation checksum inside the handler
+        if let Some(ic) = &mut handler.required_checksum {
+            ic.set_validation_checksum("expected".to_string());
+        }
+        assert_eq!(
+            handler.get_validation_checksum(),
+            &Some("expected".to_string())
+        );
+
+        // add calculated checksum and retrieve
+        handler.add_calculated_checksum("crc32", "expected".to_string());
+        assert_eq!(
+            handler.get_calculated_checksum(),
+            Some("expected".to_string())
+        );
+        assert_eq!(
+            handler.get_checksum_by_key("crc32"),
+            Some("expected".to_string())
+        );
+
+        // upsert returns previous value
+        let prev = handler.upsert_checksum("crc32", "newval");
+        assert_eq!(prev, Some("expected".to_string()));
+        assert_eq!(
+            handler.get_checksum_by_key("crc32"),
+            Some("newval".to_string())
+        );
+
+        // validate true only if calculated matches validation
+        // currently validation is "expected" and calculated is "newval" -> false
+        assert!(!handler.validate_checksum());
+
+        // set calculated to match
+        handler.upsert_checksum("crc32", "expected");
+        assert!(handler.validate_checksum());
+    }
+
+    #[test]
+    fn test_header_value_to_str() {
+        let hv = HeaderValue::from_static("somestring");
+        let s = header_value_to_str(&hv).expect("should convert");
+        assert_eq!(s, "somestring");
+
+        let invalid_hv =
+            HeaderValue::from_bytes(&[115, 195, 182, 109, 195, 169, 115, 116, 114, 105, 110, 103])
+                .unwrap();
+        let res = header_value_to_str(&invalid_hv);
+        assert!(res.is_err());
+    }
+}

--- a/components/data_proxy/src/s3_frontend/utils/mod.rs
+++ b/components/data_proxy/src/s3_frontend/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod buffered_s3_sink;
+pub mod checksum;
 pub mod crc_transformer;
 pub mod debug_transformer;
 pub mod list_objects;

--- a/components/data_proxy/src/structs.rs
+++ b/components/data_proxy/src/structs.rs
@@ -1166,12 +1166,12 @@ impl Object {
         self.hashes
             .iter()
             .map(|(k, v)| {
-                let alg = if k == "MD5" {
-                    2
-                } else if k == "SHA256" {
-                    1
+                let alg = if k == "md5" {
+                    Hashalgorithm::Md5 as i32
+                } else if k == "sha256" {
+                    Hashalgorithm::Sha256 as i32
                 } else {
-                    0
+                    Hashalgorithm::Unspecified as i32
                 };
 
                 Hash {

--- a/components/data_proxy/src/structs.rs
+++ b/components/data_proxy/src/structs.rs
@@ -1182,6 +1182,27 @@ impl Object {
             .collect()
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn get_api_safe_hashes(&self) -> Vec<Hash> {
+        self.hashes
+            .iter()
+            .filter_map(|(k, v)| {
+                let alg = if k == "md5" {
+                    Hashalgorithm::Md5 as i32
+                } else if k == "sha256" {
+                    Hashalgorithm::Sha256 as i32
+                } else {
+                    return None;
+                };
+
+                Some(Hash {
+                    alg,
+                    hash: v.to_string(),
+                })
+            })
+            .collect()
+    }
+
     #[tracing::instrument(level = "trace", skip(self, ep_id))]
     pub fn is_partial_sync(&self, ep_id: &DieselUlid) -> bool {
         self.endpoints


### PR DESCRIPTION
This integrates checksum integrity validation from the S3 specification into Aruna's S3-compatible interface for the implemented upload and get operations. The implementation validates data integrity using checksums provided by clients during PutObject, UploadPart, and CompleteMultipartUpload operations and provides all calculated checksums with the HeadObject and GetObject operations.

## Changes

- Implemented ChecksumHandler utility for evaluating and validating checksums according to S3 spec
- Integrated hash handling into protobuf Object to Dataproxy Object conversion
- Extended `UploadPart` struct to optionally store checksums for multipart uploads
- Added checksum calculation/validation in PutObject operation
- Added checksum calculation/validation in UploadPart operation
- Integrated checksum calculation in CompleteMultipartUpload operation
- Provide all calculated checksums in the response headers of HeadObject and GetObject operation
- Extended ChecksumHandler to handle empty/zero-byte objects
- Improved 0-byte object handling
- Added local hash upserting functionality
- Refactored to use only API-conform hashes for server communication
- Added checksum type to output

## Notes

Currently only `FULL_OBJECT` checksum type is supported.

## Closes

Resolves #225