### PR TITLE
feat: Improve status infos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,9 @@ dependencies = [
  "byteview",
  "crossfire",
  "fjall",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "ulid",
 ]

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -19,11 +19,12 @@ pub fn router() -> Router<Arc<ServerState>> {
     Router::new().route("/info", get(get_info))
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct InfoResponse {
     pub net_state: NetStatus,
     pub blob_status: BlobStatus,
     pub interface_status: InterfaceStatus,
+    pub database_status: DatabaseStatus,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -61,7 +62,14 @@ pub struct TimeoutConfig {
 pub struct InterfaceStatus {
     pub s3_status: String,
     pub rest_status: String,
-    pub db_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct DatabaseStatus {
+    pub requests_total: u64,
+    pub errors_total: u64,
+    pub conflicts_total: u64,
+    pub error_rate: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -130,10 +138,23 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
         }
         None => BlobStatus::Unavailable,
     };
+    // TODO: 
+    // - Replace hardcoded values
+    // - Add s3 interface address
     let interface_status = InterfaceStatus {
         s3_status: Status::Available.to_string(),
         rest_status: Status::Available.to_string(),
-        db_status: Status::Available.to_string(),
+    };
+    let storage_metrics = state.get_ctx().storage_handle.snapshot_metrics();
+    let database_status = DatabaseStatus {
+        requests_total: storage_metrics.requests_total,
+        errors_total: storage_metrics.errors_total,
+        conflicts_total: storage_metrics.conflicts_total,
+        error_rate: if storage_metrics.requests_total == 0 {
+            0.0
+        } else {
+            storage_metrics.errors_total as f64 / storage_metrics.requests_total as f64
+        },
     };
     (
         StatusCode::OK,
@@ -141,15 +162,17 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
             net_state,
             blob_status,
             interface_status,
+            database_status,
         }),
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BlobStatus, InfoResponse, InterfaceStatus, NetStatus, get_info};
+    use super::{BlobStatus, InfoResponse, InterfaceStatus, NetStatus, DatabaseStatus, get_info};
     use crate::openapi::ApiDoc;
     use crate::server_state::ServerState;
+    use aruna_core::effects::StorageEffect;
     use aruna_core::structs::{NodeCapabilities, RealmId, Status};
     use aruna_operations::driver::DriverContext;
     use aruna_storage::storage;
@@ -195,6 +218,7 @@ mod tests {
     #[tokio::test]
     async fn get_info_returns_unavailable_optional_statuses_when_handles_are_missing() {
         let (state, _tempdir) = setup_state().await;
+        let baseline = state.get_ctx().storage_handle.snapshot_metrics();
 
         let (status, Json(response)) = get_info(State(state)).await;
 
@@ -207,8 +231,46 @@ mod tests {
                 interface_status: InterfaceStatus {
                     s3_status: Status::Available.to_string(),
                     rest_status: Status::Available.to_string(),
-                    db_status: Status::Available.to_string(),
                 },
+                database_status: DatabaseStatus {
+                    requests_total: baseline.requests_total,
+                    errors_total: baseline.errors_total,
+                    conflicts_total: baseline.conflicts_total,
+                    error_rate: if baseline.requests_total == 0 {
+                        0.0
+                    } else {
+                        baseline.errors_total as f64 / baseline.requests_total as f64
+                    },
+                },
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn get_info_reports_storage_error_metrics() {
+        let (state, _tempdir) = setup_state().await;
+        let ctx = state.get_ctx();
+        let baseline = ctx.storage_handle.snapshot_metrics();
+
+        let _ = ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Read {
+                key_space: "missing".to_string(),
+                key: b"key".to_vec().into(),
+                txn_id: Some(ulid::Ulid::new()),
+            })
+            .await;
+
+        let (status, Json(response)) = get_info(State(state)).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            response.database_status,
+            DatabaseStatus {
+                requests_total: baseline.requests_total + 1,
+                errors_total: baseline.errors_total + 1,
+                conflicts_total: baseline.conflicts_total,
+                error_rate: (baseline.errors_total + 1) as f64 / (baseline.requests_total + 1) as f64,
             }
         );
     }

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1,4 +1,5 @@
 use crate::server_state::ServerState;
+use aruna_core::structs::Status;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::get;
@@ -20,7 +21,54 @@ pub fn router() -> Router<Arc<ServerState>> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct InfoResponse {
-    pub node_id: String,
+    pub net_state: NetStatus,
+    pub blob_status: BlobStatus,
+    pub interface_status: InterfaceStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum NetStatus {
+    Available {
+        realm_id: String,
+        node_id: String,
+        boostrap_nodes: Vec<String>,
+        endpoint_addr: serde_json::Value,
+        open_connections: Vec<OpenConnection>,
+    },
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum BlobStatus {
+    Available {
+        backend_type: String,
+        max_bucket_size: Option<u64>,
+        multipart_bucket: Option<String>,
+        timeouts: TimeoutConfig,
+        status: String,
+    },
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct TimeoutConfig {
+    pub control_plane_connect_timeout: String,
+    pub control_plane_io_timeout: String,
+    pub transfer_idle_timeout: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct InterfaceStatus {
+    pub s3_status: String,
+    pub rest_status: String,
+    pub db_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct OpenConnection {
+    pub alpn: Option<String>,
+    pub remote_id: String,
+    pub side: String,
 }
 
 #[utoipa::path(
@@ -32,20 +80,77 @@ pub struct InfoResponse {
     )
 )]
 pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Json<InfoResponse>) {
+    let net_state = match &state.get_ctx().net_handle {
+        Some(net) => {
+            let info = net.get_status().await;
+            NetStatus::Available {
+                realm_id: info.realm_id.to_string(),
+                node_id: info.node_id.to_string(),
+                boostrap_nodes: info.boostrap_nodes.iter().map(|n| n.to_string()).collect(),
+                endpoint_addr: serde_json::to_value(&info.endpoint_addr).unwrap(),
+                open_connections: info
+                    .open_connections
+                    .iter()
+                    .map(|c| OpenConnection {
+                        alpn: c.alpn.map(|a| a.to_string()),
+                        remote_id: c.remote_id.to_string(),
+                        side: match c.side {
+                            iroh::endpoint::Side::Client => "Client".to_string(),
+                            iroh::endpoint::Side::Server => "Server".to_string(),
+                        },
+                    })
+                    .collect(),
+            }
+        }
+        None => NetStatus::Unavailable,
+    };
+    let blob_status = match &state.get_ctx().blob_handle {
+        Some(blob) => {
+            let info = blob.get_status().await;
+            BlobStatus::Available {
+                backend_type: info.backend_type.to_string(),
+                max_bucket_size: info.max_bucket_size,
+                multipart_bucket: info.multipart_bucket,
+                timeouts: TimeoutConfig {
+                    control_plane_connect_timeout: format!(
+                        "{}s",
+                        info.timeouts.control_plane_connect_timeout.as_secs()
+                    ),
+                    control_plane_io_timeout: format!(
+                        "{}s",
+                        info.timeouts.control_plane_io_timeout.as_secs()
+                    ),
+                    transfer_idle_timeout: format!(
+                        "{}s",
+                        info.timeouts.transfer_idle_timeout.as_secs()
+                    ),
+                },
+                status: info.status.to_string(),
+            }
+        }
+        None => BlobStatus::Unavailable,
+    };
+    let interface_status = InterfaceStatus {
+        s3_status: Status::Available.to_string(),
+        rest_status: Status::Available.to_string(),
+        db_status: Status::Available.to_string(),
+    };
     (
         StatusCode::OK,
         Json(InfoResponse {
-            node_id: state.get_node_id().to_string(),
+            net_state,
+            blob_status,
+            interface_status,
         }),
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{InfoResponse, get_info};
+    use super::{BlobStatus, InfoResponse, InterfaceStatus, NetStatus, get_info};
     use crate::openapi::ApiDoc;
     use crate::server_state::ServerState;
-    use aruna_core::structs::{NodeCapabilities, RealmId};
+    use aruna_core::structs::{NodeCapabilities, RealmId, Status};
     use aruna_operations::driver::DriverContext;
     use aruna_storage::storage;
     use axum::Json;
@@ -88,9 +193,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_info_returns_local_node_id() {
+    async fn get_info_returns_unavailable_optional_statuses_when_handles_are_missing() {
         let (state, _tempdir) = setup_state().await;
-        let expected_node_id = state.get_node_id().to_string();
 
         let (status, Json(response)) = get_info(State(state)).await;
 
@@ -98,7 +202,13 @@ mod tests {
         assert_eq!(
             response,
             InfoResponse {
-                node_id: expected_node_id,
+                net_state: NetStatus::Unavailable,
+                blob_status: BlobStatus::Unavailable,
+                interface_status: InterfaceStatus {
+                    s3_status: Status::Available.to_string(),
+                    rest_status: Status::Available.to_string(),
+                    db_status: Status::Available.to_string(),
+                },
             }
         );
     }

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -31,7 +31,7 @@ pub enum NetStatus {
     Available {
         realm_id: String,
         node_id: String,
-        boostrap_nodes: Vec<String>,
+        bootstrap_nodes: Vec<String>,
         endpoint_addr: serde_json::Value,
         open_connections: Vec<OpenConnection>,
     },
@@ -97,6 +97,7 @@ pub struct DatabaseStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct OpenConnection {
     pub alpn: Option<String>,
+    pub connection_id: u64,
     pub remote_id: String,
     pub side: String,
 }
@@ -116,12 +117,14 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
             NetStatus::Available {
                 realm_id: info.realm_id.to_string(),
                 node_id: info.node_id.to_string(),
-                boostrap_nodes: info.boostrap_nodes.iter().map(|n| n.to_string()).collect(),
+                bootstrap_nodes: info.bootstrap_nodes.iter().map(|n| n.to_string()).collect(),
                 endpoint_addr: serde_json::to_value(&info.endpoint_addr).unwrap(),
                 open_connections: info
+                    .monitor
                     .open_connections
                     .iter()
                     .map(|c| OpenConnection {
+                        connection_id: c.connection_id,
                         alpn: c.alpn.map(|a| a.to_string()),
                         remote_id: c.remote_id.to_string(),
                         side: match c.side {

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -20,6 +20,7 @@ pub fn router() -> Router<Arc<ServerState>> {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct InfoResponse {
+    pub node_info: LocalNodeInfo,
     pub net_state: NetStatus,
     pub blob_status: BlobStatus,
     pub interface_status: InterfaceStatus,
@@ -27,27 +28,74 @@ pub struct InfoResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub enum NetStatus {
-    Available {
-        realm_id: String,
-        node_id: String,
-        bootstrap_nodes: Vec<String>,
-        endpoint_addr: serde_json::Value,
-        open_connections: Vec<OpenConnection>,
-    },
+pub struct LocalNodeInfo {
+    pub realm_id: String,
+    pub node_id: String,
+    pub capabilities: NodeCapabilityKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeCapabilityKind {
+    Management,
+    Server,
+    Local,
+}
+
+impl From<&aruna_core::structs::NodeCapabilities> for NodeCapabilityKind {
+    fn from(capabilities: &aruna_core::structs::NodeCapabilities) -> Self {
+        match capabilities {
+            aruna_core::structs::NodeCapabilities::Management { .. } => Self::Management,
+            aruna_core::structs::NodeCapabilities::Server { .. } => Self::Server,
+            aruna_core::structs::NodeCapabilities::Local { .. } => Self::Local,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceStatus {
+    Available,
+    NotConfigured,
     Unavailable,
 }
 
+impl From<aruna_core::structs::Status> for ServiceStatus {
+    fn from(status: aruna_core::structs::Status) -> Self {
+        match status {
+            aruna_core::structs::Status::Available => Self::Available,
+            aruna_core::structs::Status::NotConfigured => Self::NotConfigured,
+            aruna_core::structs::Status::Unavailable => Self::Unavailable,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub enum BlobStatus {
-    Available {
-        backend_type: String,
-        max_bucket_size: Option<u64>,
-        multipart_bucket: Option<String>,
-        timeouts: TimeoutConfig,
-        status: String,
-    },
-    Unavailable,
+pub struct NetStatus {
+    pub status: ServiceStatus,
+    pub realm_id: Option<String>,
+    pub node_id: Option<String>,
+    pub bootstrap_nodes: Vec<String>,
+    pub endpoint_addr: Option<serde_json::Value>,
+    pub monitor: ConnectionMonitorStatus,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ConnectionMonitorStatus {
+    pub open_connections: Vec<OpenConnection>,
+    pub observed_connections_total: u64,
+    pub dropped_observations_total: u64,
+    pub closed_connections_total: u64,
+    pub close_task_errors_total: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct BlobStatus {
+    pub status: ServiceStatus,
+    pub backend_type: Option<String>,
+    pub max_bucket_size: Option<u64>,
+    pub multipart_bucket: Option<String>,
+    pub timeouts: Option<TimeoutConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -64,40 +112,38 @@ pub struct InterfaceStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "status")]
-pub enum RestInterfaceStatus {
-    Available {
-        bind_address: String,
-        base_url: String,
-        api_base_url: String,
-        info_url: String,
-        swagger_ui_url: String,
-    },
-    Unavailable,
+pub struct RestInterfaceStatus {
+    pub status: ServiceStatus,
+    pub bind_address: Option<String>,
+    pub base_url: Option<String>,
+    pub api_base_url: Option<String>,
+    pub info_url: Option<String>,
+    pub swagger_ui_url: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "status")]
-pub enum S3InterfaceStatus {
-    Available {
-        bind_address: String,
-        base_url: String,
-    },
-    Unavailable,
+pub struct S3InterfaceStatus {
+    pub status: ServiceStatus,
+    pub bind_address: Option<String>,
+    pub base_url: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct DatabaseStatus {
+    pub status: ServiceStatus,
     pub requests_total: u64,
     pub errors_total: u64,
     pub conflicts_total: u64,
+    pub failed_total: u64,
     pub error_rate: f64,
+    pub channel_closed: bool,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct OpenConnection {
-    pub alpn: Option<String>,
     pub connection_id: u64,
+    pub alpn: Option<String>,
     pub remote_id: String,
     pub side: String,
 }
@@ -114,37 +160,52 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
     let net_state = match &state.get_ctx().net_handle {
         Some(net) => {
             let info = net.get_status().await;
-            NetStatus::Available {
-                realm_id: info.realm_id.to_string(),
-                node_id: info.node_id.to_string(),
+            NetStatus {
+                status: ServiceStatus::Available,
+                realm_id: Some(info.realm_id.to_string()),
+                node_id: Some(info.node_id.to_string()),
                 bootstrap_nodes: info.bootstrap_nodes.iter().map(|n| n.to_string()).collect(),
-                endpoint_addr: serde_json::to_value(&info.endpoint_addr).unwrap(),
-                open_connections: info
-                    .monitor
-                    .open_connections
-                    .iter()
-                    .map(|c| OpenConnection {
-                        connection_id: c.connection_id,
-                        alpn: c.alpn.map(|a| a.to_string()),
-                        remote_id: c.remote_id.to_string(),
-                        side: match c.side {
-                            iroh::endpoint::Side::Client => "Client".to_string(),
-                            iroh::endpoint::Side::Server => "Server".to_string(),
-                        },
-                    })
-                    .collect(),
+                endpoint_addr: serde_json::to_value(&info.endpoint_addr).ok(),
+                monitor: ConnectionMonitorStatus {
+                    open_connections: info
+                        .monitor
+                        .open_connections
+                        .iter()
+                        .map(|c| OpenConnection {
+                            connection_id: c.connection_id,
+                            alpn: c.alpn.map(|a| a.to_string()),
+                            remote_id: c.remote_id.to_string(),
+                            side: match c.side {
+                                iroh::endpoint::Side::Client => "Client".to_string(),
+                                iroh::endpoint::Side::Server => "Server".to_string(),
+                            },
+                        })
+                        .collect(),
+                    observed_connections_total: info.monitor.observed_connections_total,
+                    dropped_observations_total: info.monitor.dropped_observations_total,
+                    closed_connections_total: info.monitor.closed_connections_total,
+                    close_task_errors_total: info.monitor.close_task_errors_total,
+                },
             }
         }
-        None => NetStatus::Unavailable,
+        None => NetStatus {
+            status: ServiceStatus::Unavailable,
+            realm_id: None,
+            node_id: None,
+            bootstrap_nodes: Vec::new(),
+            endpoint_addr: None,
+            monitor: ConnectionMonitorStatus::default(),
+        },
     };
     let blob_status = match &state.get_ctx().blob_handle {
         Some(blob) => {
             let info = blob.get_status().await;
-            BlobStatus::Available {
-                backend_type: info.backend_type.to_string(),
+            BlobStatus {
+                status: ServiceStatus::from(info.status),
+                backend_type: Some(info.backend_type.to_string()),
                 max_bucket_size: info.max_bucket_size,
                 multipart_bucket: info.multipart_bucket,
-                timeouts: TimeoutConfig {
+                timeouts: Some(TimeoutConfig {
                     control_plane_connect_timeout: format!(
                         "{}s",
                         info.timeouts.control_plane_connect_timeout.as_secs()
@@ -157,46 +218,77 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
                         "{}s",
                         info.timeouts.transfer_idle_timeout.as_secs()
                     ),
-                },
-                status: info.status.to_string(),
+                }),
             }
         }
-        None => BlobStatus::Unavailable,
+        None => BlobStatus {
+            status: ServiceStatus::NotConfigured,
+            backend_type: None,
+            max_bucket_size: None,
+            multipart_bucket: None,
+            timeouts: None,
+        },
     };
     let interface_runtime = state.interface_state().await;
     let interface_status = InterfaceStatus {
         rest: match interface_runtime.rest {
-            Some(rest) => RestInterfaceStatus::Available {
-                bind_address: rest.bind_address.to_string(),
-                base_url: rest.base_url,
-                api_base_url: rest.api_base_url,
-                info_url: rest.info_url,
-                swagger_ui_url: rest.swagger_ui_url,
+            Some(rest) => RestInterfaceStatus {
+                status: ServiceStatus::Available,
+                bind_address: Some(rest.bind_address.to_string()),
+                base_url: Some(rest.base_url),
+                api_base_url: Some(rest.api_base_url),
+                info_url: Some(rest.info_url),
+                swagger_ui_url: Some(rest.swagger_ui_url),
             },
-            None => RestInterfaceStatus::Unavailable,
+            None => RestInterfaceStatus {
+                status: ServiceStatus::Unavailable,
+                bind_address: None,
+                base_url: None,
+                api_base_url: None,
+                info_url: None,
+                swagger_ui_url: None,
+            },
         },
         s3: match interface_runtime.s3 {
-            Some(s3) => S3InterfaceStatus::Available {
-                bind_address: s3.bind_address.to_string(),
-                base_url: s3.base_url,
+            Some(s3) => S3InterfaceStatus {
+                status: ServiceStatus::Available,
+                bind_address: Some(s3.bind_address.to_string()),
+                base_url: Some(s3.base_url),
             },
-            None => S3InterfaceStatus::Unavailable,
+            None => S3InterfaceStatus {
+                status: ServiceStatus::Unavailable,
+                bind_address: None,
+                base_url: None,
+            },
         },
     };
     let storage_metrics = state.get_ctx().storage_handle.snapshot_metrics();
     let database_status = DatabaseStatus {
+        status: if storage_metrics.channel_closed {
+            ServiceStatus::Unavailable
+        } else {
+            ServiceStatus::Available
+        },
         requests_total: storage_metrics.requests_total,
         errors_total: storage_metrics.errors_total,
         conflicts_total: storage_metrics.conflicts_total,
+        failed_total: storage_metrics.failed_total,
         error_rate: if storage_metrics.requests_total == 0 {
             0.0
         } else {
-            storage_metrics.errors_total as f64 / storage_metrics.requests_total as f64
+            storage_metrics.failed_total as f64 / storage_metrics.requests_total as f64
         },
+        channel_closed: storage_metrics.channel_closed,
+        last_error: storage_metrics.last_error,
     };
     (
         StatusCode::OK,
         Json(InfoResponse {
+            node_info: LocalNodeInfo {
+                realm_id: state.get_realm_id().to_string(),
+                node_id: state.get_node_id().to_string(),
+                capabilities: NodeCapabilityKind::from(state.node_capabilities()),
+            },
             net_state,
             blob_status,
             interface_status,
@@ -208,8 +300,9 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
 #[cfg(test)]
 mod tests {
     use super::{
-        BlobStatus, DatabaseStatus, InfoResponse, InterfaceStatus, NetStatus,
-        RestInterfaceStatus, S3InterfaceStatus, get_info,
+        BlobStatus, ConnectionMonitorStatus, DatabaseStatus, InfoResponse, InterfaceStatus,
+        LocalNodeInfo, NetStatus, NodeCapabilityKind, RestInterfaceStatus, S3InterfaceStatus,
+        ServiceStatus, get_info,
     };
     use crate::openapi::ApiDoc;
     use crate::server_state::ServerState;
@@ -260,6 +353,11 @@ mod tests {
     async fn get_info_returns_unavailable_optional_statuses_when_handles_are_missing() {
         let (state, _tempdir) = setup_state().await;
         let baseline = state.get_ctx().storage_handle.snapshot_metrics();
+        let expected_node_info = LocalNodeInfo {
+            realm_id: state.get_realm_id().to_string(),
+            node_id: state.get_node_id().to_string(),
+            capabilities: NodeCapabilityKind::Local,
+        };
 
         let (status, Json(response)) = get_info(State(state)).await;
 
@@ -267,21 +365,50 @@ mod tests {
         assert_eq!(
             response,
             InfoResponse {
-                net_state: NetStatus::Unavailable,
-                blob_status: BlobStatus::Unavailable,
+                node_info: expected_node_info,
+                net_state: NetStatus {
+                    status: ServiceStatus::Unavailable,
+                    realm_id: None,
+                    node_id: None,
+                    bootstrap_nodes: Vec::new(),
+                    endpoint_addr: None,
+                    monitor: ConnectionMonitorStatus::default(),
+                },
+                blob_status: BlobStatus {
+                    status: ServiceStatus::NotConfigured,
+                    backend_type: None,
+                    max_bucket_size: None,
+                    multipart_bucket: None,
+                    timeouts: None,
+                },
                 interface_status: InterfaceStatus {
-                    rest: RestInterfaceStatus::Unavailable,
-                    s3: S3InterfaceStatus::Unavailable,
+                    rest: RestInterfaceStatus {
+                        status: ServiceStatus::Unavailable,
+                        bind_address: None,
+                        base_url: None,
+                        api_base_url: None,
+                        info_url: None,
+                        swagger_ui_url: None,
+                    },
+                    s3: S3InterfaceStatus {
+                        status: ServiceStatus::Unavailable,
+                        bind_address: None,
+                        base_url: None,
+                    },
                 },
                 database_status: DatabaseStatus {
+                    status: ServiceStatus::Available,
                     requests_total: baseline.requests_total,
                     errors_total: baseline.errors_total,
                     conflicts_total: baseline.conflicts_total,
+                    failed_total: baseline.failed_total,
                     error_rate: if baseline.requests_total == 0 {
                         0.0
                     } else {
-                        baseline.errors_total as f64 / baseline.requests_total as f64
+                        baseline.failed_total as f64 / baseline.requests_total as f64
                     },
+                    channel_closed: baseline.channel_closed,
+                    last_error: baseline.last_error,
                 },
             }
         );
@@ -303,16 +430,18 @@ mod tests {
         assert_eq!(
             response.interface_status,
             InterfaceStatus {
-                rest: RestInterfaceStatus::Available {
-                    bind_address: "0.0.0.0:3000".to_string(),
-                    base_url: "http://127.0.0.1:3000".to_string(),
-                    api_base_url: "http://127.0.0.1:3000/api/v1".to_string(),
-                    info_url: "http://127.0.0.1:3000/api/v1/info".to_string(),
-                    swagger_ui_url: "http://127.0.0.1:3000/swagger-ui".to_string(),
+                rest: RestInterfaceStatus {
+                    status: ServiceStatus::Available,
+                    bind_address: Some("0.0.0.0:3000".to_string()),
+                    base_url: Some("http://127.0.0.1:3000".to_string()),
+                    api_base_url: Some("http://127.0.0.1:3000/api/v1".to_string()),
+                    info_url: Some("http://127.0.0.1:3000/api/v1/info".to_string()),
+                    swagger_ui_url: Some("http://127.0.0.1:3000/swagger-ui".to_string()),
                 },
-                s3: S3InterfaceStatus::Available {
-                    bind_address: "0.0.0.0:1337".to_string(),
-                    base_url: "http://localhost:1337".to_string(),
+                s3: S3InterfaceStatus {
+                    status: ServiceStatus::Available,
+                    bind_address: Some("0.0.0.0:1337".to_string()),
+                    base_url: Some("http://localhost:1337".to_string()),
                 },
             }
         );
@@ -339,10 +468,15 @@ mod tests {
         assert_eq!(
             response.database_status,
             DatabaseStatus {
+                status: ServiceStatus::Available,
                 requests_total: baseline.requests_total + 1,
                 errors_total: baseline.errors_total + 1,
                 conflicts_total: baseline.conflicts_total,
-                error_rate: (baseline.errors_total + 1) as f64 / (baseline.requests_total + 1) as f64,
+                failed_total: baseline.failed_total + 1,
+                error_rate: (baseline.failed_total + 1) as f64
+                    / (baseline.requests_total + 1) as f64,
+                channel_closed: false,
+                last_error: Some("Transaction not found".to_string()),
             }
         );
     }

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -294,10 +294,7 @@ mod tests {
             .register_rest_interface("0.0.0.0:3000".parse().unwrap())
             .await;
         state
-            .register_s3_interface(
-                "0.0.0.0:1337".parse().unwrap(),
-                "http://localhost:1337".to_string(),
-            )
+            .register_s3_interface("0.0.0.0:1337".parse().unwrap(), "localhost")
             .await;
 
         let (status, Json(response)) = get_info(State(state)).await;

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1,5 +1,4 @@
 use crate::server_state::ServerState;
-use aruna_core::structs::Status;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::get;
@@ -60,8 +59,31 @@ pub struct TimeoutConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct InterfaceStatus {
-    pub s3_status: String,
-    pub rest_status: String,
+    pub rest: RestInterfaceStatus,
+    pub s3: S3InterfaceStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "status")]
+pub enum RestInterfaceStatus {
+    Available {
+        bind_address: String,
+        base_url: String,
+        api_base_url: String,
+        info_url: String,
+        swagger_ui_url: String,
+    },
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "status")]
+pub enum S3InterfaceStatus {
+    Available {
+        bind_address: String,
+        base_url: String,
+    },
+    Unavailable,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -138,12 +160,25 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
         }
         None => BlobStatus::Unavailable,
     };
-    // TODO: 
-    // - Replace hardcoded values
-    // - Add s3 interface address
+    let interface_runtime = state.interface_state().await;
     let interface_status = InterfaceStatus {
-        s3_status: Status::Available.to_string(),
-        rest_status: Status::Available.to_string(),
+        rest: match interface_runtime.rest {
+            Some(rest) => RestInterfaceStatus::Available {
+                bind_address: rest.bind_address.to_string(),
+                base_url: rest.base_url,
+                api_base_url: rest.api_base_url,
+                info_url: rest.info_url,
+                swagger_ui_url: rest.swagger_ui_url,
+            },
+            None => RestInterfaceStatus::Unavailable,
+        },
+        s3: match interface_runtime.s3 {
+            Some(s3) => S3InterfaceStatus::Available {
+                bind_address: s3.bind_address.to_string(),
+                base_url: s3.base_url,
+            },
+            None => S3InterfaceStatus::Unavailable,
+        },
     };
     let storage_metrics = state.get_ctx().storage_handle.snapshot_metrics();
     let database_status = DatabaseStatus {
@@ -169,11 +204,14 @@ pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Jso
 
 #[cfg(test)]
 mod tests {
-    use super::{BlobStatus, InfoResponse, InterfaceStatus, NetStatus, DatabaseStatus, get_info};
+    use super::{
+        BlobStatus, DatabaseStatus, InfoResponse, InterfaceStatus, NetStatus,
+        RestInterfaceStatus, S3InterfaceStatus, get_info,
+    };
     use crate::openapi::ApiDoc;
     use crate::server_state::ServerState;
     use aruna_core::effects::StorageEffect;
-    use aruna_core::structs::{NodeCapabilities, RealmId, Status};
+    use aruna_core::structs::{NodeCapabilities, RealmId};
     use aruna_operations::driver::DriverContext;
     use aruna_storage::storage;
     use axum::Json;
@@ -229,8 +267,8 @@ mod tests {
                 net_state: NetStatus::Unavailable,
                 blob_status: BlobStatus::Unavailable,
                 interface_status: InterfaceStatus {
-                    s3_status: Status::Available.to_string(),
-                    rest_status: Status::Available.to_string(),
+                    rest: RestInterfaceStatus::Unavailable,
+                    s3: S3InterfaceStatus::Unavailable,
                 },
                 database_status: DatabaseStatus {
                     requests_total: baseline.requests_total,
@@ -241,6 +279,40 @@ mod tests {
                     } else {
                         baseline.errors_total as f64 / baseline.requests_total as f64
                     },
+                },
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn get_info_reports_registered_interface_paths() {
+        let (state, _tempdir) = setup_state().await;
+        state
+            .register_rest_interface("0.0.0.0:3000".parse().unwrap())
+            .await;
+        state
+            .register_s3_interface(
+                "0.0.0.0:1337".parse().unwrap(),
+                "http://localhost:1337".to_string(),
+            )
+            .await;
+
+        let (status, Json(response)) = get_info(State(state)).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            response.interface_status,
+            InterfaceStatus {
+                rest: RestInterfaceStatus::Available {
+                    bind_address: "0.0.0.0:3000".to_string(),
+                    base_url: "http://127.0.0.1:3000".to_string(),
+                    api_base_url: "http://127.0.0.1:3000/api/v1".to_string(),
+                    info_url: "http://127.0.0.1:3000/api/v1/info".to_string(),
+                    swagger_ui_url: "http://127.0.0.1:3000/swagger-ui".to_string(),
+                },
+                s3: S3InterfaceStatus::Available {
+                    bind_address: "0.0.0.0:1337".to_string(),
+                    base_url: "http://localhost:1337".to_string(),
                 },
             }
         );

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -42,10 +42,14 @@ impl Server {
     }
 
     pub async fn run(self) -> Result<(), ServerSetupError> {
-        let router = self.build_router();
-
-        // Create TCP listener for main HTTP server
         let listener = TcpListener::bind(self.config.http_addr).await?;
+        self.run_with_listener(listener).await
+    }
+
+    pub async fn run_with_listener(self, listener: TcpListener) -> Result<(), ServerSetupError> {
+        let bound_addr = listener.local_addr()?;
+        self.state.register_rest_interface(bound_addr).await;
+        let router = self.build_router();
 
         axum::serve(
             listener,

--- a/api/src/server_state.rs
+++ b/api/src/server_state.rs
@@ -171,11 +171,11 @@ impl ServerState {
         interface_state.rest = Some(RestInterfaceRuntime::from_bind_address(bind_address));
     }
 
-    pub async fn register_s3_interface(&self, bind_address: SocketAddr, base_url: String) {
+    pub async fn register_s3_interface(&self, bind_address: SocketAddr, advertised_host: &str) {
         let mut interface_state = self.interface_state.write().await;
         interface_state.s3 = Some(S3InterfaceRuntime {
             bind_address,
-            base_url,
+            base_url: client_base_url_from_advertised_host(advertised_host, bind_address),
         });
     }
 
@@ -507,15 +507,7 @@ pub fn swagger_ui() -> SwaggerUi {
 
 impl RestInterfaceRuntime {
     pub fn from_bind_address(bind_address: SocketAddr) -> Self {
-        let host = match bind_address.ip() {
-            std::net::IpAddr::V4(ip) if ip.is_unspecified() => {
-                std::net::Ipv4Addr::LOCALHOST.to_string()
-            }
-            std::net::IpAddr::V6(ip) if ip.is_unspecified() => "::1".to_string(),
-            std::net::IpAddr::V6(ip) => format!("[{ip}]"),
-            std::net::IpAddr::V4(ip) => ip.to_string(),
-        };
-        let base_url = format!("http://{host}:{}", bind_address.port());
+        let base_url = client_base_url_from_bind_address(bind_address);
         Self {
             bind_address,
             api_base_url: format!("{base_url}/api/v1"),
@@ -523,5 +515,66 @@ impl RestInterfaceRuntime {
             swagger_ui_url: format!("{base_url}/swagger-ui"),
             base_url,
         }
+    }
+}
+
+pub fn client_base_url_from_bind_address(bind_address: SocketAddr) -> String {
+    format!(
+        "http://{}:{}",
+        client_host_from_ip(bind_address.ip()),
+        bind_address.port()
+    )
+}
+
+pub fn client_base_url_from_advertised_host(
+    advertised_host: &str,
+    bind_address: SocketAddr,
+) -> String {
+    let host = match advertised_host.trim() {
+        "" => client_host_from_ip(bind_address.ip()),
+        host => match host.parse::<std::net::IpAddr>() {
+            Ok(ip) => client_host_from_ip(ip),
+            Err(_) => host.to_string(),
+        },
+    };
+
+    format!("http://{host}:{}", bind_address.port())
+}
+
+fn client_host_from_ip(ip: std::net::IpAddr) -> String {
+    match ip {
+        std::net::IpAddr::V4(ip) if ip.is_unspecified() => {
+            std::net::Ipv4Addr::LOCALHOST.to_string()
+        }
+        std::net::IpAddr::V6(ip) if ip.is_unspecified() => {
+            format!("[{}]", std::net::Ipv6Addr::LOCALHOST)
+        }
+        std::net::IpAddr::V6(ip) => format!("[{ip}]"),
+        std::net::IpAddr::V4(ip) => ip.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{client_base_url_from_advertised_host, client_base_url_from_bind_address};
+
+    #[test]
+    fn client_base_url_rewrites_unspecified_ipv6() {
+        assert_eq!(
+            client_base_url_from_bind_address("[::]:3000".parse().unwrap()),
+            "http://[::1]:3000"
+        );
+    }
+
+    #[test]
+    fn s3_base_url_normalizes_advertised_wildcards() {
+        assert_eq!(
+            client_base_url_from_advertised_host("0.0.0.0", "0.0.0.0:1337".parse().unwrap()),
+            "http://127.0.0.1:1337"
+        );
+        assert_eq!(
+            client_base_url_from_advertised_host("::", "[::]:1337".parse().unwrap()),
+            "http://[::1]:1337"
+        );
     }
 }

--- a/api/src/server_state.rs
+++ b/api/src/server_state.rs
@@ -27,6 +27,7 @@ use iroh::EndpointAddr;
 use jsonwebtoken::DecodingKey;
 use serde::{Serialize, de::DeserializeOwned};
 use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::RwLock;
@@ -58,6 +59,28 @@ pub struct ServerState {
     node_id: NodeId,
     // Contains OIDC config and Client
     oidc_validator: Option<Arc<OidcValidator>>,
+    interface_state: Arc<RwLock<InterfaceRuntimeState>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InterfaceRuntimeState {
+    pub rest: Option<RestInterfaceRuntime>,
+    pub s3: Option<S3InterfaceRuntime>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RestInterfaceRuntime {
+    pub bind_address: SocketAddr,
+    pub base_url: String,
+    pub api_base_url: String,
+    pub info_url: String,
+    pub swagger_ui_url: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct S3InterfaceRuntime {
+    pub bind_address: SocketAddr,
+    pub base_url: String,
 }
 
 impl ServerState {
@@ -101,6 +124,7 @@ impl ServerState {
             trusted_realms_list: Arc::new(RwLock::new(trusted_realms)),
             issuer_keys: Arc::new(RwLock::new(HashMap::default())),
             initial_admin_claim,
+            interface_state: Arc::new(RwLock::new(InterfaceRuntimeState::default())),
         };
         state.persist_trusted_realms().await;
         state
@@ -140,6 +164,23 @@ impl ServerState {
         self.oidc_validator
             .as_deref()
             .ok_or(OidcError::NotConfigured)
+    }
+
+    pub async fn register_rest_interface(&self, bind_address: SocketAddr) {
+        let mut interface_state = self.interface_state.write().await;
+        interface_state.rest = Some(RestInterfaceRuntime::from_bind_address(bind_address));
+    }
+
+    pub async fn register_s3_interface(&self, bind_address: SocketAddr, base_url: String) {
+        let mut interface_state = self.interface_state.write().await;
+        interface_state.s3 = Some(S3InterfaceRuntime {
+            bind_address,
+            base_url,
+        });
+    }
+
+    pub async fn interface_state(&self) -> InterfaceRuntimeState {
+        self.interface_state.read().await.clone()
     }
 
     pub async fn get_oidc_provider_by_token(
@@ -462,4 +503,25 @@ where
 /// - `/api-docs/s3-openapi.json` - S3-compatible API
 pub fn swagger_ui() -> SwaggerUi {
     SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi())
+}
+
+impl RestInterfaceRuntime {
+    pub fn from_bind_address(bind_address: SocketAddr) -> Self {
+        let host = match bind_address.ip() {
+            std::net::IpAddr::V4(ip) if ip.is_unspecified() => {
+                std::net::Ipv4Addr::LOCALHOST.to_string()
+            }
+            std::net::IpAddr::V6(ip) if ip.is_unspecified() => "::1".to_string(),
+            std::net::IpAddr::V6(ip) => format!("[{ip}]"),
+            std::net::IpAddr::V4(ip) => ip.to_string(),
+        };
+        let base_url = format!("http://{host}:{}", bind_address.port());
+        Self {
+            bind_address,
+            api_base_url: format!("{base_url}/api/v1"),
+            info_url: format!("{base_url}/api/v1/info"),
+            swagger_ui_url: format!("{base_url}/swagger-ui"),
+            base_url,
+        }
+    }
 }

--- a/aruna-doctor/src/error.rs
+++ b/aruna-doctor/src/error.rs
@@ -29,12 +29,20 @@ pub enum CliError {
     JsonError(#[from] serde_json::Error),
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
+    #[error("request to {url} failed")]
+    InfoRequest {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
     #[error(transparent)]
     DotenvError(#[from] dotenvy::Error),
     #[error(transparent)]
     OnboardingSecretError(#[from] OnboardingSecretError),
     #[error(transparent)]
     AddrParseError(#[from] std::net::AddrParseError),
+    #[error(transparent)]
+    ParseIntError(#[from] std::num::ParseIntError),
     #[error(transparent)]
     SetupError(#[from] Box<SetupError>),
     #[error(transparent)]

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -1,11 +1,10 @@
 use crate::error::CliError;
-use aruna::config::{BootOrigin, Config, PersistedNodeIdentity, PersistedNodeStatus, StartupMode, load};
 use aruna_api::routes::info::InfoResponse;
-use aruna_core::onboarding::OnboardingPhase;
-use aruna_core::structs::NodeCapabilities;
+use aruna_api::server_state::client_base_url_from_bind_address;
 use reqwest::Client;
 use serde::Serialize;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::SocketAddr;
+use std::time::Duration;
 
 #[derive(Debug, Serialize)]
 struct DoctorInfoOutput {
@@ -29,9 +28,6 @@ struct ConfigView {
     p2p_socket_addr: String,
     max_concurrent_uni_streams: Option<u64>,
     max_concurrent_bidi_streams: Option<u64>,
-    node_capabilities: NodeCapabilitiesView,
-    realm_id: String,
-    node_id: String,
     bootstrap_nodes: Vec<String>,
     bootstrap_endpoints: Vec<String>,
     default_metadata_replication_factor: u32,
@@ -40,8 +36,6 @@ struct ConfigView {
     s3_address: String,
     onboarding_secret_present: bool,
     oidc_providers: Vec<OidcProviderView>,
-    startup_mode: StartupModeView,
-    node_state: PersistedNodeStateView,
 }
 
 #[derive(Debug, Serialize)]
@@ -52,74 +46,12 @@ struct OidcProviderView {
     discovery_url: String,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "kind")]
-enum NodeCapabilitiesView {
-    Management,
-    Server {
-        delegation_signature: String,
-    },
-    Local,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "kind")]
-enum StartupModeView {
-    InitializeRealm {
-        realm_description: String,
-    },
-    JoinRealm {
-        phase: OnboardingPhaseView,
-    },
-    Provisioned,
-}
-
-#[derive(Debug, Serialize)]
-struct PersistedNodeStateView {
-    boot_origin: BootOriginView,
-    status: PersistedNodeStatusView,
-    realm_id: String,
-    bootstrap_endpoints: Vec<String>,
-    onboarding_phase: Option<OnboardingPhaseView>,
-    onboarding_sync_ticket_present: bool,
-    identity: PersistedNodeIdentityView,
-}
-
-#[derive(Debug, Serialize)]
-enum BootOriginView {
-    InitializedRealm,
-    Onboarded,
-}
-
-#[derive(Debug, Serialize)]
-enum PersistedNodeStatusView {
-    PendingInitialization,
-    PendingOnboarding,
-    Complete,
-}
-
-#[derive(Debug, Serialize)]
-enum OnboardingPhaseView {
-    Bootstrapped,
-    CoreDocumentsFetched,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "kind")]
-enum PersistedNodeIdentityView {
-    Management,
-    Server {
-        delegation_signature: String,
-    },
-    Local,
-}
-
 pub async fn print_info() -> Result<(), CliError> {
     let _ = dotenvy::dotenv();
-    let (config, _storage) = load().await.map_err(Box::new)?;
-    let endpoint_info = fetch_info(&config).await?;
+    let http_socket_addr: SocketAddr = dotenvy::var("SOCKET_ADDRESS")?.parse()?;
+    let endpoint_info = fetch_info(http_socket_addr).await?;
     let output = DoctorInfoOutput {
-        config: ConfigView::from_config(&config),
+        config: ConfigView::from_env(http_socket_addr)?,
         endpoint_info,
     };
 
@@ -127,173 +59,133 @@ pub async fn print_info() -> Result<(), CliError> {
     Ok(())
 }
 
-async fn fetch_info(config: &Config) -> Result<InfoResponse, CliError> {
-    let base_url = http_base_url(config.http_socket_addr);
-    let response = Client::new()
-        .get(format!("{base_url}/api/v1/info"))
+async fn fetch_info(http_socket_addr: SocketAddr) -> Result<InfoResponse, CliError> {
+    let base_url = http_base_url(http_socket_addr);
+    let url = format!("{base_url}/api/v1/info");
+    let response = Client::builder()
+        .connect_timeout(Duration::from_secs(2))
+        .timeout(Duration::from_secs(10))
+        .build()?
+        .get(&url)
         .send()
-        .await?
-        .error_for_status()?;
+        .await
+        .map_err(|source| CliError::InfoRequest {
+            url: url.clone(),
+            source,
+        })?
+        .error_for_status()
+        .map_err(|source| CliError::InfoRequest {
+            url: url.clone(),
+            source,
+        })?;
 
-    Ok(response.json::<InfoResponse>().await?)
+    response
+        .json::<InfoResponse>()
+        .await
+        .map_err(|source| CliError::InfoRequest { url, source })
 }
 
 fn http_base_url(addr: SocketAddr) -> String {
-    let host = match addr.ip() {
-        IpAddr::V4(ip) if ip.is_unspecified() => Ipv4Addr::LOCALHOST.to_string(),
-        IpAddr::V6(ip) if ip.is_unspecified() => "::1".to_string(),
-        IpAddr::V6(ip) => format!("[{ip}]"),
-        IpAddr::V4(ip) => ip.to_string(),
-    };
-    format!("http://{host}:{}", addr.port())
+    client_base_url_from_bind_address(addr)
 }
 
 impl ConfigView {
-    fn from_config(config: &Config) -> Self {
-        Self {
-            storage_path: config.storage_path.clone(),
-            metadata_storage_path: config.metadata_storage_path.clone(),
-            blob_root: config.blob_root.clone(),
-            blob_bucket_prefix: config.blob_bucket_prefix.clone(),
-            blob_max_bucket_size: config.blob_max_bucket_size,
-            blob_multipart_bucket: config.blob_multipart_bucket.clone(),
-            blob_control_plane_connect_timeout_secs: config.blob_control_plane_connect_timeout_secs,
-            blob_control_plane_io_timeout_secs: config.blob_control_plane_io_timeout_secs,
-            blob_transfer_idle_timeout_secs: config.blob_transfer_idle_timeout_secs,
-            http_socket_addr: config.http_socket_addr.to_string(),
-            http_base_url: http_base_url(config.http_socket_addr),
-            p2p_socket_addr: config.p2p_socket_addr.to_string(),
-            max_concurrent_uni_streams: config.max_concurrent_uni_streams,
-            max_concurrent_bidi_streams: config.max_concurrent_bidi_streams,
-            node_capabilities: NodeCapabilitiesView::from_capabilities(&config.node_capabilities),
-            realm_id: config.realm_id.to_string(),
-            node_id: config.node_id.to_string(),
-            bootstrap_nodes: config.bootstrap_nodes.iter().map(ToString::to_string).collect(),
-            bootstrap_endpoints: config
-                .bootstrap_endpoints
-                .iter()
-                .map(|endpoint| serde_json::to_string(endpoint).expect("endpoint addr must serialize"))
-                .collect(),
-            default_metadata_replication_factor: config.default_metadata_replication_factor,
-            s3_port: config.s3_port,
-            s3_host: config.s3_host.clone(),
-            s3_address: config.s3_address.clone(),
-            onboarding_secret_present: config.onboarding_secret.is_some(),
-            oidc_providers: config
-                .oidc_providers
-                .iter()
-                .map(|provider| OidcProviderView {
-                    id: provider.id.clone(),
-                    issuer: provider.issuer.clone(),
-                    audience: provider.audience.clone(),
-                    discovery_url: provider.discovery_url.clone(),
+    fn from_env(http_socket_addr: SocketAddr) -> Result<Self, CliError> {
+        let storage_path = dotenvy::var("STORAGE_PATH").ok();
+        let metadata_storage_path = dotenvy::var("CRAQLE_STORAGE_PATH")
+            .ok()
+            .or_else(|| storage_path.as_ref().map(|path| format!("{path}/craqle")));
+        let blob_root = dotenvy::var("BLOB_ROOT").ok().or_else(|| {
+            storage_path
+                .as_ref()
+                .map(|path| format!("{path}/blobstore"))
+        });
+        let oidc_provider_ids = dotenvy::var("OIDC_PROVIDER_IDS").unwrap_or_default();
+
+        Ok(Self {
+            storage_path: storage_path.unwrap_or_default(),
+            metadata_storage_path: metadata_storage_path.unwrap_or_default(),
+            blob_root: blob_root.unwrap_or_default(),
+            blob_bucket_prefix: dotenvy::var("BLOB_BUCKET_PREFIX").ok(),
+            blob_max_bucket_size: parse_optional_env("BLOB_MAX_BUCKET_SIZE")?,
+            blob_multipart_bucket: dotenvy::var("BLOB_MULTIPART_BUCKET")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+            blob_control_plane_connect_timeout_secs: parse_optional_env(
+                "BLOB_CONTROL_PLANE_CONNECT_TIMEOUT_SECS",
+            )?
+            .unwrap_or(30),
+            blob_control_plane_io_timeout_secs: parse_optional_env(
+                "BLOB_CONTROL_PLANE_IO_TIMEOUT_SECS",
+            )?
+            .unwrap_or(30),
+            blob_transfer_idle_timeout_secs: parse_optional_env("BLOB_TRANSFER_IDLE_TIMEOUT_SECS")?
+                .unwrap_or(30 * 60),
+            http_socket_addr: http_socket_addr.to_string(),
+            http_base_url: http_base_url(http_socket_addr),
+            p2p_socket_addr: dotenvy::var("P2P_SOCKET_ADDRESS")
+                .unwrap_or_else(|_| http_socket_addr.to_string()),
+            max_concurrent_uni_streams: parse_optional_env("MAX_CONCURRENT_UNI_STREAMS")?,
+            max_concurrent_bidi_streams: parse_optional_env("MAX_CONCURRENT_BIDI_STREAMS")?,
+            bootstrap_nodes: parse_list_env("BOOTSTRAP_NODES"),
+            bootstrap_endpoints: parse_list_env("BOOTSTRAP_ENDPOINTS"),
+            default_metadata_replication_factor: parse_optional_env("METADATA_REPLICATION_FACTOR")?
+                .unwrap_or(3),
+            s3_port: parse_optional_env("S3_PORT")?.unwrap_or_default(),
+            s3_host: dotenvy::var("S3_HOST").unwrap_or_default(),
+            s3_address: dotenvy::var("S3_ADDRESS").unwrap_or_default(),
+            onboarding_secret_present: dotenvy::var("ONBOARDING_SECRET")
+                .ok()
+                .is_some_and(|value| !value.trim().is_empty()),
+            oidc_providers: oidc_provider_ids
+                .split(',')
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(|id| OidcProviderView {
+                    id: id.to_string(),
+                    issuer: dotenvy::var(format!("OIDC_{}_ISSUER", env_key(id)))
+                        .unwrap_or_default(),
+                    audience: dotenvy::var(format!("OIDC_{}_AUDIENCE", env_key(id)))
+                        .unwrap_or_default(),
+                    discovery_url: dotenvy::var(format!("OIDC_{}_DISCOVERY_URL", env_key(id)))
+                        .unwrap_or_default(),
                 })
                 .collect(),
-            startup_mode: StartupModeView::from_startup_mode(&config.startup_mode),
-            node_state: PersistedNodeStateView::from_config(config),
-        }
+        })
     }
 }
 
-impl NodeCapabilitiesView {
-    fn from_capabilities(capabilities: &NodeCapabilities) -> Self {
-        match capabilities {
-            NodeCapabilities::Management { .. } => Self::Management,
-            NodeCapabilities::Server {
-                delegation_signature,
-                ..
-            } => Self::Server {
-                delegation_signature: delegation_signature.clone(),
-            },
-            NodeCapabilities::Local { .. } => Self::Local,
-        }
-    }
+fn parse_optional_env<T>(key: &str) -> Result<Option<T>, CliError>
+where
+    T: std::str::FromStr,
+    CliError: From<T::Err>,
+{
+    Ok(dotenvy::var(key)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.parse::<T>())
+        .transpose()?)
 }
 
-impl StartupModeView {
-    fn from_startup_mode(mode: &StartupMode) -> Self {
-        match mode {
-            StartupMode::InitializeRealm { realm_description } => Self::InitializeRealm {
-                realm_description: realm_description.clone(),
-            },
-            StartupMode::JoinRealm { phase } => Self::JoinRealm {
-                phase: OnboardingPhaseView::from_phase(*phase),
-            },
-            StartupMode::Provisioned => Self::Provisioned,
-        }
-    }
+fn parse_list_env(key: &str) -> Vec<String> {
+    dotenvy::var(key)
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
-impl PersistedNodeStateView {
-    fn from_config(config: &Config) -> Self {
-        Self {
-            boot_origin: BootOriginView::from_origin(config.node_state.boot_origin.clone()),
-            status: PersistedNodeStatusView::from_status(config.node_state.status.clone()),
-            realm_id: config.node_state.realm_id.to_string(),
-            bootstrap_endpoints: config
-                .node_state
-                .bootstrap_endpoints
-                .iter()
-                .map(|endpoint| serde_json::to_string(endpoint).expect("endpoint addr must serialize"))
-                .collect(),
-            onboarding_phase: config
-                .node_state
-                .onboarding_phase
-                .map(OnboardingPhaseView::from_phase),
-            onboarding_sync_ticket_present: config.node_state.onboarding_sync_ticket.is_some(),
-            identity: PersistedNodeIdentityView::from_identity(&config.node_state.identity),
-        }
-    }
-}
-
-impl BootOriginView {
-    fn from_origin(origin: BootOrigin) -> Self {
-        match origin {
-            BootOrigin::InitializedRealm => Self::InitializedRealm,
-            BootOrigin::Onboarded => Self::Onboarded,
-        }
-    }
-}
-
-impl PersistedNodeStatusView {
-    fn from_status(status: PersistedNodeStatus) -> Self {
-        match status {
-            PersistedNodeStatus::PendingInitialization => Self::PendingInitialization,
-            PersistedNodeStatus::PendingOnboarding => Self::PendingOnboarding,
-            PersistedNodeStatus::Complete => Self::Complete,
-        }
-    }
-}
-
-impl OnboardingPhaseView {
-    fn from_phase(phase: OnboardingPhase) -> Self {
-        match phase {
-            OnboardingPhase::Bootstrapped => Self::Bootstrapped,
-            OnboardingPhase::CoreDocumentsFetched => Self::CoreDocumentsFetched,
-        }
-    }
-}
-
-impl PersistedNodeIdentityView {
-    fn from_identity(identity: &PersistedNodeIdentity) -> Self {
-        match identity {
-            PersistedNodeIdentity::Management { .. } => Self::Management,
-            PersistedNodeIdentity::Server {
-                delegation_signature,
-                ..
-            } => Self::Server {
-                delegation_signature: delegation_signature.clone(),
-            },
-            PersistedNodeIdentity::Local => Self::Local,
-        }
-    }
+fn env_key(id: &str) -> String {
+    id.to_ascii_uppercase().replace('-', "_")
 }
 
 #[cfg(test)]
 mod tests {
     use super::{ConfigView, fetch_info, http_base_url};
     use crate::test_support::env_lock;
-    use aruna::config::{BootOrigin, PersistedNodeIdentity, PersistedNodeStatus, load};
+    use aruna::config::load;
     use aruna_api::server::{Server, ServerConfig};
     use aruna_api::server_state::ServerState;
     use aruna_core::structs::{NodeCapabilities, RealmId};
@@ -307,7 +199,6 @@ mod tests {
     use aruna_operations::task_incoming::initialize_task_incoming;
     use aruna_tasks::TaskHandle;
     use ed25519_dalek::SigningKey;
-    use std::str::FromStr;
     use std::sync::Arc;
     use tempfile::tempdir;
     use tokio::net::TcpListener;
@@ -364,10 +255,7 @@ mod tests {
         std::fs::create_dir_all(&blob_root).unwrap();
 
         let env_guard = TestEnvGuard::set(&[
-            (
-                "STORAGE_PATH",
-                storage_path.to_str().unwrap().to_string(),
-            ),
+            ("STORAGE_PATH", storage_path.to_str().unwrap().to_string()),
             ("BLOB_ROOT", blob_root.to_str().unwrap().to_string()),
             ("SOCKET_ADDRESS", "127.0.0.1:0".to_string()),
             ("P2P_SOCKET_ADDRESS", "127.0.0.1:0".to_string()),
@@ -404,7 +292,8 @@ mod tests {
         initialize_net_incoming(context.clone());
         initialize_task_incoming(context.clone(), task_handle).await;
 
-        let realm_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_signing_key =
+            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let capabilities = NodeCapabilities::management_node(realm_signing_key).unwrap();
         let bootstrap_user = aruna_core::UserId::local(Ulid::new(), realm_id);
@@ -460,51 +349,18 @@ mod tests {
     }
 
     #[test]
-    fn config_view_marks_onboarding_secret_presence_without_exposing_secret() {
-        let config = aruna::config::Config {
-            storage_path: "/tmp/storage".to_string(),
-            metadata_storage_path: "/tmp/storage/craqle".to_string(),
-            blob_root: "/tmp/blob".to_string(),
-            blob_bucket_prefix: Some("aruna-".to_string()),
-            blob_max_bucket_size: Some(123),
-            blob_multipart_bucket: Some("parts".to_string()),
-            blob_control_plane_connect_timeout_secs: 11,
-            blob_control_plane_io_timeout_secs: 12,
-            blob_transfer_idle_timeout_secs: 13,
-            http_socket_addr: "0.0.0.0:3000".parse().unwrap(),
-            p2p_socket_addr: "127.0.0.1:3001".parse().unwrap(),
-            max_concurrent_uni_streams: Some(10),
-            max_concurrent_bidi_streams: Some(20),
-            node_capabilities: NodeCapabilities::Local {
-                realm_verifying_key: RealmId::from_bytes(SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng).verifying_key().to_bytes())
-                    .to_pkcs8_pem_bytes()
-                    .unwrap(),
-            },
-            realm_id: RealmId([7u8; 32]),
-            node_id: iroh::SecretKey::from_bytes(&[9u8; 32]).public(),
-            net_secret_key: iroh::SecretKey::from_bytes(&[9u8; 32]),
-            bootstrap_nodes: Vec::new(),
-            bootstrap_endpoints: Vec::new(),
-            default_metadata_replication_factor: 3,
-            s3_port: 1337,
-            s3_host: "localhost".to_string(),
-            s3_address: "127.0.0.1".to_string(),
-            onboarding_secret: Some("secret".to_string()),
-            oidc_providers: Vec::new(),
-            startup_mode: aruna::config::StartupMode::Provisioned,
-            node_state: aruna::config::PersistedNodeState {
-                boot_origin: BootOrigin::InitializedRealm,
-                status: PersistedNodeStatus::Complete,
-                realm_id: RealmId([7u8; 32]),
-                net_secret_key: [9u8; 32],
-                bootstrap_endpoints: Vec::new(),
-                onboarding_phase: None,
-                onboarding_sync_ticket: None,
-                identity: PersistedNodeIdentity::Local,
-            },
-        };
+    fn http_base_url_rewrites_unspecified_ipv6() {
+        let addr: std::net::SocketAddr = "[::]:3000".parse().unwrap();
+        assert_eq!(http_base_url(addr), "http://[::1]:3000");
+    }
 
-        let view = ConfigView::from_config(&config);
+    #[test]
+    fn config_view_marks_onboarding_secret_presence_without_exposing_secret() {
+        let _guard = TestEnvGuard::set(&[
+            ("STORAGE_PATH", "/tmp/storage".to_string()),
+            ("ONBOARDING_SECRET", "secret".to_string()),
+        ]);
+        let view = ConfigView::from_env("0.0.0.0:3000".parse().unwrap()).unwrap();
 
         assert_eq!(view.http_base_url, "http://127.0.0.1:3000");
         assert!(view.onboarding_secret_present);
@@ -514,70 +370,27 @@ mod tests {
     async fn fetch_info_reads_live_info_endpoint() {
         let _guard = env_lock().lock().await;
         let node = spawn_test_node().await;
-        let storage_path = dotenvy::var("STORAGE_PATH").unwrap();
-        let blob_root = dotenvy::var("BLOB_ROOT").unwrap();
-        let p2p_socket_addr = std::net::SocketAddr::from_str(&dotenvy::var("P2P_SOCKET_ADDRESS").unwrap()).unwrap();
-        let s3_port = dotenvy::var("S3_PORT").unwrap().parse::<u16>().unwrap();
-        let s3_host = dotenvy::var("S3_HOST").unwrap();
-        let s3_address = dotenvy::var("S3_ADDRESS").unwrap();
-        let temp_storage = tempdir().unwrap();
-        let temp_storage_handle = aruna_storage::FjallStorage::open(temp_storage.path().to_str().unwrap()).unwrap();
-        let config = aruna::config::Config {
-            storage_path,
-            metadata_storage_path: format!("{}/craqle", temp_storage.path().display()),
-            blob_root,
-            blob_bucket_prefix: None,
-            blob_max_bucket_size: Some(100_000),
-            blob_multipart_bucket: Some("uploaded-parts".to_string()),
-            blob_control_plane_connect_timeout_secs: 30,
-            blob_control_plane_io_timeout_secs: 30,
-            blob_transfer_idle_timeout_secs: 30 * 60,
-            http_socket_addr: node.http_addr,
-            p2p_socket_addr,
-            max_concurrent_uni_streams: None,
-            max_concurrent_bidi_streams: None,
-            node_capabilities: NodeCapabilities::Local {
-                realm_verifying_key: RealmId::from_bytes(SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng).verifying_key().to_bytes())
-                    .to_pkcs8_pem_bytes()
-                    .unwrap(),
-            },
-            realm_id: RealmId([1u8; 32]),
-            node_id: iroh::SecretKey::generate().public(),
-            net_secret_key: iroh::SecretKey::generate(),
-            bootstrap_nodes: Vec::new(),
-            bootstrap_endpoints: Vec::new(),
-            default_metadata_replication_factor: 3,
-            s3_port,
-            s3_host,
-            s3_address,
-            onboarding_secret: None,
-            oidc_providers: Vec::new(),
-            startup_mode: aruna::config::StartupMode::Provisioned,
-            node_state: aruna::config::PersistedNodeState {
-                boot_origin: BootOrigin::InitializedRealm,
-                status: PersistedNodeStatus::Complete,
-                realm_id: RealmId([1u8; 32]),
-                net_secret_key: iroh::SecretKey::generate().to_bytes(),
-                bootstrap_endpoints: Vec::new(),
-                onboarding_phase: None,
-                onboarding_sync_ticket: None,
-                identity: PersistedNodeIdentity::Local,
-            },
-        };
-        drop(temp_storage_handle);
 
-        let info = fetch_info(&config).await.unwrap();
+        let info = fetch_info(node.http_addr).await.unwrap();
 
-        assert!(matches!(info.net_state, aruna_api::routes::info::NetStatus::Available { .. }));
-        assert!(matches!(
-            info.interface_status.rest,
-            aruna_api::routes::info::RestInterfaceStatus::Available {
-                ref base_url,
-                ref info_url,
-                ..
-            } if base_url == &format!("http://{}", node.http_addr)
-                && info_url == &format!("http://{}/api/v1/info", node.http_addr)
-        ));
+        assert_eq!(
+            info.net_state.status,
+            aruna_api::routes::info::ServiceStatus::Available
+        );
+        assert_eq!(
+            info.interface_status.rest.status,
+            aruna_api::routes::info::ServiceStatus::Available
+        );
+        let base_url = format!("http://{}", node.http_addr);
+        let info_url = format!("http://{}/api/v1/info", node.http_addr);
+        assert_eq!(
+            info.interface_status.rest.base_url.as_deref(),
+            Some(base_url.as_str())
+        );
+        assert_eq!(
+            info.interface_status.rest.info_url.as_deref(),
+            Some(info_url.as_str())
+        );
         node.shutdown().await;
     }
 }

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -1,0 +1,580 @@
+use crate::error::CliError;
+use aruna::config::{BootOrigin, Config, PersistedNodeIdentity, PersistedNodeStatus, StartupMode, load};
+use aruna_api::routes::info::InfoResponse;
+use aruna_core::onboarding::OnboardingPhase;
+use aruna_core::structs::NodeCapabilities;
+use reqwest::Client;
+use serde::Serialize;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+#[derive(Debug, Serialize)]
+struct DoctorInfoOutput {
+    config: ConfigView,
+    endpoint_info: InfoResponse,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigView {
+    storage_path: String,
+    metadata_storage_path: String,
+    blob_root: String,
+    blob_bucket_prefix: Option<String>,
+    blob_max_bucket_size: Option<u64>,
+    blob_multipart_bucket: Option<String>,
+    blob_control_plane_connect_timeout_secs: u64,
+    blob_control_plane_io_timeout_secs: u64,
+    blob_transfer_idle_timeout_secs: u64,
+    http_socket_addr: String,
+    http_base_url: String,
+    p2p_socket_addr: String,
+    max_concurrent_uni_streams: Option<u64>,
+    max_concurrent_bidi_streams: Option<u64>,
+    node_capabilities: NodeCapabilitiesView,
+    realm_id: String,
+    node_id: String,
+    bootstrap_nodes: Vec<String>,
+    bootstrap_endpoints: Vec<String>,
+    default_metadata_replication_factor: u32,
+    s3_port: u16,
+    s3_host: String,
+    s3_address: String,
+    onboarding_secret_present: bool,
+    oidc_providers: Vec<OidcProviderView>,
+    startup_mode: StartupModeView,
+    node_state: PersistedNodeStateView,
+}
+
+#[derive(Debug, Serialize)]
+struct OidcProviderView {
+    id: String,
+    issuer: String,
+    audience: String,
+    discovery_url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind")]
+enum NodeCapabilitiesView {
+    Management,
+    Server {
+        delegation_signature: String,
+    },
+    Local,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind")]
+enum StartupModeView {
+    InitializeRealm {
+        realm_description: String,
+    },
+    JoinRealm {
+        phase: OnboardingPhaseView,
+    },
+    Provisioned,
+}
+
+#[derive(Debug, Serialize)]
+struct PersistedNodeStateView {
+    boot_origin: BootOriginView,
+    status: PersistedNodeStatusView,
+    realm_id: String,
+    bootstrap_endpoints: Vec<String>,
+    onboarding_phase: Option<OnboardingPhaseView>,
+    onboarding_sync_ticket_present: bool,
+    identity: PersistedNodeIdentityView,
+}
+
+#[derive(Debug, Serialize)]
+enum BootOriginView {
+    InitializedRealm,
+    Onboarded,
+}
+
+#[derive(Debug, Serialize)]
+enum PersistedNodeStatusView {
+    PendingInitialization,
+    PendingOnboarding,
+    Complete,
+}
+
+#[derive(Debug, Serialize)]
+enum OnboardingPhaseView {
+    Bootstrapped,
+    CoreDocumentsFetched,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind")]
+enum PersistedNodeIdentityView {
+    Management,
+    Server {
+        delegation_signature: String,
+    },
+    Local,
+}
+
+pub async fn print_info() -> Result<(), CliError> {
+    let _ = dotenvy::dotenv();
+    let (config, _storage) = load().await.map_err(Box::new)?;
+    let endpoint_info = fetch_info(&config).await?;
+    let output = DoctorInfoOutput {
+        config: ConfigView::from_config(&config),
+        endpoint_info,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+async fn fetch_info(config: &Config) -> Result<InfoResponse, CliError> {
+    let base_url = http_base_url(config.http_socket_addr);
+    let response = Client::new()
+        .get(format!("{base_url}/api/v1/info"))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    Ok(response.json::<InfoResponse>().await?)
+}
+
+fn http_base_url(addr: SocketAddr) -> String {
+    let host = match addr.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => Ipv4Addr::LOCALHOST.to_string(),
+        IpAddr::V6(ip) if ip.is_unspecified() => "::1".to_string(),
+        IpAddr::V6(ip) => format!("[{ip}]"),
+        IpAddr::V4(ip) => ip.to_string(),
+    };
+    format!("http://{host}:{}", addr.port())
+}
+
+impl ConfigView {
+    fn from_config(config: &Config) -> Self {
+        Self {
+            storage_path: config.storage_path.clone(),
+            metadata_storage_path: config.metadata_storage_path.clone(),
+            blob_root: config.blob_root.clone(),
+            blob_bucket_prefix: config.blob_bucket_prefix.clone(),
+            blob_max_bucket_size: config.blob_max_bucket_size,
+            blob_multipart_bucket: config.blob_multipart_bucket.clone(),
+            blob_control_plane_connect_timeout_secs: config.blob_control_plane_connect_timeout_secs,
+            blob_control_plane_io_timeout_secs: config.blob_control_plane_io_timeout_secs,
+            blob_transfer_idle_timeout_secs: config.blob_transfer_idle_timeout_secs,
+            http_socket_addr: config.http_socket_addr.to_string(),
+            http_base_url: http_base_url(config.http_socket_addr),
+            p2p_socket_addr: config.p2p_socket_addr.to_string(),
+            max_concurrent_uni_streams: config.max_concurrent_uni_streams,
+            max_concurrent_bidi_streams: config.max_concurrent_bidi_streams,
+            node_capabilities: NodeCapabilitiesView::from_capabilities(&config.node_capabilities),
+            realm_id: config.realm_id.to_string(),
+            node_id: config.node_id.to_string(),
+            bootstrap_nodes: config.bootstrap_nodes.iter().map(ToString::to_string).collect(),
+            bootstrap_endpoints: config
+                .bootstrap_endpoints
+                .iter()
+                .map(|endpoint| serde_json::to_string(endpoint).expect("endpoint addr must serialize"))
+                .collect(),
+            default_metadata_replication_factor: config.default_metadata_replication_factor,
+            s3_port: config.s3_port,
+            s3_host: config.s3_host.clone(),
+            s3_address: config.s3_address.clone(),
+            onboarding_secret_present: config.onboarding_secret.is_some(),
+            oidc_providers: config
+                .oidc_providers
+                .iter()
+                .map(|provider| OidcProviderView {
+                    id: provider.id.clone(),
+                    issuer: provider.issuer.clone(),
+                    audience: provider.audience.clone(),
+                    discovery_url: provider.discovery_url.clone(),
+                })
+                .collect(),
+            startup_mode: StartupModeView::from_startup_mode(&config.startup_mode),
+            node_state: PersistedNodeStateView::from_config(config),
+        }
+    }
+}
+
+impl NodeCapabilitiesView {
+    fn from_capabilities(capabilities: &NodeCapabilities) -> Self {
+        match capabilities {
+            NodeCapabilities::Management { .. } => Self::Management,
+            NodeCapabilities::Server {
+                delegation_signature,
+                ..
+            } => Self::Server {
+                delegation_signature: delegation_signature.clone(),
+            },
+            NodeCapabilities::Local { .. } => Self::Local,
+        }
+    }
+}
+
+impl StartupModeView {
+    fn from_startup_mode(mode: &StartupMode) -> Self {
+        match mode {
+            StartupMode::InitializeRealm { realm_description } => Self::InitializeRealm {
+                realm_description: realm_description.clone(),
+            },
+            StartupMode::JoinRealm { phase } => Self::JoinRealm {
+                phase: OnboardingPhaseView::from_phase(*phase),
+            },
+            StartupMode::Provisioned => Self::Provisioned,
+        }
+    }
+}
+
+impl PersistedNodeStateView {
+    fn from_config(config: &Config) -> Self {
+        Self {
+            boot_origin: BootOriginView::from_origin(config.node_state.boot_origin.clone()),
+            status: PersistedNodeStatusView::from_status(config.node_state.status.clone()),
+            realm_id: config.node_state.realm_id.to_string(),
+            bootstrap_endpoints: config
+                .node_state
+                .bootstrap_endpoints
+                .iter()
+                .map(|endpoint| serde_json::to_string(endpoint).expect("endpoint addr must serialize"))
+                .collect(),
+            onboarding_phase: config
+                .node_state
+                .onboarding_phase
+                .map(OnboardingPhaseView::from_phase),
+            onboarding_sync_ticket_present: config.node_state.onboarding_sync_ticket.is_some(),
+            identity: PersistedNodeIdentityView::from_identity(&config.node_state.identity),
+        }
+    }
+}
+
+impl BootOriginView {
+    fn from_origin(origin: BootOrigin) -> Self {
+        match origin {
+            BootOrigin::InitializedRealm => Self::InitializedRealm,
+            BootOrigin::Onboarded => Self::Onboarded,
+        }
+    }
+}
+
+impl PersistedNodeStatusView {
+    fn from_status(status: PersistedNodeStatus) -> Self {
+        match status {
+            PersistedNodeStatus::PendingInitialization => Self::PendingInitialization,
+            PersistedNodeStatus::PendingOnboarding => Self::PendingOnboarding,
+            PersistedNodeStatus::Complete => Self::Complete,
+        }
+    }
+}
+
+impl OnboardingPhaseView {
+    fn from_phase(phase: OnboardingPhase) -> Self {
+        match phase {
+            OnboardingPhase::Bootstrapped => Self::Bootstrapped,
+            OnboardingPhase::CoreDocumentsFetched => Self::CoreDocumentsFetched,
+        }
+    }
+}
+
+impl PersistedNodeIdentityView {
+    fn from_identity(identity: &PersistedNodeIdentity) -> Self {
+        match identity {
+            PersistedNodeIdentity::Management { .. } => Self::Management,
+            PersistedNodeIdentity::Server {
+                delegation_signature,
+                ..
+            } => Self::Server {
+                delegation_signature: delegation_signature.clone(),
+            },
+            PersistedNodeIdentity::Local => Self::Local,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConfigView, fetch_info, http_base_url};
+    use crate::test_support::env_lock;
+    use aruna::config::{BootOrigin, PersistedNodeIdentity, PersistedNodeStatus, load};
+    use aruna_api::server::{Server, ServerConfig};
+    use aruna_api::server_state::ServerState;
+    use aruna_core::structs::{NodeCapabilities, RealmId};
+    use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+    use aruna_operations::announce_realm_presence::{
+        AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
+    };
+    use aruna_operations::create_realm::{CreateRealmConfig, CreateRealmOperation};
+    use aruna_operations::driver::{DriverContext, drive};
+    use aruna_operations::incoming::initialize_net_incoming;
+    use aruna_operations::task_incoming::initialize_task_incoming;
+    use aruna_tasks::TaskHandle;
+    use axum::Router;
+    use ed25519_dalek::SigningKey;
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use tokio::net::TcpListener;
+    use ulid::Ulid;
+
+    struct TestEnvGuard {
+        previous: Vec<(String, Option<String>)>,
+    }
+
+    impl TestEnvGuard {
+        fn set(vars: &[(&str, String)]) -> Self {
+            let previous = vars
+                .iter()
+                .map(|(key, _)| ((*key).to_string(), std::env::var(key).ok()))
+                .collect::<Vec<_>>();
+            for (key, value) in vars {
+                unsafe { std::env::set_var(key, value) };
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.previous.drain(..) {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
+    struct TestNode {
+        _temp_dir: tempfile::TempDir,
+        _env_guard: TestEnvGuard,
+        http_addr: std::net::SocketAddr,
+        server_task: tokio::task::JoinHandle<()>,
+        net: NetHandle,
+    }
+
+    impl TestNode {
+        async fn shutdown(self) {
+            self.server_task.abort();
+            let _ = self.server_task.await;
+            self.net.shutdown().await;
+        }
+    }
+
+    async fn spawn_test_node() -> TestNode {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("storage");
+        let blob_root = temp_dir.path().join("blobstore");
+        std::fs::create_dir_all(&blob_root).unwrap();
+
+        let env_guard = TestEnvGuard::set(&[
+            (
+                "STORAGE_PATH",
+                storage_path.to_str().unwrap().to_string(),
+            ),
+            ("BLOB_ROOT", blob_root.to_str().unwrap().to_string()),
+            ("SOCKET_ADDRESS", "127.0.0.1:0".to_string()),
+            ("P2P_SOCKET_ADDRESS", "127.0.0.1:0".to_string()),
+            ("S3_PORT", "0".to_string()),
+            ("S3_HOST", "localhost".to_string()),
+            ("S3_ADDRESS", "127.0.0.1".to_string()),
+            ("OIDC_PROVIDER_IDS", "".to_string()),
+        ]);
+
+        let (config, storage_handle) = load().await.unwrap();
+        let net = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().unwrap(),
+                secret_key: Some(config.net_secret_key.clone()),
+                realm_id: config.realm_id,
+                bootstrap_nodes: Vec::new(),
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..Default::default()
+            },
+            storage_handle.clone(),
+        )
+        .await
+        .unwrap();
+        let task_handle = TaskHandle::new();
+        let context = Arc::new(DriverContext {
+            storage_handle,
+            net_handle: Some(net.clone()),
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: Some(task_handle.clone()),
+        });
+        initialize_net_incoming(context.clone());
+        initialize_task_incoming(context.clone(), task_handle).await;
+
+        let realm_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
+        let capabilities = NodeCapabilities::management_node(realm_signing_key).unwrap();
+        let bootstrap_user = aruna_core::UserId::local(Ulid::new(), realm_id);
+        drive(
+            CreateRealmOperation::new(CreateRealmConfig {
+                actor: aruna_core::structs::Actor {
+                    node_id: net.node_id(),
+                    user_id: bootstrap_user,
+                    realm_id,
+                },
+                realm_description: "Doctor Test Realm".to_string(),
+                oidc_providers: Vec::new(),
+            }),
+            context.as_ref(),
+        )
+        .await
+        .unwrap();
+        drive(
+            AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+                realm_id,
+                node_id: net.node_id(),
+                schedule_refresh: false,
+            }),
+            context.as_ref(),
+        )
+        .await
+        .unwrap();
+
+        let state = Arc::new(
+            ServerState::new(context, realm_id, net.node_id(), capabilities, false, None).await,
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let router: Router = Server::new(state, ServerConfig { http_addr: addr }).build_router();
+        let server_task = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        TestNode {
+            _temp_dir: temp_dir,
+            _env_guard: env_guard,
+            http_addr: addr,
+            server_task,
+            net,
+        }
+    }
+
+    #[test]
+    fn http_base_url_rewrites_unspecified_ipv4() {
+        let addr: std::net::SocketAddr = "0.0.0.0:3000".parse().unwrap();
+        assert_eq!(http_base_url(addr), "http://127.0.0.1:3000");
+    }
+
+    #[test]
+    fn config_view_marks_onboarding_secret_presence_without_exposing_secret() {
+        let config = aruna::config::Config {
+            storage_path: "/tmp/storage".to_string(),
+            metadata_storage_path: "/tmp/storage/craqle".to_string(),
+            blob_root: "/tmp/blob".to_string(),
+            blob_bucket_prefix: Some("aruna-".to_string()),
+            blob_max_bucket_size: Some(123),
+            blob_multipart_bucket: Some("parts".to_string()),
+            blob_control_plane_connect_timeout_secs: 11,
+            blob_control_plane_io_timeout_secs: 12,
+            blob_transfer_idle_timeout_secs: 13,
+            http_socket_addr: "0.0.0.0:3000".parse().unwrap(),
+            p2p_socket_addr: "127.0.0.1:3001".parse().unwrap(),
+            max_concurrent_uni_streams: Some(10),
+            max_concurrent_bidi_streams: Some(20),
+            node_capabilities: NodeCapabilities::Local {
+                realm_verifying_key: RealmId::from_bytes(SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng).verifying_key().to_bytes())
+                    .to_pkcs8_pem_bytes()
+                    .unwrap(),
+            },
+            realm_id: RealmId([7u8; 32]),
+            node_id: iroh::SecretKey::from_bytes(&[9u8; 32]).public(),
+            net_secret_key: iroh::SecretKey::from_bytes(&[9u8; 32]),
+            bootstrap_nodes: Vec::new(),
+            bootstrap_endpoints: Vec::new(),
+            default_metadata_replication_factor: 3,
+            s3_port: 1337,
+            s3_host: "localhost".to_string(),
+            s3_address: "127.0.0.1".to_string(),
+            onboarding_secret: Some("secret".to_string()),
+            oidc_providers: Vec::new(),
+            startup_mode: aruna::config::StartupMode::Provisioned,
+            node_state: aruna::config::PersistedNodeState {
+                boot_origin: BootOrigin::InitializedRealm,
+                status: PersistedNodeStatus::Complete,
+                realm_id: RealmId([7u8; 32]),
+                net_secret_key: [9u8; 32],
+                bootstrap_endpoints: Vec::new(),
+                onboarding_phase: None,
+                onboarding_sync_ticket: None,
+                identity: PersistedNodeIdentity::Local,
+            },
+        };
+
+        let view = ConfigView::from_config(&config);
+
+        assert_eq!(view.http_base_url, "http://127.0.0.1:3000");
+        assert!(view.onboarding_secret_present);
+    }
+
+    #[tokio::test]
+    async fn fetch_info_reads_live_info_endpoint() {
+        let _guard = env_lock().lock().await;
+        let node = spawn_test_node().await;
+        let storage_path = dotenvy::var("STORAGE_PATH").unwrap();
+        let blob_root = dotenvy::var("BLOB_ROOT").unwrap();
+        let p2p_socket_addr = std::net::SocketAddr::from_str(&dotenvy::var("P2P_SOCKET_ADDRESS").unwrap()).unwrap();
+        let s3_port = dotenvy::var("S3_PORT").unwrap().parse::<u16>().unwrap();
+        let s3_host = dotenvy::var("S3_HOST").unwrap();
+        let s3_address = dotenvy::var("S3_ADDRESS").unwrap();
+        let temp_storage = tempdir().unwrap();
+        let temp_storage_handle = aruna_storage::FjallStorage::open(temp_storage.path().to_str().unwrap()).unwrap();
+        let config = aruna::config::Config {
+            storage_path,
+            metadata_storage_path: format!("{}/craqle", temp_storage.path().display()),
+            blob_root,
+            blob_bucket_prefix: None,
+            blob_max_bucket_size: Some(100_000),
+            blob_multipart_bucket: Some("uploaded-parts".to_string()),
+            blob_control_plane_connect_timeout_secs: 30,
+            blob_control_plane_io_timeout_secs: 30,
+            blob_transfer_idle_timeout_secs: 30 * 60,
+            http_socket_addr: node.http_addr,
+            p2p_socket_addr,
+            max_concurrent_uni_streams: None,
+            max_concurrent_bidi_streams: None,
+            node_capabilities: NodeCapabilities::Local {
+                realm_verifying_key: RealmId::from_bytes(SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng).verifying_key().to_bytes())
+                    .to_pkcs8_pem_bytes()
+                    .unwrap(),
+            },
+            realm_id: RealmId([1u8; 32]),
+            node_id: iroh::SecretKey::generate().public(),
+            net_secret_key: iroh::SecretKey::generate(),
+            bootstrap_nodes: Vec::new(),
+            bootstrap_endpoints: Vec::new(),
+            default_metadata_replication_factor: 3,
+            s3_port,
+            s3_host,
+            s3_address,
+            onboarding_secret: None,
+            oidc_providers: Vec::new(),
+            startup_mode: aruna::config::StartupMode::Provisioned,
+            node_state: aruna::config::PersistedNodeState {
+                boot_origin: BootOrigin::InitializedRealm,
+                status: PersistedNodeStatus::Complete,
+                realm_id: RealmId([1u8; 32]),
+                net_secret_key: iroh::SecretKey::generate().to_bytes(),
+                bootstrap_endpoints: Vec::new(),
+                onboarding_phase: None,
+                onboarding_sync_ticket: None,
+                identity: PersistedNodeIdentity::Local,
+            },
+        };
+        drop(temp_storage_handle);
+
+        let info = fetch_info(&config).await.unwrap();
+
+        assert!(matches!(info.net_state, aruna_api::routes::info::NetStatus::Available { .. }));
+        node.shutdown().await;
+    }
+}

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -306,7 +306,6 @@ mod tests {
     use aruna_operations::incoming::initialize_net_incoming;
     use aruna_operations::task_incoming::initialize_task_incoming;
     use aruna_tasks::TaskHandle;
-    use axum::Router;
     use ed25519_dalek::SigningKey;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -440,14 +439,9 @@ mod tests {
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let router: Router = Server::new(state, ServerConfig { http_addr: addr }).build_router();
+        let server = Server::new(state, ServerConfig { http_addr: addr });
         let server_task = tokio::spawn(async move {
-            axum::serve(
-                listener,
-                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-            )
-            .await
-            .unwrap();
+            server.run_with_listener(listener).await.unwrap();
         });
 
         TestNode {
@@ -575,6 +569,15 @@ mod tests {
         let info = fetch_info(&config).await.unwrap();
 
         assert!(matches!(info.net_state, aruna_api::routes::info::NetStatus::Available { .. }));
+        assert!(matches!(
+            info.interface_status.rest,
+            aruna_api::routes::info::RestInterfaceStatus::Available {
+                ref base_url,
+                ref info_url,
+                ..
+            } if base_url == &format!("http://{}", node.http_addr)
+                && info_url == &format!("http://{}/api/v1/info", node.http_addr)
+        ));
         node.shutdown().await;
     }
 }

--- a/aruna-doctor/src/main.rs
+++ b/aruna-doctor/src/main.rs
@@ -1,11 +1,13 @@
 use crate::error::CliError;
 use crate::explorer::{explore_entries, explore_keyspaces};
+use crate::info::print_info;
 use crate::storage::{import, snapshot};
 use crate::tokens::{create_local_bootstrap_token, create_oidc_token, view_token};
 use clap::{Parser, Subcommand};
 
 mod error;
 mod explorer;
+mod info;
 mod storage;
 #[cfg(test)]
 mod test_support;
@@ -48,6 +50,7 @@ pub enum Commands {
         snapshot_path: String,
         target_path: String,
     },
+    Info,
 }
 
 #[derive(Subcommand, Debug)]
@@ -102,6 +105,7 @@ pub async fn main() -> Result<(), CliError> {
             snapshot_path,
             target_path,
         } => import(snapshot_path, target_path).await?,
+        Commands::Info => print_info().await?,
     };
 
     Ok(())

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -32,6 +32,7 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_tasks::TaskHandle;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::net::TcpListener;
 use tracing::{error, info, warn};
 
 #[tokio::main]
@@ -228,7 +229,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let server_config = ServerConfig {
         http_addr: config.http_socket_addr,
     };
-    let server = Server::new(state, server_config);
+    let server = Server::new(state.clone(), server_config);
 
     // S3 Server
     let s3_address = format!("{}:{}", config.s3_address, config.s3_port);
@@ -243,7 +244,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     .await
     .unwrap();
 
-    let server_handle = s3_server.run().await.unwrap();
+    let s3_listener = TcpListener::bind(&s3_address).await.unwrap();
+    let s3_bound_addr = s3_listener.local_addr().unwrap();
+    state
+        .register_s3_interface(
+            s3_bound_addr,
+            format!("http://{}:{}", config.s3_host, s3_bound_addr.port()),
+        )
+        .await;
+    let (_s3_addr, server_handle) = s3_server.run_with_listener(s3_listener).unwrap();
+
+    let rest_listener = TcpListener::bind(config.http_socket_addr).await?;
 
     tokio::select! {
         res = server_handle => {
@@ -252,7 +263,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 Err(e) => error!("S3 Server panicked: {:?}", e),
             }
         }
-        res = server.run() => {
+        res = server.run_with_listener(rest_listener) => {
             match res {
                 Ok(_) => info!("REST Server stopped normally"),
                 Err(e) => error!("REST Server panicked: {:?}", e),

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -247,10 +247,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let s3_listener = TcpListener::bind(&s3_address).await.unwrap();
     let s3_bound_addr = s3_listener.local_addr().unwrap();
     state
-        .register_s3_interface(
-            s3_bound_addr,
-            format!("http://{}:{}", config.s3_host, s3_bound_addr.port()),
-        )
+        .register_s3_interface(s3_bound_addr, &config.s3_host)
         .await;
     let (_s3_addr, server_handle) = s3_server.run_with_listener(s3_listener).unwrap();
 

--- a/blob/src/blob/mod.rs
+++ b/blob/src/blob/mod.rs
@@ -8,7 +8,7 @@ use bao_tree::BlockSize;
 use crossfire::{mpsc, oneshot};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use ulid::Ulid;
 
 mod backend;
@@ -40,6 +40,7 @@ pub struct BlobHandler {
     storage: StorageHandle,
     net: NetHandle,
     connections: Arc<Mutex<HashMap<Ulid, BiStream>>>,
+    operator_status: Arc<RwLock<aruna_core::structs::Status>>,
 }
 
 #[derive(Clone, Debug)]

--- a/blob/src/blob/runtime.rs
+++ b/blob/src/blob/runtime.rs
@@ -1,12 +1,13 @@
 use super::{BlobHandle, BlobHandler, EffectReceiver};
 use crate::error::BlobLibError;
+use crate::opendal::init_operator;
 use aruna_core::NodeId;
 use aruna_core::alpn::Alpn;
 use aruna_core::effects::{BlobEffect, Effect, StagingSourceEffect};
 use aruna_core::errors::BlobError;
 use aruna_core::events::{BlobEvent, Event};
 use aruna_core::handle::Handle;
-use aruna_core::structs::BackendConfig;
+use aruna_core::structs::{BackendConfig, BlobState, Status};
 use aruna_net::NetHandle;
 use aruna_net::streams::BiStream;
 use aruna_storage::storage::StorageHandle;
@@ -87,6 +88,19 @@ impl BlobHandle {
 
     pub async fn store_connection(&mut self, stream: BiStream) -> Ulid {
         self.handler.add_connection(None, stream).await
+    }
+
+    pub async fn get_status(&self) -> BlobState {
+        let backend_type = self.handler.backend_config.backend_type.clone();
+        let status = self.handler.get_operator_status().await;
+
+        BlobState {
+            backend_type,
+            max_bucket_size: self.handler.backend_config.max_bucket_size,
+            multipart_bucket: self.handler.backend_config.multipart_bucket.clone(),
+            timeouts: self.handler.backend_config.timeouts,
+            status,
+        }
     }
 }
 
@@ -268,5 +282,22 @@ impl BlobHandler {
         _ = sx.finish();
         _ = rx.stop(0u32.into());
         BlobEvent::ConnectionClosed { stream_id }
+    }
+
+    async fn get_operator_status(&self) -> Status {
+        let backend_type = self.backend_config.backend_type.clone();
+        let mut config = self.backend_config.service_config.clone();
+        if !self.backend_config.root.trim().is_empty() {
+            config.insert("root".to_string(), self.backend_config.root.clone());
+        }
+
+        match init_operator(backend_type, config) {
+            Ok(operator) => match operator.check().await {
+                Ok(_) => Status::Available,
+                Err(_) => Status::Unavailable,
+            },
+            Err(BlobError::OperatorCreationFailed(_)) => Status::NotConfigured,
+            Err(_) => Status::Unavailable,
+        }
     }
 }

--- a/blob/src/blob/runtime.rs
+++ b/blob/src/blob/runtime.rs
@@ -15,7 +15,8 @@ use async_trait::async_trait;
 use crossfire::{mpsc, oneshot};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::{Duration, interval, timeout};
 use ulid::Ulid;
 
 #[async_trait]
@@ -92,7 +93,7 @@ impl BlobHandle {
 
     pub async fn get_status(&self) -> BlobState {
         let backend_type = self.handler.backend_config.backend_type.clone();
-        let status = self.handler.get_operator_status().await;
+        let status = *self.handler.operator_status.read().await;
 
         BlobState {
             backend_type,
@@ -116,9 +117,17 @@ impl BlobHandler {
             storage,
             net,
             connections: Arc::new(Mutex::new(HashMap::new())),
+            operator_status: Arc::new(RwLock::new(Status::Unavailable)),
         };
+        let initial_status = blob_handler.probe_operator_status().await;
+        *blob_handler.operator_status.write().await = initial_status;
         blob_handler.ensure_multipart_bucket().await?;
+        *blob_handler.operator_status.write().await = Status::Available;
         let (blob_handle, rx) = BlobHandle::new(blob_handler.clone());
+        let status_handler = blob_handler.clone();
+        tokio::spawn(async move {
+            status_handler.monitor_operator_status().await;
+        });
         tokio::spawn(async move {
             blob_handler.receive_loop(rx).await;
         });
@@ -284,7 +293,16 @@ impl BlobHandler {
         BlobEvent::ConnectionClosed { stream_id }
     }
 
-    async fn get_operator_status(&self) -> Status {
+    async fn monitor_operator_status(&self) {
+        let mut interval = interval(Duration::from_secs(30));
+        loop {
+            interval.tick().await;
+            let status = self.probe_operator_status().await;
+            *self.operator_status.write().await = status;
+        }
+    }
+
+    async fn probe_operator_status(&self) -> Status {
         let backend_type = self.backend_config.backend_type.clone();
         let mut config = self.backend_config.service_config.clone();
         if !self.backend_config.root.trim().is_empty() {
@@ -292,12 +310,22 @@ impl BlobHandler {
         }
 
         match init_operator(backend_type, config) {
-            Ok(operator) => match operator.check().await {
-                Ok(_) => Status::Available,
-                Err(_) => Status::Unavailable,
-            },
+            Ok(operator) => {
+                let probe_timeout = self.handler_probe_timeout();
+                match timeout(probe_timeout, operator.check()).await {
+                    Ok(Ok(_)) => Status::Available,
+                    Ok(Err(_)) | Err(_) => Status::Unavailable,
+                }
+            }
             Err(BlobError::OperatorCreationFailed(_)) => Status::NotConfigured,
             Err(_) => Status::Unavailable,
         }
+    }
+
+    fn handler_probe_timeout(&self) -> Duration {
+        self.backend_config
+            .timeouts
+            .control_plane_io_timeout
+            .min(Duration::from_secs(5))
     }
 }

--- a/core/src/structs/info.rs
+++ b/core/src/structs/info.rs
@@ -1,0 +1,54 @@
+use crate::NodeId;
+use crate::alpn::Alpn;
+use crate::structs::{Backend, BlobTimeoutConfig, RealmId};
+use iroh::EndpointAddr;
+
+#[derive(Debug, Clone)]
+pub struct OpenConnection {
+    pub alpn: Option<Alpn>,
+    pub remote_id: iroh::EndpointId,
+    pub side: iroh::endpoint::Side,
+}
+
+pub struct NetState {
+    pub realm_id: RealmId,
+    pub node_id: NodeId,
+    pub boostrap_nodes: Vec<NodeId>,
+    pub endpoint_addr: EndpointAddr,
+    pub open_connections: Vec<OpenConnection>,
+}
+
+pub struct BlobState {
+    pub backend_type: Backend,
+    pub max_bucket_size: Option<u64>,
+    pub multipart_bucket: Option<String>,
+    pub timeouts: BlobTimeoutConfig,
+    pub status: Status,
+}
+
+pub struct InterfaceState {
+    pub s3_status: Status,
+    pub rest_status: Status,
+    pub db_status: Status,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Status {
+    Available,
+    NotConfigured,
+    Unavailable,
+}
+
+impl std::fmt::Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Status::Available => "Available",
+                Status::NotConfigured => "NotConfigured",
+                Status::Unavailable => "Unavailable",
+            }
+        )
+    }
+}

--- a/core/src/structs/info.rs
+++ b/core/src/structs/info.rs
@@ -5,17 +5,27 @@ use iroh::EndpointAddr;
 
 #[derive(Debug, Clone)]
 pub struct OpenConnection {
+    pub connection_id: u64,
     pub alpn: Option<Alpn>,
     pub remote_id: iroh::EndpointId,
     pub side: iroh::endpoint::Side,
 }
 
+#[derive(Debug, Clone)]
+pub struct ConnectionMonitorState {
+    pub open_connections: Vec<OpenConnection>,
+    pub observed_connections_total: u64,
+    pub dropped_observations_total: u64,
+    pub closed_connections_total: u64,
+    pub close_task_errors_total: u64,
+}
+
 pub struct NetState {
     pub realm_id: RealmId,
     pub node_id: NodeId,
-    pub boostrap_nodes: Vec<NodeId>,
+    pub bootstrap_nodes: Vec<NodeId>,
     pub endpoint_addr: EndpointAddr,
-    pub open_connections: Vec<OpenConnection>,
+    pub monitor: ConnectionMonitorState,
 }
 
 pub struct BlobState {

--- a/core/src/structs/mod.rs
+++ b/core/src/structs/mod.rs
@@ -1,6 +1,7 @@
 mod blob;
 pub mod checksum;
 mod group;
+mod info;
 mod metadata_registry;
 mod multipart;
 mod realm;
@@ -13,6 +14,7 @@ mod structs;
 
 pub use blob::*;
 pub use group::*;
+pub use info::*;
 pub use metadata_registry::*;
 pub use multipart::*;
 pub use realm::*;

--- a/net/src/gossip.rs
+++ b/net/src/gossip.rs
@@ -11,7 +11,7 @@ use aruna_core::structs::RealmId;
 use aruna_storage::StorageHandle;
 use bytes::Bytes;
 use byteview::ByteView;
-use iroh::Endpoint;
+use iroh::{Endpoint, PublicKey};
 use iroh_gossip::api::GossipSender;
 use iroh_gossip::net::Gossip;
 use parking_lot::RwLock;
@@ -123,6 +123,10 @@ impl GossipService {
         if !nodes.contains(&node_id) {
             nodes.push(node_id);
         }
+    }
+
+    pub fn get_bootstrap_nodes(&self) -> Vec<PublicKey> {
+        self.bootstrap_nodes.read().clone()
     }
 
     pub async fn broadcast(&self, topic: TopicId, message: Vec<u8>) -> Result<()> {

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -5,6 +5,7 @@ pub mod dht;
 mod effect_handlers;
 pub mod error;
 pub mod gossip;
+mod monitoring;
 pub mod streams;
 
 use std::net::SocketAddr;
@@ -15,7 +16,7 @@ use aruna_core::effects::{Effect, NetEffect};
 use aruna_core::events::{Event, NetError as CoreNetError, NetEvent};
 use aruna_core::handle::Handle;
 use aruna_core::id::{NodeId, TopicId};
-use aruna_core::structs::RealmId;
+use aruna_core::structs::{NetState, RealmId};
 use aruna_storage::StorageHandle;
 use async_trait::async_trait;
 use crossfire::TrySendError;
@@ -32,8 +33,10 @@ use tracing::{Instrument, Span, warn};
 pub use dht::DhtHandle;
 pub use error::{NetError, Result};
 pub use gossip::GossipService;
+pub use monitoring::Monitor;
 pub use streams::StreamsService;
 
+#[derive(Clone)]
 pub struct NetConfig {
     pub bind_addr: SocketAddr,
     pub secret_key: Option<iroh::SecretKey>,
@@ -98,6 +101,7 @@ pub trait InboundEventHandler: Send + Sync {
 #[derive(Clone)]
 pub struct NetHandle {
     inner: Arc<NetInner>,
+    monitor: Monitor,
 }
 
 struct NetInner {
@@ -138,7 +142,10 @@ impl NetHandle {
                 transport_config.max_concurrent_bidi_streams(VarInt::from_u64(max_bidi)?);
         }
 
+        let monitor = Monitor::new();
+
         let mut endpoint_builder = Endpoint::builder(presets::Minimal)
+            .hooks(monitor.clone())
             .transport_config(transport_config.build())
             .secret_key(secret_key)
             .address_lookup(address_lookup.clone())
@@ -382,7 +389,7 @@ impl NetHandle {
             tasks: Mutex::new(tasks),
         });
 
-        Ok(Self { inner })
+        Ok(Self { inner, monitor })
     }
 
     pub fn node_id(&self) -> NodeId {
@@ -455,6 +462,16 @@ impl NetHandle {
         let mut tasks = self.inner.tasks.lock().await;
         while let Some(handle) = tasks.pop() {
             let _ = handle.await;
+        }
+    }
+
+    pub async fn get_status(&self) -> NetState {
+        NetState {
+            endpoint_addr: local_endpoint_addr(&self.inner.endpoint),
+            realm_id: *self.realm_id(),
+            node_id: self.node_id(),
+            boostrap_nodes: self.inner.gossip.get_bootstrap_nodes(),
+            open_connections: self.monitor.get_connections().await,
         }
     }
 }

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -470,8 +470,8 @@ impl NetHandle {
             endpoint_addr: local_endpoint_addr(&self.inner.endpoint),
             realm_id: *self.realm_id(),
             node_id: self.node_id(),
-            boostrap_nodes: self.inner.gossip.get_bootstrap_nodes(),
-            open_connections: self.monitor.get_connections().await,
+            bootstrap_nodes: self.inner.gossip.get_bootstrap_nodes(),
+            monitor: self.monitor.get_status().await,
         }
     }
 }
@@ -519,6 +519,9 @@ impl Handle for NetHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::time::{Duration, sleep};
 
     #[tokio::test]
     async fn test_net_handle_creates() -> Result<()> {
@@ -540,6 +543,92 @@ mod tests {
         let handle = NetHandle::new(config, storage).await?;
         assert_ne!(handle.node_id().as_bytes(), &[0u8; 32]);
         handle.shutdown().await;
+        Ok(())
+    }
+
+    struct HoldingInboundHandler {
+        streams: tokio::sync::Mutex<Vec<streams::BiStream>>,
+    }
+
+    #[async_trait]
+    impl InboundEventHandler for HoldingInboundHandler {
+        async fn handle_gossip_message(&self, _topic: TopicId, _sender: NodeId, _data: Vec<u8>) {}
+
+        async fn handle_incoming_stream(
+            &self,
+            _alpn: Alpn,
+            stream: streams::BiStream,
+            _node_id: NodeId,
+        ) {
+            self.streams.lock().await.push(stream);
+        }
+    }
+
+    async fn test_net_handle() -> Result<(NetHandle, TempDir)> {
+        let temp_dir = tempfile::tempdir().map_err(|e| NetError::Io(e.to_string()))?;
+        let storage = aruna_storage::FjallStorage::open(
+            temp_dir
+                .path()
+                .to_str()
+                .ok_or_else(|| NetError::Io("Invalid temp path".to_string()))?,
+        )
+        .map_err(|e| NetError::Io(e.to_string()))?;
+        let handle = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().unwrap(),
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage,
+        )
+        .await?;
+        handle.set_inbound_handler(Arc::new(HoldingInboundHandler {
+            streams: tokio::sync::Mutex::new(Vec::new()),
+        }));
+
+        Ok((handle, temp_dir))
+    }
+
+    async fn wait_for_open_connections(handle: &NetHandle, expected: usize) -> NetState {
+        for _ in 0..50 {
+            let status = handle.get_status().await;
+            if status.monitor.open_connections.len() >= expected {
+                return status;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+
+        handle.get_status().await
+    }
+
+    #[tokio::test]
+    async fn monitor_tracks_multiple_open_connections() -> Result<()> {
+        let (a, _a_dir) = test_net_handle().await?;
+        let (b, _b_dir) = test_net_handle().await?;
+        a.add_peer_addr(b.endpoint_addr()).await;
+        b.add_peer_addr(a.endpoint_addr()).await;
+
+        let _a_to_b = a.open_stream(b.node_id(), Alpn::Bao).await?;
+        let _b_to_a = b.open_stream(a.node_id(), Alpn::Bao).await?;
+
+        let status = wait_for_open_connections(&a, 2).await;
+        assert_eq!(status.monitor.open_connections.len(), 2);
+        assert!(status.monitor.observed_connections_total >= 2);
+        assert_eq!(status.monitor.dropped_observations_total, 0);
+
+        let mut connection_ids = status
+            .monitor
+            .open_connections
+            .iter()
+            .map(|connection| connection.connection_id)
+            .collect::<Vec<_>>();
+        connection_ids.sort_unstable();
+        connection_ids.dedup();
+        assert_eq!(connection_ids.len(), status.monitor.open_connections.len());
+
+        a.shutdown().await;
+        b.shutdown().await;
         Ok(())
     }
 }

--- a/net/src/monitoring.rs
+++ b/net/src/monitoring.rs
@@ -1,21 +1,38 @@
-use aruna_core::{alpn::Alpn, structs::OpenConnection};
+use aruna_core::{
+    alpn::Alpn,
+    structs::{ConnectionMonitorState, OpenConnection},
+};
 use iroh::endpoint::{AfterHandshakeOutcome, ConnectionInfo, EndpointHooks, Side};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use tokio::{
     sync::{
         Mutex,
-        mpsc::{UnboundedReceiver, UnboundedSender},
+        mpsc::{Receiver, Sender, error::TrySendError},
     },
     task::JoinSet,
 };
 use tokio_util::task::AbortOnDropHandle;
-use tracing::{Instrument, info_span, trace};
+use tracing::{Instrument, info_span, trace, warn};
+
+const MONITOR_CHANNEL_CAPACITY: usize = 4096;
 
 #[derive(Clone, Debug)]
 pub struct Monitor {
     connections: Arc<Mutex<Vec<OpenConnection>>>,
-    tx: UnboundedSender<ObservedConnection>,
+    stats: Arc<MonitorStats>,
+    tx: Sender<ObservedConnection>,
     _task: Arc<AbortOnDropHandle<()>>,
+}
+
+#[derive(Debug, Default)]
+struct MonitorStats {
+    observed_connections_total: AtomicU64,
+    dropped_observations_total: AtomicU64,
+    closed_connections_total: AtomicU64,
+    close_task_errors_total: AtomicU64,
 }
 
 #[derive(Debug, Clone)]
@@ -34,7 +51,18 @@ impl EndpointHooks for Monitor {
             side: conn.side(),
             handle: conn.clone(),
         };
-        self.tx.send(info).ok();
+        self.stats
+            .observed_connections_total
+            .fetch_add(1, Ordering::Relaxed);
+        if let Err(error) = self.tx.try_send(info) {
+            self.stats
+                .dropped_observations_total
+                .fetch_add(1, Ordering::Relaxed);
+            match error {
+                TrySendError::Full(_) => trace!("connection monitor channel full"),
+                TrySendError::Closed(_) => trace!("connection monitor task is unavailable"),
+            }
+        }
         AfterHandshakeOutcome::Accept
     }
 }
@@ -42,11 +70,14 @@ impl EndpointHooks for Monitor {
 impl Monitor {
     pub fn new() -> Self {
         let connections = Arc::new(Mutex::new(Vec::new()));
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let stats = Arc::new(MonitorStats::default());
+        let (tx, rx) = tokio::sync::mpsc::channel(MONITOR_CHANNEL_CAPACITY);
         let conn = connections.clone();
-        let task = tokio::spawn(Self::run(conn, rx).instrument(info_span!("watcher")));
+        let task =
+            tokio::spawn(Self::run(conn, stats.clone(), rx).instrument(info_span!("watcher")));
         Self {
             connections,
+            stats,
             tx,
             _task: Arc::new(AbortOnDropHandle::new(task)),
         }
@@ -54,15 +85,19 @@ impl Monitor {
 
     async fn run(
         connections: Arc<Mutex<Vec<OpenConnection>>>,
-        mut rx: UnboundedReceiver<ObservedConnection>,
+        stats: Arc<MonitorStats>,
+        mut rx: Receiver<ObservedConnection>,
     ) {
         let mut tasks = JoinSet::new();
+        let next_connection_id = AtomicU64::new(1);
         let conn = connections.clone();
         loop {
             tokio::select! {
                 Some(ObservedConnection { alpn, remote_id, side, handle }) = rx.recv() => {
-                    conn.lock().await.push(OpenConnection{ alpn: Alpn::from_bytes(&alpn), remote_id: remote_id.clone(), side });
+                    let connection_id = next_connection_id.fetch_add(1, Ordering::Relaxed);
+                    conn.lock().await.push(OpenConnection{ connection_id, alpn: Alpn::from_bytes(&alpn), remote_id, side });
                     let conn_clone = conn.clone();
+                    let stats = stats.clone();
                     tasks.spawn(async move {
                         match handle.closed().await {
                             Some((error, state)) => {
@@ -75,19 +110,40 @@ impl Monitor {
                             }
 
                         };
-                        conn_clone.lock().await.retain(|mx| mx.remote_id != remote_id);
+                        stats.closed_connections_total.fetch_add(1, Ordering::Relaxed);
+                        conn_clone.lock().await.retain(|mx| mx.connection_id != connection_id);
                     }.instrument(tracing::Span::current()));
                 }
-                Some(res) = tasks.join_next(), if !tasks.is_empty() => res.expect("conn close task panicked"),
+                Some(res) = tasks.join_next(), if !tasks.is_empty() => {
+                    if let Err(error) = res {
+                        stats.close_task_errors_total.fetch_add(1, Ordering::Relaxed);
+                        warn!(?error, "connection close watcher task failed");
+                    }
+                },
                 else => break,
-            }
-            while let Some(res) = tasks.join_next().await {
-                res.expect("conn close task panicked");
             }
         }
     }
 
-    pub async fn get_connections(&self) -> Vec<OpenConnection> {
-        self.connections.lock().await.clone()
+    pub async fn get_status(&self) -> ConnectionMonitorState {
+        ConnectionMonitorState {
+            open_connections: self.connections.lock().await.clone(),
+            observed_connections_total: self
+                .stats
+                .observed_connections_total
+                .load(Ordering::Relaxed),
+            dropped_observations_total: self
+                .stats
+                .dropped_observations_total
+                .load(Ordering::Relaxed),
+            closed_connections_total: self.stats.closed_connections_total.load(Ordering::Relaxed),
+            close_task_errors_total: self.stats.close_task_errors_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for Monitor {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/net/src/monitoring.rs
+++ b/net/src/monitoring.rs
@@ -1,0 +1,93 @@
+use aruna_core::{alpn::Alpn, structs::OpenConnection};
+use iroh::endpoint::{AfterHandshakeOutcome, ConnectionInfo, EndpointHooks, Side};
+use std::sync::Arc;
+use tokio::{
+    sync::{
+        Mutex,
+        mpsc::{UnboundedReceiver, UnboundedSender},
+    },
+    task::JoinSet,
+};
+use tokio_util::task::AbortOnDropHandle;
+use tracing::{Instrument, info_span, trace};
+
+#[derive(Clone, Debug)]
+pub struct Monitor {
+    connections: Arc<Mutex<Vec<OpenConnection>>>,
+    tx: UnboundedSender<ObservedConnection>,
+    _task: Arc<AbortOnDropHandle<()>>,
+}
+
+#[derive(Debug, Clone)]
+struct ObservedConnection {
+    alpn: Vec<u8>,
+    remote_id: iroh::EndpointId,
+    side: Side,
+    handle: ConnectionInfo,
+}
+
+impl EndpointHooks for Monitor {
+    async fn after_handshake(&self, conn: &ConnectionInfo) -> AfterHandshakeOutcome {
+        let info = ObservedConnection {
+            alpn: conn.alpn().to_vec(),
+            remote_id: conn.remote_id(),
+            side: conn.side(),
+            handle: conn.clone(),
+        };
+        self.tx.send(info).ok();
+        AfterHandshakeOutcome::Accept
+    }
+}
+
+impl Monitor {
+    pub fn new() -> Self {
+        let connections = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let conn = connections.clone();
+        let task = tokio::spawn(Self::run(conn, rx).instrument(info_span!("watcher")));
+        Self {
+            connections,
+            tx,
+            _task: Arc::new(AbortOnDropHandle::new(task)),
+        }
+    }
+
+    async fn run(
+        connections: Arc<Mutex<Vec<OpenConnection>>>,
+        mut rx: UnboundedReceiver<ObservedConnection>,
+    ) {
+        let mut tasks = JoinSet::new();
+        let conn = connections.clone();
+        loop {
+            tokio::select! {
+                Some(ObservedConnection { alpn, remote_id, side, handle }) = rx.recv() => {
+                    conn.lock().await.push(OpenConnection{ alpn: Alpn::from_bytes(&alpn), remote_id: remote_id.clone(), side });
+                    let conn_clone = conn.clone();
+                    tasks.spawn(async move {
+                        match handle.closed().await {
+                            Some((error, state)) => {
+                                // We have access to the final stats of the connection!
+                                trace!(%remote_id, ?alpn, ?error, udp_rx=state.udp_rx.bytes, udp_tx=state.udp_tx.bytes, "connection closed");
+                            }
+                            None => {
+                                // The connection was closed before we could register our stats-on-close listener.
+                                trace!(%remote_id, ?alpn, "connection closed before tracking started");
+                            }
+
+                        };
+                        conn_clone.lock().await.retain(|mx| mx.remote_id != remote_id);
+                    }.instrument(tracing::Span::current()));
+                }
+                Some(res) = tasks.join_next(), if !tasks.is_empty() => res.expect("conn close task panicked"),
+                else => break,
+            }
+            while let Some(res) = tasks.join_next().await {
+                res.expect("conn close task panicked");
+            }
+        }
+    }
+
+    pub async fn get_connections(&self) -> Vec<OpenConnection> {
+        self.connections.lock().await.clone()
+    }
+}

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -15,3 +15,7 @@ ulid = { workspace = true }
 byteview = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::ops::Bound::{Excluded, Included, Unbounded};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use aruna_core::effects::{Effect, StorageEffect};
@@ -63,13 +63,18 @@ struct StorageMetrics {
     requests_total: AtomicU64,
     errors_total: AtomicU64,
     conflicts_total: AtomicU64,
+    channel_closed: AtomicBool,
+    last_error: Mutex<Option<String>>,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct StorageMetricsSnapshot {
     pub requests_total: u64,
     pub errors_total: u64,
     pub conflicts_total: u64,
+    pub failed_total: u64,
+    pub channel_closed: bool,
+    pub last_error: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -95,10 +100,19 @@ impl StorageHandle {
     }
 
     pub fn snapshot_metrics(&self) -> StorageMetricsSnapshot {
+        let errors_total = self.metrics.errors_total.load(Ordering::Relaxed);
         StorageMetricsSnapshot {
             requests_total: self.metrics.requests_total.load(Ordering::Relaxed),
-            errors_total: self.metrics.errors_total.load(Ordering::Relaxed),
+            errors_total,
             conflicts_total: self.metrics.conflicts_total.load(Ordering::Relaxed),
+            failed_total: errors_total,
+            channel_closed: self.metrics.channel_closed.load(Ordering::Relaxed),
+            last_error: self
+                .metrics
+                .last_error
+                .lock()
+                .expect("storage metrics mutex poisoned")
+                .clone(),
         }
     }
 
@@ -133,13 +147,19 @@ impl StorageHandle {
     }
 
     fn observe_storage_error(&self, error: &StorageError) {
-        match error {
-            StorageError::TransactionConflict => {
-                self.metrics.conflicts_total.fetch_add(1, Ordering::Relaxed);
-            }
-            _ => {
-                self.metrics.errors_total.fetch_add(1, Ordering::Relaxed);
-            }
+        self.metrics.errors_total.fetch_add(1, Ordering::Relaxed);
+        *self
+            .metrics
+            .last_error
+            .lock()
+            .expect("storage metrics mutex poisoned") = Some(error.to_string());
+
+        if matches!(error, StorageError::TransactionConflict) {
+            self.metrics.conflicts_total.fetch_add(1, Ordering::Relaxed);
+        }
+
+        if matches!(error, StorageError::ChannelClosed) {
+            self.metrics.channel_closed.store(true, Ordering::Relaxed);
         }
     }
 }
@@ -148,7 +168,9 @@ impl StorageHandle {
 impl Handle for StorageHandle {
     async fn send_effect(&self, effect: Effect) -> Event {
         match effect {
-            Effect::Storage(storage_effect) => Event::Storage(self.dispatch_storage_effect(storage_effect).await),
+            Effect::Storage(storage_effect) => {
+                Event::Storage(self.dispatch_storage_effect(storage_effect).await)
+            }
             _ => {
                 self.metrics.requests_total.fetch_add(1, Ordering::Relaxed);
                 let error = StorageError::InvalidEffect;
@@ -632,6 +654,9 @@ mod tests {
                 requests_total: 1,
                 errors_total: 1,
                 conflicts_total: 0,
+                failed_total: 1,
+                channel_closed: false,
+                last_error: Some("Transaction not found".to_string()),
             }
         );
     }
@@ -647,7 +672,10 @@ mod tests {
             });
 
             let (effect, response_tx) = receiver.recv().expect("second effect should arrive");
-            assert!(matches!(effect, StorageEffect::StartTransaction { read: false }));
+            assert!(matches!(
+                effect,
+                StorageEffect::StartTransaction { read: false }
+            ));
             response_tx.send(StorageEvent::Error {
                 error: StorageError::TransactionConflict,
             });
@@ -665,6 +693,11 @@ mod tests {
         assert_eq!(metrics_after_not_found.requests_total, 1);
         assert_eq!(metrics_after_not_found.errors_total, 1);
         assert_eq!(metrics_after_not_found.conflicts_total, 0);
+        assert_eq!(metrics_after_not_found.failed_total, 1);
+        assert_eq!(
+            metrics_after_not_found.last_error,
+            Some("Transaction not found".to_string())
+        );
 
         let event = handle
             .send_storage_effect(StorageEffect::StartTransaction { read: false })
@@ -679,7 +712,12 @@ mod tests {
 
         let metrics_after_conflict = handle.snapshot_metrics();
         assert_eq!(metrics_after_conflict.requests_total, 2);
-        assert_eq!(metrics_after_conflict.errors_total, 1);
+        assert_eq!(metrics_after_conflict.errors_total, 2);
         assert_eq!(metrics_after_conflict.conflicts_total, 1);
+        assert_eq!(metrics_after_conflict.failed_total, 2);
+        assert_eq!(
+            metrics_after_conflict.last_error,
+            Some("Transaction conflict".to_string())
+        );
     }
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::ops::Bound::{Excluded, Included, Unbounded};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 
 use aruna_core::effects::{Effect, StorageEffect};
@@ -21,7 +23,6 @@ enum Txn {
     Read(fjall::Snapshot),
     Write(Box<fjall::OptimisticWriteTx>),
 }
-
 type PageResult = (Vec<(ByteView, ByteView)>, Option<ByteView>);
 
 struct Store {
@@ -57,9 +58,24 @@ pub struct FjallStorage {
     txns: HashMap<Ulid, Txn>,
 }
 
+#[derive(Debug, Default)]
+struct StorageMetrics {
+    requests_total: AtomicU64,
+    errors_total: AtomicU64,
+    conflicts_total: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StorageMetricsSnapshot {
+    pub requests_total: u64,
+    pub errors_total: u64,
+    pub conflicts_total: u64,
+}
+
 #[derive(Clone, Debug)]
 pub struct StorageHandle {
     write_channel: EffectSender,
+    metrics: Arc<StorageMetrics>,
 }
 
 impl StorageHandle {
@@ -68,27 +84,63 @@ impl StorageHandle {
         (
             StorageHandle {
                 write_channel: sender,
+                metrics: Arc::new(StorageMetrics::default()),
             },
             receiver,
         )
     }
 
+    pub fn get_errors(&self) -> u64 {
+        self.metrics.errors_total.load(Ordering::Relaxed)
+    }
+
+    pub fn snapshot_metrics(&self) -> StorageMetricsSnapshot {
+        StorageMetricsSnapshot {
+            requests_total: self.metrics.requests_total.load(Ordering::Relaxed),
+            errors_total: self.metrics.errors_total.load(Ordering::Relaxed),
+            conflicts_total: self.metrics.conflicts_total.load(Ordering::Relaxed),
+        }
+    }
+
     pub async fn send_storage_effect(&self, effect: StorageEffect) -> Event {
-        let storage_event = {
-            let (response_tx, response_rx) = crossfire::oneshot::oneshot();
-            if self.write_channel.send((effect, response_tx)).is_err() {
-                return Event::Storage(StorageEvent::Error {
-                    error: StorageError::ChannelClosed,
-                });
+        Event::Storage(self.dispatch_storage_effect(effect).await)
+    }
+
+    async fn dispatch_storage_effect(&self, effect: StorageEffect) -> StorageEvent {
+        self.metrics.requests_total.fetch_add(1, Ordering::Relaxed);
+
+        let (response_tx, response_rx) = crossfire::oneshot::oneshot();
+        if self.write_channel.send((effect, response_tx)).is_err() {
+            return self.observe_storage_event(StorageEvent::Error {
+                error: StorageError::ChannelClosed,
+            });
+        }
+
+        match response_rx.await {
+            Ok(event) => self.observe_storage_event(event),
+            Err(_) => self.observe_storage_event(StorageEvent::Error {
+                error: StorageError::ChannelClosed,
+            }),
+        }
+    }
+
+    fn observe_storage_event(&self, event: StorageEvent) -> StorageEvent {
+        if let StorageEvent::Error { error } = &event {
+            self.observe_storage_error(error);
+        }
+
+        event
+    }
+
+    fn observe_storage_error(&self, error: &StorageError) {
+        match error {
+            StorageError::TransactionConflict => {
+                self.metrics.conflicts_total.fetch_add(1, Ordering::Relaxed);
             }
-            match response_rx.await {
-                Ok(event) => event,
-                Err(_) => StorageEvent::Error {
-                    error: StorageError::ChannelClosed,
-                },
+            _ => {
+                self.metrics.errors_total.fetch_add(1, Ordering::Relaxed);
             }
-        };
-        Event::Storage(storage_event)
+        }
     }
 }
 
@@ -96,27 +148,13 @@ impl StorageHandle {
 impl Handle for StorageHandle {
     async fn send_effect(&self, effect: Effect) -> Event {
         match effect {
-            Effect::Storage(storage_effect) => {
-                let (response_tx, response_rx) = crossfire::oneshot::oneshot();
-                if self
-                    .write_channel
-                    .send((storage_effect, response_tx))
-                    .is_err()
-                {
-                    return Event::Storage(StorageEvent::Error {
-                        error: StorageError::ChannelClosed,
-                    });
-                }
-                match response_rx.await {
-                    Ok(event) => Event::Storage(event),
-                    Err(_) => Event::Storage(StorageEvent::Error {
-                        error: StorageError::ChannelClosed,
-                    }),
-                }
+            Effect::Storage(storage_effect) => Event::Storage(self.dispatch_storage_effect(storage_effect).await),
+            _ => {
+                self.metrics.requests_total.fetch_add(1, Ordering::Relaxed);
+                let error = StorageError::InvalidEffect;
+                self.observe_storage_error(&error);
+                Event::Storage(StorageEvent::Error { error })
             }
-            _ => Event::Storage(StorageEvent::Error {
-                error: StorageError::InvalidEffect,
-            }),
         }
     }
 }
@@ -561,4 +599,87 @@ fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FjallStorage, StorageHandle};
+    use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::errors::StorageError;
+    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::handle::Handle;
+    use std::thread;
+    use tempfile::tempdir;
+    use ulid::Ulid;
+
+    #[tokio::test]
+    async fn send_storage_effect_counts_requests_and_errors() {
+        let dir = tempdir().unwrap();
+        let handle = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+
+        let event = handle
+            .send_storage_effect(StorageEffect::Read {
+                key_space: "missing".to_string(),
+                key: b"key".to_vec().into(),
+                txn_id: Some(Ulid::new()),
+            })
+            .await;
+
+        assert!(matches!(event, Event::Storage(StorageEvent::Error { .. })));
+        assert_eq!(
+            handle.snapshot_metrics(),
+            super::StorageMetricsSnapshot {
+                requests_total: 1,
+                errors_total: 1,
+                conflicts_total: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn send_effect_counts_conflicts_separately_from_errors() {
+        let (handle, receiver) = StorageHandle::new();
+        thread::spawn(move || {
+            let (effect, response_tx) = receiver.recv().expect("first effect should arrive");
+            assert!(matches!(effect, StorageEffect::CommitTransaction { .. }));
+            response_tx.send(StorageEvent::Error {
+                error: StorageError::TransactionNotFound,
+            });
+
+            let (effect, response_tx) = receiver.recv().expect("second effect should arrive");
+            assert!(matches!(effect, StorageEffect::StartTransaction { read: false }));
+            response_tx.send(StorageEvent::Error {
+                error: StorageError::TransactionConflict,
+            });
+        });
+
+        let event = handle
+            .send_effect(Effect::Storage(StorageEffect::CommitTransaction {
+                txn_id: Ulid::new(),
+            }))
+            .await;
+
+        assert!(matches!(event, Event::Storage(StorageEvent::Error { .. })));
+
+        let metrics_after_not_found = handle.snapshot_metrics();
+        assert_eq!(metrics_after_not_found.requests_total, 1);
+        assert_eq!(metrics_after_not_found.errors_total, 1);
+        assert_eq!(metrics_after_not_found.conflicts_total, 0);
+
+        let event = handle
+            .send_storage_effect(StorageEffect::StartTransaction { read: false })
+            .await;
+
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::Error {
+                error: StorageError::TransactionConflict,
+            })
+        ));
+
+        let metrics_after_conflict = handle.snapshot_metrics();
+        assert_eq!(metrics_after_conflict.requests_total, 2);
+        assert_eq!(metrics_after_conflict.errors_total, 1);
+        assert_eq!(metrics_after_conflict.conflicts_total, 1);
+    }
 }


### PR DESCRIPTION
Adds a richer `/api/v1/info` response and an `aruna-doctor info` command for inspecting live node health.

## Changes

- Reports node identity, network status, blob backend health, REST/S3 interface URLs, and database/storage error metrics.
- Tracks iroh connection monitor state, blob backend availability, and storage request/error counters.
- Registers bound REST/S3 listener addresses so status output shows real client-facing URLs.
- Adds tests for status responses, URL normalization, storage metrics, connection monitoring, and doctor info fetching.