### PR TITLE
Integrate S3 metadata handling

### DIFF
--- a/components/data_proxy/src/caching/grpc_query_handler.rs
+++ b/components/data_proxy/src/caching/grpc_query_handler.rs
@@ -569,16 +569,15 @@ impl GrpcQueryHandler {
     }
 
     #[tracing::instrument(level = "trace", skip(self, request, token))]
-    pub async fn init_object_revision(
+    pub async fn apply_object_update(
         &self,
         request: UpdateObjectRequest,
         token: &str,
     ) -> Result<DPObject> {
-        trace!(?request, "Initializing object revision");
+        trace!(?request, "Applying object update");
 
         // Crate gRPC request with provided token in header
         let mut req = Request::new(request);
-
         Self::add_token_to_md(req.metadata_mut(), token)?;
 
         // Update Object in ArunaServer and validate response

--- a/components/data_proxy/src/caching/grpc_query_handler.rs
+++ b/components/data_proxy/src/caching/grpc_query_handler.rs
@@ -539,19 +539,16 @@ impl GrpcQueryHandler {
 
     #[tracing::instrument(level = "trace", skip(self, obj, token))]
     pub async fn remove_cors_from_project(&self, token: &str, obj: DPObject) -> Result<()> {
-        let cors = match obj
+        let cors = obj
             .key_values
             .iter()
             .find(|e| e.key == "app.aruna-storage.org/cors")
             .cloned()
-        {
-            Some(cors) => cors,
-            None => KeyValue {
+            .unwrap_or_else(|| KeyValue {
                 key: "app.aruna-storage.org/cors".to_string(),
                 value: String::new(),
                 variant: KeyValueVariant::Label as i32,
-            },
-        };
+            });
         let mut req = Request::new(UpdateProjectKeyValuesRequest {
             project_id: obj.id.to_string(),
             add_key_values: vec![],
@@ -571,21 +568,16 @@ impl GrpcQueryHandler {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self, object, token, force_update))]
-    pub async fn init_object_update(
+    #[tracing::instrument(level = "trace", skip(self, request, token))]
+    pub async fn init_object_revision(
         &self,
-        object: DPObject,
+        request: UpdateObjectRequest,
         token: &str,
-        force_update: bool,
     ) -> Result<DPObject> {
-        trace!(?object, "Initializing object update");
-
-        // Create UpdateObjectRequest with provided value for force_revision parameter
-        let mut inner_request = UpdateObjectRequest::from(object);
-        inner_request.force_revision = force_update;
+        trace!(?request, "Initializing object revision");
 
         // Crate gRPC request with provided token in header
-        let mut req = Request::new(inner_request);
+        let mut req = Request::new(request);
 
         Self::add_token_to_md(req.metadata_mut(), token)?;
 

--- a/components/data_proxy/src/data_backends/s3_backend.rs
+++ b/components/data_proxy/src/data_backends/s3_backend.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use async_channel::{Receiver, Sender};
 use async_trait::async_trait;
 use aws_sdk_s3::config::RequestChecksumCalculation;
+use aws_sdk_s3::operation::create_bucket::CreateBucketError;
 use aws_sdk_s3::primitives::SdkBody;
 use aws_sdk_s3::{
     config::Region,
@@ -424,10 +425,14 @@ impl S3Backend {
             Ok(_) => Ok(()),
             Err(e1) => match self.s3_client.create_bucket().bucket(bucket).send().await {
                 Ok(_) => Ok(()),
-                Err(err) => {
-                    error!(?e1, ?err, "Error creating bucket");
-                    Err(err.into())
-                }
+                Err(err) => match err.into_service_error() {
+                    CreateBucketError::BucketAlreadyExists(_)
+                    | CreateBucketError::BucketAlreadyOwnedByYou(_) => Ok(()),
+                    a => {
+                        error!(?e1, ?a, "Error creating bucket");
+                        Err(a.into())
+                    }
+                },
             },
         }
     }

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -7,6 +7,7 @@ use crate::data_backends::storage_backend::StorageBackend;
 use crate::s3_frontend::utils::checksum::{ChecksumHandler, IntegrityChecksum};
 use crate::s3_frontend::utils::crc_transformer::CrcTransformer;
 use crate::s3_frontend::utils::list_objects::list_response;
+use crate::s3_frontend::utils::metadata::{MetadataPatch, S3UserMetadata};
 use crate::structs::CheckAccessResult;
 use crate::structs::NewOrExistingObject;
 use crate::structs::Object as ProxyObject;
@@ -80,6 +81,98 @@ impl ArunaS3Service {
             backend: backend.clone(),
             cache,
         })
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, impersonating_token))]
+    async fn init_object_revision_from_patch(
+        &self,
+        object_id: String,
+        patch: MetadataPatch,
+        impersonating_token: Option<&str>,
+    ) -> S3Result<ProxyObject> {
+        let handler = self
+            .cache
+            .aruna_client
+            .read()
+            .await
+            .clone()
+            .ok_or_else(|| {
+                error!("ArunaServer client not available");
+                s3_error!(InternalError, "ArunaServer client not available")
+            })?;
+
+        let token = impersonating_token.ok_or_else(|| {
+            error!("missing impersonating token");
+            s3_error!(InternalError, "Token creation failed")
+        })?;
+
+        handler
+            .init_object_revision(patch.into_update_request(object_id), token)
+            .await
+            .map_err(|_| {
+                error!(error = "Object update failed");
+                s3_error!(InternalError, "Object update failed")
+            })
+    }
+
+    fn reset_prepared_upload_object(object: &mut ProxyObject) {
+        object.hashes = HashMap::default();
+        object.synced = false;
+        object.children = None;
+        object.dynamic = false;
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, object, metadata, impersonating_token))]
+    async fn prepare_object(
+        &self,
+        object: &NewOrExistingObject,
+        metadata: &S3UserMetadata,
+        impersonating_token: Option<&str>,
+    ) -> S3Result<(ProxyObject, bool)> {
+        match object {
+            NewOrExistingObject::Existing(object) => {
+                if object.object_status == Status::Initializing {
+                    let mut object = object.clone();
+                    metadata.apply_to_key_values(&mut object.key_values);
+                    Ok((object, true))
+                } else {
+                    let patch = metadata.diff_against(&object.key_values);
+                    let mut new_revision = self
+                        .init_object_revision_from_patch(
+                            object.id.to_string(),
+                            patch,
+                            impersonating_token,
+                        )
+                        .await?;
+                    Self::reset_prepared_upload_object(&mut new_revision);
+                    Ok((new_revision, true))
+                }
+            }
+            NewOrExistingObject::Missing(object) => {
+                let mut object = object.clone();
+                metadata.apply_to_key_values(&mut object.key_values);
+                Ok((object, false))
+            }
+            NewOrExistingObject::None => Err(s3_error!(
+                InvalidObjectState,
+                "Object in invalid state: None"
+            )),
+        }
+    }
+
+    fn merge_headers(
+        headers: &mut Option<HashMap<String, String>>,
+        new_headers: HashMap<String, String>,
+    ) {
+        if new_headers.is_empty() {
+            return;
+        }
+
+        if let Some(headers) = headers.as_mut() {
+            headers.extend(new_headers);
+        } else {
+            *headers = Some(new_headers);
+        }
     }
 
     #[tracing::instrument(level = "trace", skip(object, headers))]
