### PR TITLE
Implement ListObjectsV2 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "iroh",
  "jsonwebtoken",
  "opentelemetry",
+ "percent-encoding",
  "postcard",
  "rand 0.10.1",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "futures-util",
  "globset",
+ "hex",
  "iroh",
  "jsonwebtoken",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
 ] }
 oxrdf = "0.3"
 parking_lot = { version = "0.12.5", features = ["deadlock_detection"] }
+percent-encoding = "2.3.2"
 postcard = { version = "1.1.3", features = ["alloc"] }
 rand = "0.10.1"
 reqwest = { version = "0.13.3", default-features = false, features = [

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,6 +16,7 @@ ahash = { workspace = true }
 base64 = { workspace = true }
 hex.workspace = true
 opentelemetry = { workspace = true }
+percent-encoding = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/api/src/routes/drs.rs
+++ b/api/src/routes/drs.rs
@@ -149,8 +149,8 @@ pub struct DownloadQuery {
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct DrsErrorPayload {
-    status: u16,
-    message: String,
+    status_code: u16,
+    msg: String,
 }
 
 enum RequestedObjectId {
@@ -302,15 +302,15 @@ pub async fn post_objects(
     let mut objects = Vec::with_capacity(body.object_ids.len());
     for object_id in body.object_ids {
         let result = match resolve_object(state.as_ref(), &auth, &object_id).await {
-            Ok(ResolveOutcome::Found(resolved)) => {
-                serde_json::to_value(build_object_response(&headers, &resolved))
-                    .unwrap_or_else(|_| json!({ "status": 500, "message": "serialization failed" }))
-            }
-            Ok(ResolveOutcome::Denied) => json!({ "status": 403, "message": "Forbidden" }),
+            Ok(ResolveOutcome::Found(resolved)) => serde_json::to_value(build_object_response(
+                &headers, &resolved,
+            ))
+            .unwrap_or_else(|_| json!({ "status_code": 500, "msg": "serialization failed" })),
+            Ok(ResolveOutcome::Denied) => json!({ "status_code": 403, "msg": "Forbidden" }),
             Ok(ResolveOutcome::NotFound) => {
-                json!({ "status": 404, "message": "DRS object not found" })
+                json!({ "status_code": 404, "msg": "DRS object not found" })
             }
-            Err(error) => json!({ "status": error.status.as_u16(), "message": error.message }),
+            Err(error) => json!({ "status_code": error.status.as_u16(), "msg": error.message }),
         };
         objects.push(DrsBulkObjectItem { object_id, result });
     }
@@ -641,8 +641,8 @@ fn drs_error(status: StatusCode, message: impl Into<String>) -> Response {
     drs_json_response(
         status,
         DrsErrorPayload {
-            status: status.as_u16(),
-            message: message.into(),
+            status_code: status.as_u16(),
+            msg: message.into(),
         },
     )
 }

--- a/api/src/routes/drs.rs
+++ b/api/src/routes/drs.rs
@@ -1,9 +1,10 @@
+use crate::auth::{ensure_permission, require_realm_auth};
+use crate::error::ServerError;
 use crate::server_state::ServerState;
 use aruna_core::structs::{
     ArunaArn, ArunaArnType, AuthContext, BackendLocation, Permission, SourceMetadata,
 };
 use aruna_operations::blob::resolve_blob_permission_paths::ResolveBlobPermissionPathsOperation;
-use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use aruna_operations::driver::drive;
 use aruna_operations::s3::get_object::{GetObjectError, GetObjectInput, GetObjectOperation};
 use aruna_operations::s3::head_object::{HeadObjectError, HeadObjectInput, HeadObjectOperation};
@@ -262,11 +263,12 @@ pub async fn get_object(
     headers: HeaderMap,
     Path(object_id): Path<String>,
 ) -> Response {
-    if auth.is_none() {
-        return DrsError::forbidden("Forbidden").into_response();
-    }
+    let auth = match require_drs_auth(state.as_ref(), auth) {
+        Ok(auth) => auth,
+        Err(error) => return error.into_response(),
+    };
 
-    match resolve_object(state.as_ref(), auth.as_ref(), &object_id).await {
+    match resolve_object(state.as_ref(), &auth, &object_id).await {
         Ok(ResolveOutcome::Found(resolved)) => {
             drs_json_response(StatusCode::OK, build_object_response(&headers, &resolved))
         }
@@ -292,13 +294,14 @@ pub async fn post_objects(
     headers: HeaderMap,
     Json(body): Json<DrsBulkObjectsRequestBody>,
 ) -> Response {
-    if auth.is_none() {
-        return DrsError::forbidden("Forbidden").into_response();
-    }
+    let auth = match require_drs_auth(state.as_ref(), auth) {
+        Ok(auth) => auth,
+        Err(error) => return error.into_response(),
+    };
 
     let mut objects = Vec::with_capacity(body.object_ids.len());
     for object_id in body.object_ids {
-        let result = match resolve_object(state.as_ref(), auth.as_ref(), &object_id).await {
+        let result = match resolve_object(state.as_ref(), &auth, &object_id).await {
             Ok(ResolveOutcome::Found(resolved)) => {
                 serde_json::to_value(build_object_response(&headers, &resolved))
                     .unwrap_or_else(|_| json!({ "status": 500, "message": "serialization failed" }))
@@ -330,10 +333,10 @@ pub async fn download_object(
     Extension(auth): Extension<Option<AuthContext>>,
     Query(query): Query<DownloadQuery>,
 ) -> Response {
-    let Some(auth) = auth else {
+    let Ok(auth) = require_realm_auth(state.as_ref(), auth) else {
         return drs_error(StatusCode::NOT_FOUND, "DRS object not found");
     };
-    let resolved = match resolve_object(state.as_ref(), Some(&auth), &query.object_id).await {
+    let resolved = match resolve_object(state.as_ref(), &auth, &query.object_id).await {
         Ok(ResolveOutcome::Found(resolved)) => resolved,
         Ok(ResolveOutcome::Denied) => return DrsError::forbidden("Forbidden").into_response(),
         Ok(ResolveOutcome::NotFound) => {
@@ -442,9 +445,16 @@ fn build_object_response(headers: &HeaderMap, resolved: &ResolvedObject) -> DrsO
     }
 }
 
+fn require_drs_auth(
+    state: &ServerState,
+    auth: Option<AuthContext>,
+) -> Result<AuthContext, DrsError> {
+    require_realm_auth(state, auth).map_err(|_| DrsError::forbidden("Forbidden"))
+}
+
 async fn resolve_object(
     state: &ServerState,
-    auth: Option<&AuthContext>,
+    auth: &AuthContext,
     object_id: &str,
 ) -> Result<ResolveOutcome, DrsError> {
     match parse_requested_object_id(object_id)? {
@@ -461,7 +471,7 @@ async fn resolve_object(
 
 async fn resolve_content_hash(
     state: &ServerState,
-    auth: Option<&AuthContext>,
+    auth: &AuthContext,
     requested_id: &str,
     requested_scope: Option<(aruna_core::structs::RealmId, aruna_core::NodeId)>,
     hash: &[u8; 32],
@@ -548,35 +558,14 @@ async fn resolve_content_hash(
 
 async fn can_read_permission_path(
     state: &ServerState,
-    auth: Option<&AuthContext>,
+    auth: &AuthContext,
     path: &str,
 ) -> Result<bool, DrsError> {
-    let Some(auth) = auth.cloned() else {
-        debug!("No auth context available");
-        return Ok(false);
-    };
-    if auth.realm_id != state.get_realm_id() {
-        debug!(
-            "Realm id mismatch: {} - {}",
-            auth.realm_id,
-            state.get_realm_id()
-        );
-        return Ok(false);
+    match ensure_permission(state, auth, path.to_string(), Permission::READ).await {
+        Ok(()) => Ok(true),
+        Err(ServerError::Forbidden) => Ok(false),
+        Err(error) => Err(DrsError::internal(error.to_string())),
     }
-
-    let res = drive(
-        CheckPermissionsOperation::new(CheckPermissionsConfig {
-            auth_context: auth,
-            path: path.to_string(),
-            required_permission: Permission::READ,
-        }),
-        &state.get_ctx(),
-    )
-    .await
-    .map_err(|error| DrsError::internal(error.to_string()));
-
-    debug!(check_permissions_result = ?res);
-    res
 }
 
 fn parse_requested_object_id(object_id: &str) -> Result<RequestedObjectId, DrsError> {

--- a/api/src/routes/drs.rs
+++ b/api/src/routes/drs.rs
@@ -491,6 +491,7 @@ async fn resolve_content_hash(
     debug!(?mappings);
 
     let mut any_mapping_on_this_node = false;
+    let mut last_permission_check: Option<(String, bool)> = None;
 
     for mapping in mappings {
         if mapping.realm_id != state.get_realm_id() || mapping.node_id != state.get_node_id() {
@@ -498,8 +499,17 @@ async fn resolve_content_hash(
             continue;
         }
         any_mapping_on_this_node = true;
-        if !can_read_permission_path(state, auth, &mapping.permission_path()).await? {
-            debug!("No permissions for path: {}", mapping.permission_path());
+        let path = mapping.permission_path();
+        let allowed = match &last_permission_check {
+            Some((cached_path, allowed)) if cached_path == &path => *allowed,
+            _ => {
+                let allowed = can_read_permission_path(state, auth, &path).await?;
+                last_permission_check = Some((path.clone(), allowed));
+                allowed
+            }
+        };
+        if !allowed {
+            debug!("No permissions for path: {path}");
             continue;
         }
         let head = match drive(

--- a/api/src/s3/error.rs
+++ b/api/src/s3/error.rs
@@ -9,6 +9,7 @@ use aruna_operations::s3::delete_object::DeleteObjectError;
 use aruna_operations::s3::get_object::GetObjectError;
 use aruna_operations::s3::head_object::HeadObjectError;
 use aruna_operations::s3::list_buckets::ListBucketsError;
+use aruna_operations::s3::list_objects_v2::ListObjectsV2Error;
 use aruna_operations::s3::put_bucket_replication::{
     DeleteBucketReplicationError, GetBucketReplicationError, PutBucketReplicationError,
 };
@@ -87,6 +88,12 @@ impl IntoS3Error for CreateBucketError {
 }
 
 impl IntoS3Error for ListBucketsError {
+    fn into_s3_error(self) -> S3Error {
+        internal_error(self)
+    }
+}
+
+impl IntoS3Error for ListObjectsV2Error {
     fn into_s3_error(self) -> S3Error {
         internal_error(self)
     }

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -65,7 +65,6 @@ use s3s::dto::{
     ReplicationRule, ReplicationRuleStatus, StreamingBlob, UploadPartInput, UploadPartOutput,
 };
 use s3s::{S3, S3ErrorCode, S3Request, S3Response, S3Result, s3_error};
-use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -88,6 +87,28 @@ struct ReferenceMetadataRefresh {
     version_id: ulid::Ulid,
     metadata: SourceMetadata,
     refreshed_at: SystemTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct ListObjectsV2ContinuationCursor {
+    backend_continuation_token: Vec<u8>,
+    last_common_prefix: Option<String>,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum ListObjectsV2LogicalEntry {
+    Content(Object),
+    CommonPrefix(String),
+}
+
+impl ListObjectsV2LogicalEntry {
+    fn last_common_prefix(&self) -> Option<&str> {
+        match self {
+            Self::Content(_) => None,
+            Self::CommonPrefix(prefix) => Some(prefix.as_str()),
+        }
+    }
 }
 
 fn object_range_request(range: s3s::dto::Range) -> ObjectRangeRequest {
@@ -434,18 +455,28 @@ impl ArunaS3Service {
         }
     }
 
-    fn decode_list_objects_v2_continuation_token(token: Option<&str>) -> S3Result<Option<Vec<u8>>> {
+    fn decode_list_objects_v2_continuation_token(
+        token: Option<&str>,
+    ) -> S3Result<Option<ListObjectsV2ContinuationCursor>> {
         token
             .map(|token| {
-                STANDARD
+                let decoded = STANDARD
                     .decode(token)
+                    .map_err(|_| s3_error!(InvalidArgument, "Invalid continuation token"))?;
+                postcard::from_bytes(&decoded)
                     .map_err(|_| s3_error!(InvalidArgument, "Invalid continuation token"))
             })
             .transpose()
     }
 
-    fn encode_list_objects_v2_continuation_token(token: Option<&[u8]>) -> Option<String> {
-        token.map(|token| STANDARD.encode(token))
+    fn encode_list_objects_v2_continuation_token(
+        token: Option<&ListObjectsV2ContinuationCursor>,
+    ) -> Option<String> {
+        token.and_then(|token| {
+            postcard::to_allocvec(token)
+                .ok()
+                .map(|token| STANDARD.encode(token))
+        })
     }
 }
 
@@ -696,9 +727,15 @@ impl S3 for ArunaS3Service {
         })?;
         let bucket_info = req.extensions.get::<BucketInfo>().cloned();
         let requested_continuation_token = req.input.continuation_token.clone();
-        let mut continuation_token = Self::decode_list_objects_v2_continuation_token(
+        let continuation_cursor = Self::decode_list_objects_v2_continuation_token(
             requested_continuation_token.as_deref(),
         )?;
+        let mut continuation_token = continuation_cursor
+            .as_ref()
+            .map(|cursor| cursor.backend_continuation_token.clone());
+        let mut resume_common_prefix = continuation_cursor
+            .as_ref()
+            .and_then(|cursor| cursor.last_common_prefix.clone());
         let max_keys = req
             .input
             .max_keys
@@ -709,9 +746,9 @@ impl S3 for ArunaS3Service {
         let delimiter = req.input.delimiter.clone();
         let start_after = req.input.start_after.clone();
 
-        let mut contents = Vec::new();
-        let mut common_prefixes = BTreeSet::new();
+        let mut logical_entries = Vec::new();
 
+        // Early return in case of max_keys = 0
         if req.input.max_keys == Some(0) {
             return Ok(S3Response::new(ListObjectsV2Output {
                 name: Some(bucket),
@@ -721,7 +758,7 @@ impl S3 for ArunaS3Service {
                 continuation_token: requested_continuation_token,
                 is_truncated: Some(false),
                 next_continuation_token: None,
-                contents: Some(contents),
+                contents: Some(Vec::new()),
                 common_prefixes: Some(Vec::new()),
                 delimiter,
                 encoding_type: req.input.encoding_type,
@@ -756,71 +793,123 @@ impl S3 for ArunaS3Service {
             let page_next_continuation_token = result.continuation_token.clone();
             let page_len = result.objects.len();
             backend_pages_scanned += 1;
+            let mut previous_raw_token = continuation_token.clone();
 
-            for (index, object) in result.objects.into_iter().enumerate() {
+            for object in result.objects.into_iter() {
                 let head_bytes = object
                     .head
                     .to_bytes()
                     .map_err(|err| s3_error!(InternalError, "{}", err.to_string()))?;
                 let key = object.head.key;
 
-                if continuation_token.is_none()
+                if requested_continuation_token.is_none()
                     && start_after
                         .as_ref()
                         .is_some_and(|start_after| key.as_str() <= start_after.as_str())
                 {
+                    previous_raw_token = Some(head_bytes);
                     continue;
                 }
 
-                if let Some(delimiter) = delimiter.as_ref() {
+                let logical_entry = if let Some(delimiter) = delimiter.as_ref() {
                     let prefix_start = prefix.as_ref().map(|prefix| prefix.len()).unwrap_or(0);
                     if let Some(relative_match) = key[prefix_start..].find(delimiter) {
                         let group_end = prefix_start + relative_match + delimiter.len();
                         let candidate_prefix = key[..group_end].to_string();
-                        if continuation_token.is_none()
+                        if requested_continuation_token.is_none()
                             && start_after.as_ref().is_some_and(|start_after| {
                                 candidate_prefix.as_str() <= start_after.as_str()
                             })
                         {
+                            previous_raw_token = Some(head_bytes);
                             continue;
                         }
-                        common_prefixes.insert(candidate_prefix);
-                        if contents.len() + common_prefixes.len() >= max_keys {
-                            next_continuation_token = if index + 1 < page_len {
-                                Some(head_bytes)
-                            } else {
-                                page_next_continuation_token.clone()
-                            };
-                            break;
+                        if resume_common_prefix.as_ref() == Some(&candidate_prefix) {
+                            previous_raw_token = Some(head_bytes);
+                            continue;
                         }
-                        continue;
+                        if logical_entries
+                            .last()
+                            .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
+                            == Some(candidate_prefix.as_str())
+                        {
+                            previous_raw_token = Some(head_bytes);
+                            continue;
+                        }
+
+                        ListObjectsV2LogicalEntry::CommonPrefix(candidate_prefix)
+                    } else {
+                        let response_fields = self.build_object_response_fields(
+                            object.location.as_ref(),
+                            object.source_metadata.as_ref(),
+                            object.last_refresh,
+                        );
+                        ListObjectsV2LogicalEntry::Content(Object {
+                            e_tag: response_fields.e_tag,
+                            key: Some(key),
+                            last_modified: response_fields.last_modified,
+                            owner: None,
+                            size: response_fields.content_length,
+                            ..Default::default()
+                        })
                     }
+                } else {
+                    let response_fields = self.build_object_response_fields(
+                        object.location.as_ref(),
+                        object.source_metadata.as_ref(),
+                        object.last_refresh,
+                    );
+                    ListObjectsV2LogicalEntry::Content(Object {
+                        e_tag: response_fields.e_tag,
+                        key: Some(key),
+                        last_modified: response_fields.last_modified,
+                        owner: None,
+                        size: response_fields.content_length,
+                        ..Default::default()
+                    })
+                };
+
+                resume_common_prefix = None;
+
+                if logical_entries.len() < max_keys {
+                    logical_entries.push(logical_entry);
+                    previous_raw_token = Some(head_bytes);
+                    continue;
                 }
 
-                let response_fields = self.build_object_response_fields(
-                    object.location.as_ref(),
-                    object.source_metadata.as_ref(),
-                    object.last_refresh,
-                );
-                contents.push(Object {
-                    e_tag: response_fields.e_tag,
-                    key: Some(key),
-                    last_modified: response_fields.last_modified,
-                    owner: None,
-                    size: response_fields.content_length,
-                    ..Default::default()
-                });
-                if contents.len() + common_prefixes.len() >= max_keys {
-                    next_continuation_token = if index + 1 < page_len {
-                        Some(head_bytes)
-                    } else {
-                        page_next_continuation_token.clone()
-                    };
+                next_continuation_token =
+                    previous_raw_token
+                        .clone()
+                        .map(
+                            |backend_continuation_token| ListObjectsV2ContinuationCursor {
+                                backend_continuation_token,
+                                last_common_prefix: logical_entries
+                                    .last()
+                                    .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
+                                    .map(str::to_string),
+                            },
+                        );
+                if next_continuation_token.is_none() && page_len > 0 {
+                    next_continuation_token =
+                        page_next_continuation_token
+                            .clone()
+                            .map(
+                                |backend_continuation_token| ListObjectsV2ContinuationCursor {
+                                    backend_continuation_token,
+                                    last_common_prefix: logical_entries
+                                        .last()
+                                        .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
+                                        .map(str::to_string),
+                                },
+                            );
+                }
+                if next_continuation_token.is_some() {
                     break;
                 }
+                previous_raw_token = Some(head_bytes);
             }
 
-            if contents.len() + common_prefixes.len() >= max_keys {
+            if next_continuation_token.is_some() {
                 break;
             }
 
@@ -832,34 +921,47 @@ impl S3 for ArunaS3Service {
                     prefix = ?prefix,
                     delimiter = ?delimiter,
                     max_keys = %max_keys,
-                    visible_count = contents.len() + common_prefixes.len(),
+                    visible_count = logical_entries.len(),
                     pages = backend_pages_scanned,
                     "ListObjectsV2 pagination guard triggered; returning truncated response"
                 );
-                next_continuation_token = page_next_continuation_token.clone();
+                next_continuation_token =
+                    page_next_continuation_token
+                        .clone()
+                        .map(
+                            |backend_continuation_token| ListObjectsV2ContinuationCursor {
+                                backend_continuation_token,
+                                last_common_prefix: logical_entries
+                                    .last()
+                                    .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
+                                    .map(str::to_string),
+                            },
+                        );
                 break;
             }
 
-            next_continuation_token = page_next_continuation_token.clone();
-            if next_continuation_token.is_none() {
+            continuation_token = page_next_continuation_token;
+            if continuation_token.is_none() {
                 break;
             }
-
-            continuation_token = next_continuation_token.clone();
         }
 
         let is_truncated = next_continuation_token.is_some();
-        if contents.len() > max_keys {
-            contents.truncate(max_keys);
+        let mut contents = Vec::new();
+        let mut common_prefixes = Vec::new();
+        for entry in logical_entries {
+            match entry {
+                ListObjectsV2LogicalEntry::Content(object) => contents.push(object),
+                ListObjectsV2LogicalEntry::CommonPrefix(prefix) => {
+                    common_prefixes.push(CommonPrefix {
+                        prefix: Some(prefix),
+                    });
+                }
+            }
         }
-        let remaining_common_prefixes = max_keys.saturating_sub(contents.len());
-        let common_prefixes: Vec<_> = common_prefixes
-            .into_iter()
-            .take(remaining_common_prefixes)
-            .collect();
         let key_count = contents.len() + common_prefixes.len();
         let next_continuation_token =
-            Self::encode_list_objects_v2_continuation_token(next_continuation_token.as_deref());
+            Self::encode_list_objects_v2_continuation_token(next_continuation_token.as_ref());
 
         Ok(S3Response::new(ListObjectsV2Output {
             name: Some(bucket),
@@ -870,14 +972,7 @@ impl S3 for ArunaS3Service {
             is_truncated: Some(is_truncated),
             next_continuation_token,
             contents: Some(contents),
-            common_prefixes: Some(
-                common_prefixes
-                    .into_iter()
-                    .map(|prefix| CommonPrefix {
-                        prefix: Some(prefix),
-                    })
-                    .collect(),
-            ),
+            common_prefixes: Some(common_prefixes),
             delimiter,
             encoding_type: req.input.encoding_type,
             start_after,
@@ -2001,15 +2096,198 @@ mod tests {
             }
         }
 
-        // First page emitted the "a/" common prefix (from a/1)
-        // Second page re-emitted "a/" (from a/2, now correctly on page 2)
-        // Third page returned b.txt as a content key
-        // Common prefixes are repeated per page because the API
-        // accumulates them from scratch on each request.
-        assert!(!all_prefixes.is_empty());
-        assert!(all_prefixes.iter().all(|p| p == "a/"));
+        assert_eq!(all_prefixes, vec!["a/"]);
         assert_eq!(all_keys, vec!["b.txt"]);
-        assert!(total_pages >= 2);
+        assert_eq!(total_pages, 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_prefix_only_page_is_not_truncated() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([33u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+
+        let service =
+            ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["a/1", "a/2"],
+            created_by,
+            UNIX_EPOCH,
+        )
+        .await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: Some("/".to_string()),
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(1),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+        );
+
+        let response = service.list_objects_v2(req).await.unwrap();
+        let output = response.output;
+
+        let prefixes: Vec<_> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|prefix| prefix.prefix)
+            .collect();
+
+        assert_eq!(prefixes, vec!["a/"]);
+        assert_eq!(output.contents.unwrap_or_default().len(), 0);
+        assert_eq!(output.key_count, Some(1));
+        assert_eq!(output.is_truncated, Some(false));
+        assert!(output.next_continuation_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_counts_prefixes_and_contents_in_order() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([34u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+
+        let service = ArunaS3Service::new(
+            context.clone(),
+            realm_id,
+            NodeId::from_bytes(&[0u8; 32]).unwrap(),
+        )
+        .await;
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["a.txt", "b/1", "c.txt"],
+            created_by,
+            UNIX_EPOCH,
+        )
+        .await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let first_response = service
+            .list_objects_v2(test_list_objects_v2_request(
+                extensions,
+                ListObjectsV2Input {
+                    bucket: "bucket".to_string(),
+                    continuation_token: None,
+                    delimiter: Some("/".to_string()),
+                    encoding_type: None,
+                    expected_bucket_owner: None,
+                    fetch_owner: None,
+                    max_keys: Some(2),
+                    optional_object_attributes: None,
+                    prefix: None,
+                    request_payer: None,
+                    start_after: None,
+                },
+            ))
+            .await
+            .unwrap()
+            .output;
+
+        let first_keys: Vec<_> = first_response
+            .contents
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|object| object.key)
+            .collect();
+        let first_prefixes: Vec<_> = first_response
+            .common_prefixes
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|prefix| prefix.prefix)
+            .collect();
+
+        assert_eq!(first_keys, vec!["a.txt"]);
+        assert_eq!(first_prefixes, vec!["b/"]);
+        assert_eq!(first_response.key_count, Some(2));
+        assert_eq!(first_response.is_truncated, Some(true));
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let second_response = service
+            .list_objects_v2(test_list_objects_v2_request(
+                extensions,
+                ListObjectsV2Input {
+                    bucket: "bucket".to_string(),
+                    continuation_token: first_response.next_continuation_token,
+                    delimiter: Some("/".to_string()),
+                    encoding_type: None,
+                    expected_bucket_owner: None,
+                    fetch_owner: None,
+                    max_keys: Some(2),
+                    optional_object_attributes: None,
+                    prefix: None,
+                    request_payer: None,
+                    start_after: None,
+                },
+            ))
+            .await
+            .unwrap()
+            .output;
+
+        let second_keys: Vec<_> = second_response
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|object| object.key)
+            .collect();
+        let second_prefixes: Vec<_> = second_response
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|prefix| prefix.prefix)
+            .collect();
+
+        assert_eq!(second_keys, vec!["c.txt"]);
+        assert!(second_prefixes.is_empty());
+        assert_eq!(second_response.key_count, Some(1));
+        assert_eq!(second_response.is_truncated, Some(false));
     }
 
     #[tokio::test]

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -123,8 +123,6 @@ impl Debug for ArunaS3Service {
 }
 
 impl ArunaS3Service {
-    const LIST_OBJECTS_V2_MAX_KEYS: usize = 1000;
-
     #[tracing::instrument(level = "trace", skip(driver_ctx))]
     pub async fn new(driver_ctx: Arc<DriverContext>, realm_id: RealmId, node_id: NodeId) -> Self {
         ArunaS3Service {
@@ -720,10 +718,10 @@ impl S3 for ArunaS3Service {
             requested_continuation_token.as_deref(),
         )?;
         let max_keys = match req.input.max_keys {
-            None => Self::LIST_OBJECTS_V2_MAX_KEYS,
+            None => ListObjectsV2Operation::DEFAULT_MAX_KEYS,
             Some(max_keys) => usize::try_from(max_keys)
                 .map_err(|_| s3_error!(InvalidArgument, "max-keys must be non-negative"))?
-                .min(Self::LIST_OBJECTS_V2_MAX_KEYS),
+                .min(ListObjectsV2Operation::DEFAULT_MAX_KEYS),
         };
         let bucket = req.input.bucket.clone();
         let prefix = req.input.prefix.clone();

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -43,7 +43,9 @@ use aruna_operations::s3::get_object::{
 };
 use aruna_operations::s3::head_object::{HeadObjectInput as HOI, HeadObjectOperation};
 use aruna_operations::s3::list_buckets::{ListBucketsInput as LBI, ListBucketsOperation};
-use aruna_operations::s3::list_objects_v2::{ListObjectsV2Input as LOV2I, ListObjectsV2Operation};
+use aruna_operations::s3::list_objects_v2::{
+    ListObjectsV2ContinuationToken, ListObjectsV2Input as LOV2I, ListObjectsV2Operation,
+};
 use aruna_operations::s3::put_bucket_replication::{
     DeleteBucketReplicationOperation, GetBucketReplicationOperation, PutBucketReplicationOperation,
 };
@@ -89,28 +91,6 @@ struct ReferenceMetadataRefresh {
     refreshed_at: SystemTime,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-struct ListObjectsV2ContinuationCursor {
-    backend_continuation_token: Vec<u8>,
-    last_common_prefix: Option<String>,
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-enum ListObjectsV2LogicalEntry {
-    Content(Object),
-    CommonPrefix(String),
-}
-
-impl ListObjectsV2LogicalEntry {
-    fn last_common_prefix(&self) -> Option<&str> {
-        match self {
-            Self::Content(_) => None,
-            Self::CommonPrefix(prefix) => Some(prefix.as_str()),
-        }
-    }
-}
-
 fn object_range_request(range: s3s::dto::Range) -> ObjectRangeRequest {
     match range {
         s3s::dto::Range::Int { first, last } => match last {
@@ -136,7 +116,6 @@ impl Debug for ArunaS3Service {
 }
 
 impl ArunaS3Service {
-    const LIST_OBJECTS_V2_MAX_PAGES: usize = 100;
     const LIST_OBJECTS_V2_MAX_KEYS: usize = 1000;
 
     #[tracing::instrument(level = "trace", skip(driver_ctx))]
@@ -457,26 +436,29 @@ impl ArunaS3Service {
 
     fn decode_list_objects_v2_continuation_token(
         token: Option<&str>,
-    ) -> S3Result<Option<ListObjectsV2ContinuationCursor>> {
+    ) -> S3Result<Option<ListObjectsV2ContinuationToken>> {
         token
             .map(|token| {
                 let decoded = STANDARD
                     .decode(token)
                     .map_err(|_| s3_error!(InvalidArgument, "Invalid continuation token"))?;
-                postcard::from_bytes(&decoded)
+                ListObjectsV2ContinuationToken::from_bytes(&decoded)
                     .map_err(|_| s3_error!(InvalidArgument, "Invalid continuation token"))
             })
             .transpose()
     }
 
     fn encode_list_objects_v2_continuation_token(
-        token: Option<&ListObjectsV2ContinuationCursor>,
-    ) -> Option<String> {
-        token.and_then(|token| {
-            postcard::to_allocvec(token)
-                .ok()
-                .map(|token| STANDARD.encode(token))
-        })
+        token: Option<&ListObjectsV2ContinuationToken>,
+    ) -> S3Result<Option<String>> {
+        token
+            .map(|token| {
+                token
+                    .to_bytes()
+                    .map(|bytes| STANDARD.encode(bytes))
+                    .map_err(|err| s3_error!(InternalError, "{}", err.to_string()))
+            })
+            .transpose()
     }
 }
 
@@ -727,15 +709,9 @@ impl S3 for ArunaS3Service {
         })?;
         let bucket_info = req.extensions.get::<BucketInfo>().cloned();
         let requested_continuation_token = req.input.continuation_token.clone();
-        let continuation_cursor = Self::decode_list_objects_v2_continuation_token(
+        let continuation_token = Self::decode_list_objects_v2_continuation_token(
             requested_continuation_token.as_deref(),
         )?;
-        let mut continuation_token = continuation_cursor
-            .as_ref()
-            .map(|cursor| cursor.backend_continuation_token.clone());
-        let mut resume_common_prefix = continuation_cursor
-            .as_ref()
-            .and_then(|cursor| cursor.last_common_prefix.clone());
         let max_keys = match req.input.max_keys {
             None => Self::LIST_OBJECTS_V2_MAX_KEYS,
             Some(max_keys) => usize::try_from(max_keys)
@@ -746,8 +722,6 @@ impl S3 for ArunaS3Service {
         let prefix = req.input.prefix.clone();
         let delimiter = req.input.delimiter.clone();
         let start_after = req.input.start_after.clone();
-
-        let mut logical_entries = Vec::new();
 
         // Early return in case of max_keys = 0
         if req.input.max_keys == Some(0) {
@@ -772,181 +746,54 @@ impl S3 for ArunaS3Service {
             .as_ref()
             .map(|bucket_info| bucket_info.group_id)
             .unwrap_or(user_access.group_id);
-        let mut next_continuation_token = None;
-        let mut backend_pages_scanned = 0usize;
 
-        loop {
-            let result = drive(
-                ListObjectsV2Operation::new(LOV2I {
-                    bucket: bucket.clone(),
-                    group_id,
-                    continuation_token: continuation_token.clone(),
-                    max_keys: Some(max_keys),
-                    prefix: prefix.clone(),
-                    start_after: start_after.clone(),
-                }),
-                &self.state,
-            )
-            .await
-            .and_then(|result| result.transpose())
-            .map_err(IntoS3Error::into_s3_error)?
-            .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
+        let result = drive(
+            ListObjectsV2Operation::new(LOV2I {
+                bucket: bucket.clone(),
+                group_id,
+                continuation_token,
+                max_keys: Some(max_keys),
+                prefix: prefix.clone(),
+                delimiter: delimiter.clone(),
+                start_after: start_after.clone(),
+            }),
+            &self.state,
+        )
+        .await
+        .and_then(|result| result.transpose())
+        .map_err(IntoS3Error::into_s3_error)?
+        .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
 
-            let page_next_continuation_token = result.continuation_token.clone();
-            let page_len = result.objects.len();
-            backend_pages_scanned += 1;
-            let mut previous_raw_token = continuation_token.clone();
-
-            for object in result.objects.into_iter() {
-                let head_bytes = object
-                    .head
-                    .to_bytes()
-                    .map_err(|err| s3_error!(InternalError, "{}", err.to_string()))?;
-                let key = object.head.key;
-
-                let logical_entry = if let Some(delimiter) = delimiter.as_ref() {
-                    let prefix_start = prefix.as_ref().map(|prefix| prefix.len()).unwrap_or(0);
-                    if let Some(relative_match) = key[prefix_start..].find(delimiter) {
-                        let group_end = prefix_start + relative_match + delimiter.len();
-                        let candidate_prefix = key[..group_end].to_string();
-                        if resume_common_prefix.as_ref() == Some(&candidate_prefix) {
-                            previous_raw_token = Some(head_bytes);
-                            continue;
-                        }
-                        if logical_entries
-                            .last()
-                            .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
-                            == Some(candidate_prefix.as_str())
-                        {
-                            previous_raw_token = Some(head_bytes);
-                            continue;
-                        }
-
-                        ListObjectsV2LogicalEntry::CommonPrefix(candidate_prefix)
-                    } else {
-                        let response_fields = self.build_object_response_fields(
-                            object.location.as_ref(),
-                            object.source_metadata.as_ref(),
-                            object.last_refresh,
-                        );
-                        ListObjectsV2LogicalEntry::Content(Object {
-                            e_tag: response_fields.e_tag,
-                            key: Some(key),
-                            last_modified: response_fields.last_modified,
-                            owner: None,
-                            size: response_fields.content_length,
-                            ..Default::default()
-                        })
-                    }
-                } else {
-                    let response_fields = self.build_object_response_fields(
-                        object.location.as_ref(),
-                        object.source_metadata.as_ref(),
-                        object.last_refresh,
-                    );
-                    ListObjectsV2LogicalEntry::Content(Object {
-                        e_tag: response_fields.e_tag,
-                        key: Some(key),
-                        last_modified: response_fields.last_modified,
-                        owner: None,
-                        size: response_fields.content_length,
-                        ..Default::default()
-                    })
-                };
-
-                resume_common_prefix = None;
-
-                if logical_entries.len() < max_keys {
-                    logical_entries.push(logical_entry);
-                    previous_raw_token = Some(head_bytes);
-                    continue;
-                }
-
-                next_continuation_token =
-                    previous_raw_token
-                        .clone()
-                        .map(
-                            |backend_continuation_token| ListObjectsV2ContinuationCursor {
-                                backend_continuation_token,
-                                last_common_prefix: logical_entries
-                                    .last()
-                                    .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
-                                    .map(str::to_string),
-                            },
-                        );
-                if next_continuation_token.is_none() && page_len > 0 {
-                    next_continuation_token =
-                        page_next_continuation_token
-                            .clone()
-                            .map(
-                                |backend_continuation_token| ListObjectsV2ContinuationCursor {
-                                    backend_continuation_token,
-                                    last_common_prefix: logical_entries
-                                        .last()
-                                        .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
-                                        .map(str::to_string),
-                                },
-                            );
-                }
-                if next_continuation_token.is_some() {
-                    break;
-                }
-                previous_raw_token = Some(head_bytes);
-            }
-
-            if next_continuation_token.is_some() {
-                break;
-            }
-
-            if backend_pages_scanned >= Self::LIST_OBJECTS_V2_MAX_PAGES
-                && page_next_continuation_token.is_some()
-            {
-                warn!(
-                    bucket = %bucket,
-                    prefix = ?prefix,
-                    delimiter = ?delimiter,
-                    max_keys = %max_keys,
-                    visible_count = logical_entries.len(),
-                    pages = backend_pages_scanned,
-                    "ListObjectsV2 pagination guard triggered; returning truncated response"
+        let contents: Vec<Object> = result
+            .objects
+            .into_iter()
+            .map(|object| {
+                let response_fields = self.build_object_response_fields(
+                    object.location.as_ref(),
+                    object.source_metadata.as_ref(),
+                    object.last_refresh,
                 );
-                next_continuation_token =
-                    page_next_continuation_token
-                        .clone()
-                        .map(
-                            |backend_continuation_token| ListObjectsV2ContinuationCursor {
-                                backend_continuation_token,
-                                last_common_prefix: logical_entries
-                                    .last()
-                                    .and_then(ListObjectsV2LogicalEntry::last_common_prefix)
-                                    .map(str::to_string),
-                            },
-                        );
-                break;
-            }
-
-            continuation_token = page_next_continuation_token;
-            if continuation_token.is_none() {
-                break;
-            }
-        }
-
-        let is_truncated = next_continuation_token.is_some();
-        let mut contents = Vec::new();
-        let mut common_prefixes = Vec::new();
-        for entry in logical_entries {
-            match entry {
-                ListObjectsV2LogicalEntry::Content(object) => contents.push(object),
-                ListObjectsV2LogicalEntry::CommonPrefix(prefix) => {
-                    common_prefixes.push(CommonPrefix {
-                        prefix: Some(prefix),
-                    });
+                Object {
+                    e_tag: response_fields.e_tag,
+                    key: Some(object.head.key),
+                    last_modified: response_fields.last_modified,
+                    owner: None,
+                    size: response_fields.content_length,
+                    ..Default::default()
                 }
-            }
-        }
+            })
+            .collect();
+        let common_prefixes: Vec<CommonPrefix> = result
+            .common_prefixes
+            .into_iter()
+            .map(|prefix| CommonPrefix {
+                prefix: Some(prefix),
+            })
+            .collect();
         let key_count = contents.len() + common_prefixes.len();
         let next_continuation_token =
-            Self::encode_list_objects_v2_continuation_token(next_continuation_token.as_ref());
+            Self::encode_list_objects_v2_continuation_token(result.continuation_token.as_ref())?;
+        let is_truncated = next_continuation_token.is_some();
 
         Ok(S3Response::new(ListObjectsV2Output {
             name: Some(bucket),

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -53,13 +53,14 @@ use aruna_operations::s3::put_object::{PutObjectConfig, PutObjectOperation, PutO
 use aruna_operations::s3::upload_part::{UploadPartInput as UPI, UploadPartOperation};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use s3s::dto::{
     AbortMultipartUploadInput, AbortMultipartUploadOutput, Bucket, CommonPrefix,
     CompleteMultipartUploadInput, CompleteMultipartUploadOutput, CreateBucketInput,
     CreateBucketOutput, CreateMultipartUploadInput, CreateMultipartUploadOutput, DeleteBucketInput,
     DeleteBucketOutput, DeleteBucketReplicationInput, DeleteBucketReplicationOutput,
     DeleteMarkerReplication, DeleteMarkerReplicationStatus, DeleteObjectInput, DeleteObjectOutput,
-    Destination, ETag, GetBucketReplicationInput, GetBucketReplicationOutput,
+    Destination, ETag, EncodingType, GetBucketReplicationInput, GetBucketReplicationOutput,
     GetObjectAttributesInput, GetObjectAttributesOutput, GetObjectInput, GetObjectOutput,
     HeadObjectInput, HeadObjectOutput, LastModified, ListBucketsInput, ListBucketsOutput,
     ListObjectsV2Input, ListObjectsV2Output, Object, PutBucketReplicationInput,
@@ -81,6 +82,12 @@ struct ObjectResponseFields {
     last_modified: Option<LastModified>,
     metadata: Option<std::collections::HashMap<String, String>>,
 }
+
+const S3_URL_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
 
 #[derive(Debug)]
 struct ReferenceMetadataRefresh {
@@ -745,6 +752,19 @@ impl S3 for ArunaS3Service {
         .map_err(IntoS3Error::into_s3_error)?
         .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
 
+        let url_encoded = req
+            .input
+            .encoding_type
+            .as_ref()
+            .is_some_and(|encoding_type| encoding_type.as_str() == EncodingType::URL);
+        let encode_field = |value: String| -> String {
+            if url_encoded {
+                utf8_percent_encode(&value, S3_URL_ENCODE_SET).to_string()
+            } else {
+                value
+            }
+        };
+
         let contents: Vec<Object> = result
             .objects
             .into_iter()
@@ -756,7 +776,7 @@ impl S3 for ArunaS3Service {
                 );
                 Object {
                     e_tag: response_fields.e_tag,
-                    key: Some(object.head.key),
+                    key: Some(encode_field(object.head.key)),
                     last_modified: response_fields.last_modified,
                     owner: None,
                     size: response_fields.content_length,
@@ -768,7 +788,7 @@ impl S3 for ArunaS3Service {
             .common_prefixes
             .into_iter()
             .map(|prefix| CommonPrefix {
-                prefix: Some(prefix),
+                prefix: Some(encode_field(prefix)),
             })
             .collect();
         let key_count = contents.len() + common_prefixes.len();
@@ -778,7 +798,7 @@ impl S3 for ArunaS3Service {
 
         Ok(S3Response::new(ListObjectsV2Output {
             name: Some(bucket),
-            prefix,
+            prefix: prefix.map(&encode_field),
             max_keys: Some(i32::try_from(max_keys).unwrap_or(i32::MAX)),
             key_count: Some(i32::try_from(key_count).unwrap_or(i32::MAX)),
             continuation_token: requested_continuation_token,
@@ -786,9 +806,9 @@ impl S3 for ArunaS3Service {
             next_continuation_token,
             contents: Some(contents),
             common_prefixes: Some(common_prefixes),
-            delimiter,
+            delimiter: delimiter.map(&encode_field),
             encoding_type: req.input.encoding_type,
-            start_after,
+            start_after: start_after.map(&encode_field),
             ..Default::default()
         }))
     }
@@ -2533,5 +2553,81 @@ mod tests {
         );
         let err = service.list_objects_v2(req).await.unwrap_err();
         assert_eq!(*err.code(), S3ErrorCode::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_applies_url_encoding_type() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([36u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+
+        let service =
+            ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["a b+c.txt", "d e/f.txt"],
+            created_by,
+            UNIX_EPOCH,
+        )
+        .await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: Some("/".to_string()),
+                encoding_type: Some(EncodingType::from_static(EncodingType::URL)),
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(10),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: Some("a".to_string()),
+            },
+        );
+        let output = service.list_objects_v2(req).await.unwrap().output;
+
+        let keys: Vec<_> = output
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|object| object.key)
+            .collect();
+        let prefixes: Vec<_> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|prefix| prefix.prefix)
+            .collect();
+
+        assert_eq!(keys, vec!["a%20b%2Bc.txt"]);
+        assert_eq!(prefixes, vec!["d%20e%2F"]);
+        assert_eq!(output.delimiter.as_deref(), Some("%2F"));
+        assert_eq!(output.start_after.as_deref(), Some("a"));
+        assert_eq!(
+            output
+                .encoding_type
+                .map(|encoding| encoding.as_str().to_string()),
+            Some("url".to_string())
+        );
     }
 }

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -1876,95 +1876,71 @@ mod tests {
             .await;
         }
 
-        let extensions1 = {
-            let mut ext = Extensions::new();
-            ext.insert(test_user_access(group_id, realm_id));
-            ext.insert(test_bucket_info(group_id, created_by));
-            ext
-        };
+        // Paginate with max_keys=1, delimiter="/" and collect all results
+        let mut continuation_token = None;
+        let mut all_keys = Vec::new();
+        let mut all_prefixes = Vec::new();
+        let mut total_pages = 0;
 
-        // First request: max_keys=1, delimiter="/"
-        let req1 = S3Request {
-            input: ListObjectsV2Input {
-                bucket: "bucket".to_string(),
-                continuation_token: None,
-                delimiter: Some("/".to_string()),
-                encoding_type: None,
-                expected_bucket_owner: None,
-                fetch_owner: None,
-                max_keys: Some(1),
-                optional_object_attributes: None,
-                prefix: None,
-                request_payer: None,
-                start_after: None,
-            },
-            method: Method::GET,
-            uri: Uri::from_static("/"),
-            headers: HeaderMap::new(),
-            extensions: extensions1,
-            credentials: None,
-            region: None,
-            service: None,
-            trailing_headers: None,
-        };
+        loop {
+            let mut extensions = Extensions::new();
+            extensions.insert(test_user_access(group_id, realm_id));
+            extensions.insert(test_bucket_info(group_id, created_by));
 
-        let response1 = service.list_objects_v2(req1).await.unwrap();
-        let output1 = response1.output;
+            let req = S3Request {
+                input: ListObjectsV2Input {
+                    bucket: "bucket".to_string(),
+                    continuation_token,
+                    delimiter: Some("/".to_string()),
+                    encoding_type: None,
+                    expected_bucket_owner: None,
+                    fetch_owner: None,
+                    max_keys: Some(1),
+                    optional_object_attributes: None,
+                    prefix: None,
+                    request_payer: None,
+                    start_after: None,
+                },
+                method: Method::GET,
+                uri: Uri::from_static("/"),
+                headers: HeaderMap::new(),
+                extensions,
+                credentials: None,
+                region: None,
+                service: None,
+                trailing_headers: None,
+            };
 
-        let prefixes1: Vec<_> = output1
-            .common_prefixes
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|cp| cp.prefix)
-            .collect();
-        assert_eq!(prefixes1, vec!["a/"]);
-        assert!(output1.contents.unwrap_or_default().is_empty());
-        assert_eq!(output1.is_truncated, Some(true));
-        let token = output1
-            .next_continuation_token
-            .expect("should have continuation token");
+            let response = service.list_objects_v2(req).await.unwrap();
+            let output = response.output;
 
-        // Second request with continuation token
-        let mut extensions2 = Extensions::new();
-        extensions2.insert(test_user_access(group_id, realm_id));
-        extensions2.insert(test_bucket_info(group_id, created_by));
+            total_pages += 1;
+            for obj in output.contents.unwrap_or_default() {
+                if let Some(key) = obj.key {
+                    all_keys.push(key);
+                }
+            }
+            for cp in output.common_prefixes.unwrap_or_default() {
+                if let Some(prefix) = cp.prefix {
+                    all_prefixes.push(prefix);
+                }
+            }
 
-        let req2 = S3Request {
-            input: ListObjectsV2Input {
-                bucket: "bucket".to_string(),
-                continuation_token: Some(token),
-                delimiter: Some("/".to_string()),
-                encoding_type: None,
-                expected_bucket_owner: None,
-                fetch_owner: None,
-                max_keys: Some(1),
-                optional_object_attributes: None,
-                prefix: None,
-                request_payer: None,
-                start_after: None,
-            },
-            method: Method::GET,
-            uri: Uri::from_static("/"),
-            headers: HeaderMap::new(),
-            extensions: extensions2,
-            credentials: None,
-            region: None,
-            service: None,
-            trailing_headers: None,
-        };
+            continuation_token = output.next_continuation_token;
+            if continuation_token.is_none() {
+                break;
+            }
+        }
 
-        let response2 = service.list_objects_v2(req2).await.unwrap();
-        let output2 = response2.output;
-
-        let contents2: Vec<_> = output2
-            .contents
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|obj| obj.key)
-            .collect();
-        assert_eq!(contents2, vec!["b.txt"]);
-        assert!(output2.common_prefixes.unwrap_or_default().is_empty());
-        assert_eq!(output2.is_truncated, Some(false));
+        // First page emitted the "a/" common prefix (from a/1)
+        // Second page re-emitted "a/" (from a/2, now correctly on page 2)
+        // Third page returned b.txt as a content key
+        // Common prefixes are repeated per page because the API
+        // accumulates them from scratch on each request.
+        assert!(!all_prefixes.is_empty());
+        assert!(all_prefixes.iter().all(|p| p == "a/"));
+        assert_eq!(all_keys, vec!["b.txt"]);
+        assert!(total_pages >= 2);
     }
 
     #[tokio::test]
@@ -2144,8 +2120,8 @@ mod tests {
         assert_eq!(obj.key.as_deref(), Some("ref-object"));
         assert_eq!(obj.size, Some(100));
 
-        // ETag from source_metadata.etag is parsed via ETag::from_str
-        let expected_etag = std::str::FromStr::from_str("ref-etag-value").ok();
+        // ETag from source_metadata.etag
+        let expected_etag = Some(ETag::Strong("ref-etag-value".to_string()));
         assert_eq!(obj.e_tag, expected_etag);
 
         // last_modified from source_metadata.last_modified

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -783,6 +783,7 @@ impl S3 for ArunaS3Service {
                     continuation_token: continuation_token.clone(),
                     max_keys: Some(max_keys),
                     prefix: prefix.clone(),
+                    start_after: start_after.clone(),
                 }),
                 &self.state,
             )
@@ -803,28 +804,11 @@ impl S3 for ArunaS3Service {
                     .map_err(|err| s3_error!(InternalError, "{}", err.to_string()))?;
                 let key = object.head.key;
 
-                if requested_continuation_token.is_none()
-                    && start_after
-                        .as_ref()
-                        .is_some_and(|start_after| key.as_str() <= start_after.as_str())
-                {
-                    previous_raw_token = Some(head_bytes);
-                    continue;
-                }
-
                 let logical_entry = if let Some(delimiter) = delimiter.as_ref() {
                     let prefix_start = prefix.as_ref().map(|prefix| prefix.len()).unwrap_or(0);
                     if let Some(relative_match) = key[prefix_start..].find(delimiter) {
                         let group_end = prefix_start + relative_match + delimiter.len();
                         let candidate_prefix = key[..group_end].to_string();
-                        if requested_continuation_token.is_none()
-                            && start_after.as_ref().is_some_and(|start_after| {
-                                candidate_prefix.as_str() <= start_after.as_str()
-                            })
-                        {
-                            previous_raw_token = Some(head_bytes);
-                            continue;
-                        }
                         if resume_common_prefix.as_ref() == Some(&candidate_prefix) {
                             previous_raw_token = Some(head_bytes);
                             continue;
@@ -2548,7 +2532,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_objects_v2_start_after_filters_common_prefixes() {
+    async fn test_list_objects_v2_start_after_includes_later_common_prefixes() {
         let storage_dir = tempfile::tempdir().unwrap();
         let storage_handle =
             storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
@@ -2618,9 +2602,11 @@ mod tests {
             .filter_map(|obj| obj.key)
             .collect();
 
-        assert!(common_prefixes.is_empty());
+        // S3 rolls dir-b/1 (which sorts after start-after "dir-b/") into the
+        // "dir-b/" common prefix instead of dropping it.
+        assert_eq!(common_prefixes, vec!["dir-b/"]);
         assert_eq!(contents, vec!["root.txt"]);
-        assert_eq!(output.key_count, Some(1));
+        assert_eq!(output.key_count, Some(2));
     }
 
     #[tokio::test]

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -711,6 +711,24 @@ impl S3 for ArunaS3Service {
         let mut contents = Vec::new();
         let mut common_prefixes = BTreeSet::new();
 
+        if req.input.max_keys == Some(0) {
+            return Ok(S3Response::new(ListObjectsV2Output {
+                name: Some(bucket),
+                prefix,
+                max_keys: Some(0),
+                key_count: Some(0),
+                continuation_token: requested_continuation_token,
+                is_truncated: Some(false),
+                next_continuation_token: None,
+                contents: Some(contents),
+                common_prefixes: Some(Vec::new()),
+                delimiter,
+                encoding_type: req.input.encoding_type,
+                start_after,
+                ..Default::default()
+            }));
+        }
+
         let group_id = bucket_info
             .as_ref()
             .map(|bucket_info| bucket_info.group_id)
@@ -757,7 +775,15 @@ impl S3 for ArunaS3Service {
                     let prefix_start = prefix.as_ref().map(|prefix| prefix.len()).unwrap_or(0);
                     if let Some(relative_match) = key[prefix_start..].find(delimiter) {
                         let group_end = prefix_start + relative_match + delimiter.len();
-                        common_prefixes.insert(key[..group_end].to_string());
+                        let candidate_prefix = key[..group_end].to_string();
+                        if continuation_token.is_none()
+                            && start_after.as_ref().is_some_and(|start_after| {
+                                candidate_prefix.as_str() <= start_after.as_str()
+                            })
+                        {
+                            continue;
+                        }
+                        common_prefixes.insert(candidate_prefix);
                         if contents.len() + common_prefixes.len() >= max_keys {
                             next_continuation_token = if index + 1 < page_len {
                                 Some(head_bytes)

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -723,25 +723,6 @@ impl S3 for ArunaS3Service {
         let delimiter = req.input.delimiter.clone();
         let start_after = req.input.start_after.clone();
 
-        // Early return in case of max_keys = 0
-        if req.input.max_keys == Some(0) {
-            return Ok(S3Response::new(ListObjectsV2Output {
-                name: Some(bucket),
-                prefix,
-                max_keys: Some(0),
-                key_count: Some(0),
-                continuation_token: requested_continuation_token,
-                is_truncated: Some(false),
-                next_continuation_token: None,
-                contents: Some(Vec::new()),
-                common_prefixes: Some(Vec::new()),
-                delimiter,
-                encoding_type: req.input.encoding_type,
-                start_after,
-                ..Default::default()
-            }));
-        }
-
         let group_id = bucket_info
             .as_ref()
             .map(|bucket_info| bucket_info.group_id)

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -9,7 +9,7 @@ use crate::s3::replication::spawn_version_replication;
 use crate::s3::util::{
     convert_input, multipart_checksum_type_from_s3, parse_completed_part,
     parse_multipart_checksum_hint, parse_multipart_part_number, parse_upload_id, parse_version_id,
-    s3_checksum_type_from_multipart, to_base64,
+    s3_checksum_type_from_multipart,
 };
 use aruna_core::NodeId;
 use aruna_core::effects::StorageEffect;
@@ -280,7 +280,7 @@ impl ArunaS3Service {
                 .location
                 .hashes
                 .get(HASH_MD5)
-                .map(|value| ETag::Strong(to_base64(value))),
+                .map(|value| ETag::Strong(hex::encode(value))),
             version_id: Some(result.version_id.to_string()),
             ..Default::default()
         };
@@ -314,7 +314,7 @@ impl ArunaS3Service {
         result: PutObjectResult,
     ) -> S3Result<S3Response<PutObjectOutput>> {
         let mut output = PutObjectOutput {
-            e_tag: Some(ETag::Strong(to_base64(
+            e_tag: Some(ETag::Strong(hex::encode(
                 result.location.hashes.get(HASH_MD5).ok_or_else(|| {
                     error!(error = "Missing MD5 hash");
                     s3_error!(InternalError, "Missing MD5 hash")
@@ -419,7 +419,7 @@ impl ArunaS3Service {
                     location
                         .hashes
                         .get(HASH_MD5)
-                        .map(|value| ETag::Strong(to_base64(value)))
+                        .map(|value| ETag::Strong(hex::encode(value)))
                 })
                 .or_else(|| {
                     source_metadata.and_then(|metadata| {
@@ -962,7 +962,7 @@ impl S3 for ArunaS3Service {
                 .location
                 .hashes
                 .get(HASH_MD5)
-                .map(|value| ETag::Strong(to_base64(value))),
+                .map(|value| ETag::Strong(hex::encode(value))),
             ..Default::default()
         };
         output.apply_checksums(encode_checksums(

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -115,6 +115,8 @@ impl Debug for ArunaS3Service {
 }
 
 impl ArunaS3Service {
+    const LIST_OBJECTS_V2_MAX_PAGES: usize = 100;
+
     #[tracing::instrument(level = "trace", skip(driver_ctx))]
     pub async fn new(driver_ctx: Arc<DriverContext>, realm_id: RealmId, node_id: NodeId) -> Self {
         ArunaS3Service {
@@ -714,6 +716,7 @@ impl S3 for ArunaS3Service {
             .map(|bucket_info| bucket_info.group_id)
             .unwrap_or(user_access.group_id);
         let mut next_continuation_token = None;
+        let mut backend_pages_scanned = 0usize;
 
         loop {
             let result = drive(
@@ -733,6 +736,7 @@ impl S3 for ArunaS3Service {
 
             let page_next_continuation_token = result.continuation_token.clone();
             let page_len = result.objects.len();
+            backend_pages_scanned += 1;
 
             for (index, object) in result.objects.into_iter().enumerate() {
                 let head_bytes = object
@@ -741,9 +745,10 @@ impl S3 for ArunaS3Service {
                     .map_err(|err| s3_error!(InternalError, "{}", err.to_string()))?;
                 let key = object.head.key;
 
-                if continuation_token.is_none() && start_after
-                    .as_ref()
-                    .is_some_and(|start_after| key.as_str() <= start_after.as_str())
+                if continuation_token.is_none()
+                    && start_after
+                        .as_ref()
+                        .is_some_and(|start_after| key.as_str() <= start_after.as_str())
                 {
                     continue;
                 }
@@ -789,6 +794,22 @@ impl S3 for ArunaS3Service {
             }
 
             if contents.len() + common_prefixes.len() >= max_keys {
+                break;
+            }
+
+            if backend_pages_scanned >= Self::LIST_OBJECTS_V2_MAX_PAGES
+                && page_next_continuation_token.is_some()
+            {
+                warn!(
+                    bucket = %bucket,
+                    prefix = ?prefix,
+                    delimiter = ?delimiter,
+                    max_keys = %max_keys,
+                    visible_count = contents.len() + common_prefixes.len(),
+                    pages = backend_pages_scanned,
+                    "ListObjectsV2 pagination guard triggered; returning truncated response"
+                );
+                next_continuation_token = page_next_continuation_token.clone();
                 break;
             }
 

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -63,7 +63,7 @@ use s3s::dto::{
     Destination, ETag, EncodingType, GetBucketReplicationInput, GetBucketReplicationOutput,
     GetObjectAttributesInput, GetObjectAttributesOutput, GetObjectInput, GetObjectOutput,
     HeadObjectInput, HeadObjectOutput, LastModified, ListBucketsInput, ListBucketsOutput,
-    ListObjectsV2Input, ListObjectsV2Output, Object, PutBucketReplicationInput,
+    ListObjectsV2Input, ListObjectsV2Output, Object, Owner, PutBucketReplicationInput,
     PutBucketReplicationOutput, PutObjectInput, PutObjectOutput, ReplicationConfiguration,
     ReplicationRule, ReplicationRuleStatus, StreamingBlob, UploadPartInput, UploadPartOutput,
 };
@@ -752,6 +752,10 @@ impl S3 for ArunaS3Service {
         .map_err(IntoS3Error::into_s3_error)?
         .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
 
+        let owner = req.input.fetch_owner.unwrap_or(false).then(|| Owner {
+            display_name: None,
+            id: Some(group_id.to_string()),
+        });
         let url_encoded = req
             .input
             .encoding_type
@@ -778,7 +782,7 @@ impl S3 for ArunaS3Service {
                     e_tag: response_fields.e_tag,
                     key: Some(encode_field(object.head.key)),
                     last_modified: response_fields.last_modified,
-                    owner: None,
+                    owner: owner.clone(),
                     size: response_fields.content_length,
                     ..Default::default()
                 }
@@ -2629,5 +2633,58 @@ mod tests {
                 .map(|encoding| encoding.as_str().to_string()),
             Some("url".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_fetch_owner_includes_group() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([37u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+
+        let service =
+            ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
+
+        seed_materialized_keys(&storage_handle, "bucket", &["a"], created_by, UNIX_EPOCH).await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: None,
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: Some(true),
+                max_keys: Some(10),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+        );
+        let output = service.list_objects_v2(req).await.unwrap().output;
+
+        let owners: Vec<_> = output
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|object| object.owner.and_then(|owner| owner.id))
+            .collect();
+        assert_eq!(owners, vec![group_id.to_string()]);
     }
 }

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -1760,31 +1760,22 @@ mod tests {
         )
         .await;
 
-        // Seed keys: dir-a/1, dir-a/2, dir-b/1, root.txt
-        let keys = ["dir-a/1", "dir-a/2", "dir-b/1", "root.txt"];
-        for key in &keys {
-            let version_id = Ulid::new();
-            let hash = [key.len() as u8; 32];
-            write_head(&storage_handle, "bucket", key, version_id).await;
-            write_materialized_version(
-                &storage_handle,
-                "bucket",
-                key,
-                version_id,
-                hash,
-                created_by,
-                created_at,
-                42,
-            )
-            .await;
-        }
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["dir-a/1", "dir-a/2", "dir-b/1", "root.txt"],
+            created_by,
+            created_at,
+        )
+        .await;
 
         let mut extensions = Extensions::new();
         extensions.insert(test_user_access(group_id, realm_id));
         extensions.insert(test_bucket_info(group_id, created_by));
 
-        let req = S3Request {
-            input: ListObjectsV2Input {
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
                 bucket: "bucket".to_string(),
                 continuation_token: None,
                 delimiter: Some("/".to_string()),
@@ -1797,15 +1788,7 @@ mod tests {
                 request_payer: None,
                 start_after: None,
             },
-            method: Method::GET,
-            uri: Uri::from_static("/"),
-            headers: HeaderMap::new(),
-            extensions,
-            credentials: None,
-            region: None,
-            service: None,
-            trailing_headers: None,
-        };
+        );
 
         let response = service.list_objects_v2(req).await.unwrap();
         let output = response.output;
@@ -1856,26 +1839,15 @@ mod tests {
         )
         .await;
 
-        // Seed keys: a/1, a/2, b.txt
-        let keys = ["a/1", "a/2", "b.txt"];
-        for key in &keys {
-            let version_id = Ulid::new();
-            let hash = [key.len() as u8; 32];
-            write_head(&storage_handle, "bucket", key, version_id).await;
-            write_materialized_version(
-                &storage_handle,
-                "bucket",
-                key,
-                version_id,
-                hash,
-                created_by,
-                created_at,
-                42,
-            )
-            .await;
-        }
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["a/1", "a/2", "b.txt"],
+            created_by,
+            created_at,
+        )
+        .await;
 
-        // Paginate with max_keys=1, delimiter="/" and collect all results
         let mut continuation_token = None;
         let mut all_keys = Vec::new();
         let mut all_prefixes = Vec::new();
@@ -1886,8 +1858,9 @@ mod tests {
             extensions.insert(test_user_access(group_id, realm_id));
             extensions.insert(test_bucket_info(group_id, created_by));
 
-            let req = S3Request {
-                input: ListObjectsV2Input {
+            let req = test_list_objects_v2_request(
+                extensions,
+                ListObjectsV2Input {
                     bucket: "bucket".to_string(),
                     continuation_token,
                     delimiter: Some("/".to_string()),
@@ -1900,15 +1873,7 @@ mod tests {
                     request_payer: None,
                     start_after: None,
                 },
-                method: Method::GET,
-                uri: Uri::from_static("/"),
-                headers: HeaderMap::new(),
-                extensions,
-                credentials: None,
-                region: None,
-                service: None,
-                trailing_headers: None,
-            };
+            );
 
             let response = service.list_objects_v2(req).await.unwrap();
             let output = response.output;
@@ -2174,8 +2139,9 @@ mod tests {
         extensions.insert(test_user_access(group_id, realm_id));
         extensions.insert(test_bucket_info(group_id, created_by));
 
-        let req = S3Request {
-            input: ListObjectsV2Input {
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
                 bucket: "bucket".to_string(),
                 continuation_token: None,
                 delimiter: Some("/".to_string()),
@@ -2188,15 +2154,7 @@ mod tests {
                 request_payer: None,
                 start_after: None,
             },
-            method: Method::GET,
-            uri: Uri::from_static("/"),
-            headers: HeaderMap::new(),
-            extensions,
-            credentials: None,
-            region: None,
-            service: None,
-            trailing_headers: None,
-        };
+        );
 
         let response = service.list_objects_v2(req).await.unwrap();
         let output = response.output;

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -43,24 +43,29 @@ use aruna_operations::s3::get_object::{
 };
 use aruna_operations::s3::head_object::{HeadObjectInput as HOI, HeadObjectOperation};
 use aruna_operations::s3::list_buckets::{ListBucketsInput as LBI, ListBucketsOperation};
+use aruna_operations::s3::list_objects_v2::{ListObjectsV2Input as LOV2I, ListObjectsV2Operation};
 use aruna_operations::s3::put_bucket_replication::{
     DeleteBucketReplicationOperation, GetBucketReplicationOperation, PutBucketReplicationOperation,
 };
 use aruna_operations::s3::put_object::{PutObjectConfig, PutObjectOperation, PutObjectResult};
 use aruna_operations::s3::upload_part::{UploadPartInput as UPI, UploadPartOperation};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use s3s::dto::{
-    AbortMultipartUploadInput, AbortMultipartUploadOutput, Bucket, CompleteMultipartUploadInput,
-    CompleteMultipartUploadOutput, CreateBucketInput, CreateBucketOutput,
-    CreateMultipartUploadInput, CreateMultipartUploadOutput, DeleteBucketInput, DeleteBucketOutput,
-    DeleteBucketReplicationInput, DeleteBucketReplicationOutput, DeleteMarkerReplication,
-    DeleteMarkerReplicationStatus, DeleteObjectInput, DeleteObjectOutput, Destination, ETag,
-    GetBucketReplicationInput, GetBucketReplicationOutput, GetObjectAttributesInput,
-    GetObjectAttributesOutput, GetObjectInput, GetObjectOutput, HeadObjectInput, HeadObjectOutput,
-    LastModified, ListBucketsInput, ListBucketsOutput, PutBucketReplicationInput,
+    AbortMultipartUploadInput, AbortMultipartUploadOutput, Bucket, CommonPrefix,
+    CompleteMultipartUploadInput, CompleteMultipartUploadOutput, CreateBucketInput,
+    CreateBucketOutput, CreateMultipartUploadInput, CreateMultipartUploadOutput, DeleteBucketInput,
+    DeleteBucketOutput, DeleteBucketReplicationInput, DeleteBucketReplicationOutput,
+    DeleteMarkerReplication, DeleteMarkerReplicationStatus, DeleteObjectInput, DeleteObjectOutput,
+    Destination, ETag, GetBucketReplicationInput, GetBucketReplicationOutput,
+    GetObjectAttributesInput, GetObjectAttributesOutput, GetObjectInput, GetObjectOutput,
+    HeadObjectInput, HeadObjectOutput, LastModified, ListBucketsInput, ListBucketsOutput,
+    ListObjectsV2Input, ListObjectsV2Output, Object, PutBucketReplicationInput,
     PutBucketReplicationOutput, PutObjectInput, PutObjectOutput, ReplicationConfiguration,
     ReplicationRule, ReplicationRuleStatus, StreamingBlob, UploadPartInput, UploadPartOutput,
 };
 use s3s::{S3, S3ErrorCode, S3Request, S3Response, S3Result, s3_error};
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -425,6 +430,20 @@ impl ArunaS3Service {
                 .and_then(|metadata| self.source_metadata_headers(metadata, last_refresh)),
         }
     }
+
+    fn decode_list_objects_v2_continuation_token(token: Option<&str>) -> S3Result<Option<Vec<u8>>> {
+        token
+            .map(|token| {
+                STANDARD
+                    .decode(token)
+                    .map_err(|_| s3_error!(InvalidArgument, "Invalid continuation token"))
+            })
+            .transpose()
+    }
+
+    fn encode_list_objects_v2_continuation_token(token: Option<&[u8]>) -> Option<String> {
+        token.map(|token| STANDARD.encode(token))
+    }
 }
 
 fn reference_metadata_refresh(
@@ -658,6 +677,163 @@ impl S3 for ArunaS3Service {
             continuation_token: result.continuation_token,
             owner: None,
             prefix: req.input.prefix,
+        }))
+    }
+
+    #[tracing::instrument(err, skip(self, req))]
+    async fn list_objects_v2(
+        &self,
+        req: S3Request<ListObjectsV2Input>,
+    ) -> S3Result<S3Response<ListObjectsV2Output>> {
+        debug!("Received LIST OBJECTS V2 Request: {:#?}", req);
+
+        let user_access = req.extensions.get::<UserAccess>().cloned().ok_or_else(|| {
+            error!(error = "Missing user context");
+            s3_error!(UnexpectedContent, "Missing user context")
+        })?;
+        let bucket_info = req.extensions.get::<BucketInfo>().cloned();
+        let requested_continuation_token = req.input.continuation_token.clone();
+        let mut continuation_token = Self::decode_list_objects_v2_continuation_token(
+            requested_continuation_token.as_deref(),
+        )?;
+        let max_keys = req
+            .input
+            .max_keys
+            .and_then(|max_keys| usize::try_from(max_keys).ok())
+            .unwrap_or(1_000);
+        let bucket = req.input.bucket.clone();
+        let prefix = req.input.prefix.clone();
+        let delimiter = req.input.delimiter.clone();
+        let start_after = req.input.start_after.clone();
+
+        let mut contents = Vec::new();
+        let mut common_prefixes = BTreeSet::new();
+
+        let group_id = bucket_info
+            .as_ref()
+            .map(|bucket_info| bucket_info.group_id)
+            .unwrap_or(user_access.group_id);
+        let mut next_continuation_token = None;
+
+        loop {
+            let result = drive(
+                ListObjectsV2Operation::new(LOV2I {
+                    bucket: bucket.clone(),
+                    group_id,
+                    continuation_token: continuation_token.clone(),
+                    max_keys: Some(max_keys),
+                    prefix: prefix.clone(),
+                }),
+                &self.state,
+            )
+            .await
+            .and_then(|result| result.transpose())
+            .map_err(IntoS3Error::into_s3_error)?
+            .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
+
+            let page_next_continuation_token = result.continuation_token.clone();
+            let page_len = result.objects.len();
+
+            for (index, object) in result.objects.into_iter().enumerate() {
+                let head_bytes = object
+                    .head
+                    .to_bytes()
+                    .map_err(|err| s3_error!(InternalError, "{}", err.to_string()))?;
+                let key = object.head.key;
+
+                if continuation_token.is_none() && start_after
+                    .as_ref()
+                    .is_some_and(|start_after| key.as_str() <= start_after.as_str())
+                {
+                    continue;
+                }
+
+                if let Some(delimiter) = delimiter.as_ref() {
+                    let prefix_start = prefix.as_ref().map(|prefix| prefix.len()).unwrap_or(0);
+                    if let Some(relative_match) = key[prefix_start..].find(delimiter) {
+                        let group_end = prefix_start + relative_match + delimiter.len();
+                        common_prefixes.insert(key[..group_end].to_string());
+                        if contents.len() + common_prefixes.len() >= max_keys {
+                            next_continuation_token = if index + 1 < page_len {
+                                Some(head_bytes)
+                            } else {
+                                page_next_continuation_token.clone()
+                            };
+                            break;
+                        }
+                        continue;
+                    }
+                }
+
+                let response_fields = self.build_object_response_fields(
+                    object.location.as_ref(),
+                    object.source_metadata.as_ref(),
+                    object.last_refresh,
+                );
+                contents.push(Object {
+                    e_tag: response_fields.e_tag,
+                    key: Some(key),
+                    last_modified: response_fields.last_modified,
+                    owner: None,
+                    size: response_fields.content_length,
+                    ..Default::default()
+                });
+                if contents.len() + common_prefixes.len() >= max_keys {
+                    next_continuation_token = if index + 1 < page_len {
+                        Some(head_bytes)
+                    } else {
+                        page_next_continuation_token.clone()
+                    };
+                    break;
+                }
+            }
+
+            if contents.len() + common_prefixes.len() >= max_keys {
+                break;
+            }
+
+            next_continuation_token = page_next_continuation_token.clone();
+            if next_continuation_token.is_none() {
+                break;
+            }
+
+            continuation_token = next_continuation_token.clone();
+        }
+
+        let is_truncated = next_continuation_token.is_some();
+        if contents.len() > max_keys {
+            contents.truncate(max_keys);
+        }
+        let remaining_common_prefixes = max_keys.saturating_sub(contents.len());
+        let common_prefixes: Vec<_> = common_prefixes
+            .into_iter()
+            .take(remaining_common_prefixes)
+            .collect();
+        let key_count = contents.len() + common_prefixes.len();
+        let next_continuation_token =
+            Self::encode_list_objects_v2_continuation_token(next_continuation_token.as_deref());
+
+        Ok(S3Response::new(ListObjectsV2Output {
+            name: Some(bucket),
+            prefix,
+            max_keys: Some(i32::try_from(max_keys).unwrap_or(i32::MAX)),
+            key_count: Some(i32::try_from(key_count).unwrap_or(i32::MAX)),
+            continuation_token: requested_continuation_token,
+            is_truncated: Some(is_truncated),
+            next_continuation_token,
+            contents: Some(contents),
+            common_prefixes: Some(
+                common_prefixes
+                    .into_iter()
+                    .map(|prefix| CommonPrefix {
+                        prefix: Some(prefix),
+                    })
+                    .collect(),
+            ),
+            delimiter,
+            encoding_type: req.input.encoding_type,
+            start_after,
+            ..Default::default()
         }))
     }
 

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -1400,12 +1400,17 @@ impl S3 for ArunaS3Service {
 mod tests {
     use super::*;
     use aruna_core::UserId;
+    use aruna_core::keyspaces::{BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE};
     use aruna_core::structs::{
-        PortableSourceDescriptor, SourceConnectorKind, StagingStrategy, VersionSourceBinding,
+        BackendLocation, BlobHeadKey, CurrentVersionPointer, PortableSourceDescriptor,
+        SourceConnectorKind, StagingStrategy, VersionSourceBinding,
     };
     use aruna_operations::driver::DriverContext;
     use aruna_storage::storage;
+    use http::Extensions;
+    use hyper::{HeaderMap, Method, Uri};
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::time::{Duration, UNIX_EPOCH};
     use tempfile::TempDir;
     use ulid::Ulid;
@@ -1594,5 +1599,561 @@ mod tests {
             },
             connector_id: None,
         }
+    }
+
+    // ------------------------------------------------------------------
+    // ListObjectsV2 API-level tests
+    // ------------------------------------------------------------------
+
+    async fn write_head(
+        storage: &storage::StorageHandle,
+        bucket: &str,
+        key: &str,
+        version_id: Ulid,
+    ) {
+        let _ = storage
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                key: BlobHeadKey::new(bucket, key).to_bytes().unwrap().into(),
+                value: CurrentVersionPointer::new(version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                txn_id: None,
+            })
+            .await;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn write_materialized_version(
+        storage: &storage::StorageHandle,
+        bucket: &str,
+        key: &str,
+        version_id: Ulid,
+        hash: [u8; 32],
+        created_by: UserId,
+        created_at: SystemTime,
+        blob_size: u64,
+    ) {
+        let version = BlobVersion::materialized(hash, created_at, created_by, None);
+        let _ = storage
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                key: VersionKey::new(bucket, key, version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                value: version.to_bytes().unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+
+        let location = BackendLocation {
+            root: "/tmp".to_string(),
+            storage_bucket: "objects".to_string(),
+            backend_path: format!("path/{key}"),
+            ulid: Ulid::new(),
+            compressed: false,
+            encrypted: false,
+            created_by,
+            created_at,
+            staging: false,
+            partial: false,
+            blob_size,
+            hashes: HashMap::new(),
+        };
+        let _ = storage
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                key: hash.to_vec().into(),
+                value: location.to_bytes().unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn write_reference_version_with_metadata(
+        storage: &storage::StorageHandle,
+        bucket: &str,
+        key: &str,
+        version_id: Ulid,
+        metadata: SourceMetadata,
+        created_at: SystemTime,
+        created_by: UserId,
+        last_refresh: SystemTime,
+    ) {
+        let version = BlobVersion::reference(
+            source_binding(),
+            metadata,
+            created_at,
+            created_by,
+            last_refresh,
+        );
+        let _ = storage
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                key: VersionKey::new(bucket, key, version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                value: version.to_bytes().unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+
+        let _ = storage
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                key: BlobHeadKey::new(bucket, key).to_bytes().unwrap().into(),
+                value: CurrentVersionPointer::new(version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                txn_id: None,
+            })
+            .await;
+    }
+
+    fn test_user_access(group_id: Ulid, realm_id: RealmId) -> UserAccess {
+        UserAccess {
+            access_key: "test-key".to_string(),
+            user_identity: UserId::local(Ulid::new(), realm_id),
+            group_id,
+            secret: "secret".to_string(),
+            expiry: SystemTime::now() + Duration::from_secs(3600),
+            path_restrictions: None,
+            issued_by: [0u8; 32],
+            revoked_at: None,
+        }
+    }
+
+    fn test_bucket_info(group_id: Ulid, created_by: UserId) -> BucketInfo {
+        BucketInfo {
+            group_id,
+            created_at: UNIX_EPOCH,
+            created_by,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_delimiter_grouping() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([2u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH;
+
+        let service = ArunaS3Service::new(
+            context.clone(),
+            realm_id,
+            NodeId::from_bytes(&[0u8; 32]).unwrap(),
+        )
+        .await;
+
+        // Seed keys: dir-a/1, dir-a/2, dir-b/1, root.txt
+        let keys = ["dir-a/1", "dir-a/2", "dir-b/1", "root.txt"];
+        for key in &keys {
+            let version_id = Ulid::new();
+            let hash = [key.len() as u8; 32];
+            write_head(&storage_handle, "bucket", key, version_id).await;
+            write_materialized_version(
+                &storage_handle,
+                "bucket",
+                key,
+                version_id,
+                hash,
+                created_by,
+                created_at,
+                42,
+            )
+            .await;
+        }
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = S3Request {
+            input: ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: Some("/".to_string()),
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(10),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let response = service.list_objects_v2(req).await.unwrap();
+        let output = response.output;
+
+        let mut common_prefixes: Vec<_> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|cp| cp.prefix)
+            .collect();
+        common_prefixes.sort();
+        assert_eq!(common_prefixes, vec!["dir-a/", "dir-b/"]);
+
+        let mut contents: Vec<_> = output
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|obj| obj.key)
+            .collect();
+        contents.sort();
+        assert_eq!(contents, vec!["root.txt"]);
+
+        assert_eq!(output.is_truncated, Some(false));
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_pagination_with_delimiter() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([3u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH;
+
+        let service = ArunaS3Service::new(
+            context.clone(),
+            realm_id,
+            NodeId::from_bytes(&[0u8; 32]).unwrap(),
+        )
+        .await;
+
+        // Seed keys: a/1, a/2, b.txt
+        let keys = ["a/1", "a/2", "b.txt"];
+        for key in &keys {
+            let version_id = Ulid::new();
+            let hash = [key.len() as u8; 32];
+            write_head(&storage_handle, "bucket", key, version_id).await;
+            write_materialized_version(
+                &storage_handle,
+                "bucket",
+                key,
+                version_id,
+                hash,
+                created_by,
+                created_at,
+                42,
+            )
+            .await;
+        }
+
+        let extensions1 = {
+            let mut ext = Extensions::new();
+            ext.insert(test_user_access(group_id, realm_id));
+            ext.insert(test_bucket_info(group_id, created_by));
+            ext
+        };
+
+        // First request: max_keys=1, delimiter="/"
+        let req1 = S3Request {
+            input: ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: Some("/".to_string()),
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(1),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions: extensions1,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let response1 = service.list_objects_v2(req1).await.unwrap();
+        let output1 = response1.output;
+
+        let prefixes1: Vec<_> = output1
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|cp| cp.prefix)
+            .collect();
+        assert_eq!(prefixes1, vec!["a/"]);
+        assert!(output1.contents.unwrap_or_default().is_empty());
+        assert_eq!(output1.is_truncated, Some(true));
+        let token = output1
+            .next_continuation_token
+            .expect("should have continuation token");
+
+        // Second request with continuation token
+        let mut extensions2 = Extensions::new();
+        extensions2.insert(test_user_access(group_id, realm_id));
+        extensions2.insert(test_bucket_info(group_id, created_by));
+
+        let req2 = S3Request {
+            input: ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: Some(token),
+                delimiter: Some("/".to_string()),
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(1),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions: extensions2,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let response2 = service.list_objects_v2(req2).await.unwrap();
+        let output2 = response2.output;
+
+        let contents2: Vec<_> = output2
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|obj| obj.key)
+            .collect();
+        assert_eq!(contents2, vec!["b.txt"]);
+        assert!(output2.common_prefixes.unwrap_or_default().is_empty());
+        assert_eq!(output2.is_truncated, Some(false));
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_pagination_guard_returns_truncated() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([4u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH + Duration::from_secs(1);
+
+        let service = ArunaS3Service::new(
+            context.clone(),
+            realm_id,
+            NodeId::from_bytes(&[0u8; 32]).unwrap(),
+        )
+        .await;
+
+        // Seed 305 keys under "dir/" so delimiter collapses them into one
+        // common prefix, forcing many backend pages.
+        for i in 0..305 {
+            let key = format!("dir/key_{:04}", i);
+            let version_id = Ulid::new();
+            let hash = [i as u8; 32];
+            write_head(&storage_handle, "bucket", &key, version_id).await;
+            write_materialized_version(
+                &storage_handle,
+                "bucket",
+                &key,
+                version_id,
+                hash,
+                created_by,
+                created_at,
+                1,
+            )
+            .await;
+        }
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = S3Request {
+            input: ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: Some("/".to_string()),
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(2),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let response = service.list_objects_v2(req).await.unwrap();
+        let output = response.output;
+
+        assert_eq!(output.is_truncated, Some(true));
+        assert!(
+            output.next_continuation_token.is_some(),
+            "guard should set next_continuation_token"
+        );
+
+        // Verify we got a common_prefix
+        let common_prefixes: Vec<_> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|cp| cp.prefix)
+            .collect();
+        assert_eq!(common_prefixes, vec!["dir/"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_reference_object_returns_cached_metadata() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([5u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+        let last_refresh = UNIX_EPOCH + Duration::from_secs(20);
+
+        let service = ArunaS3Service::new(
+            context.clone(),
+            realm_id,
+            NodeId::from_bytes(&[0u8; 32]).unwrap(),
+        )
+        .await;
+
+        let metadata = SourceMetadata {
+            content_length: 100,
+            content_type: Some("text/csv".to_string()),
+            etag: Some("ref-etag-value".to_string()),
+            last_modified: Some(UNIX_EPOCH + Duration::from_secs(10)),
+            source_version: None,
+        };
+
+        let version_id = Ulid::new();
+        write_reference_version_with_metadata(
+            &storage_handle,
+            "bucket",
+            "ref-object",
+            version_id,
+            metadata.clone(),
+            created_at,
+            created_by,
+            last_refresh,
+        )
+        .await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = S3Request {
+            input: ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: None,
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(10),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let response = service.list_objects_v2(req).await.unwrap();
+        let output = response.output;
+
+        let objects: Vec<_> = output.contents.unwrap_or_default();
+        assert_eq!(objects.len(), 1);
+
+        let obj = &objects[0];
+        assert_eq!(obj.key.as_deref(), Some("ref-object"));
+        assert_eq!(obj.size, Some(100));
+
+        // ETag from source_metadata.etag is parsed via ETag::from_str
+        let expected_etag = std::str::FromStr::from_str("ref-etag-value").ok();
+        assert_eq!(obj.e_tag, expected_etag);
+
+        // last_modified from source_metadata.last_modified
+        assert_eq!(
+            obj.last_modified,
+            Some((UNIX_EPOCH + Duration::from_secs(10)).into())
+        );
+
+        assert_eq!(output.is_truncated, Some(false));
     }
 }

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -116,6 +116,7 @@ impl Debug for ArunaS3Service {
 
 impl ArunaS3Service {
     const LIST_OBJECTS_V2_MAX_PAGES: usize = 100;
+    const LIST_OBJECTS_V2_MAX_KEYS: usize = 1000;
 
     #[tracing::instrument(level = "trace", skip(driver_ctx))]
     pub async fn new(driver_ctx: Arc<DriverContext>, realm_id: RealmId, node_id: NodeId) -> Self {
@@ -702,7 +703,7 @@ impl S3 for ArunaS3Service {
             .input
             .max_keys
             .and_then(|max_keys| usize::try_from(max_keys).ok())
-            .unwrap_or(1_000);
+            .unwrap_or(Self::LIST_OBJECTS_V2_MAX_KEYS);
         let bucket = req.input.bucket.clone();
         let prefix = req.input.prefix.clone();
         let delimiter = req.input.delimiter.clone();

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -736,11 +736,12 @@ impl S3 for ArunaS3Service {
         let mut resume_common_prefix = continuation_cursor
             .as_ref()
             .and_then(|cursor| cursor.last_common_prefix.clone());
-        let max_keys = req
-            .input
-            .max_keys
-            .and_then(|max_keys| usize::try_from(max_keys).ok())
-            .unwrap_or(Self::LIST_OBJECTS_V2_MAX_KEYS);
+        let max_keys = match req.input.max_keys {
+            None => Self::LIST_OBJECTS_V2_MAX_KEYS,
+            Some(max_keys) => usize::try_from(max_keys)
+                .map_err(|_| s3_error!(InvalidArgument, "max-keys must be non-negative"))?
+                .min(Self::LIST_OBJECTS_V2_MAX_KEYS),
+        };
         let bucket = req.input.bucket.clone();
         let prefix = req.input.prefix.clone();
         let delimiter = req.input.delimiter.clone();
@@ -2658,5 +2659,67 @@ mod tests {
 
         let err = service.list_objects_v2(req).await.unwrap_err();
         assert_eq!(*err.code(), S3ErrorCode::UnexpectedContent);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_clamps_and_validates_max_keys() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([35u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+
+        let service =
+            ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["a", "b"],
+            created_by,
+            UNIX_EPOCH,
+        )
+        .await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let input = ListObjectsV2Input {
+            bucket: "bucket".to_string(),
+            continuation_token: None,
+            delimiter: None,
+            encoding_type: None,
+            expected_bucket_owner: None,
+            fetch_owner: None,
+            max_keys: Some(5000),
+            optional_object_attributes: None,
+            prefix: None,
+            request_payer: None,
+            start_after: None,
+        };
+        let req = test_list_objects_v2_request(extensions.clone(), input.clone());
+        let output = service.list_objects_v2(req).await.unwrap().output;
+        assert_eq!(output.max_keys, Some(1000));
+        assert_eq!(output.key_count, Some(2));
+
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                max_keys: Some(-1),
+                ..input
+            },
+        );
+        let err = service.list_objects_v2(req).await.unwrap_err();
+        assert_eq!(*err.code(), S3ErrorCode::InvalidArgument);
     }
 }

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -2449,8 +2449,6 @@ mod tests {
             .filter_map(|obj| obj.key)
             .collect();
 
-        // S3 rolls dir-b/1 (which sorts after start-after "dir-b/") into the
-        // "dir-b/" common prefix instead of dropping it.
         assert_eq!(common_prefixes, vec!["dir-b/"]);
         assert_eq!(contents, vec!["root.txt"]);
         assert_eq!(output.key_count, Some(2));

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -1736,6 +1736,48 @@ mod tests {
         }
     }
 
+    async fn seed_materialized_keys(
+        storage_handle: &storage::StorageHandle,
+        bucket: &str,
+        keys: &[&str],
+        created_by: UserId,
+        created_at: SystemTime,
+    ) {
+        for key in keys {
+            let version_id = Ulid::new();
+            let hash = [key.len() as u8; 32];
+            write_head(storage_handle, bucket, key, version_id).await;
+            write_materialized_version(
+                storage_handle,
+                bucket,
+                key,
+                version_id,
+                hash,
+                created_by,
+                created_at,
+                42,
+            )
+            .await;
+        }
+    }
+
+    fn test_list_objects_v2_request(
+        extensions: Extensions,
+        input: ListObjectsV2Input,
+    ) -> S3Request<ListObjectsV2Input> {
+        S3Request {
+            input,
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_list_objects_v2_delimiter_grouping() {
         let storage_dir = tempfile::tempdir().unwrap();
@@ -2131,5 +2173,185 @@ mod tests {
         );
 
         assert_eq!(output.is_truncated, Some(false));
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_honors_explicit_zero_max_keys() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([6u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+
+        let service = ArunaS3Service::new(
+            context.clone(),
+            realm_id,
+            NodeId::from_bytes(&[0u8; 32]).unwrap(),
+        )
+        .await;
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["alpha"],
+            created_by,
+            created_at,
+        )
+        .await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: None,
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(0),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+        );
+
+        let response = service.list_objects_v2(req).await.unwrap();
+        let output = response.output;
+
+        assert_eq!(output.max_keys, Some(0));
+        assert_eq!(output.key_count, Some(0));
+        assert_eq!(output.is_truncated, Some(false));
+        assert_eq!(output.contents.unwrap_or_default().len(), 0);
+        assert_eq!(output.common_prefixes.unwrap_or_default().len(), 0);
+        assert!(output.next_continuation_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_start_after_filters_common_prefixes() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([7u8; 32]);
+        let group_id = Ulid::new();
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH;
+
+        let service = ArunaS3Service::new(
+            context.clone(),
+            realm_id,
+            NodeId::from_bytes(&[0u8; 32]).unwrap(),
+        )
+        .await;
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["dir-a/1", "dir-b/1", "root.txt"],
+            created_by,
+            created_at,
+        )
+        .await;
+
+        let mut extensions = Extensions::new();
+        extensions.insert(test_user_access(group_id, realm_id));
+        extensions.insert(test_bucket_info(group_id, created_by));
+
+        let req = test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: Some("/".to_string()),
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(10),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: Some("dir-b/".to_string()),
+            },
+        );
+
+        let response = service.list_objects_v2(req).await.unwrap();
+        let output = response.output;
+
+        let common_prefixes: Vec<_> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|cp| cp.prefix)
+            .collect();
+        let contents: Vec<_> = output
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|obj| obj.key)
+            .collect();
+
+        assert!(common_prefixes.is_empty());
+        assert_eq!(contents, vec!["root.txt"]);
+        assert_eq!(output.key_count, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_requires_user_access_extension() {
+        let storage_dir = tempfile::tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_id = RealmId([8u8; 32]);
+        let service =
+            ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
+
+        let req = test_list_objects_v2_request(
+            Extensions::new(),
+            ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                continuation_token: None,
+                delimiter: None,
+                encoding_type: None,
+                expected_bucket_owner: None,
+                fetch_owner: None,
+                max_keys: Some(10),
+                optional_object_attributes: None,
+                prefix: None,
+                request_payer: None,
+                start_after: None,
+            },
+        );
+
+        let err = service.list_objects_v2(req).await.unwrap_err();
+        assert_eq!(*err.code(), S3ErrorCode::UnexpectedContent);
     }
 }

--- a/api/src/s3/util.rs
+++ b/api/src/s3/util.rs
@@ -12,10 +12,6 @@ use s3s::dto::{
 use s3s::{S3Error, S3ErrorCode, S3Result, s3_error};
 use ulid::Ulid;
 
-pub fn to_base64<T: AsRef<[u8]>>(input: T) -> String {
-    BASE64_STANDARD.encode(input)
-}
-
 pub fn get_s3_operation_permission(operation_name: &str) -> Option<Action> {
     match operation_name {
         // Write operations (operations that modify state/data)

--- a/aruna/tests/credentials.rs
+++ b/aruna/tests/credentials.rs
@@ -2,11 +2,12 @@ mod shared;
 
 use aruna_api::routes::credentials::CreateS3PathRestriction;
 use aruna_core::structs::{PathRestriction, Permission, blob_group_permission_path};
+use aws_sdk_s3::error::ProvideErrorMetadata;
 use reqwest::StatusCode;
 use shared::{
-    TestResult, create_bearer_token, create_group_via_http,
-    create_s3_credentials_with_restrictions_via_http, get_user_access, sign_scoped_bearer_token,
-    spawn_seed_node,
+    TestResult, create_bearer_token, create_group_via_http, create_s3_credentials_via_http,
+    create_s3_credentials_with_restrictions_via_http, get_user_access, s3_client,
+    sign_scoped_bearer_token, spawn_full_seed_node, spawn_seed_node,
 };
 
 fn create_request_restriction(pattern: String, permission: Permission) -> CreateS3PathRestriction {
@@ -34,6 +35,17 @@ async fn post_credentials(
         )
         .send()
         .await?)
+}
+
+fn service_error_code<T, E>(result: &Result<T, aws_sdk_s3::error::SdkError<E>>) -> Option<String>
+where
+    E: ProvideErrorMetadata,
+{
+    result
+        .as_ref()
+        .err()
+        .and_then(|err| err.as_service_error().and_then(|inner| inner.code()))
+        .map(ToOwned::to_owned)
 }
 
 #[tokio::test]
@@ -237,6 +249,66 @@ async fn scoped_token_for_other_group_is_rejected() -> TestResult<()> {
     let response = post_credentials(&seed.base_url, &scoped_token, &group_b.group_id, None).await?;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    seed.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_objects_v2_scoped_credentials_still_deny_outside_bucket_scope() -> TestResult<()> {
+    let seed = spawn_full_seed_node().await?;
+    let admin_token = create_bearer_token(
+        seed.context.as_ref(),
+        seed.user_id,
+        seed.realm_id,
+        seed.capabilities.clone(),
+    )
+    .await?;
+    let group =
+        create_group_via_http(&seed.base_url, &admin_token, "credentials-scope-list").await?;
+    let group_root =
+        blob_group_permission_path(seed.realm_id, group.group_id.parse()?, seed.net.node_id());
+    let bootstrap_credentials =
+        create_s3_credentials_via_http(&seed.base_url, &admin_token, &group.group_id).await?;
+    let s3_endpoint = seed
+        .s3
+        .as_ref()
+        .ok_or_else(|| std::io::Error::other("missing s3 endpoint"))?;
+    let bootstrap_client = s3_client(s3_endpoint, &bootstrap_credentials);
+
+    bootstrap_client
+        .create_bucket()
+        .bucket("allowed")
+        .send()
+        .await?;
+    bootstrap_client
+        .create_bucket()
+        .bucket("blocked")
+        .send()
+        .await?;
+
+    let scoped_token = sign_scoped_bearer_token(
+        &seed,
+        seed.user_id,
+        vec![PathRestriction {
+            pattern: format!("{group_root}/allowed/**"),
+            permission: Permission::WRITE,
+        }],
+    )?;
+    let credentials = create_s3_credentials_with_restrictions_via_http(
+        &seed.base_url,
+        &scoped_token,
+        &group.group_id,
+        None,
+    )
+    .await?;
+    let client = s3_client(s3_endpoint, &credentials);
+
+    let blocked_list = client.list_objects_v2().bucket("blocked").send().await;
+    assert_eq!(
+        service_error_code(&blocked_list).as_deref(),
+        Some("AccessDenied")
+    );
 
     seed.shutdown().await;
     Ok(())

--- a/aruna/tests/drs.rs
+++ b/aruna/tests/drs.rs
@@ -1,10 +1,7 @@
 mod shared;
 
-use aruna_core::effects::Effect;
-use aruna_core::events::{Event, StorageEvent};
-use aruna_core::handle::Handle;
-use aruna_core::keyspaces::HASH_PATHS_INDEX_KEYSPACE;
 use aruna_core::structs::HashPathIndexKey;
+use aruna_operations::blob::resolve_blob_permission_paths::ResolveBlobPermissionPathsOperation;
 use aruna_operations::driver::drive;
 use aruna_operations::s3::head_object::{HeadObjectInput, HeadObjectOperation};
 use aws_sdk_s3::primitives::ByteStream;
@@ -27,26 +24,9 @@ async fn iter_hash_path_index(
     context: &aruna_operations::driver::DriverContext,
     hash: [u8; 32],
 ) -> TestResult<Vec<HashPathIndexKey>> {
-    let prefix = HashPathIndexKey::hash_prefix(&hash)?;
-    let event = context
-        .storage_handle
-        .send_effect(Effect::Storage(aruna_core::effects::StorageEffect::Iter {
-            key_space: HASH_PATHS_INDEX_KEYSPACE.to_string(),
-            prefix: Some(prefix.into()),
-            start_after: None,
-            limit: 10_000,
-            txn_id: None,
-        }))
-        .await;
-
-    let Event::Storage(StorageEvent::IterResult { values, .. }) = event else {
-        return Err(std::io::Error::other("unexpected hash-path iteration result").into());
-    };
-
-    values
-        .into_iter()
-        .map(|(key, _)| HashPathIndexKey::from_bytes(key.as_ref()).map_err(Into::into))
-        .collect()
+    drive(ResolveBlobPermissionPathsOperation::new(hash), context)
+        .await
+        .map_err(Into::into)
 }
 
 #[tokio::test]

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -189,17 +189,6 @@ pub struct BlobHeadKey {
     pub key: String,
 }
 
-#[derive(Serialize)]
-struct BlobHeadKeyPrefix<'a> {
-    bucket: &'a str,
-}
-
-#[derive(Serialize)]
-struct BlobHeadKeyObjectPrefix<'a> {
-    bucket: &'a str,
-    key: &'a str,
-}
-
 impl BlobHeadKey {
     pub fn new(bucket: impl Into<String>, key: impl Into<String>) -> Self {
         Self {
@@ -208,23 +197,27 @@ impl BlobHeadKey {
         }
     }
 
+    // Encoded as raw UTF-8 `{bucket}/{key}`: bucket names cannot contain
+    // `/`, so the first `/` separates unambiguously, and the raw key suffix
+    // makes storage byte order match S3's lexicographic key order.
     pub fn bucket_prefix(bucket: &str) -> Result<Vec<u8>, ConversionError> {
-        Ok(postcard::to_allocvec(&BlobHeadKeyPrefix { bucket })?)
+        Ok(format!("{bucket}/").into_bytes())
     }
 
     pub fn object_prefix(bucket: &str, key: &str) -> Result<Vec<u8>, ConversionError> {
-        Ok(postcard::to_allocvec(&BlobHeadKeyObjectPrefix {
-            bucket,
-            key,
-        })?)
+        Ok(format!("{bucket}/{key}").into_bytes())
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
-        Ok(postcard::to_allocvec(&self)?)
+        Self::object_prefix(&self.bucket, &self.key)
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
-        Ok(postcard::from_bytes(bytes)?)
+        let raw = String::from_utf8(bytes.to_vec())?;
+        let (bucket, key) = raw.split_once('/').ok_or_else(|| {
+            ConversionError::FromStrError("blob head key is missing the bucket separator".into())
+        })?;
+        Ok(Self::new(bucket, key))
     }
 }
 
@@ -629,6 +622,23 @@ mod tests {
             .unwrap();
         let prefix = BlobHeadKey::object_prefix("bucket_a", "docs/").unwrap();
         assert!(!key.starts_with(&prefix));
+    }
+
+    #[test]
+    fn blob_head_key_byte_order_matches_lexicographic_key_order() {
+        let short = BlobHeadKey::new("bucket", "b").to_bytes().unwrap();
+        let long = BlobHeadKey::new("bucket", "aa").to_bytes().unwrap();
+        assert!(long < short);
+    }
+
+    #[test]
+    fn blob_head_key_prefix_range_is_contiguous() {
+        let prefix = BlobHeadKey::object_prefix("bucket", "rare/").unwrap();
+        let inside = BlobHeadKey::new("bucket", "rare/1").to_bytes().unwrap();
+        let outside = BlobHeadKey::new("bucket", "rare0").to_bytes().unwrap();
+        assert!(inside.starts_with(&prefix));
+        assert!(!outside.starts_with(&prefix));
+        assert!(outside > inside);
     }
 
     #[test]

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -213,7 +213,10 @@ impl BlobHeadKey {
     }
 
     pub fn object_prefix(bucket: &str, key: &str) -> Result<Vec<u8>, ConversionError> {
-        Ok(postcard::to_allocvec(&BlobHeadKeyObjectPrefix { bucket, key })?)
+        Ok(postcard::to_allocvec(&BlobHeadKeyObjectPrefix {
+            bucket,
+            key,
+        })?)
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
@@ -621,7 +624,9 @@ mod tests {
 
     #[test]
     fn blob_head_key_object_prefix_rejects_wrong_bucket() {
-        let key = BlobHeadKey::new("bucket_b", "docs/file.txt").to_bytes().unwrap();
+        let key = BlobHeadKey::new("bucket_b", "docs/file.txt")
+            .to_bytes()
+            .unwrap();
         let prefix = BlobHeadKey::object_prefix("bucket_a", "docs/").unwrap();
         assert!(!key.starts_with(&prefix));
     }

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -197,9 +197,6 @@ impl BlobHeadKey {
         }
     }
 
-    // Encoded as raw UTF-8 `{bucket}/{key}`: bucket names cannot contain
-    // `/`, so the first `/` separates unambiguously, and the raw key suffix
-    // makes storage byte order match S3's lexicographic key order.
     pub fn bucket_prefix(bucket: &str) -> Result<Vec<u8>, ConversionError> {
         Ok(format!("{bucket}/").into_bytes())
     }

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -194,6 +194,12 @@ struct BlobHeadKeyPrefix<'a> {
     bucket: &'a str,
 }
 
+#[derive(Serialize)]
+struct BlobHeadKeyObjectPrefix<'a> {
+    bucket: &'a str,
+    key: &'a str,
+}
+
 impl BlobHeadKey {
     pub fn new(bucket: impl Into<String>, key: impl Into<String>) -> Self {
         Self {
@@ -204,6 +210,10 @@ impl BlobHeadKey {
 
     pub fn bucket_prefix(bucket: &str) -> Result<Vec<u8>, ConversionError> {
         Ok(postcard::to_allocvec(&BlobHeadKeyPrefix { bucket })?)
+    }
+
+    pub fn object_prefix(bucket: &str, key: &str) -> Result<Vec<u8>, ConversionError> {
+        Ok(postcard::to_allocvec(&BlobHeadKeyObjectPrefix { bucket, key })?)
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
@@ -600,6 +610,20 @@ mod tests {
 
         assert_eq!(key, restored);
         assert!(key.to_bytes().unwrap().starts_with(&prefix));
+    }
+
+    #[test]
+    fn blob_head_key_object_prefix_roundtrip() {
+        let prefix = BlobHeadKey::object_prefix("bucket", "rare/").unwrap();
+        let key = BlobHeadKey::new("bucket", "rare/").to_bytes().unwrap();
+        assert_eq!(prefix, key);
+    }
+
+    #[test]
+    fn blob_head_key_object_prefix_rejects_wrong_bucket() {
+        let key = BlobHeadKey::new("bucket_b", "docs/file.txt").to_bytes().unwrap();
+        let prefix = BlobHeadKey::object_prefix("bucket_a", "docs/").unwrap();
+        assert!(!key.starts_with(&prefix));
     }
 
     #[test]

--- a/operations/Cargo.toml
+++ b/operations/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = { workspace = true }
 automerge = { workspace = true }
 autosurgeon = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
 byteview = { workspace = true }

--- a/operations/src/blob/resolve_blob_permission_paths.rs
+++ b/operations/src/blob/resolve_blob_permission_paths.rs
@@ -71,11 +71,8 @@ impl ResolveBlobPermissionPathsOperation {
             .map(|(key, _)| HashPathIndexKey::from_bytes(key.as_ref()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        candidates.sort_by(|left, right| {
-            left.permission_path()
-                .cmp(&right.permission_path())
-                .then_with(|| left.version_id.cmp(&right.version_id))
-        });
+        candidates
+            .sort_by_cached_key(|candidate| (candidate.permission_path(), candidate.version_id));
 
         self.output = Some(Ok(candidates));
 

--- a/operations/src/replication/incoming_version_replication.rs
+++ b/operations/src/replication/incoming_version_replication.rs
@@ -1,6 +1,6 @@
 use crate::blob::blob_keyspace_helper::{
-    HeadAliasContext, build_head_transition_effects, write_blob_location_effect,
-    write_blob_version_effect,
+    HeadAliasContext, add_hash_path_index_effect, build_head_transition_effects,
+    write_blob_location_effect, write_blob_version_effect,
 };
 use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::replication::error::ReplicationError;
@@ -105,6 +105,7 @@ pub struct IncomingVersionReplicationOperation {
     pending_new_pointer: Option<CurrentVersionPointer>,
     pending_new_current_hash: Option<[u8; 32]>,
     pending_head_transition_effects: VecDeque<Effect>,
+    pending_version_effects: VecDeque<Effect>,
     cleanup_blob_location: Option<BackendLocation>,
     apply_committed: bool,
     output: Option<Result<(), IncomingVersionReplicationError>>,
@@ -132,6 +133,7 @@ impl IncomingVersionReplicationOperation {
             pending_new_pointer: None,
             pending_new_current_hash: None,
             pending_head_transition_effects: VecDeque::new(),
+            pending_version_effects: VecDeque::new(),
             cleanup_blob_location: None,
             apply_committed: false,
             output: None,
@@ -521,7 +523,7 @@ impl IncomingVersionReplicationOperation {
             &self.manifest.key,
             self.manifest.version_id,
         );
-        let version = match self.manifest.kind {
+        let (version, materialized_hash) = match self.manifest.kind {
             ReplicationItemKind::Materialized => {
                 let Ok(location) = self.effective_materialized_location() else {
                     return self.fail(IncomingVersionReplicationError::MissingBlobLocation);
@@ -529,25 +531,41 @@ impl IncomingVersionReplicationOperation {
                 let Some(blake3_hash) = location.get_blake3() else {
                     return self.fail(IncomingVersionReplicationError::MissingBlobLocation);
                 };
-                BlobVersion::materialized(
-                    match blake3_hash.try_into() {
-                        Ok(hash) => hash,
-                        Err(err) => return self.fail(ConversionError::from(err).into()),
-                    },
-                    self.manifest.created_at,
-                    self.manifest.created_by,
-                    self.manifest.source.clone(),
+                let hash: [u8; 32] = match blake3_hash.try_into() {
+                    Ok(hash) => hash,
+                    Err(err) => return self.fail(ConversionError::from(err).into()),
+                };
+                (
+                    BlobVersion::materialized(
+                        hash,
+                        self.manifest.created_at,
+                        self.manifest.created_by,
+                        self.manifest.source.clone(),
+                    ),
+                    Some(hash),
                 )
             }
-            ReplicationItemKind::DeleteMarker => {
-                BlobVersion::deleted(self.manifest.created_at, self.manifest.created_by)
-            }
+            ReplicationItemKind::DeleteMarker => (
+                BlobVersion::deleted(self.manifest.created_at, self.manifest.created_by),
+                None,
+            ),
         };
 
         let effect = match write_blob_version_effect(&version_key, &version, self.txn_id) {
             Ok(effect) => effect,
             Err(err) => return self.fail(err.into()),
         };
+        if let Some(hash) = materialized_hash {
+            let context = match self.alias_context() {
+                Ok(context) => context,
+                Err(err) => return self.fail(err),
+            };
+            match add_hash_path_index_effect(&context, hash, self.manifest.version_id, self.txn_id)
+            {
+                Ok(index_effect) => self.pending_version_effects.push_back(index_effect),
+                Err(err) => return self.fail(err.into()),
+            }
+        }
         smallvec![effect]
     }
 
@@ -990,6 +1008,9 @@ impl Operation for IncomingVersionReplicationOperation {
                         received: event,
                     });
                 };
+                if let Some(effect) = self.pending_version_effects.pop_front() {
+                    return smallvec![effect];
+                }
                 self.write_multipart_metadata_or_continue()
             }
             IncomingVersionReplicationState::WriteMultipartMetadata => {
@@ -1170,12 +1191,13 @@ mod tests {
     use aruna_core::events::{BlobEvent, Event, StorageEvent, SubOperationEvent};
     use aruna_core::keyspaces::{
         BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE,
+        HASH_PATHS_INDEX_KEYSPACE,
     };
     use aruna_core::operation::Operation;
     use aruna_core::structs::{
-        AuthContext, BackendLocation, BlobVersion, BucketInfo, CurrentVersionPointer, RealmId,
-        ReplicationItemKind, ReplicationNegotiationResult, SourceConnectorKind, StagingStrategy,
-        VersionSourceBinding,
+        AuthContext, BackendLocation, BlobVersion, BucketInfo, CurrentVersionPointer,
+        HashPathIndexKey, RealmId, ReplicationItemKind, ReplicationNegotiationResult,
+        SourceConnectorKind, StagingStrategy, VersionSourceBinding,
     };
     use std::collections::HashMap;
     use std::time::SystemTime;
@@ -1490,6 +1512,7 @@ mod tests {
             manifest,
         );
         op.txn_id = Some(Ulid::new());
+        op.destination_group_id = Some(Ulid::new());
         op.existing_blob_location = Some(make_location());
 
         let effects = op.write_version();
@@ -1499,6 +1522,52 @@ mod tests {
         };
         let version = BlobVersion::from_bytes(value.as_ref()).unwrap();
         assert_eq!(version.source_binding(), Some(&source));
+    }
+
+    #[test]
+    fn write_version_indexes_non_current_materialized_version_by_content_hash() {
+        let mut manifest = make_manifest(ReplicationItemKind::Materialized);
+        manifest.current_version = false;
+        let group_id = Ulid::new();
+        let mut op = IncomingVersionReplicationOperation::new(
+            Ulid::new(),
+            iroh::SecretKey::generate().public(),
+            RealmId::from_bytes([7u8; 32]),
+            manifest.clone(),
+        );
+        op.txn_id = Some(Ulid::new());
+        op.destination_group_id = Some(group_id);
+        op.existing_blob_location = Some(make_location());
+
+        let effects = op.write_version();
+        let [Effect::Storage(StorageEffect::Write { key_space, .. })] = effects.as_slice() else {
+            panic!("expected blob version write")
+        };
+        assert_eq!(key_space, BLOB_VERSIONS_KEYSPACE);
+
+        let effects = op.step(Event::Storage(StorageEvent::WriteResult {
+            key: vec![0u8; 4].into(),
+        }));
+        let [Effect::Storage(StorageEffect::Write { key_space, key, .. })] = effects.as_slice()
+        else {
+            panic!("expected hash path index write")
+        };
+        assert_eq!(key_space, HASH_PATHS_INDEX_KEYSPACE);
+        let index_key = HashPathIndexKey::from_bytes(key.as_ref()).unwrap();
+        assert_eq!(index_key.blake3_hash, [1u8; 32]);
+        assert_eq!(index_key.version_id, manifest.version_id);
+        assert_eq!(index_key.group_id, group_id);
+        assert_eq!(index_key.bucket, manifest.bucket);
+        assert_eq!(index_key.key, manifest.key);
+
+        let effects = op.step(Event::Storage(StorageEvent::WriteResult {
+            key: vec![0u8; 4].into(),
+        }));
+        assert_eq!(op.state, IncomingVersionReplicationState::CommitTransaction);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::CommitTransaction { .. })]
+        ));
     }
 
     #[test]

--- a/operations/src/s3/complete_multipart_upload.rs
+++ b/operations/src/s3/complete_multipart_upload.rs
@@ -18,8 +18,6 @@ use aruna_core::structs::{
     MultipartUploadPart, MultipartUploadPartKey, MultipartUploadStatus, RealmId, VersionKey,
 };
 use aruna_core::types::{Effects, NodeId, TxnId, UserId};
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
 use smallvec::smallvec;
 use std::collections::HashMap;
 use std::time::SystemTime;
@@ -1017,7 +1015,7 @@ fn validate_requested_part(
         let Some(md5) = record.location.hashes.get(HASH_MD5) else {
             return Err(CompleteMultipartUploadError::MissingPartEtag);
         };
-        if STANDARD.encode(md5) != *etag {
+        if hex::encode(md5) != *etag {
             return Err(CompleteMultipartUploadError::PartEtagMismatch);
         }
     }

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -603,74 +603,19 @@ mod test {
         let temp_handle = tempdir().unwrap();
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
-        let driver_ctx = DriverContext {
-            storage_handle: storage_handle.clone(),
-            net_handle: None,
-            blob_handle: None,
-            automerge_handle: None,
-            metadata_handle: None,
-            task_handle: None,
-        };
+        let driver_ctx = driver_context(storage_handle.clone());
 
         let group_id = Ulid::new();
-        let realm_id = RealmId([7u8; 32]);
-        let created_by = UserId::local(Ulid::new(), realm_id);
-        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
 
-        let keys = ["common/a", "common/b", "rare/1", "rare/2", "rare/3"];
-        for key in keys {
-            let version_id = Ulid::new();
-            let hash = [key.len() as u8; 32];
-            let version = BlobVersion::materialized(hash, created_at, created_by, None);
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
-                    key: BlobHeadKey::new("bucket", key).to_bytes().unwrap().into(),
-                    value: CurrentVersionPointer::new(version_id)
-                        .to_bytes()
-                        .unwrap()
-                        .into(),
-                    txn_id: None,
-                })
-                .await;
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
-                    key: VersionKey::new("bucket", key, version_id)
-                        .to_bytes()
-                        .unwrap()
-                        .into(),
-                    value: version.to_bytes().unwrap().into(),
-                    txn_id: None,
-                })
-                .await;
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
-                    key: hash.to_vec().into(),
-                    value: BackendLocation {
-                        root: "/tmp".to_string(),
-                        storage_bucket: "objects".to_string(),
-                        backend_path: format!("path/{key}"),
-                        ulid: Ulid::new(),
-                        compressed: false,
-                        encrypted: false,
-                        created_by,
-                        created_at,
-                        staging: false,
-                        partial: false,
-                        blob_size: 42,
-                        hashes: HashMap::new(),
-                    }
-                    .to_bytes()
-                    .unwrap()
-                    .into(),
-                    txn_id: None,
-                })
-                .await;
-        }
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["common/a", "common/b", "rare/1", "rare/2", "rare/3"],
+            created_by,
+        )
+        .await;
 
-        // Run with prefix filter; collect all results across pages
         let mut continuation_token = None;
         let mut all_keys = Vec::new();
 
@@ -715,79 +660,25 @@ mod test {
         let temp_handle = tempdir().unwrap();
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
-        let driver_ctx = DriverContext {
-            storage_handle: storage_handle.clone(),
-            net_handle: None,
-            blob_handle: None,
-            automerge_handle: None,
-            metadata_handle: None,
-            task_handle: None,
-        };
+        let driver_ctx = driver_context(storage_handle.clone());
 
         let group_id = Ulid::new();
-        let realm_id = RealmId([7u8; 32]);
-        let created_by = UserId::local(Ulid::new(), realm_id);
-        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
 
-        let keys = [
-            "common/01",
-            "common/02",
-            "common/03",
-            "common/04",
-            "common/05",
-            "rare/01",
-        ];
-        for key in keys {
-            let version_id = Ulid::new();
-            let hash = [key.len() as u8; 32];
-            let version = BlobVersion::materialized(hash, created_at, created_by, None);
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
-                    key: BlobHeadKey::new("bucket", key).to_bytes().unwrap().into(),
-                    value: CurrentVersionPointer::new(version_id)
-                        .to_bytes()
-                        .unwrap()
-                        .into(),
-                    txn_id: None,
-                })
-                .await;
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
-                    key: VersionKey::new("bucket", key, version_id)
-                        .to_bytes()
-                        .unwrap()
-                        .into(),
-                    value: version.to_bytes().unwrap().into(),
-                    txn_id: None,
-                })
-                .await;
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
-                    key: hash.to_vec().into(),
-                    value: BackendLocation {
-                        root: "/tmp".to_string(),
-                        storage_bucket: "objects".to_string(),
-                        backend_path: format!("path/{key}"),
-                        ulid: Ulid::new(),
-                        compressed: false,
-                        encrypted: false,
-                        created_by,
-                        created_at,
-                        staging: false,
-                        partial: false,
-                        blob_size: 42,
-                        hashes: HashMap::new(),
-                    }
-                    .to_bytes()
-                    .unwrap()
-                    .into(),
-                    txn_id: None,
-                })
-                .await;
-        }
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &[
+                "common/01",
+                "common/02",
+                "common/03",
+                "common/04",
+                "common/05",
+                "rare/01",
+            ],
+            created_by,
+        )
+        .await;
 
         let result = drive(
             ListObjectsV2Operation::new(ListObjectsV2Input {
@@ -891,74 +782,19 @@ mod test {
         let temp_handle = tempdir().unwrap();
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
-        let driver_ctx = DriverContext {
-            storage_handle: storage_handle.clone(),
-            net_handle: None,
-            blob_handle: None,
-            automerge_handle: None,
-            metadata_handle: None,
-            task_handle: None,
-        };
+        let driver_ctx = driver_context(storage_handle.clone());
 
         let group_id = Ulid::new();
-        let realm_id = RealmId([7u8; 32]);
-        let created_by = UserId::local(Ulid::new(), realm_id);
-        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
 
-        let keys = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta"];
-        for key in keys {
-            let version_id = Ulid::new();
-            let hash = [key.len() as u8; 32];
-            let version = BlobVersion::materialized(hash, created_at, created_by, None);
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
-                    key: BlobHeadKey::new("bucket", key).to_bytes().unwrap().into(),
-                    value: CurrentVersionPointer::new(version_id)
-                        .to_bytes()
-                        .unwrap()
-                        .into(),
-                    txn_id: None,
-                })
-                .await;
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
-                    key: VersionKey::new("bucket", key, version_id)
-                        .to_bytes()
-                        .unwrap()
-                        .into(),
-                    value: version.to_bytes().unwrap().into(),
-                    txn_id: None,
-                })
-                .await;
-            let _ = storage_handle
-                .send_storage_effect(StorageEffect::Write {
-                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
-                    key: hash.to_vec().into(),
-                    value: BackendLocation {
-                        root: "/tmp".to_string(),
-                        storage_bucket: "objects".to_string(),
-                        backend_path: format!("path/{key}"),
-                        ulid: Ulid::new(),
-                        compressed: false,
-                        encrypted: false,
-                        created_by,
-                        created_at,
-                        staging: false,
-                        partial: false,
-                        blob_size: 42,
-                        hashes: HashMap::new(),
-                    }
-                    .to_bytes()
-                    .unwrap()
-                    .into(),
-                    txn_id: None,
-                })
-                .await;
-        }
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta"],
+            created_by,
+        )
+        .await;
 
-        // Paginate without prefix; collect all results across pages
         let mut continuation_token = None;
         let mut all_keys = Vec::new();
 

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -49,6 +49,7 @@ pub struct ListObjectsV2Input {
     pub continuation_token: Option<Vec<u8>>,
     pub max_keys: Option<usize>,
     pub prefix: Option<String>,
+    pub start_after: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -136,7 +137,24 @@ impl ListObjectsV2Operation {
             Ok(prefix) => prefix,
             Err(err) => return self.emit_error(err.into()),
         };
-        let iter_start_key = self.input.continuation_token.clone();
+        // start_after only applies to the first page; the exclusive Iter
+        // start bound matches S3's StartAfter semantics exactly.
+        let iter_start_key = match (&self.input.continuation_token, &self.input.start_after) {
+            (Some(token), _) => Some(token.clone()),
+            (None, Some(start_after)) if !start_after.is_empty() => {
+                match BlobHeadKey::object_prefix(&self.input.bucket, start_after) {
+                    Ok(key) => Some(key),
+                    Err(err) => return self.emit_error(err.into()),
+                }
+            }
+            _ => None,
+        };
+        if let Some(start) = iter_start_key.as_ref()
+            && start.as_slice() > prefix.as_slice()
+            && !start.starts_with(&prefix)
+        {
+            return self.read_next_version_or_finish();
+        }
 
         let limit = self.max_keys().saturating_add(1);
 
@@ -474,6 +492,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(10),
                 prefix: None,
+                start_after: None,
             }),
             &driver_ctx,
         )
@@ -572,6 +591,7 @@ mod test {
                     continuation_token,
                     max_keys: Some(2),
                     prefix: Some("rare/".to_string()),
+                    start_after: None,
                 }),
                 &driver_ctx,
             )
@@ -684,6 +704,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(1),
                 prefix: Some("rare/".to_string()),
+                start_after: None,
             }),
             &driver_ctx,
         )
@@ -758,6 +779,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(0),
                 prefix: None,
+                start_after: None,
             }),
             &driver_ctx,
         )
@@ -854,6 +876,7 @@ mod test {
                     continuation_token,
                     max_keys: Some(3),
                     prefix: None,
+                    start_after: None,
                 }),
                 &driver_ctx,
             )
@@ -904,6 +927,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(10),
                 prefix: None,
+                start_after: None,
             }),
             &driver_ctx,
         )
@@ -1000,6 +1024,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(10),
                 prefix: None,
+                start_after: None,
             }),
             &driver_ctx,
         )
@@ -1091,6 +1116,7 @@ mod test {
         driver_ctx: &DriverContext,
         bucket: &str,
         prefix: Option<&str>,
+        start_after: Option<&str>,
     ) -> Vec<String> {
         let result = drive(
             ListObjectsV2Operation::new(ListObjectsV2Input {
@@ -1099,6 +1125,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(100),
                 prefix: prefix.map(str::to_string),
+                start_after: start_after.map(str::to_string),
             }),
             driver_ctx,
         )
@@ -1129,10 +1156,10 @@ mod test {
         )
         .await;
 
-        let keys = list_keys(&driver_ctx, "bucket", Some("docs/")).await;
+        let keys = list_keys(&driver_ctx, "bucket", Some("docs/"), None).await;
         assert_eq!(keys, vec!["docs/", "docs/readme.md"]);
 
-        let keys = list_keys(&driver_ctx, "bucket", Some("docs/readme.md")).await;
+        let keys = list_keys(&driver_ctx, "bucket", Some("docs/readme.md"), None).await;
         assert_eq!(keys, vec!["docs/readme.md"]);
     }
 
@@ -1148,7 +1175,7 @@ mod test {
         // orderings; the contiguous prefix range must not be cut by it.
         seed_materialized_keys(&storage_handle, "bucket", &["rare0", "rare/1"], created_by).await;
 
-        let keys = list_keys(&driver_ctx, "bucket", Some("rare/")).await;
+        let keys = list_keys(&driver_ctx, "bucket", Some("rare/"), None).await;
         assert_eq!(keys, vec!["rare/1"]);
     }
 
@@ -1162,7 +1189,44 @@ mod test {
 
         seed_materialized_keys(&storage_handle, "bucket", &["b", "aa", "a/1"], created_by).await;
 
-        let keys = list_keys(&driver_ctx, "bucket", None).await;
+        let keys = list_keys(&driver_ctx, "bucket", None, None).await;
         assert_eq!(keys, vec!["a/1", "aa", "b"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_start_after_skips_preceding_keys() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = driver_context(storage_handle.clone());
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+
+        seed_materialized_keys(&storage_handle, "bucket", &["a", "b", "c"], created_by).await;
+
+        let keys = list_keys(&driver_ctx, "bucket", None, Some("a")).await;
+        assert_eq!(keys, vec!["b", "c"]);
+
+        let keys = list_keys(&driver_ctx, "bucket", None, Some("b")).await;
+        assert_eq!(keys, vec!["c"]);
+
+        let keys = list_keys(&driver_ctx, "bucket", None, Some("c")).await;
+        assert!(keys.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_start_after_beyond_prefix_range_returns_empty() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = driver_context(storage_handle.clone());
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+
+        seed_materialized_keys(&storage_handle, "bucket", &["docs/1", "docs/2"], created_by).await;
+
+        let keys = list_keys(&driver_ctx, "bucket", Some("docs/"), Some("zzz")).await;
+        assert!(keys.is_empty());
+
+        let keys = list_keys(&driver_ctx, "bucket", Some("docs/"), Some("a")).await;
+        assert_eq!(keys, vec!["docs/1", "docs/2"]);
     }
 }

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -124,7 +124,7 @@ impl ListObjectsV2Operation {
             Ok(prefix) => prefix,
             Err(err) => return self.emit_error(err.into()),
         };
-        let start_after = if self.input.continuation_token.is_some() {
+        let iter_start_key = if self.input.continuation_token.is_some() {
             self.input.continuation_token.clone()
         } else if let Some(prefix) = self
             .input
@@ -146,7 +146,7 @@ impl ListObjectsV2Operation {
         smallvec![Effect::Storage(StorageEffect::Iter {
             key_space: BLOB_HEAD_KEYSPACE.to_string(),
             prefix: Some(prefix.into()),
-            start_after: start_after.map(Into::into),
+            start_after: iter_start_key.map(Into::into),
             limit,
             txn_id: self.txn_id,
         })]

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -632,6 +632,178 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_list_objects_v2_prefix_scan_does_not_stop_on_prefix_miss() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        let group_id = Ulid::new();
+        let realm_id = RealmId([7u8; 32]);
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+
+        let keys = [
+            "common/01",
+            "common/02",
+            "common/03",
+            "common/04",
+            "common/05",
+            "rare/01",
+        ];
+        for key in keys {
+            let version_id = Ulid::new();
+            let hash = [key.len() as u8; 32];
+            let version = BlobVersion::materialized(hash, created_at, created_by, None);
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                    key: BlobHeadKey::new("bucket", key).to_bytes().unwrap().into(),
+                    value: CurrentVersionPointer::new(version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                    key: VersionKey::new("bucket", key, version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    value: version.to_bytes().unwrap().into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                    key: hash.to_vec().into(),
+                    value: BackendLocation {
+                        root: "/tmp".to_string(),
+                        storage_bucket: "objects".to_string(),
+                        backend_path: format!("path/{key}"),
+                        ulid: Ulid::new(),
+                        compressed: false,
+                        encrypted: false,
+                        created_by,
+                        created_at,
+                        staging: false,
+                        partial: false,
+                        blob_size: 42,
+                        hashes: HashMap::new(),
+                    }
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                    txn_id: None,
+                })
+                .await;
+        }
+
+        let result = drive(
+            ListObjectsV2Operation::new(ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                group_id,
+                continuation_token: None,
+                max_keys: Some(1),
+                prefix: Some("rare/".to_string()),
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        let keys: Vec<_> = result
+            .objects
+            .into_iter()
+            .map(|object| object.head.key)
+            .collect();
+        assert_eq!(keys, vec!["rare/01"]);
+        assert!(result.continuation_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_honors_explicit_zero_max_keys() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        let group_id = Ulid::new();
+        let realm_id = RealmId([7u8; 32]);
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+        let version_id = Ulid::new();
+        let hash = [3u8; 32];
+
+        let _ = storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                key: BlobHeadKey::new("bucket", "alpha")
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                value: CurrentVersionPointer::new(version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                txn_id: None,
+            })
+            .await;
+        let _ = storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                key: VersionKey::new("bucket", "alpha", version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                value: BlobVersion::materialized(hash, created_at, created_by, None)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                txn_id: None,
+            })
+            .await;
+
+        let result = drive(
+            ListObjectsV2Operation::new(ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                group_id,
+                continuation_token: None,
+                max_keys: Some(0),
+                prefix: None,
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert!(result.objects.is_empty());
+        assert!(result.continuation_token.is_none());
+    }
+
+    #[tokio::test]
     async fn test_list_objects_v2_pagination_without_prefix() {
         let temp_handle = tempdir().unwrap();
         let storage_handle =

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -100,10 +100,7 @@ impl ListObjectsV2Operation {
     }
 
     fn max_keys(&self) -> usize {
-        self.input
-            .max_keys
-            .filter(|limit| *limit > 0)
-            .unwrap_or(Self::DEFAULT_MAX_KEYS)
+        self.input.max_keys.unwrap_or(Self::DEFAULT_MAX_KEYS)
     }
 
     fn handle_init(&mut self) -> Effects {
@@ -124,21 +121,32 @@ impl ListObjectsV2Operation {
 
         self.txn_id = Some(txn_id);
         let prefix = match BlobHeadKey::bucket_prefix(&self.input.bucket) {
-            Ok(p) => p,
+            Ok(prefix) => prefix,
             Err(err) => return self.emit_error(err.into()),
         };
-
-        let limit = if self.input.prefix.as_ref().is_some_and(|p| !p.is_empty()) {
-            self.max_keys().saturating_mul(4).saturating_add(1)
+        let start_after = if self.input.continuation_token.is_some() {
+            self.input.continuation_token.clone()
+        } else if let Some(prefix) = self
+            .input
+            .prefix
+            .as_ref()
+            .filter(|prefix| !prefix.is_empty())
+        {
+            match BlobHeadKey::object_prefix(&self.input.bucket, prefix) {
+                Ok(prefix) => Some(prefix),
+                Err(err) => return self.emit_error(err.into()),
+            }
         } else {
-            self.max_keys().saturating_add(1)
+            None
         };
+
+        let limit = self.max_keys().saturating_add(1);
 
         self.state = ListObjectsV2State::ReadHeads;
         smallvec![Effect::Storage(StorageEffect::Iter {
             key_space: BLOB_HEAD_KEYSPACE.to_string(),
             prefix: Some(prefix.into()),
-            start_after: self.input.continuation_token.clone().map(Into::into),
+            start_after: start_after.map(Into::into),
             limit,
             txn_id: self.txn_id,
         })]
@@ -156,6 +164,10 @@ impl ListObjectsV2Operation {
         let max_keys = self.max_keys();
         self.pending.clear();
         self.continuation_token = None;
+
+        if max_keys == 0 {
+            return self.read_next_version_or_finish();
+        }
 
         let has_prefix = self.input.prefix.as_ref().is_some_and(|p| !p.is_empty());
         let raw_count = values.len();
@@ -193,10 +205,11 @@ impl ListObjectsV2Operation {
                 self.continuation_token = continuation;
             }
         } else {
-            // Prefix filter: collect all matching keys; use non-matching
-            // keys as continuation points so no matches are skipped
+            // Prefix filter: we start scanning at the requested object prefix,
+            // then stop at the first key outside that contiguous prefix range.
             let prefix = self.input.prefix.as_ref().unwrap();
             let mut continuation = None;
+            let mut has_more_matches = false;
             for (key, value) in values {
                 let head = match BlobHeadKey::from_bytes(key.as_ref()) {
                     Ok(head) => head,
@@ -209,14 +222,18 @@ impl ListObjectsV2Operation {
                 if head.bucket != self.input.bucket {
                     continue;
                 }
-                if head.key.starts_with(prefix.as_str()) {
-                    if self.pending.len() < max_keys {
-                        self.pending.push((head, pointer.version_id));
-                        continuation = Some(key.to_vec());
-                    }
+                if !head.key.starts_with(prefix.as_str()) {
+                    break;
+                }
+                if self.pending.len() < max_keys {
+                    self.pending.push((head, pointer.version_id));
+                    continuation = Some(key.to_vec());
+                } else {
+                    has_more_matches = true;
+                    break;
                 }
             }
-            if self.pending.len() >= max_keys {
+            if has_more_matches {
                 self.continuation_token = continuation;
             }
         }

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -389,7 +389,10 @@ mod test {
     use aruna_core::keyspaces::{
         BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE,
     };
-    use aruna_core::structs::{BlobVersion, CurrentVersionPointer, RealmId};
+    use aruna_core::structs::{
+        BlobVersion, CurrentVersionPointer, PortableSourceDescriptor, RealmId, SourceConnectorKind,
+        StagingStrategy, VersionSourceBinding,
+    };
     use aruna_storage::storage;
     use std::collections::HashMap;
     use std::time::{Duration, UNIX_EPOCH};
@@ -524,15 +527,11 @@ mod test {
         for key in keys {
             let version_id = Ulid::new();
             let hash = [key.len() as u8; 32];
-            let version =
-                BlobVersion::materialized(hash, created_at, created_by, None);
+            let version = BlobVersion::materialized(hash, created_at, created_by, None);
             let _ = storage_handle
                 .send_storage_effect(StorageEffect::Write {
                     key_space: BLOB_HEAD_KEYSPACE.to_string(),
-                    key: BlobHeadKey::new("bucket", key)
-                        .to_bytes()
-                        .unwrap()
-                        .into(),
+                    key: BlobHeadKey::new("bucket", key).to_bytes().unwrap().into(),
                     value: CurrentVersionPointer::new(version_id)
                         .to_bytes()
                         .unwrap()
@@ -613,5 +612,140 @@ mod test {
         let mut sorted = all_keys.clone();
         sorted.sort();
         assert_eq!(sorted, vec!["rare/1", "rare/2", "rare/3"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_empty_bucket() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        let group_id = Ulid::new();
+
+        let result = drive(
+            ListObjectsV2Operation::new(ListObjectsV2Input {
+                bucket: "empty-bucket".to_string(),
+                group_id,
+                continuation_token: None,
+                max_keys: Some(10),
+                prefix: None,
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert!(result.objects.is_empty());
+        assert!(result.continuation_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_reference_object() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        let group_id = Ulid::new();
+        let realm_id = RealmId([7u8; 32]);
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let version_id = Ulid::new();
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+        let last_refresh = UNIX_EPOCH + Duration::from_secs(20);
+
+        let source_metadata = SourceMetadata {
+            content_length: 42,
+            content_type: Some("text/plain".to_string()),
+            etag: Some("ref-etag-1".to_string()),
+            last_modified: Some(UNIX_EPOCH + Duration::from_secs(10)),
+            source_version: None,
+        };
+
+        let version = BlobVersion::reference(
+            VersionSourceBinding {
+                strategy: StagingStrategy::Reference,
+                descriptor: PortableSourceDescriptor {
+                    kind: SourceConnectorKind::Http,
+                    public_config: HashMap::new(),
+                    source_path: "source/path".to_string(),
+                    version_selector: None,
+                    capabilities: Vec::new(),
+                    origin_node_id: None,
+                },
+                connector_id: None,
+            },
+            source_metadata.clone(),
+            created_at,
+            created_by,
+            last_refresh,
+        );
+
+        // Write head entry
+        let _ = storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                key: BlobHeadKey::new("bucket", "ref-object")
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                value: CurrentVersionPointer::new(version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                txn_id: None,
+            })
+            .await;
+
+        // Write version entry (reference — no location)
+        let _ = storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                key: VersionKey::new("bucket", "ref-object", version_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                value: version.to_bytes().unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+
+        let result = drive(
+            ListObjectsV2Operation::new(ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                group_id,
+                continuation_token: None,
+                max_keys: Some(10),
+                prefix: None,
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(result.objects.len(), 1);
+        assert_eq!(result.objects[0].head.key, "ref-object");
+        assert_eq!(result.objects[0].location, None);
+        assert_eq!(result.objects[0].source_metadata, Some(source_metadata));
+        assert_eq!(result.objects[0].last_refresh, Some(last_refresh));
+        assert!(result.continuation_token.is_none());
     }
 }

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -158,12 +158,21 @@ impl ListObjectsV2Operation {
         self.continuation_token = None;
 
         let has_prefix = self.input.prefix.as_ref().is_some_and(|p| !p.is_empty());
+        let raw_count = values.len();
 
         if !has_prefix {
-            // Original index-based logic for bucket-only iteration
+            // Track the key of the last pushed item as the continuation
+            // token.  Since the Iter effect uses an *exclusive* start_after
+            // bound, using the first excluded item (index == max_keys) would
+            // skip it on the next page.
+            //
+            // Only set the token when the storage returned a full page
+            // (more than max_keys items), which is our signal that more
+            // items likely exist.  When fewer items are returned we are
+            // at the end and there is nothing left to page.
+            let mut continuation = None;
             for (index, (key, value)) in values.into_iter().enumerate() {
                 if index >= max_keys {
-                    self.continuation_token = Some(key.to_vec());
                     break;
                 }
                 let head = match BlobHeadKey::from_bytes(key.as_ref()) {
@@ -177,7 +186,11 @@ impl ListObjectsV2Operation {
                 if head.bucket != self.input.bucket {
                     continue;
                 }
+                continuation = Some(key.to_vec());
                 self.pending.push((head, pointer.version_id));
+            }
+            if raw_count > max_keys {
+                self.continuation_token = continuation;
             }
         } else {
             // Prefix filter: collect all matching keys; use non-matching

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -1,0 +1,617 @@
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::{BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE};
+use aruna_core::operation::Operation;
+use aruna_core::structs::{
+    BackendLocation, BlobHeadKey, BlobVersion, BlobVersionState, CurrentVersionPointer,
+    SourceMetadata, VersionKey,
+};
+use aruna_core::types::{Effects, GroupId};
+use smallvec::smallvec;
+use thiserror::Error;
+use ulid::Ulid;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ListObjectsV2State {
+    Init,
+    StartTransaction,
+    ReadHeads,
+    ReadVersion,
+    ReadBlobLocation,
+    CommitTransaction,
+    Finish,
+    Error,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum ListObjectsV2Error {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error("State [{state:?}] invalid: expected [{expected:?}] - received [{received:?}]")]
+    InvalidStateEvent {
+        state: ListObjectsV2State,
+        expected: &'static str,
+        received: Event,
+    },
+    #[error("No transaction found")]
+    NoTransactionFound,
+    #[error("ListObjectsV2 failed")]
+    ListObjectsV2Failed,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListObjectsV2Input {
+    pub bucket: String,
+    pub group_id: GroupId,
+    pub continuation_token: Option<Vec<u8>>,
+    pub max_keys: Option<usize>,
+    pub prefix: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListObjectsV2Object {
+    pub head: BlobHeadKey,
+    pub location: Option<BackendLocation>,
+    pub source_metadata: Option<SourceMetadata>,
+    pub last_refresh: Option<std::time::SystemTime>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListObjectsV2Result {
+    pub objects: Vec<ListObjectsV2Object>,
+    pub continuation_token: Option<Vec<u8>>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ListObjectsV2Operation {
+    input: ListObjectsV2Input,
+    state: ListObjectsV2State,
+    txn_id: Option<Ulid>,
+    pending: Vec<(BlobHeadKey, Ulid)>,
+    objects: Vec<ListObjectsV2Object>,
+    continuation_token: Option<Vec<u8>>,
+    current_head: Option<BlobHeadKey>,
+    output: Option<Result<ListObjectsV2Result, ListObjectsV2Error>>,
+}
+
+impl ListObjectsV2Operation {
+    const DEFAULT_MAX_KEYS: usize = 1_000;
+
+    pub fn new(input: ListObjectsV2Input) -> Self {
+        Self {
+            input,
+            state: ListObjectsV2State::Init,
+            txn_id: None,
+            pending: Vec::new(),
+            objects: Vec::new(),
+            continuation_token: None,
+            current_head: None,
+            output: None,
+        }
+    }
+
+    fn emit_error(&mut self, error: ListObjectsV2Error) -> Effects {
+        self.state = ListObjectsV2State::Error;
+        self.output = Some(Err(error));
+        smallvec![]
+    }
+
+    fn max_keys(&self) -> usize {
+        self.input
+            .max_keys
+            .filter(|limit| *limit > 0)
+            .unwrap_or(Self::DEFAULT_MAX_KEYS)
+    }
+
+    fn handle_init(&mut self) -> Effects {
+        self.state = ListObjectsV2State::StartTransaction;
+        smallvec![Effect::Storage(StorageEffect::StartTransaction {
+            read: true
+        })]
+    }
+
+    fn handle_transaction_started(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = event else {
+            return self.emit_error(ListObjectsV2Error::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::TransactionStarted)",
+                received: event,
+            });
+        };
+
+        self.txn_id = Some(txn_id);
+        let prefix = match BlobHeadKey::bucket_prefix(&self.input.bucket) {
+            Ok(p) => p,
+            Err(err) => return self.emit_error(err.into()),
+        };
+
+        let limit = if self.input.prefix.as_ref().is_some_and(|p| !p.is_empty()) {
+            self.max_keys().saturating_mul(4).saturating_add(1)
+        } else {
+            self.max_keys().saturating_add(1)
+        };
+
+        self.state = ListObjectsV2State::ReadHeads;
+        smallvec![Effect::Storage(StorageEffect::Iter {
+            key_space: BLOB_HEAD_KEYSPACE.to_string(),
+            prefix: Some(prefix.into()),
+            start_after: self.input.continuation_token.clone().map(Into::into),
+            limit,
+            txn_id: self.txn_id,
+        })]
+    }
+
+    fn handle_heads_read(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::IterResult { values, .. }) = event else {
+            return self.emit_error(ListObjectsV2Error::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::IterResult)",
+                received: event,
+            });
+        };
+
+        let max_keys = self.max_keys();
+        self.pending.clear();
+        self.continuation_token = None;
+
+        let has_prefix = self.input.prefix.as_ref().is_some_and(|p| !p.is_empty());
+
+        if !has_prefix {
+            // Original index-based logic for bucket-only iteration
+            for (index, (key, value)) in values.into_iter().enumerate() {
+                if index >= max_keys {
+                    self.continuation_token = Some(key.to_vec());
+                    break;
+                }
+                let head = match BlobHeadKey::from_bytes(key.as_ref()) {
+                    Ok(head) => head,
+                    Err(err) => return self.emit_error(err.into()),
+                };
+                let pointer = match CurrentVersionPointer::from_bytes(value.as_ref()) {
+                    Ok(pointer) => pointer,
+                    Err(err) => return self.emit_error(err.into()),
+                };
+                if head.bucket != self.input.bucket {
+                    continue;
+                }
+                self.pending.push((head, pointer.version_id));
+            }
+        } else {
+            // Prefix filter: collect all matching keys; use non-matching
+            // keys as continuation points so no matches are skipped
+            let prefix = self.input.prefix.as_ref().unwrap();
+            for (key, value) in values {
+                let head = match BlobHeadKey::from_bytes(key.as_ref()) {
+                    Ok(head) => head,
+                    Err(err) => return self.emit_error(err.into()),
+                };
+                let pointer = match CurrentVersionPointer::from_bytes(value.as_ref()) {
+                    Ok(pointer) => pointer,
+                    Err(err) => return self.emit_error(err.into()),
+                };
+                if head.bucket != self.input.bucket {
+                    continue;
+                }
+                if head.key.starts_with(prefix.as_str()) {
+                    self.pending.push((head, pointer.version_id));
+                } else if self.pending.len() >= max_keys {
+                    self.continuation_token = Some(key.to_vec());
+                    break;
+                }
+            }
+        }
+
+        self.pending.reverse();
+
+        self.read_next_version_or_finish()
+    }
+
+    fn read_next_version_or_finish(&mut self) -> Effects {
+        let Some((head, version_id)) = self.pending.pop() else {
+            let Some(txn_id) = self.txn_id else {
+                return self.emit_error(ListObjectsV2Error::NoTransactionFound);
+            };
+
+            self.state = ListObjectsV2State::CommitTransaction;
+            self.output = Some(Ok(ListObjectsV2Result {
+                objects: std::mem::take(&mut self.objects),
+                continuation_token: self.continuation_token.clone(),
+            }));
+            return smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })];
+        };
+
+        self.current_head = Some(head.clone());
+        let key = match VersionKey::new(&head.bucket, &head.key, version_id).to_bytes() {
+            Ok(key) => key.into(),
+            Err(err) => return self.emit_error(err.into()),
+        };
+
+        self.state = ListObjectsV2State::ReadVersion;
+        smallvec![Effect::Storage(StorageEffect::Read {
+            key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+            key,
+            txn_id: self.txn_id,
+        })]
+    }
+
+    fn handle_version_read(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            return self.emit_error(ListObjectsV2Error::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::ReadResult)",
+                received: event,
+            });
+        };
+
+        let Some(value) = value else {
+            return self.emit_error(ListObjectsV2Error::ListObjectsV2Failed);
+        };
+
+        let version = match BlobVersion::from_bytes(value.as_ref()) {
+            Ok(version) => version,
+            Err(err) => return self.emit_error(err.into()),
+        };
+
+        match version.state {
+            BlobVersionState::Deleted => self.read_next_version_or_finish(),
+            BlobVersionState::Reference {
+                cached_metadata,
+                last_refresh,
+                ..
+            } => {
+                let Some(head) = self.current_head.clone() else {
+                    return self.emit_error(ListObjectsV2Error::ListObjectsV2Failed);
+                };
+
+                self.objects.push(ListObjectsV2Object {
+                    head,
+                    location: None,
+                    source_metadata: Some(cached_metadata),
+                    last_refresh: Some(last_refresh),
+                });
+                self.read_next_version_or_finish()
+            }
+            BlobVersionState::Materialized { blob_hash, .. } => {
+                self.state = ListObjectsV2State::ReadBlobLocation;
+                smallvec![Effect::Storage(StorageEffect::Read {
+                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                    key: blob_hash.to_vec().into(),
+                    txn_id: self.txn_id,
+                })]
+            }
+        }
+    }
+
+    fn handle_blob_location_read(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            return self.emit_error(ListObjectsV2Error::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::ReadResult)",
+                received: event,
+            });
+        };
+
+        let Some(value) = value else {
+            return self.emit_error(ListObjectsV2Error::ListObjectsV2Failed);
+        };
+
+        let location = match BackendLocation::from_bytes(value.as_ref()) {
+            Ok(location) => location,
+            Err(err) => return self.emit_error(err.into()),
+        };
+
+        let Some(head) = self.current_head.clone() else {
+            return self.emit_error(ListObjectsV2Error::ListObjectsV2Failed);
+        };
+
+        self.objects.push(ListObjectsV2Object {
+            head,
+            location: Some(location),
+            source_metadata: None,
+            last_refresh: None,
+        });
+        self.read_next_version_or_finish()
+    }
+
+    fn handle_transaction_committed(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::TransactionCommitted { .. }) = event else {
+            return self.emit_error(ListObjectsV2Error::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::TransactionCommitted)",
+                received: event,
+            });
+        };
+
+        self.state = ListObjectsV2State::Finish;
+        smallvec![]
+    }
+}
+
+impl Operation for ListObjectsV2Operation {
+    type Output = Option<Result<ListObjectsV2Result, ListObjectsV2Error>>;
+    type Error = ListObjectsV2Error;
+
+    fn start(&mut self) -> Effects {
+        self.handle_init()
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        if let Event::Storage(StorageEvent::Error { error }) = event {
+            return self.emit_error(ListObjectsV2Error::StorageError(error));
+        }
+
+        match self.state {
+            ListObjectsV2State::Init => self.handle_init(),
+            ListObjectsV2State::StartTransaction => self.handle_transaction_started(event),
+            ListObjectsV2State::ReadHeads => self.handle_heads_read(event),
+            ListObjectsV2State::ReadVersion => self.handle_version_read(event),
+            ListObjectsV2State::ReadBlobLocation => self.handle_blob_location_read(event),
+            ListObjectsV2State::CommitTransaction => self.handle_transaction_committed(event),
+            ListObjectsV2State::Finish | ListObjectsV2State::Error => smallvec![],
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            ListObjectsV2State::Finish | ListObjectsV2State::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        if self.state == ListObjectsV2State::Error {
+            if let Some(Err(error)) = self.output {
+                return Err(error);
+            }
+            return Err(ListObjectsV2Error::ListObjectsV2Failed);
+        }
+        Ok(self.output)
+    }
+
+    fn abort(&mut self) -> Effects {
+        match self.txn_id {
+            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
+            None => smallvec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::driver::{DriverContext, drive};
+    use aruna_core::UserId;
+    use aruna_core::effects::StorageEffect;
+    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::keyspaces::{
+        BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE,
+    };
+    use aruna_core::structs::{BlobVersion, CurrentVersionPointer, RealmId};
+    use aruna_storage::storage;
+    use std::collections::HashMap;
+    use std::time::{Duration, UNIX_EPOCH};
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_list_objects_v2_skips_deleted_versions() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        let group_id = Ulid::new();
+        let realm_id = RealmId([7u8; 32]);
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let live_version_id = Ulid::new();
+        let deleted_version_id = Ulid::new();
+        let live_hash = [3u8; 32];
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+
+        for (key, version_id, version) in [
+            (
+                "alpha",
+                live_version_id,
+                BlobVersion::materialized(live_hash, created_at, created_by, None),
+            ),
+            (
+                "beta",
+                deleted_version_id,
+                BlobVersion::deleted(created_at, created_by),
+            ),
+        ] {
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                    key: BlobHeadKey::new("bucket", key).to_bytes().unwrap().into(),
+                    value: CurrentVersionPointer::new(version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                    key: VersionKey::new("bucket", key, version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    value: version.to_bytes().unwrap().into(),
+                    txn_id: None,
+                })
+                .await;
+        }
+
+        let location = BackendLocation {
+            root: "/tmp".to_string(),
+            storage_bucket: "objects".to_string(),
+            backend_path: "path".to_string(),
+            ulid: Ulid::new(),
+            compressed: false,
+            encrypted: false,
+            created_by,
+            created_at,
+            staging: false,
+            partial: false,
+            blob_size: 42,
+            hashes: HashMap::new(),
+        };
+        let event = storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                key: live_hash.to_vec().into(),
+                value: location.to_bytes().unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+
+        let result = drive(
+            ListObjectsV2Operation::new(ListObjectsV2Input {
+                bucket: "bucket".to_string(),
+                group_id,
+                continuation_token: None,
+                max_keys: Some(10),
+                prefix: None,
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(result.objects.len(), 1);
+        assert_eq!(result.objects[0].head.key, "alpha");
+        assert_eq!(result.objects[0].location, Some(location));
+        assert_eq!(result.continuation_token, None);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_with_prefix() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        let group_id = Ulid::new();
+        let realm_id = RealmId([7u8; 32]);
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+
+        let keys = ["common/a", "common/b", "rare/1", "rare/2", "rare/3"];
+        for key in keys {
+            let version_id = Ulid::new();
+            let hash = [key.len() as u8; 32];
+            let version =
+                BlobVersion::materialized(hash, created_at, created_by, None);
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                    key: BlobHeadKey::new("bucket", key)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    value: CurrentVersionPointer::new(version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                    key: VersionKey::new("bucket", key, version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    value: version.to_bytes().unwrap().into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                    key: hash.to_vec().into(),
+                    value: BackendLocation {
+                        root: "/tmp".to_string(),
+                        storage_bucket: "objects".to_string(),
+                        backend_path: format!("path/{key}"),
+                        ulid: Ulid::new(),
+                        compressed: false,
+                        encrypted: false,
+                        created_by,
+                        created_at,
+                        staging: false,
+                        partial: false,
+                        blob_size: 42,
+                        hashes: HashMap::new(),
+                    }
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                    txn_id: None,
+                })
+                .await;
+        }
+
+        // Run with prefix filter; collect all results across pages
+        let mut continuation_token = None;
+        let mut all_keys = Vec::new();
+
+        loop {
+            let result = drive(
+                ListObjectsV2Operation::new(ListObjectsV2Input {
+                    bucket: "bucket".to_string(),
+                    group_id,
+                    continuation_token,
+                    max_keys: Some(2),
+                    prefix: Some("rare/".to_string()),
+                }),
+                &driver_ctx,
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+            for obj in result.objects {
+                all_keys.push(obj.head.key);
+            }
+
+            continuation_token = result.continuation_token;
+            if continuation_token.is_none() {
+                break;
+            }
+        }
+
+        // Verify prefix filtered correctly — all returned keys start with "rare/"
+        assert!(all_keys.iter().all(|k| k.starts_with("rare/")));
+        // And we got the right ones
+        let mut sorted = all_keys.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["rare/1", "rare/2", "rare/3"]);
+    }
+}

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -139,6 +139,16 @@ impl ListObjectsV2Operation {
     }
 
     fn handle_init(&mut self) -> Effects {
+        if self.max_keys() == 0 {
+            self.state = ListObjectsV2State::Finish;
+            self.output = Some(Ok(ListObjectsV2Result {
+                objects: Vec::new(),
+                common_prefixes: Vec::new(),
+                continuation_token: None,
+            }));
+            return smallvec![];
+        }
+
         self.state = ListObjectsV2State::StartTransaction;
         smallvec![Effect::Storage(StorageEffect::StartTransaction {
             read: true
@@ -241,10 +251,6 @@ impl ListObjectsV2Operation {
         };
 
         let max_keys = self.max_keys();
-        if max_keys == 0 {
-            return self.finish_scan();
-        }
-
         let round_len = values.len();
         for (key, value) in values.into_iter() {
             let head = match BlobHeadKey::from_bytes(key.as_ref()) {

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -196,6 +196,7 @@ impl ListObjectsV2Operation {
             // Prefix filter: collect all matching keys; use non-matching
             // keys as continuation points so no matches are skipped
             let prefix = self.input.prefix.as_ref().unwrap();
+            let mut continuation = None;
             for (key, value) in values {
                 let head = match BlobHeadKey::from_bytes(key.as_ref()) {
                     Ok(head) => head,
@@ -209,11 +210,14 @@ impl ListObjectsV2Operation {
                     continue;
                 }
                 if head.key.starts_with(prefix.as_str()) {
-                    self.pending.push((head, pointer.version_id));
-                } else if self.pending.len() >= max_keys {
-                    self.continuation_token = Some(key.to_vec());
-                    break;
+                    if self.pending.len() < max_keys {
+                        self.pending.push((head, pointer.version_id));
+                        continuation = Some(key.to_vec());
+                    }
                 }
+            }
+            if self.pending.len() >= max_keys {
+                self.continuation_token = continuation;
             }
         }
 
@@ -260,7 +264,7 @@ impl ListObjectsV2Operation {
         };
 
         let Some(value) = value else {
-            return self.emit_error(ListObjectsV2Error::ListObjectsV2Failed);
+            return self.read_next_version_or_finish();
         };
 
         let version = match BlobVersion::from_bytes(value.as_ref()) {
@@ -308,7 +312,7 @@ impl ListObjectsV2Operation {
         };
 
         let Some(value) = value else {
-            return self.emit_error(ListObjectsV2Error::ListObjectsV2Failed);
+            return self.read_next_version_or_finish();
         };
 
         let location = match BackendLocation::from_bytes(value.as_ref()) {

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -120,25 +120,23 @@ impl ListObjectsV2Operation {
         };
 
         self.txn_id = Some(txn_id);
-        let prefix = match BlobHeadKey::bucket_prefix(&self.input.bucket) {
-            Ok(prefix) => prefix,
-            Err(err) => return self.emit_error(err.into()),
-        };
-        let iter_start_key = if self.input.continuation_token.is_some() {
-            self.input.continuation_token.clone()
-        } else if let Some(prefix) = self
+        // The object prefix is a byte prefix of every matching head key, so
+        // the storage layer bounds the scan to the contiguous prefix range
+        // (including a key equal to the prefix itself).
+        let prefix = match self
             .input
             .prefix
             .as_ref()
             .filter(|prefix| !prefix.is_empty())
         {
-            match BlobHeadKey::object_prefix(&self.input.bucket, prefix) {
-                Ok(prefix) => Some(prefix),
-                Err(err) => return self.emit_error(err.into()),
-            }
-        } else {
-            None
+            Some(key_prefix) => BlobHeadKey::object_prefix(&self.input.bucket, key_prefix),
+            None => BlobHeadKey::bucket_prefix(&self.input.bucket),
         };
+        let prefix = match prefix {
+            Ok(prefix) => prefix,
+            Err(err) => return self.emit_error(err.into()),
+        };
+        let iter_start_key = self.input.continuation_token.clone();
 
         let limit = self.max_keys().saturating_add(1);
 
@@ -169,73 +167,25 @@ impl ListObjectsV2Operation {
             return self.read_next_version_or_finish();
         }
 
-        let has_prefix = self.input.prefix.as_ref().is_some_and(|p| !p.is_empty());
-        let raw_count = values.len();
-
-        if !has_prefix {
-            // Track the key of the last pushed item as the continuation
-            // token.  Since the Iter effect uses an *exclusive* start_after
-            // bound, using the first excluded item (index == max_keys) would
-            // skip it on the next page.
-            //
-            // Only set the token when the storage returned a full page
-            // (more than max_keys items), which is our signal that more
-            // items likely exist.  When fewer items are returned we are
-            // at the end and there is nothing left to page.
-            let mut continuation = None;
-            for (index, (key, value)) in values.into_iter().enumerate() {
-                if index >= max_keys {
-                    break;
-                }
-                let head = match BlobHeadKey::from_bytes(key.as_ref()) {
-                    Ok(head) => head,
-                    Err(err) => return self.emit_error(err.into()),
-                };
-                let pointer = match CurrentVersionPointer::from_bytes(value.as_ref()) {
-                    Ok(pointer) => pointer,
-                    Err(err) => return self.emit_error(err.into()),
-                };
-                if head.bucket != self.input.bucket {
-                    continue;
-                }
-                continuation = Some(key.to_vec());
-                self.pending.push((head, pointer.version_id));
-            }
-            if raw_count > max_keys {
-                self.continuation_token = continuation;
-            }
-        } else {
-            // Prefix filter: we start scanning at the requested object prefix,
-            // then stop at the first key outside that contiguous prefix range.
-            let prefix = self.input.prefix.as_ref().unwrap();
-            let mut continuation = None;
-            let mut has_more_matches = false;
-            for (key, value) in values {
-                let head = match BlobHeadKey::from_bytes(key.as_ref()) {
-                    Ok(head) => head,
-                    Err(err) => return self.emit_error(err.into()),
-                };
-                let pointer = match CurrentVersionPointer::from_bytes(value.as_ref()) {
-                    Ok(pointer) => pointer,
-                    Err(err) => return self.emit_error(err.into()),
-                };
-                if head.bucket != self.input.bucket {
-                    continue;
-                }
-                if !head.key.starts_with(prefix.as_str()) {
-                    break;
-                }
-                if self.pending.len() < max_keys {
-                    self.pending.push((head, pointer.version_id));
-                    continuation = Some(key.to_vec());
-                } else {
-                    has_more_matches = true;
-                    break;
-                }
-            }
-            if has_more_matches {
-                self.continuation_token = continuation;
-            }
+        // The continuation token is the key of the last returned item: the
+        // Iter start_after bound is exclusive, and a full page (more than
+        // max_keys items) signals that more items exist in the range.
+        let has_more = values.len() > max_keys;
+        let mut last_key = None;
+        for (key, value) in values.into_iter().take(max_keys) {
+            let head = match BlobHeadKey::from_bytes(key.as_ref()) {
+                Ok(head) => head,
+                Err(err) => return self.emit_error(err.into()),
+            };
+            let pointer = match CurrentVersionPointer::from_bytes(value.as_ref()) {
+                Ok(pointer) => pointer,
+                Err(err) => return self.emit_error(err.into()),
+            };
+            last_key = Some(key);
+            self.pending.push((head, pointer.version_id));
+        }
+        if has_more {
+            self.continuation_token = last_key.map(|key| key.to_vec());
         }
 
         self.pending.reverse();
@@ -1064,5 +1014,155 @@ mod test {
         assert_eq!(result.objects[0].source_metadata, Some(source_metadata));
         assert_eq!(result.objects[0].last_refresh, Some(last_refresh));
         assert!(result.continuation_token.is_none());
+    }
+
+    fn driver_context(storage_handle: storage::StorageHandle) -> DriverContext {
+        DriverContext {
+            storage_handle,
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        }
+    }
+
+    async fn seed_materialized_keys(
+        storage_handle: &storage::StorageHandle,
+        bucket: &str,
+        keys: &[&str],
+        created_by: UserId,
+    ) {
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+        for (index, key) in keys.iter().enumerate() {
+            let version_id = Ulid::new();
+            let hash = [index as u8 + 1; 32];
+            let version = BlobVersion::materialized(hash, created_at, created_by, None);
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                    key: BlobHeadKey::new(bucket, *key).to_bytes().unwrap().into(),
+                    value: CurrentVersionPointer::new(version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                    key: VersionKey::new(bucket, *key, version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    value: version.to_bytes().unwrap().into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                    key: hash.to_vec().into(),
+                    value: BackendLocation {
+                        root: "/tmp".to_string(),
+                        storage_bucket: "objects".to_string(),
+                        backend_path: format!("path/{key}"),
+                        ulid: Ulid::new(),
+                        compressed: false,
+                        encrypted: false,
+                        created_by,
+                        created_at,
+                        staging: false,
+                        partial: false,
+                        blob_size: 42,
+                        hashes: HashMap::new(),
+                    }
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                    txn_id: None,
+                })
+                .await;
+        }
+    }
+
+    async fn list_keys(
+        driver_ctx: &DriverContext,
+        bucket: &str,
+        prefix: Option<&str>,
+    ) -> Vec<String> {
+        let result = drive(
+            ListObjectsV2Operation::new(ListObjectsV2Input {
+                bucket: bucket.to_string(),
+                group_id: Ulid::new(),
+                continuation_token: None,
+                max_keys: Some(100),
+                prefix: prefix.map(str::to_string),
+            }),
+            driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+        result
+            .objects
+            .into_iter()
+            .map(|object| object.head.key)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_prefix_includes_key_equal_to_prefix() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = driver_context(storage_handle.clone());
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["docs/", "docs/readme.md"],
+            created_by,
+        )
+        .await;
+
+        let keys = list_keys(&driver_ctx, "bucket", Some("docs/")).await;
+        assert_eq!(keys, vec!["docs/", "docs/readme.md"]);
+
+        let keys = list_keys(&driver_ctx, "bucket", Some("docs/readme.md")).await;
+        assert_eq!(keys, vec!["docs/readme.md"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_prefix_scan_with_interleaved_shorter_key() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = driver_context(storage_handle.clone());
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+
+        // "rare0" sorts between "rare/" and "rare/1" under length-first
+        // orderings; the contiguous prefix range must not be cut by it.
+        seed_materialized_keys(&storage_handle, "bucket", &["rare0", "rare/1"], created_by).await;
+
+        let keys = list_keys(&driver_ctx, "bucket", Some("rare/")).await;
+        assert_eq!(keys, vec!["rare/1"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_returns_keys_in_lexicographic_order() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = driver_context(storage_handle.clone());
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+
+        seed_materialized_keys(&storage_handle, "bucket", &["b", "aa", "a/1"], created_by).await;
+
+        let keys = list_keys(&driver_ctx, "bucket", None).await;
+        assert_eq!(keys, vec!["a/1", "aa", "b"]);
     }
 }

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -628,6 +628,117 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_list_objects_v2_pagination_without_prefix() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            automerge_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        let group_id = Ulid::new();
+        let realm_id = RealmId([7u8; 32]);
+        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_at = UNIX_EPOCH + Duration::from_secs(5);
+
+        let keys = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta"];
+        for key in keys {
+            let version_id = Ulid::new();
+            let hash = [key.len() as u8; 32];
+            let version = BlobVersion::materialized(hash, created_at, created_by, None);
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                    key: BlobHeadKey::new("bucket", key).to_bytes().unwrap().into(),
+                    value: CurrentVersionPointer::new(version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                    key: VersionKey::new("bucket", key, version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    value: version.to_bytes().unwrap().into(),
+                    txn_id: None,
+                })
+                .await;
+            let _ = storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                    key: hash.to_vec().into(),
+                    value: BackendLocation {
+                        root: "/tmp".to_string(),
+                        storage_bucket: "objects".to_string(),
+                        backend_path: format!("path/{key}"),
+                        ulid: Ulid::new(),
+                        compressed: false,
+                        encrypted: false,
+                        created_by,
+                        created_at,
+                        staging: false,
+                        partial: false,
+                        blob_size: 42,
+                        hashes: HashMap::new(),
+                    }
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                    txn_id: None,
+                })
+                .await;
+        }
+
+        // Paginate without prefix; collect all results across pages
+        let mut continuation_token = None;
+        let mut all_keys = Vec::new();
+
+        loop {
+            let result = drive(
+                ListObjectsV2Operation::new(ListObjectsV2Input {
+                    bucket: "bucket".to_string(),
+                    group_id,
+                    continuation_token,
+                    max_keys: Some(3),
+                    prefix: None,
+                }),
+                &driver_ctx,
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+            for obj in result.objects {
+                all_keys.push(obj.head.key);
+            }
+
+            continuation_token = result.continuation_token;
+            if continuation_token.is_none() {
+                break;
+            }
+        }
+
+        // Verify all 7 keys were returned
+        let mut sorted = all_keys.clone();
+        sorted.sort();
+        assert_eq!(
+            sorted,
+            vec!["alpha", "beta", "delta", "epsilon", "eta", "gamma", "zeta"]
+        );
+    }
+
+    #[tokio::test]
     async fn test_list_objects_v2_empty_bucket() {
         let temp_handle = tempdir().unwrap();
         let storage_handle =

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -105,7 +105,7 @@ pub struct ListObjectsV2Operation {
 }
 
 impl ListObjectsV2Operation {
-    const DEFAULT_MAX_KEYS: usize = 1_000;
+    pub const DEFAULT_MAX_KEYS: usize = 1_000;
     const MAX_SCAN_ROUNDS: usize = 100;
 
     pub fn new(input: ListObjectsV2Input) -> Self {

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -8,6 +8,7 @@ use aruna_core::structs::{
     SourceMetadata, VersionKey,
 };
 use aruna_core::types::{Effects, GroupId};
+use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
 use thiserror::Error;
 use ulid::Ulid;
@@ -46,10 +47,27 @@ pub enum ListObjectsV2Error {
 pub struct ListObjectsV2Input {
     pub bucket: String,
     pub group_id: GroupId,
-    pub continuation_token: Option<Vec<u8>>,
+    pub continuation_token: Option<ListObjectsV2ContinuationToken>,
     pub max_keys: Option<usize>,
     pub prefix: Option<String>,
+    pub delimiter: Option<String>,
     pub start_after: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ListObjectsV2ContinuationToken {
+    pub last_key: Vec<u8>,
+    pub last_common_prefix: Option<String>,
+}
+
+impl ListObjectsV2ContinuationToken {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
+        Ok(postcard::to_allocvec(self)?)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
+        Ok(postcard::from_bytes(bytes)?)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -63,7 +81,8 @@ pub struct ListObjectsV2Object {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListObjectsV2Result {
     pub objects: Vec<ListObjectsV2Object>,
-    pub continuation_token: Option<Vec<u8>>,
+    pub common_prefixes: Vec<String>,
+    pub continuation_token: Option<ListObjectsV2ContinuationToken>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -73,13 +92,21 @@ pub struct ListObjectsV2Operation {
     txn_id: Option<Ulid>,
     pending: Vec<(BlobHeadKey, Ulid)>,
     objects: Vec<ListObjectsV2Object>,
-    continuation_token: Option<Vec<u8>>,
+    common_prefixes: Vec<String>,
+    continuation_token: Option<ListObjectsV2ContinuationToken>,
     current_head: Option<BlobHeadKey>,
+    scan_prefix: Vec<u8>,
+    scan_limit: usize,
+    scan_rounds: usize,
+    resume_common_prefix: Option<String>,
+    cursor_group: Option<String>,
+    last_consumed_key: Option<Vec<u8>>,
     output: Option<Result<ListObjectsV2Result, ListObjectsV2Error>>,
 }
 
 impl ListObjectsV2Operation {
     const DEFAULT_MAX_KEYS: usize = 1_000;
+    const MAX_SCAN_ROUNDS: usize = 100;
 
     pub fn new(input: ListObjectsV2Input) -> Self {
         Self {
@@ -88,8 +115,15 @@ impl ListObjectsV2Operation {
             txn_id: None,
             pending: Vec::new(),
             objects: Vec::new(),
+            common_prefixes: Vec::new(),
             continuation_token: None,
             current_head: None,
+            scan_prefix: Vec::new(),
+            scan_limit: 0,
+            scan_rounds: 0,
+            resume_common_prefix: None,
+            cursor_group: None,
+            last_consumed_key: None,
             output: None,
         }
     }
@@ -121,9 +155,6 @@ impl ListObjectsV2Operation {
         };
 
         self.txn_id = Some(txn_id);
-        // The object prefix is a byte prefix of every matching head key, so
-        // the storage layer bounds the scan to the contiguous prefix range
-        // (including a key equal to the prefix itself).
         let prefix = match self
             .input
             .prefix
@@ -137,10 +168,11 @@ impl ListObjectsV2Operation {
             Ok(prefix) => prefix,
             Err(err) => return self.emit_error(err.into()),
         };
-        // start_after only applies to the first page; the exclusive Iter
-        // start bound matches S3's StartAfter semantics exactly.
         let iter_start_key = match (&self.input.continuation_token, &self.input.start_after) {
-            (Some(token), _) => Some(token.clone()),
+            (Some(token), _) => {
+                self.resume_common_prefix = token.last_common_prefix.clone();
+                Some(token.last_key.clone())
+            }
             (None, Some(start_after)) if !start_after.is_empty() => {
                 match BlobHeadKey::object_prefix(&self.input.bucket, start_after) {
                     Ok(key) => Some(key),
@@ -153,19 +185,50 @@ impl ListObjectsV2Operation {
             && start.as_slice() > prefix.as_slice()
             && !start.starts_with(&prefix)
         {
-            return self.read_next_version_or_finish();
+            return self.finish_scan();
         }
 
-        let limit = self.max_keys().saturating_add(1);
+        self.scan_prefix = prefix;
+        self.last_consumed_key = iter_start_key;
+        self.issue_scan_round()
+    }
+
+    fn issue_scan_round(&mut self) -> Effects {
+        let visible = self.pending.len() + self.common_prefixes.len();
+        self.scan_limit = self.max_keys().saturating_sub(visible).saturating_add(1);
+        self.scan_rounds += 1;
 
         self.state = ListObjectsV2State::ReadHeads;
         smallvec![Effect::Storage(StorageEffect::Iter {
             key_space: BLOB_HEAD_KEYSPACE.to_string(),
-            prefix: Some(prefix.into()),
-            start_after: iter_start_key.map(Into::into),
-            limit,
+            prefix: Some(self.scan_prefix.clone().into()),
+            start_after: self.last_consumed_key.clone().map(Into::into),
+            limit: self.scan_limit,
             txn_id: self.txn_id,
         })]
+    }
+
+    fn truncate_scan(&mut self) -> Effects {
+        self.continuation_token =
+            self.last_consumed_key
+                .clone()
+                .map(|last_key| ListObjectsV2ContinuationToken {
+                    last_key,
+                    last_common_prefix: self.cursor_group.clone(),
+                });
+        self.finish_scan()
+    }
+
+    fn finish_scan(&mut self) -> Effects {
+        self.pending.reverse();
+        self.read_next_version_or_finish()
+    }
+
+    fn common_prefix_of(&self, key: &str) -> Option<String> {
+        let delimiter = self.input.delimiter.as_ref().filter(|d| !d.is_empty())?;
+        let prefix_len = self.input.prefix.as_ref().map_or(0, String::len);
+        let relative_match = key.get(prefix_len..)?.find(delimiter.as_str())?;
+        Some(key[..prefix_len + relative_match + delimiter.len()].to_string())
     }
 
     fn handle_heads_read(&mut self, event: Event) -> Effects {
@@ -178,19 +241,12 @@ impl ListObjectsV2Operation {
         };
 
         let max_keys = self.max_keys();
-        self.pending.clear();
-        self.continuation_token = None;
-
         if max_keys == 0 {
-            return self.read_next_version_or_finish();
+            return self.finish_scan();
         }
 
-        // The continuation token is the key of the last returned item: the
-        // Iter start_after bound is exclusive, and a full page (more than
-        // max_keys items) signals that more items exist in the range.
-        let has_more = values.len() > max_keys;
-        let mut last_key = None;
-        for (key, value) in values.into_iter().take(max_keys) {
+        let round_len = values.len();
+        for (key, value) in values.into_iter() {
             let head = match BlobHeadKey::from_bytes(key.as_ref()) {
                 Ok(head) => head,
                 Err(err) => return self.emit_error(err.into()),
@@ -199,16 +255,43 @@ impl ListObjectsV2Operation {
                 Ok(pointer) => pointer,
                 Err(err) => return self.emit_error(err.into()),
             };
-            last_key = Some(key);
-            self.pending.push((head, pointer.version_id));
-        }
-        if has_more {
-            self.continuation_token = last_key.map(|key| key.to_vec());
+
+            let visible = self.pending.len() + self.common_prefixes.len();
+            match self.common_prefix_of(&head.key) {
+                Some(group) => {
+                    let already_emitted = self.resume_common_prefix.as_deref()
+                        == Some(group.as_str())
+                        || self.common_prefixes.last().map(String::as_str) == Some(group.as_str());
+                    if !already_emitted {
+                        if visible >= max_keys {
+                            return self.truncate_scan();
+                        }
+                        self.resume_common_prefix = None;
+                        self.common_prefixes.push(group.clone());
+                    }
+                    self.cursor_group = Some(group);
+                    self.last_consumed_key = Some(key.to_vec());
+                }
+                None => {
+                    if visible >= max_keys {
+                        return self.truncate_scan();
+                    }
+                    self.resume_common_prefix = None;
+                    self.cursor_group = None;
+                    self.last_consumed_key = Some(key.to_vec());
+                    self.pending.push((head, pointer.version_id));
+                }
+            }
         }
 
-        self.pending.reverse();
+        if round_len < self.scan_limit {
+            return self.finish_scan();
+        }
+        if self.scan_rounds >= Self::MAX_SCAN_ROUNDS {
+            return self.truncate_scan();
+        }
 
-        self.read_next_version_or_finish()
+        self.issue_scan_round()
     }
 
     fn read_next_version_or_finish(&mut self) -> Effects {
@@ -220,6 +303,7 @@ impl ListObjectsV2Operation {
             self.state = ListObjectsV2State::CommitTransaction;
             self.output = Some(Ok(ListObjectsV2Result {
                 objects: std::mem::take(&mut self.objects),
+                common_prefixes: std::mem::take(&mut self.common_prefixes),
                 continuation_token: self.continuation_token.clone(),
             }));
             return smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })];
@@ -492,6 +576,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(10),
                 prefix: None,
+                delimiter: None,
                 start_after: None,
             }),
             &driver_ctx,
@@ -591,6 +676,7 @@ mod test {
                     continuation_token,
                     max_keys: Some(2),
                     prefix: Some("rare/".to_string()),
+                    delimiter: None,
                     start_after: None,
                 }),
                 &driver_ctx,
@@ -704,6 +790,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(1),
                 prefix: Some("rare/".to_string()),
+                delimiter: None,
                 start_after: None,
             }),
             &driver_ctx,
@@ -779,6 +866,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(0),
                 prefix: None,
+                delimiter: None,
                 start_after: None,
             }),
             &driver_ctx,
@@ -876,6 +964,7 @@ mod test {
                     continuation_token,
                     max_keys: Some(3),
                     prefix: None,
+                    delimiter: None,
                     start_after: None,
                 }),
                 &driver_ctx,
@@ -927,6 +1016,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(10),
                 prefix: None,
+                delimiter: None,
                 start_after: None,
             }),
             &driver_ctx,
@@ -1024,6 +1114,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(10),
                 prefix: None,
+                delimiter: None,
                 start_after: None,
             }),
             &driver_ctx,
@@ -1125,6 +1216,7 @@ mod test {
                 continuation_token: None,
                 max_keys: Some(100),
                 prefix: prefix.map(str::to_string),
+                delimiter: None,
                 start_after: start_after.map(str::to_string),
             }),
             driver_ctx,
@@ -1171,8 +1263,6 @@ mod test {
         let driver_ctx = driver_context(storage_handle.clone());
         let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
 
-        // "rare0" sorts between "rare/" and "rare/1" under length-first
-        // orderings; the contiguous prefix range must not be cut by it.
         seed_materialized_keys(&storage_handle, "bucket", &["rare0", "rare/1"], created_by).await;
 
         let keys = list_keys(&driver_ctx, "bucket", Some("rare/"), None).await;
@@ -1228,5 +1318,103 @@ mod test {
 
         let keys = list_keys(&driver_ctx, "bucket", Some("docs/"), Some("a")).await;
         assert_eq!(keys, vec!["docs/1", "docs/2"]);
+    }
+
+    async fn list_page(
+        driver_ctx: &DriverContext,
+        bucket: &str,
+        delimiter: Option<&str>,
+        max_keys: usize,
+        continuation_token: Option<ListObjectsV2ContinuationToken>,
+    ) -> ListObjectsV2Result {
+        drive(
+            ListObjectsV2Operation::new(ListObjectsV2Input {
+                bucket: bucket.to_string(),
+                group_id: Ulid::new(),
+                continuation_token,
+                max_keys: Some(max_keys),
+                prefix: None,
+                delimiter: delimiter.map(str::to_string),
+                start_after: None,
+            }),
+            driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_delimiter_groups_keys() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = driver_context(storage_handle.clone());
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["a.txt", "dir/1", "dir/2", "z.txt"],
+            created_by,
+        )
+        .await;
+
+        let result = list_page(&driver_ctx, "bucket", Some("/"), 100, None).await;
+
+        let keys: Vec<_> = result
+            .objects
+            .into_iter()
+            .map(|object| object.head.key)
+            .collect();
+        assert_eq!(keys, vec!["a.txt", "z.txt"]);
+        assert_eq!(result.common_prefixes, vec!["dir/"]);
+        assert!(result.continuation_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_objects_v2_delimiter_pagination_never_repeats_prefixes() {
+        let temp_handle = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
+        let driver_ctx = driver_context(storage_handle.clone());
+        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+
+        seed_materialized_keys(
+            &storage_handle,
+            "bucket",
+            &["a", "dir/1", "dir/2", "dir/3", "z"],
+            created_by,
+        )
+        .await;
+
+        let mut continuation_token = None;
+        let mut all_keys = Vec::new();
+        let mut all_prefixes = Vec::new();
+        let mut pages = 0;
+
+        loop {
+            let result = list_page(
+                &driver_ctx,
+                "bucket",
+                Some("/"),
+                1,
+                continuation_token.take(),
+            )
+            .await;
+            all_keys.extend(result.objects.into_iter().map(|object| object.head.key));
+            all_prefixes.extend(result.common_prefixes);
+            pages += 1;
+            assert!(pages < 10);
+
+            continuation_token = result.continuation_token;
+            if continuation_token.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(all_keys, vec!["a", "z"]);
+        assert_eq!(all_prefixes, vec!["dir/"]);
     }
 }

--- a/operations/src/s3/mod.rs
+++ b/operations/src/s3/mod.rs
@@ -10,6 +10,7 @@ pub mod get_object;
 pub mod get_user_access;
 pub mod head_object;
 pub mod list_buckets;
+pub mod list_objects_v2;
 pub mod put_bucket_replication;
 pub mod put_object;
 pub mod revoke_user_access;

--- a/operations/tests/multipart.rs
+++ b/operations/tests/multipart.rs
@@ -31,7 +31,6 @@ use aruna_operations::s3::delete_object::{DeleteObjectInput, DeleteObjectOperati
 use aruna_operations::s3::put_object::{PutObjectConfig, PutObjectInput, PutObjectOperation};
 use aruna_operations::s3::upload_part::{UploadPartInput, UploadPartOperation};
 use aruna_storage::storage;
-use base64::Engine;
 use std::collections::HashMap;
 use std::fs::{create_dir_all, exists, read_dir, read_to_string};
 use std::path::Path;
@@ -203,10 +202,7 @@ async fn complete_upload(
                 .enumerate()
                 .map(|(idx, part)| CompleteMultipartPart {
                     part_number: (idx + 1) as u16,
-                    etag: Some(
-                        base64::engine::general_purpose::STANDARD
-                            .encode(part.location.hashes.get("md5").unwrap()),
-                    ),
+                    etag: Some(hex::encode(part.location.hashes.get("md5").unwrap())),
                     expected_checksums: vec![],
                 })
                 .collect(),
@@ -310,18 +306,16 @@ async fn completes_multipart_upload_and_persists_object_part_metadata() {
             completed_parts: vec![
                 CompleteMultipartPart {
                     part_number: 1,
-                    etag: Some(
-                        base64::engine::general_purpose::STANDARD
-                            .encode(uploaded_part1.location.hashes.get("md5").unwrap()),
-                    ),
+                    etag: Some(hex::encode(
+                        uploaded_part1.location.hashes.get("md5").unwrap(),
+                    )),
                     expected_checksums: vec![],
                 },
                 CompleteMultipartPart {
                     part_number: 2,
-                    etag: Some(
-                        base64::engine::general_purpose::STANDARD
-                            .encode(uploaded_part2.location.hashes.get("md5").unwrap()),
-                    ),
+                    etag: Some(hex::encode(
+                        uploaded_part2.location.hashes.get("md5").unwrap(),
+                    )),
                     expected_checksums: vec![],
                 },
             ],
@@ -678,18 +672,16 @@ async fn completes_multipart_upload_retains_previous_current_hash_path_index() {
             completed_parts: vec![
                 CompleteMultipartPart {
                     part_number: 1,
-                    etag: Some(
-                        base64::engine::general_purpose::STANDARD
-                            .encode(uploaded_part1.location.hashes.get("md5").unwrap()),
-                    ),
+                    etag: Some(hex::encode(
+                        uploaded_part1.location.hashes.get("md5").unwrap(),
+                    )),
                     expected_checksums: vec![],
                 },
                 CompleteMultipartPart {
                     part_number: 2,
-                    etag: Some(
-                        base64::engine::general_purpose::STANDARD
-                            .encode(uploaded_part2.location.hashes.get("md5").unwrap()),
-                    ),
+                    etag: Some(hex::encode(
+                        uploaded_part2.location.hashes.get("md5").unwrap(),
+                    )),
                     expected_checksums: vec![],
                 },
             ],
@@ -1295,18 +1287,16 @@ async fn delete_object_removes_completed_multipart_metadata() {
             completed_parts: vec![
                 CompleteMultipartPart {
                     part_number: 1,
-                    etag: Some(
-                        base64::engine::general_purpose::STANDARD
-                            .encode(uploaded_part1.location.hashes.get("md5").unwrap()),
-                    ),
+                    etag: Some(hex::encode(
+                        uploaded_part1.location.hashes.get("md5").unwrap(),
+                    )),
                     expected_checksums: vec![],
                 },
                 CompleteMultipartPart {
                     part_number: 2,
-                    etag: Some(
-                        base64::engine::general_purpose::STANDARD
-                            .encode(uploaded_part2.location.hashes.get("md5").unwrap()),
-                    ),
+                    etag: Some(hex::encode(
+                        uploaded_part2.location.hashes.get("md5").unwrap(),
+                    )),
                     expected_checksums: vec![],
                 },
             ],


### PR DESCRIPTION
Implements the S3 `ListObjectsV2` operation for the Aruna S3 interface.

**Key features:**
- Full `ListObjectsV2` operation with pagination via continuation tokens
- Prefix filtering, delimiter-based common prefix grouping (e.g. `"/"`)
- `StartAfter` filtering on both object keys and common prefixes
- Pagination guard limiting backend page scans to prevent runaway reads
- Correct handling of `max_keys=0` and edge cases (empty buckets, reference objects)
- Continuation token encoding/decoding for opaque pagination across requests
- `BlobHeadKey::object_prefix` serialization utility for building prefix-based key ranges

**Testing:**
- Unit tests covering prefix filtering, pagination, common prefix grouping, `StartAfter` with common prefixes, empty buckets, reference objects, and scoped credential denial
- Integration test coverage for S3-scoped credentials denying out-of-scope access