@@ -376,50 +469,13 @@ impl S3 for ArunaS3Service {
         let (states, _) = objects_state.require_regular()?;
 
         let (_, collection, dataset, object, location_state) = states.to_new_or_existing()?;
+        let user_metadata = S3UserMetadata::try_from(&req.headers)?;
 
         trace!(?collection, ?dataset, ?object);
 
-        let mut new_object = match &object {
-            NewOrExistingObject::Existing(ob) => {
-                if ob.object_status == Status::Initializing {
-                    trace!("Object is initializing");
-                    ob.clone()
-                } else {
-                    let mut new_revision = if let Some(handler) =
-                        self.cache.aruna_client.read().await.as_ref()
-                    {
-                        if let Some(token) = &impersonating_token {
-                            handler
-                                .init_object_update(ob.clone(), token, true)
-                                .await
-                                .map_err(|_| {
-                                    error!(error = "Object update failed");
-                                    s3_error!(InternalError, "Object update failed")
-                                })?
-                        } else {
-                            error!("missing impersonating token");
-                            return Err(s3_error!(InternalError, "Token creation failed"));
-                        }
-                    } else {
-                        //TODO: Enable offline mode
-                        error!("ArunaServer client not available");
-                        return Err(s3_error!(InternalError, "ArunaServer client not available"));
-                    };
-                    new_revision.hashes = HashMap::default();
-                    new_revision.synced = false;
-                    new_revision.children = None;
-                    new_revision.dynamic = false;
-                    new_revision
-                }
-            }
-            NewOrExistingObject::Missing(object) => object.clone(),
-            NewOrExistingObject::None => {
-                return Err(s3_error!(
-                    InvalidObjectState,
-                    "Object in invalid state: None"
-                ))
-            }
-        };
+        let (mut new_object, _) = self
+            .prepare_object(&object, &user_metadata, impersonating_token.as_deref())
+            .await?;
 
         trace!(?new_object);
 
@@ -941,7 +997,7 @@ impl S3 for ArunaS3Service {
     ) -> S3Result<S3Response<HeadObjectOutput>> {
         let CheckAccessResult {
             objects_state,
-            headers,
+            mut headers,
             ..
         } = req
             .extensions
@@ -974,12 +1030,14 @@ impl S3 for ArunaS3Service {
         }
 
         let (object, location) = objects_state.extract_object()?;
-
         let content_len = location.map(|l| l.raw_content_len).unwrap_or_default();
-
         let mime = mime_guess::from_path(object.name.as_str())
             .first()
             .and_then(|mime_guess| ContentType::from_str(mime_guess.as_ref()).ok());
+        Self::merge_headers(
+            &mut headers,
+            S3UserMetadata::from(object.key_values.as_slice()).into_headers(),
+        );
 
         let mut output = HeadObjectOutput {
             content_length: Some(content_len),
@@ -1028,6 +1086,7 @@ impl S3 for ArunaS3Service {
                 );
             }
         }
+        debug!(?resp);
 
         Ok(resp)
     }
@@ -1758,47 +1817,11 @@ impl S3 for ArunaS3Service {
         let (states, _) = objects_state.require_regular()?;
 
         let (_, collection, dataset, object, location_state) = states.to_new_or_existing()?;
+        let user_metadata = S3UserMetadata::try_from(&req.headers)?;
 
-        let (mut new_object, was_init) = match object {
-            NewOrExistingObject::Existing(ob) => {
-                if ob.object_status == Status::Initializing {
-                    trace!("Object is initializing");
-                    (ob, true)
-                } else {
-                    let mut new_revision = if let Some(handler) =
-                        self.cache.aruna_client.read().await.as_ref()
-                    {
-                        if let Some(token) = &impersonating_token {
-                            handler
-                                .init_object_update(ob, token, true)
-                                .await
-                                .map_err(|_| {
-                                    error!(error = "Object update failed");
-                                    s3_error!(InternalError, "Object update failed")
-                                })?
-                        } else {
-                            error!("missing impersonating token");
-                            return Err(s3_error!(InternalError, "Token creation failed"));
-                        }
-                    } else {
-                        error!("ArunaServer client not available");
-                        return Err(s3_error!(InternalError, "ArunaServer client not available"));
-                    };
-                    new_revision.hashes = HashMap::default();
-                    new_revision.synced = false;
-                    new_revision.children = None;
-                    new_revision.dynamic = false;
-                    (new_revision, true)
-                }
-            }
-            NewOrExistingObject::Missing(object) => (object, false),
-            NewOrExistingObject::None => {
-                return Err(s3_error!(
-                    InvalidObjectState,
-                    "Object in invalid state: None"
-                ))
-            }
-        };
+        let (mut new_object, was_init) = self
+            .prepare_object(&object, &user_metadata, impersonating_token.as_deref())
+            .await?;
 
         trace!(?new_object);
         match req.input.content_length {
@@ -2430,33 +2453,23 @@ impl S3 for ArunaS3Service {
                 }
                 (new_object, false)
             }
-            NewOrExistingObject::Existing(mut object) => {
+            NewOrExistingObject::Existing(object) => {
                 if object.object_status == Status::Initializing {
                     (object, true)
                 } else {
-                    if let Some(handler) = self.cache.aruna_client.read().await.as_ref() {
-                        if let Some(token) = &impersonating_token {
-                            handler
-                                .init_object_update(object.clone(), token, true)
-                                .await
-                                .map_err(|_| {
-                                    error!(error = "Object update failed");
-                                    s3_error!(InternalError, "Object update failed")
-                                })?
-                        } else {
-                            error!("missing impersonating token");
-                            return Err(s3_error!(InternalError, "Token creation failed"));
-                        }
-                    } else {
-                        error!("ArunaServer client not available");
-                        return Err(s3_error!(InternalError, "ArunaServer client not available"));
-                    };
-                    object.hashes = existing_object.hashes.clone();
-                    object.synced = existing_object.synced;
-                    object.children = None; // This should be None anyway, because this is an Object
-                    object.dynamic = existing_object.dynamic;
+                    let mut new_revision = self
+                        .init_object_revision_from_patch(
+                            object.id.to_string(),
+                            MetadataPatch::default(),
+                            impersonating_token.as_deref(),
+                        )
+                        .await?;
+                    new_revision.hashes = existing_object.hashes.clone();
+                    new_revision.synced = existing_object.synced;
+                    new_revision.children = None; // This should be None anyway, because this is an Object
+                    new_revision.dynamic = existing_object.dynamic;
 
-                    (object, true)
+                    (new_revision, true)
                 }
             }
             NewOrExistingObject::None => {

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -84,7 +84,7 @@ impl ArunaS3Service {
     }
 
     #[tracing::instrument(level = "trace", skip(self, impersonating_token))]
-    async fn init_object_revision_from_patch(
+    async fn apply_object_update_from_patch(
         &self,
         object_id: String,
         patch: MetadataPatch,
@@ -107,7 +107,7 @@ impl ArunaS3Service {
         })?;
 
         handler
-            .init_object_revision(patch.into_update_request(object_id), token)
+            .apply_object_update(patch.into_update_request(object_id), token)
             .await
             .map_err(|_| {
                 error!(error = "Object update failed");
@@ -131,14 +131,24 @@ impl ArunaS3Service {
     ) -> S3Result<(ProxyObject, bool)> {
         match object {
             NewOrExistingObject::Existing(object) => {
+                let patch = metadata.diff_against(&object.key_values);
+
                 if object.object_status == Status::Initializing {
-                    let mut object = object.clone();
-                    metadata.apply_to_key_values(&mut object.key_values);
-                    Ok((object, true))
+                    if patch.is_empty() {
+                        Ok((object.clone(), true))
+                    } else {
+                        let updated_object = self
+                            .apply_object_update_from_patch(
+                                object.id.to_string(),
+                                patch,
+                                impersonating_token,
+                            )
+                            .await?;
+                        Ok((updated_object, true))
+                    }
                 } else {
-                    let patch = metadata.diff_against(&object.key_values);
                     let mut new_revision = self
-                        .init_object_revision_from_patch(
+                        .apply_object_update_from_patch(
                             object.id.to_string(),
                             patch,
                             impersonating_token,
@@ -2458,7 +2468,7 @@ impl S3 for ArunaS3Service {
                     (object, true)
                 } else {
                     let mut new_revision = self
-                        .init_object_revision_from_patch(
+                        .apply_object_update_from_patch(
                             object.id.to_string(),
                             MetadataPatch::default(),
                             impersonating_token.as_deref(),

--- a/components/data_proxy/src/s3_frontend/utils/metadata.rs
+++ b/components/data_proxy/src/s3_frontend/utils/metadata.rs
@@ -53,6 +53,10 @@ impl S3UserMetadata {
 }
 
 impl MetadataPatch {
+    pub fn is_empty(&self) -> bool {
+        self.add_key_values.is_empty() && self.remove_key_values.is_empty()
+    }
+
     pub fn into_update_request(self, object_id: String) -> UpdateObjectRequest {
         UpdateObjectRequest {
             object_id,
@@ -62,7 +66,7 @@ impl MetadataPatch {
             remove_key_values: self.remove_key_values,
             data_class: 0,
             hashes: vec![],
-            force_revision: true,
+            force_revision: false,
             parent: None,
             metadata_license_tag: None,
             data_license_tag: None,
@@ -297,6 +301,18 @@ mod tests {
     }
 
     #[test]
+    fn diff_against_returns_empty_patch_for_unchanged_metadata() {
+        let key_values = vec![metadata("x-amz-meta-owner", "alice")];
+
+        let patch = S3UserMetadata {
+            entries: BTreeMap::from([("x-amz-meta-owner".to_string(), "alice".to_string())]),
+        }
+        .diff_against(&key_values);
+
+        assert!(patch.is_empty());
+    }
+
+    #[test]
     fn into_headers_merges_keys_in_canonical_form() {
         let headers = S3UserMetadata::from(
             [
@@ -322,7 +338,7 @@ mod tests {
         }
         .into_update_request("object-id".to_string());
 
-        assert!(request.force_revision);
+        assert!(!request.force_revision);
         assert_eq!(request.object_id, "object-id");
         assert_eq!(
             request.add_key_values,
@@ -332,5 +348,14 @@ mod tests {
             request.remove_key_values,
             vec![metadata("x-amz-meta-mtime", "1")]
         );
+    }
+
+    #[test]
+    fn empty_patch_into_update_request_still_uses_force_revision_flag() {
+        let request = MetadataPatch::default().into_update_request("object-id".to_string());
+
+        assert!(!request.force_revision);
+        assert!(request.add_key_values.is_empty());
+        assert!(request.remove_key_values.is_empty());
     }
 }

--- a/components/data_proxy/src/s3_frontend/utils/metadata.rs
+++ b/components/data_proxy/src/s3_frontend/utils/metadata.rs
@@ -1,0 +1,336 @@
+use super::checksum::header_value_to_str;
+use aruna_rust_api::api::storage::models::v2::{KeyValue, KeyValueVariant};
+use aruna_rust_api::api::storage::services::v2::UpdateObjectRequest;
+use http::{HeaderMap, HeaderValue};
+use s3s::{s3_error, S3Error};
+use std::collections::{BTreeMap, HashMap};
+
+pub const USER_METADATA_PREFIX: &str = "x-amz-meta-";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct S3UserMetadata {
+    entries: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MetadataPatch {
+    pub add_key_values: Vec<KeyValue>,
+    pub remove_key_values: Vec<KeyValue>,
+}
+
+impl S3UserMetadata {
+    pub fn apply_to_key_values(&self, key_values: &mut Vec<KeyValue>) {
+        key_values.retain(|key_value| normalize_user_metadata_key(&key_value.key).is_none());
+        key_values.extend(Vec::<KeyValue>::from(self));
+    }
+
+    pub fn into_headers(self) -> HashMap<String, String> {
+        self.entries.into_iter().collect()
+    }
+
+    pub fn diff_against(&self, key_values: &[KeyValue]) -> MetadataPatch {
+        let current = S3UserMetadata::from(key_values);
+        let desired_key_values = Vec::<KeyValue>::from(self);
+        let current_key_values = Vec::<KeyValue>::from(&current);
+
+        let add_key_values = desired_key_values
+            .iter()
+            .filter(|desired| !current_key_values.contains(desired))
+            .cloned()
+            .collect();
+
+        let remove_key_values = current_key_values
+            .iter()
+            .filter(|existing| !desired_key_values.contains(existing))
+            .cloned()
+            .collect();
+
+        MetadataPatch {
+            add_key_values,
+            remove_key_values,
+        }
+    }
+}
+
+impl MetadataPatch {
+    pub fn into_update_request(self, object_id: String) -> UpdateObjectRequest {
+        UpdateObjectRequest {
+            object_id,
+            name: None,
+            description: None,
+            add_key_values: self.add_key_values,
+            remove_key_values: self.remove_key_values,
+            data_class: 0,
+            hashes: vec![],
+            force_revision: true,
+            parent: None,
+            metadata_license_tag: None,
+            data_license_tag: None,
+        }
+    }
+}
+
+impl TryFrom<&HeaderMap<HeaderValue>> for S3UserMetadata {
+    type Error = S3Error;
+
+    fn try_from(headers: &HeaderMap<HeaderValue>) -> Result<Self, Self::Error> {
+        let mut entries = BTreeMap::new();
+
+        for (name, value) in headers {
+            let header_name = name.as_str();
+            if header_name.eq_ignore_ascii_case(USER_METADATA_PREFIX) {
+                return Err(s3_error!(
+                    InvalidArgument,
+                    "invalid user metadata header name"
+                ));
+            }
+
+            let Some(header_name) = normalize_user_metadata_key(header_name) else {
+                continue;
+            };
+
+            let header_value = header_value_to_str(value)?;
+            entries
+                .entry(header_name)
+                .and_modify(|existing: &mut String| {
+                    existing.push(',');
+                    existing.push_str(header_value);
+                })
+                .or_insert_with(|| header_value.to_string());
+        }
+
+        Ok(S3UserMetadata { entries })
+    }
+}
+
+impl From<&[KeyValue]> for S3UserMetadata {
+    fn from(key_values: &[KeyValue]) -> Self {
+        let mut entries = BTreeMap::new();
+
+        for key_value in key_values {
+            let Some(key) = normalize_user_metadata_key(&key_value.key) else {
+                continue;
+            };
+
+            entries
+                .entry(key)
+                .and_modify(|existing: &mut String| {
+                    existing.push(',');
+                    existing.push_str(&key_value.value);
+                })
+                .or_insert_with(|| key_value.value.clone());
+        }
+
+        S3UserMetadata { entries }
+    }
+}
+
+impl From<&S3UserMetadata> for Vec<KeyValue> {
+    fn from(metadata: &S3UserMetadata) -> Self {
+        metadata
+            .entries
+            .iter()
+            .map(|(key, value)| KeyValue {
+                key: key.clone(),
+                value: value.clone(),
+                variant: KeyValueVariant::StaticLabel as i32,
+            })
+            .collect()
+    }
+}
+
+fn normalize_user_metadata_key(key: &str) -> Option<String> {
+    let key = key.to_ascii_lowercase();
+    let suffix = key.strip_prefix(USER_METADATA_PREFIX)?;
+
+    if suffix.is_empty() {
+        None
+    } else {
+        Some(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_rust_api::api::storage::models::v2::KeyValueVariant;
+    use http::{HeaderMap, HeaderName, HeaderValue};
+
+    fn metadata(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: value.to_string(),
+            variant: KeyValueVariant::StaticLabel as i32,
+        }
+    }
+
+    #[test]
+    fn try_from_headers_combines_duplicate_headers() {
+        let mut headers = HeaderMap::new();
+        let metadata_name = HeaderName::from_static("x-amz-meta-author");
+
+        headers.append(metadata_name.clone(), HeaderValue::from_static("alice"));
+        headers.append(metadata_name, HeaderValue::from_static("bob"));
+        headers.insert(
+            "content-type",
+            HeaderValue::from_static("application/octet-stream"),
+        );
+
+        let extracted = S3UserMetadata::try_from(&headers).expect("metadata should parse");
+
+        assert_eq!(
+            extracted,
+            S3UserMetadata {
+                entries: BTreeMap::from([(
+                    "x-amz-meta-author".to_string(),
+                    "alice,bob".to_string(),
+                )]),
+            }
+        );
+    }
+
+    #[test]
+    fn try_from_headers_rejects_non_ascii_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-amz-meta-nonascii",
+            HeaderValue::from_bytes(&[
+                0x3d, 0x3f, 0x55, 0x54, 0x46, 0x2d, 0x38, 0x3f, 0x42, 0x3f, 0xc3,
+            ])
+            .expect("header value should be constructible"),
+        );
+
+        assert!(S3UserMetadata::try_from(&headers).is_err());
+    }
+
+    #[test]
+    fn from_key_values_extracts_only_s3_metadata() {
+        let metadata = S3UserMetadata::from(
+            [
+                metadata("x-amz-meta-owner", "alice"),
+                metadata("X-Amz-Meta-Mtime", "1"),
+                KeyValue {
+                    key: "app.aruna-storage.org/cors".to_string(),
+                    value: "cors".to_string(),
+                    variant: KeyValueVariant::Label as i32,
+                },
+            ]
+            .as_slice(),
+        );
+
+        assert_eq!(
+            metadata,
+            S3UserMetadata {
+                entries: BTreeMap::from([
+                    ("x-amz-meta-mtime".to_string(), "1".to_string()),
+                    ("x-amz-meta-owner".to_string(), "alice".to_string()),
+                ]),
+            }
+        );
+    }
+
+    #[test]
+    fn into_key_values_creates_static_labels() {
+        let s3_metadata = S3UserMetadata {
+            entries: BTreeMap::from([("x-amz-meta-owner".to_string(), "alice".to_string())]),
+        };
+
+        assert_eq!(
+            Vec::<KeyValue>::from(&s3_metadata),
+            vec![metadata("x-amz-meta-owner", "alice")]
+        );
+    }
+
+    #[test]
+    fn apply_to_key_values_preserves_non_s3_key_values() {
+        let mut key_values = vec![
+            metadata("x-amz-meta-old", "before"),
+            KeyValue {
+                key: "app.aruna-storage.org/cors".to_string(),
+                value: "cors".to_string(),
+                variant: KeyValueVariant::Label as i32,
+            },
+        ];
+
+        S3UserMetadata {
+            entries: BTreeMap::from([("x-amz-meta-new".to_string(), "after".to_string())]),
+        }
+        .apply_to_key_values(&mut key_values);
+
+        assert_eq!(
+            key_values,
+            vec![
+                KeyValue {
+                    key: "app.aruna-storage.org/cors".to_string(),
+                    value: "cors".to_string(),
+                    variant: KeyValueVariant::Label as i32,
+                },
+                metadata("x-amz-meta-new", "after"),
+            ]
+        );
+    }
+
+    #[test]
+    fn diff_against_only_touches_s3_metadata_subset() {
+        let key_values = vec![
+            metadata("x-amz-meta-mtime", "1"),
+            KeyValue {
+                key: "app.aruna-storage.org/cors".to_string(),
+                value: "cors".to_string(),
+                variant: KeyValueVariant::Label as i32,
+            },
+        ];
+
+        let patch = S3UserMetadata {
+            entries: BTreeMap::from([("x-amz-meta-owner".to_string(), "alice".to_string())]),
+        }
+        .diff_against(&key_values);
+
+        assert_eq!(
+            patch.add_key_values,
+            vec![metadata("x-amz-meta-owner", "alice")]
+        );
+        assert_eq!(
+            patch.remove_key_values,
+            vec![metadata("x-amz-meta-mtime", "1")]
+        );
+    }
+
+    #[test]
+    fn into_headers_merges_keys_in_canonical_form() {
+        let headers = S3UserMetadata::from(
+            [
+                metadata("x-amz-meta-owner", "alice"),
+                metadata("X-Amz-Meta-Owner", "bob"),
+            ]
+            .as_slice(),
+        )
+        .into_headers();
+
+        assert_eq!(headers.len(), 1);
+        assert_eq!(
+            headers.get("x-amz-meta-owner"),
+            Some(&"alice,bob".to_string())
+        );
+    }
+
+    #[test]
+    fn metadata_patch_into_update_request_forces_revision() {
+        let request = MetadataPatch {
+            add_key_values: vec![metadata("x-amz-meta-owner", "alice")],
+            remove_key_values: vec![metadata("x-amz-meta-mtime", "1")],
+        }
+        .into_update_request("object-id".to_string());
+
+        assert!(request.force_revision);
+        assert_eq!(request.object_id, "object-id");
+        assert_eq!(
+            request.add_key_values,
+            vec![metadata("x-amz-meta-owner", "alice")]
+        );
+        assert_eq!(
+            request.remove_key_values,
+            vec![metadata("x-amz-meta-mtime", "1")]
+        );
+    }
+}

--- a/components/data_proxy/src/s3_frontend/utils/mod.rs
+++ b/components/data_proxy/src/s3_frontend/utils/mod.rs
@@ -3,5 +3,6 @@ pub mod checksum;
 pub mod crc_transformer;
 pub mod debug_transformer;
 pub mod list_objects;
+pub mod metadata;
 pub mod ranges;
 pub mod replication_sink;

--- a/components/data_proxy/src/structs.rs
+++ b/components/data_proxy/src/structs.rs
@@ -1361,10 +1361,12 @@ impl ResourceStates {
             self.objects[2].is_missing(),
             self.objects[3].is_missing(),
         ) {
-            (false, true, true, true)
-            | (false, true, false, true)
-            | (false, false, true, true)
-            | (false, false, false, true)
+            (false, true, true, true)     // Project
+            | (false, false, true, true)  // Project -> Collection
+            | (false, true, false, true)  // Project -> Dataset
+            | (false, true, true, false)  // Project -> Object
+            | (false, false, true, false) // Project -> Collection -> Object exists
+            | (false, false, false, true) // Project -> Collection -> Dataset exists
             | (false, false, false, false) => {}
             _ => {
                 bail!("Invalid resource state")

--- a/components/data_proxy/src/structs.rs
+++ b/components/data_proxy/src/structs.rs
@@ -17,7 +17,6 @@ use aruna_rust_api::api::storage::services::v2::CreateCollectionRequest;
 use aruna_rust_api::api::storage::services::v2::CreateDatasetRequest;
 use aruna_rust_api::api::storage::services::v2::CreateObjectRequest;
 use aruna_rust_api::api::storage::services::v2::CreateProjectRequest;
-use aruna_rust_api::api::storage::services::v2::UpdateObjectRequest;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use diesel_ulid::DieselUlid;
 use http::{HeaderValue, Method};
@@ -1128,7 +1127,7 @@ impl From<Object> for CreateObjectRequest {
             name: value.name,
             title: value.title,
             description: "".to_string(),
-            key_values: vec![],
+            key_values: value.key_values,
             relations: vec![],
             data_class: value.data_class.into(),
             parent: value
@@ -1139,25 +1138,6 @@ impl From<Object> for CreateObjectRequest {
             metadata_license_tag: value.metadata_license,
             data_license_tag: value.data_license,
             authors: vec![],
-        }
-    }
-}
-
-impl From<Object> for UpdateObjectRequest {
-    #[tracing::instrument(level = "trace", skip(value))]
-    fn from(value: Object) -> Self {
-        UpdateObjectRequest {
-            object_id: value.id.to_string(),
-            name: None,
-            description: None,
-            add_key_values: vec![],
-            remove_key_values: vec![],
-            data_class: value.data_class as i32,
-            hashes: vec![],
-            force_revision: false,
-            parent: None,
-            metadata_license_tag: Some(value.metadata_license),
-            data_license_tag: Some(value.data_license),
         }
     }
 }

--- a/components/server/src/database/dsls/internal_relation_dsl.rs
+++ b/components/server/src/database/dsls/internal_relation_dsl.rs
@@ -256,6 +256,35 @@ impl InternalRelation {
         Ok(())
     }
 
+    pub async fn batch_delete_by_target_and_relation(
+        target_pid: DieselUlid,
+        relation_name: &str,
+        client: &Client,
+    ) -> Result<()> {
+        let query = "DELETE FROM internal_relations
+            WHERE target_pid = $1 AND relation_name = $2;";
+        let prepared = client.prepare(query).await?;
+        client
+            .execute(&prepared, &[&target_pid, &relation_name])
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update_target_name(
+        target_pid: DieselUlid,
+        target_name: &str,
+        client: &Client,
+    ) -> Result<()> {
+        let query = "UPDATE internal_relations
+            SET target_name = $2
+            WHERE target_pid = $1;";
+        let prepared = client.prepare(query).await?;
+        client
+            .execute(&prepared, &[&target_pid, &target_name])
+            .await?;
+        Ok(())
+    }
+
     pub fn as_origin_object_mapping(&self) -> ObjectMapping<DieselUlid> {
         match self.origin_type {
             ObjectType::PROJECT => ObjectMapping::PROJECT(self.origin_pid),

--- a/components/server/src/database/dsls/object_dsl.rs
+++ b/components/server/src/database/dsls/object_dsl.rs
@@ -687,6 +687,32 @@ impl Object {
         Ok(())
     }
 
+    pub async fn update_staging(&self, client: &Client) -> Result<()> {
+        let query = "UPDATE objects
+        SET name = $2, description = $3, key_values = $4, data_class = $5, hashes = $6,
+            metadata_license = $7, data_license = $8
+        WHERE id = $1;";
+
+        let prepared = client.prepare(query).await?;
+
+        client
+            .execute(
+                &prepared,
+                &[
+                    &self.id,
+                    &self.name,
+                    &self.description,
+                    &self.key_values,
+                    &self.data_class,
+                    &self.hashes,
+                    &self.metadata_license,
+                    &self.data_license,
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
     //ToDo: Docs
     pub async fn batch_claim(
         user_id: &DieselUlid,

--- a/components/server/src/middlelayer/finish_db_handler.rs
+++ b/components/server/src/middlelayer/finish_db_handler.rs
@@ -49,7 +49,7 @@ impl DatabaseHandler {
             None,
             "ARUNA_SERVER", // Endpoint name?
         );
-        let config = aws_config::defaults(BehaviorVersion::v2024_03_28())
+        let config = aws_config::defaults(BehaviorVersion::v2025_01_17())
             .credentials_provider(creds)
             .load()
             .await;

--- a/components/server/src/middlelayer/presigned_url_handler.rs
+++ b/components/server/src/middlelayer/presigned_url_handler.rs
@@ -427,7 +427,7 @@ impl DatabaseHandler {
             None,
             "ARUNA_SERVER", // Endpoint name?
         );
-        let config = aws_config::defaults(BehaviorVersion::v2024_03_28())
+        let config = aws_config::defaults(BehaviorVersion::v2025_01_17())
             .credentials_provider(creds)
             .load()
             .await;

--- a/components/server/src/middlelayer/update_db_handler.rs
+++ b/components/server/src/middlelayer/update_db_handler.rs
@@ -4,7 +4,7 @@ use super::update_request_types::{
 use crate::database::crud::CrudDb;
 use crate::database::dsls::hook_dsl::TriggerVariant;
 use crate::database::dsls::internal_relation_dsl::{
-    InternalRelation, INTERNAL_RELATION_VARIANT_VERSION,
+    InternalRelation, INTERNAL_RELATION_VARIANT_BELONGS_TO, INTERNAL_RELATION_VARIANT_VERSION,
 };
 use crate::database::dsls::license_dsl::ALL_RIGHTS_RESERVED;
 use crate::database::dsls::object_dsl::{KeyValue, KeyValueVariant, Object, ObjectWithRelations};
@@ -15,6 +15,7 @@ use crate::middlelayer::update_request_types::{
 };
 use anyhow::{anyhow, Result};
 use aruna_rust_api::api::notification::services::v2::EventVariant;
+use aruna_rust_api::api::storage::services::v2::update_object_request::Parent;
 use aruna_rust_api::api::storage::services::v2::UpdateObjectRequest;
 use deadpool_postgres::GenericClient;
 use diesel_ulid::DieselUlid;
@@ -312,14 +313,16 @@ impl DatabaseHandler {
                 (_, _) => true,
             },
         };
+        let initializing_object = old.object_status == ObjectStatus::INITIALIZING;
         let (data_class, dataclass_triggers_new_revision) =
             req.get_dataclass(old.clone(), is_service_account)?;
-        let (id, is_new, affected) = if request.force_revision
-            || request.name.is_some()
-            || !request.remove_key_values.is_empty()
-            || !request.hashes.is_empty()
-            || license_triggers_new_revision
-            || dataclass_triggers_new_revision
+        let (id, is_new, affected) = if !initializing_object
+            && (request.force_revision
+                || request.name.is_some()
+                || !request.remove_key_values.is_empty()
+                || !request.hashes.is_empty()
+                || license_triggers_new_revision
+                || dataclass_triggers_new_revision)
         {
             let object_status = if request.force_revision {
                 ObjectStatus::INITIALIZING
@@ -388,9 +391,9 @@ impl DatabaseHandler {
                 )?;
                 relation.create(transaction_client).await?;
                 let changed = match p {
-                    aruna_rust_api::api::storage::services::v2::update_object_request::Parent::ProjectId(id) => DieselUlid::from_str(&id)?,
-                    aruna_rust_api::api::storage::services::v2::update_object_request::Parent::CollectionId(id) => DieselUlid::from_str(&id)?,
-                    aruna_rust_api::api::storage::services::v2::update_object_request::Parent::DatasetId(id) => DieselUlid::from_str(&id)?,
+                    Parent::ProjectId(id) => DieselUlid::from_str(&id)?,
+                    Parent::CollectionId(id) => DieselUlid::from_str(&id)?,
+                    Parent::DatasetId(id) => DieselUlid::from_str(&id)?,
                 };
                 affected.push(changed);
             }
@@ -400,43 +403,73 @@ impl DatabaseHandler {
             (id, true, affected)
         } else {
             // Update in place
-            let update_object = Object {
-                id: old.id,
-                content_len: old.content_len,
-                count: 1,
-                revision_number: old.revision_number,
-                external_relations: old.clone().external_relations,
-                created_at: None,
-                created_by: old.created_by,
-                authors: old.authors.clone(),
-                data_class,
-                description: req.get_description(old.clone()),
-                name: old.clone().name,
-                title: old.title.clone(),
-                key_values: Json(req.get_add_keyvals(old.clone())?),
-                hashes: old.clone().hashes,
-                object_type: crate::database::enums::ObjectType::OBJECT,
-                object_status: old.object_status.clone(),
-                dynamic: false,
-                endpoints: Json(req.get_endpoints(old.clone(), false)?),
-                metadata_license: old.metadata_license,
-                data_license: old.data_license,
-            };
-            update_object.update(transaction_client).await?;
+            let mut update_object = old.clone();
+            update_object.data_class = data_class;
+            update_object.description = req.get_description(old.clone());
+
+            if initializing_object {
+                let (metadata_license, data_license) =
+                    req.get_license(&old, transaction_client).await?;
+                update_object.name = req.get_name(old.clone());
+                update_object.key_values = Json(req.get_all_kvs(old.clone())?);
+                update_object.hashes = Json(req.get_hashes(old.clone())?);
+                update_object.metadata_license = metadata_license;
+                update_object.data_license = data_license;
+                update_object.update_staging(transaction_client).await?;
+
+                if update_object.name != old.name {
+                    InternalRelation::update_target_name(
+                        update_object.id,
+                        &update_object.name,
+                        transaction_client,
+                    )
+                    .await?;
+                }
+            } else {
+                update_object.key_values = Json(req.get_add_keyvals(old.clone())?);
+                update_object.update(transaction_client).await?;
+            }
+
             // Create & return all affected ids for cache sync
             let affected = if let Some(p) = request.parent.clone() {
-                let mut relation = UpdateObject::add_parent_relation(
-                    id,
-                    p.clone(),
-                    update_object.name.to_string(),
-                )?;
-                relation.create(transaction_client).await?;
-                let p_id = match p {
-                    aruna_rust_api::api::storage::services::v2::update_object_request::Parent::ProjectId(id) => DieselUlid::from_str(&id)?,
-                    aruna_rust_api::api::storage::services::v2::update_object_request::Parent::CollectionId(id) => DieselUlid::from_str(&id)?,
-                    aruna_rust_api::api::storage::services::v2::update_object_request::Parent::DatasetId(id) => DieselUlid::from_str(&id)?,
-                };
-                vec![p_id, update_object.id]
+                let mut affected = vec![update_object.id];
+
+                if initializing_object {
+                    if UpdateObject::parent_relation_changed(&owr, &p)? {
+                        InternalRelation::batch_delete_by_target_and_relation(
+                            update_object.id,
+                            INTERNAL_RELATION_VARIANT_BELONGS_TO,
+                            transaction_client,
+                        )
+                        .await?;
+
+                        let mut relation = UpdateObject::add_parent_relation(
+                            id,
+                            p.clone(),
+                            update_object.name.to_string(),
+                        )?;
+                        relation.create(transaction_client).await?;
+                    }
+
+                    affected.extend(UpdateObject::get_parent_affected_ids(&owr, &p)?);
+                    affected.sort();
+                    affected.dedup();
+                } else {
+                    let mut relation = UpdateObject::add_parent_relation(
+                        id,
+                        p.clone(),
+                        update_object.name.to_string(),
+                    )?;
+                    relation.create(transaction_client).await?;
+                    let p_id = match p {
+                        Parent::ProjectId(id) => DieselUlid::from_str(&id)?,
+                        Parent::CollectionId(id) => DieselUlid::from_str(&id)?,
+                        Parent::DatasetId(id) => DieselUlid::from_str(&id)?,
+                    };
+                    affected.push(p_id);
+                }
+
+                affected
             } else {
                 vec![update_object.id]
             };

--- a/components/server/src/middlelayer/update_request_types.rs
+++ b/components/server/src/middlelayer/update_request_types.rs
@@ -383,6 +383,41 @@ impl UpdateObject {
             target_name: name,
         })
     }
+
+    pub fn get_parent_id(parent: &UpdateParent) -> Result<DieselUlid> {
+        match parent {
+            UpdateParent::ProjectId(id) => Ok(DieselUlid::from_str(id)?),
+            UpdateParent::CollectionId(id) => Ok(DieselUlid::from_str(id)?),
+            UpdateParent::DatasetId(id) => Ok(DieselUlid::from_str(id)?),
+        }
+    }
+
+    pub fn parent_relation_changed(
+        old_object: &ObjectWithRelations,
+        parent: &UpdateParent,
+    ) -> Result<bool> {
+        let requested_parent_id = Self::get_parent_id(parent)?;
+        Ok(!old_object
+            .inbound_belongs_to
+            .0
+            .contains_key(&requested_parent_id))
+    }
+
+    pub fn get_parent_affected_ids(
+        old_object: &ObjectWithRelations,
+        parent: &UpdateParent,
+    ) -> Result<Vec<DieselUlid>> {
+        let requested_parent_id = Self::get_parent_id(parent)?;
+        let mut affected = vec![requested_parent_id];
+
+        affected.extend(old_object.inbound_belongs_to.0.iter().filter_map(|entry| {
+            let parent_id = *entry.key();
+            (parent_id != requested_parent_id).then_some(parent_id)
+        }));
+
+        Ok(affected)
+    }
+
     pub fn get_all_relations(
         old_object: ObjectWithRelations,
         new_object: Object,

--- a/components/server/tests/middlelayer/updates.rs
+++ b/components/server/tests/middlelayer/updates.rs
@@ -1,15 +1,16 @@
 use crate::common::init::init_database_handler_middlelayer;
 use crate::common::test_utils;
-use aruna_rust_api::api::storage::models::v2::{Hash, KeyValue as APIKeyValue};
+use aruna_rust_api::api::storage::models::v2::{Hash as APIHash, KeyValue as APIKeyValue};
 use aruna_rust_api::api::storage::services::v2::{
-    UpdateCollectionDataClassRequest, UpdateCollectionDescriptionRequest,
-    UpdateCollectionKeyValuesRequest, UpdateCollectionNameRequest, UpdateDatasetDataClassRequest,
-    UpdateDatasetDescriptionRequest, UpdateDatasetKeyValuesRequest, UpdateDatasetNameRequest,
-    UpdateObjectRequest, UpdateProjectDataClassRequest, UpdateProjectDescriptionRequest,
-    UpdateProjectKeyValuesRequest, UpdateProjectNameRequest,
+    update_object_request::Parent, UpdateCollectionDataClassRequest,
+    UpdateCollectionDescriptionRequest, UpdateCollectionKeyValuesRequest,
+    UpdateCollectionNameRequest, UpdateDatasetDataClassRequest, UpdateDatasetDescriptionRequest,
+    UpdateDatasetKeyValuesRequest, UpdateDatasetNameRequest, UpdateObjectRequest,
+    UpdateProjectDataClassRequest, UpdateProjectDescriptionRequest, UpdateProjectKeyValuesRequest,
+    UpdateProjectNameRequest,
 };
 use aruna_server::database::crud::CrudDb;
-use aruna_server::database::dsls::license_dsl::ALL_RIGHTS_RESERVED;
+use aruna_server::database::dsls::license_dsl::{License, ALL_RIGHTS_RESERVED};
 use aruna_server::database::dsls::object_dsl::{KeyValue, KeyValueVariant, KeyValues, Object};
 use aruna_server::database::enums::{DataClass, ObjectMapping, ObjectStatus, ObjectType};
 use aruna_server::middlelayer::update_request_types::{
@@ -461,7 +462,7 @@ async fn update_object_test() {
             variant: 1,
         }],
         data_class: 1,
-        hashes: vec![Hash {
+        hashes: vec![APIHash {
             alg: 1,
             hash: "dd98d701915b2bc5aad5dc9190194844".to_string(),
         }],
@@ -536,4 +537,158 @@ async fn update_object_test() {
         license_update.data_license_tag,
         Some(license_updated.object.data_license)
     )
+}
+
+#[tokio::test]
+async fn update_initializing_object_in_place_test() {
+    let db_handler = init_database_handler_middlelayer().await;
+    let object_id = DieselUlid::generate();
+    let object_mapping = ObjectMapping::OBJECT(object_id);
+    let old_parent_id = DieselUlid::generate();
+    let old_parent_mapping = ObjectMapping::PROJECT(old_parent_id);
+    let new_parent_id = DieselUlid::generate();
+    let new_parent_mapping = ObjectMapping::PROJECT(new_parent_id);
+    let mut user =
+        test_utils::new_user(vec![object_mapping, old_parent_mapping, new_parent_mapping]);
+    let mut object = test_utils::object_from_mapping(user.id, object_mapping);
+    let mut old_parent = test_utils::object_from_mapping(user.id, old_parent_mapping);
+    let mut new_parent = test_utils::object_from_mapping(user.id, new_parent_mapping);
+    let mut relation = test_utils::new_internal_relation(&old_parent, &object);
+    let hash_value = "dd98d701915b2bc5aad5dc9190194844".to_string();
+    let metadata_license_tag = format!("stage-meta-{}", DieselUlid::generate());
+    let data_license_tag = format!("stage-data-{}", DieselUlid::generate());
+    let mut metadata_license = License {
+        tag: metadata_license_tag.clone(),
+        name: "Staging metadata license".to_string(),
+        text: "Staging metadata license".to_string(),
+        url: "https://example.com/staging-metadata".to_string(),
+    };
+    let mut data_license = License {
+        tag: data_license_tag.clone(),
+        name: "Staging data license".to_string(),
+        text: "Staging data license".to_string(),
+        url: "https://example.com/staging-data".to_string(),
+    };
+
+    object.object_status = ObjectStatus::INITIALIZING;
+    object.revision_number = 7;
+    object.key_values.0 .0.push(KeyValue {
+        key: "to_delete".to_string(),
+        value: "deleted".to_string(),
+        variant: KeyValueVariant::LABEL,
+    });
+    old_parent.name = "old-parent".to_string();
+    new_parent.name = "new-parent".to_string();
+
+    let client = db_handler.database.get_client().await.unwrap();
+    user.create(&client).await.unwrap();
+    metadata_license.create(&client).await.unwrap();
+    data_license.create(&client).await.unwrap();
+    object.create(&client).await.unwrap();
+    old_parent.create(&client).await.unwrap();
+    new_parent.create(&client).await.unwrap();
+    relation.create(&client).await.unwrap();
+
+    let updates =
+        Object::get_objects_with_relations(&vec![object_id, old_parent_id, new_parent_id], &client)
+            .await
+            .unwrap();
+    for o in updates {
+        db_handler.cache.add_object(o)
+    }
+
+    let request = UpdateObjectRequest {
+        object_id: object_id.to_string(),
+        name: Some("staging-name".to_string()),
+        description: Some("staging-description".to_string()),
+        add_key_values: vec![APIKeyValue {
+            key: "New".to_string(),
+            value: "value".to_string(),
+            variant: 1,
+        }],
+        remove_key_values: vec![APIKeyValue {
+            key: "to_delete".to_string(),
+            value: "deleted".to_string(),
+            variant: 1,
+        }],
+        data_class: 1,
+        hashes: vec![APIHash {
+            alg: 1,
+            hash: hash_value.clone(),
+        }],
+        parent: Some(Parent::ProjectId(new_parent_id.to_string())),
+        force_revision: true,
+        metadata_license_tag: Some(metadata_license_tag.clone()),
+        data_license_tag: Some(data_license_tag.clone()),
+    };
+
+    let (updated, is_new) = db_handler
+        .update_grpc_object(request, user.id, false)
+        .await
+        .unwrap();
+
+    assert!(!is_new);
+    assert_eq!(updated.object.id, object_id);
+    assert_eq!(updated.object.revision_number, 7);
+    assert_eq!(updated.object.object_status, ObjectStatus::INITIALIZING);
+    assert_eq!(updated.object.name, "staging-name".to_string());
+    assert_eq!(
+        updated.object.description,
+        "staging-description".to_string()
+    );
+    assert_eq!(updated.object.data_class, DataClass::PUBLIC);
+    assert_eq!(updated.object.metadata_license, metadata_license_tag);
+    assert_eq!(updated.object.data_license, data_license_tag);
+    assert!(updated.object.key_values.0 .0.contains(&KeyValue {
+        key: "New".to_string(),
+        value: "value".to_string(),
+        variant: KeyValueVariant::LABEL,
+    }));
+    assert!(!updated.object.key_values.0 .0.contains(&KeyValue {
+        key: "to_delete".to_string(),
+        value: "deleted".to_string(),
+        variant: KeyValueVariant::LABEL,
+    }));
+    assert_eq!(updated.object.hashes.0 .0.len(), 1);
+    assert!(updated
+        .object
+        .hashes
+        .0
+         .0
+        .iter()
+        .any(|hash| hash.hash == hash_value));
+    assert!(!updated.inbound_belongs_to.0.contains_key(&old_parent_id));
+    assert!(updated.inbound_belongs_to.0.contains_key(&new_parent_id));
+
+    let rename_request = UpdateObjectRequest {
+        object_id: object_id.to_string(),
+        name: Some("staging-name-2".to_string()),
+        description: None,
+        add_key_values: vec![],
+        remove_key_values: vec![],
+        data_class: 0,
+        hashes: vec![],
+        parent: Some(Parent::ProjectId(new_parent_id.to_string())),
+        force_revision: true,
+        metadata_license_tag: None,
+        data_license_tag: None,
+    };
+
+    let (renamed, renamed_is_new) = db_handler
+        .update_grpc_object(rename_request, user.id, false)
+        .await
+        .unwrap();
+
+    assert!(!renamed_is_new);
+    assert_eq!(renamed.object.id, object_id);
+    assert_eq!(renamed.object.name, "staging-name-2".to_string());
+    assert_eq!(
+        renamed
+            .inbound_belongs_to
+            .0
+            .get(&new_parent_id)
+            .unwrap()
+            .target_name,
+        "staging-name-2".to_string()
+    );
 }


### PR DESCRIPTION
This pull request refactors and improves the S3 backend logic in the data proxy, focusing on how object updates and metadata handling are performed. The changes introduce a more modular and reusable approach for preparing and updating objects, enhance metadata management, and improve error handling.

**Refactoring and Metadata Handling:**

- Refactored object update logic:
  * Introduced the `prepare_object` and `apply_object_update_from_patch` helper methods in `ArunaS3Service` to encapsulate and simplify the logic for preparing and updating objects, replacing repeated code in multiple S3 operations.
  * Updated S3 operations (e.g., `put_object`, `put_object_part`, `complete_multipart_upload`) to use these new helpers, reducing code duplication and improving maintainability.

- Improved metadata handling:
  * Integrated `S3UserMetadata` and `MetadataPatch` for more robust and consistent object metadata management.
  * Added logic to merge user metadata into S3 response headers, ensuring custom metadata is correctly returned in `HeadObject` responses. 

**Backend and Error Handling Improvements:**

- Enhanced S3 backend error handling:
  * Improved bucket creation logic to gracefully handle cases where the bucket already exists or is already owned by the user, instead of treating these as errors.

This resolves #230 