### PR TITLE
Feat/cors: Add CORS handling to API and S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,14 @@ METADATA_REPLICATION_FACTOR=3
 S3_HOST=127.0.0.1:1337
 S3_ADDRESS=0.0.0.0:1337
 
+# Comma-separated list of origins allowed to call the REST and S3 interfaces
+# from a browser (e.g. http://localhost:5173 for the portal dev server).
+# Empty = deny all cross-origin requests. A literal * allows every origin.
+CORS_ALLOWED_ORIGINS=
+
+# Maximum REST request body size in bytes (default 1 MiB). Oversized bodies
+# are rejected with 413.
+MAX_HTTP_BODY_SIZE=
+
 RUST_LOG=
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ CORS_ALLOWED_ORIGINS=
 
 # Maximum REST request body size in bytes (default 1 MiB). Oversized bodies
 # are rejected with 413.
-MAX_HTTP_BODY_SIZE=
+MAX_HTTP_BODY_SIZE=1048576
 
 RUST_LOG=
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "ulid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full", "tracing"] }
 tokio-util = "0.7.18"
+tower-http = { version = "0.6.7", features = ["cors"] }
 tracing = "0.1.44"
 tracing-opentelemetry = { version = "0.33.0", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = [

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -46,6 +46,7 @@ async-trait = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
 http = { workspace = true }
+tower-http = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 s3s = { workspace = true }

--- a/api/src/cors.rs
+++ b/api/src/cors.rs
@@ -1,5 +1,6 @@
 use axum::http::Method;
 use http::HeaderMap;
+use http::HeaderName;
 use http::HeaderValue;
 use http::header;
 use std::time::Duration;
@@ -12,10 +13,10 @@ const S3_DEFAULT_ALLOWED_HEADERS: &str = "authorization,content-type,content-md5
 const S3_EXPOSED_HEADERS: &str = "etag,content-range,accept-ranges,content-length,last-modified,\
      x-amz-request-id,x-amz-version-id,x-amz-delete-marker,aruna-source-content-type,\
      aruna-source-etag,aruna-source-last-modified,aruna-last-refresh";
-pub(crate) const S3_PREFLIGHT_VARY: &[&str] = &[
-    "Origin",
-    "Access-Control-Request-Method",
-    "Access-Control-Request-Headers",
+pub(crate) const S3_PREFLIGHT_VARY: &[HeaderName] = &[
+    header::ORIGIN,
+    header::ACCESS_CONTROL_REQUEST_METHOD,
+    header::ACCESS_CONTROL_REQUEST_HEADERS,
 ];
 
 /// Allowed cross-origin request origins, shared by the REST and S3 interfaces.
@@ -154,11 +155,11 @@ impl CorsConfig {
             header::ACCESS_CONTROL_EXPOSE_HEADERS,
             HeaderValue::from_static(S3_EXPOSED_HEADERS),
         );
-        headers.append(header::VARY, HeaderValue::from_static("origin"));
+        append_vary_headers(headers, &[header::ORIGIN]);
     }
 }
 
-pub(crate) fn append_vary_headers(headers: &mut HeaderMap, values: &[&str]) {
+pub(crate) fn append_vary_headers(headers: &mut HeaderMap, values: &[HeaderName]) {
     let mut vary_values = headers
         .get(header::VARY)
         .and_then(|value| value.to_str().ok())
@@ -175,9 +176,9 @@ pub(crate) fn append_vary_headers(headers: &mut HeaderMap, values: &[&str]) {
     for value in values {
         if !vary_values
             .iter()
-            .any(|existing| existing.eq_ignore_ascii_case(value))
+            .any(|existing| existing.eq_ignore_ascii_case(value.as_str()))
         {
-            vary_values.push((*value).to_string());
+            vary_values.push(value.as_str().to_string());
         }
     }
 
@@ -270,7 +271,7 @@ mod tests {
         );
         assert_eq!(
             headers.get(header::VARY).unwrap(),
-            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"
+            "origin, access-control-request-method, access-control-request-headers"
         );
     }
 }

--- a/api/src/cors.rs
+++ b/api/src/cors.rs
@@ -1,0 +1,237 @@
+use axum::http::Method;
+use http::HeaderMap;
+use http::HeaderValue;
+use http::header;
+use std::time::Duration;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+const CORS_MAX_AGE: Duration = Duration::from_secs(3600);
+const S3_ALLOWED_METHODS: &str = "GET,HEAD,PUT,POST,DELETE,OPTIONS";
+const S3_DEFAULT_ALLOWED_HEADERS: &str = "authorization,content-type,content-md5,range,\
+     x-amz-content-sha256,x-amz-date,x-amz-security-token,x-amz-user-agent";
+const S3_EXPOSED_HEADERS: &str = "etag,content-range,accept-ranges,content-length,last-modified,\
+     x-amz-request-id,x-amz-version-id,x-amz-delete-marker,aruna-source-content-type,\
+     aruna-source-etag,aruna-source-last-modified,aruna-last-refresh";
+
+/// Allowed cross-origin request origins, shared by the REST and S3 interfaces.
+/// An empty configuration denies all cross-origin access (no CORS headers are
+/// emitted); a literal `*` entry allows every origin.
+#[derive(Clone, Debug, Default)]
+pub struct CorsConfig {
+    allowed_origins: Vec<String>,
+    allow_any: bool,
+}
+
+impl CorsConfig {
+    pub fn new(origins: impl IntoIterator<Item = String>) -> Self {
+        let mut allowed_origins = Vec::new();
+        let mut allow_any = false;
+        for origin in origins {
+            let origin = origin.trim().trim_end_matches('/');
+            if origin.is_empty() {
+                continue;
+            }
+            if origin == "*" {
+                allow_any = true;
+            } else {
+                allowed_origins.push(origin.to_string());
+            }
+        }
+        Self {
+            allowed_origins,
+            allow_any,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.allow_any || !self.allowed_origins.is_empty()
+    }
+
+    pub fn allows(&self, origin: &HeaderValue) -> bool {
+        if self.allow_any {
+            return true;
+        }
+        origin
+            .to_str()
+            .map(|origin| {
+                self.allowed_origins
+                    .iter()
+                    .any(|allowed| allowed == origin.trim_end_matches('/'))
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn rest_layer(&self) -> Option<CorsLayer> {
+        if !self.is_enabled() {
+            return None;
+        }
+        let allow_origin = if self.allow_any {
+            AllowOrigin::any()
+        } else {
+            AllowOrigin::list(
+                self.allowed_origins
+                    .iter()
+                    .filter_map(|origin| origin.parse().ok()),
+            )
+        };
+        Some(
+            CorsLayer::new()
+                .allow_origin(allow_origin)
+                .allow_methods([
+                    Method::GET,
+                    Method::POST,
+                    Method::PUT,
+                    Method::PATCH,
+                    Method::DELETE,
+                    Method::HEAD,
+                    Method::OPTIONS,
+                ])
+                .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
+                .max_age(CORS_MAX_AGE),
+        )
+    }
+
+    fn allow_origin_value(&self, origin: &HeaderValue) -> HeaderValue {
+        if self.allow_any {
+            HeaderValue::from_static("*")
+        } else {
+            origin.clone()
+        }
+    }
+
+    /// Headers for an S3 preflight response. Returns `None` when the origin is
+    /// not allowed; the preflight is then answered without CORS headers.
+    pub fn s3_preflight_headers(
+        &self,
+        origin: &HeaderValue,
+        requested_headers: Option<&HeaderValue>,
+    ) -> Option<HeaderMap> {
+        if !self.allows(origin) {
+            return None;
+        }
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            self.allow_origin_value(origin),
+        );
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_METHODS,
+            HeaderValue::from_static(S3_ALLOWED_METHODS),
+        );
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_HEADERS,
+            requested_headers
+                .cloned()
+                .unwrap_or_else(|| HeaderValue::from_static(S3_DEFAULT_ALLOWED_HEADERS)),
+        );
+        headers.insert(
+            header::ACCESS_CONTROL_MAX_AGE,
+            HeaderValue::from(CORS_MAX_AGE.as_secs()),
+        );
+        headers.insert(header::VARY, HeaderValue::from_static("origin"));
+        Some(headers)
+    }
+
+    /// Adds CORS headers to a normal (non-preflight) S3 response when the
+    /// request origin is allowed.
+    pub fn apply_s3_response_headers(&self, origin: Option<&HeaderValue>, headers: &mut HeaderMap) {
+        let Some(origin) = origin else {
+            return;
+        };
+        if !self.allows(origin) {
+            return;
+        }
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            self.allow_origin_value(origin),
+        );
+        headers.insert(
+            header::ACCESS_CONTROL_EXPOSE_HEADERS,
+            HeaderValue::from_static(S3_EXPOSED_HEADERS),
+        );
+        headers.append(header::VARY, HeaderValue::from_static("origin"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_config_denies_everything() {
+        let config = CorsConfig::default();
+        assert!(!config.is_enabled());
+        assert!(!config.allows(&HeaderValue::from_static("http://portal.test")));
+        assert!(config.rest_layer().is_none());
+        assert!(
+            config
+                .s3_preflight_headers(&HeaderValue::from_static("http://portal.test"), None)
+                .is_none()
+        );
+        let mut headers = HeaderMap::new();
+        config.apply_s3_response_headers(
+            Some(&HeaderValue::from_static("http://portal.test")),
+            &mut headers,
+        );
+        assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn listed_origin_is_allowed_and_reflected() {
+        let config = CorsConfig::new(vec!["http://portal.test".to_string()]);
+        let origin = HeaderValue::from_static("http://portal.test");
+        assert!(config.allows(&origin));
+        assert!(!config.allows(&HeaderValue::from_static("http://evil.test")));
+
+        let headers = config.s3_preflight_headers(&origin, None).unwrap();
+        assert_eq!(
+            headers.get(header::ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+            &origin
+        );
+
+        let mut response_headers = HeaderMap::new();
+        config.apply_s3_response_headers(Some(&origin), &mut response_headers);
+        assert_eq!(
+            response_headers
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap(),
+            &origin
+        );
+        assert!(
+            response_headers
+                .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("etag")
+        );
+    }
+
+    #[test]
+    fn wildcard_allows_any_origin() {
+        let config = CorsConfig::new(vec!["*".to_string()]);
+        let origin = HeaderValue::from_static("http://anywhere.test");
+        assert!(config.allows(&origin));
+        let headers = config.s3_preflight_headers(&origin, None).unwrap();
+        assert_eq!(
+            headers.get(header::ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+            "*"
+        );
+    }
+
+    #[test]
+    fn preflight_echoes_requested_headers() {
+        let config = CorsConfig::new(vec!["http://portal.test".to_string()]);
+        let requested = HeaderValue::from_static("authorization,x-amz-meta-custom");
+        let headers = config
+            .s3_preflight_headers(
+                &HeaderValue::from_static("http://portal.test"),
+                Some(&requested),
+            )
+            .unwrap();
+        assert_eq!(
+            headers.get(header::ACCESS_CONTROL_ALLOW_HEADERS).unwrap(),
+            &requested
+        );
+    }
+}

--- a/api/src/cors.rs
+++ b/api/src/cors.rs
@@ -133,7 +133,7 @@ impl CorsConfig {
             header::ACCESS_CONTROL_MAX_AGE,
             HeaderValue::from(CORS_MAX_AGE.as_secs()),
         );
-        headers.insert(header::VARY, HeaderValue::from_static("origin"));
+        append_vary_headers(&mut headers, S3_PREFLIGHT_VARY);
         Some(headers)
     }
 
@@ -267,6 +267,10 @@ mod tests {
         assert_eq!(
             headers.get(header::ACCESS_CONTROL_ALLOW_HEADERS).unwrap(),
             &requested
+        );
+        assert_eq!(
+            headers.get(header::VARY).unwrap(),
+            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"
         );
     }
 }

--- a/api/src/cors.rs
+++ b/api/src/cors.rs
@@ -12,6 +12,11 @@ const S3_DEFAULT_ALLOWED_HEADERS: &str = "authorization,content-type,content-md5
 const S3_EXPOSED_HEADERS: &str = "etag,content-range,accept-ranges,content-length,last-modified,\
      x-amz-request-id,x-amz-version-id,x-amz-delete-marker,aruna-source-content-type,\
      aruna-source-etag,aruna-source-last-modified,aruna-last-refresh";
+pub(crate) const S3_PREFLIGHT_VARY: &[&str] = &[
+    "Origin",
+    "Access-Control-Request-Method",
+    "Access-Control-Request-Headers",
+];
 
 /// Allowed cross-origin request origins, shared by the REST and S3 interfaces.
 /// An empty configuration denies all cross-origin access (no CORS headers are
@@ -150,6 +155,36 @@ impl CorsConfig {
             HeaderValue::from_static(S3_EXPOSED_HEADERS),
         );
         headers.append(header::VARY, HeaderValue::from_static("origin"));
+    }
+}
+
+pub(crate) fn append_vary_headers(headers: &mut HeaderMap, values: &[&str]) {
+    let mut vary_values = headers
+        .get(header::VARY)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    for value in values {
+        if !vary_values
+            .iter()
+            .any(|existing| existing.eq_ignore_ascii_case(value))
+        {
+            vary_values.push((*value).to_string());
+        }
+    }
+
+    if !vary_values.is_empty()
+        && let Ok(value) = HeaderValue::from_str(&vary_values.join(", "))
+    {
+        headers.insert(header::VARY, value);
     }
 }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_large_err)]
 
 pub mod auth;
+pub mod cors;
 pub mod error;
 pub mod openapi;
 pub mod routes;

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -2367,6 +2367,59 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[tokio::test]
+    async fn list_with_summary_tolerates_pending_projection() {
+        let test = setup_state().await;
+
+        let (_, Json(_created)) = create_metadata_document(
+            State(test.state.clone()),
+            Extension(Some(test.auth.clone())),
+            Json(CreateMetadataRequest::Scaffold(
+                CreateMetadataScaffoldRequest {
+                    group_id: test.group_id.to_string(),
+                    path: "datasets/pending-summary".to_string(),
+                    name: "Pending Summary".to_string(),
+                    description: "Summary projection in flight".to_string(),
+                    date_published: "2026-01-01".to_string(),
+                    license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+                    public: true,
+                },
+            )),
+        )
+        .await
+        .unwrap();
+
+        let summary_query = ListMetadataQuery {
+            include: Some("summary".to_string()),
+            ..ListMetadataQuery::default()
+        };
+
+        // No drain_metadata_background: the graph projection is still pending,
+        // the list must stay 200 with a null summary for that document.
+        let (_, Json(listed)) = list_metadata_documents(
+            State(test.state.clone()),
+            Extension(None),
+            Path(test.group_id.to_string()),
+            Query(summary_query.clone()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(listed.documents.len(), 1);
+        assert!(listed.documents[0].rocrate_summary.is_none());
+
+        drain_metadata_background(test.state.as_ref()).await;
+        let (_, Json(listed)) = list_metadata_documents(
+            State(test.state.clone()),
+            Extension(None),
+            Path(test.group_id.to_string()),
+            Query(summary_query),
+        )
+        .await
+        .unwrap();
+        assert_eq!(listed.documents.len(), 1);
+        assert!(listed.documents[0].rocrate_summary.is_some());
+    }
+
     #[test]
     fn metadata_openapi_includes_examples_and_public_field_names() {
         let openapi = serde_json::to_value(MetadataApiDoc::openapi()).unwrap();

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -621,6 +621,7 @@ mod tests {
             group_id: bucket_group_id,
             created_at: std::time::SystemTime::UNIX_EPOCH,
             created_by: user_with_source_read,
+            cors_configuration: None,
         };
         write_doc(
             &driver_ctx,

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -1162,6 +1162,7 @@ mod tests {
             ServerConfig {
                 http_addr: addr,
                 max_http_body_size: crate::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+                cors: crate::cors::CorsConfig::default(),
             },
         )
         .build_router();

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -232,6 +232,8 @@ fn map_inspect_onboarding_error(error: InspectOnboardingSecretError) -> ServerEr
     }
 }
 
+const USER_TOKEN_EXPIRY_SECONDS: u64 = 24 * 60 * 60;
+
 async fn issue_user_token(
     state: &Arc<ServerState>,
     user_id: UserId,
@@ -566,7 +568,7 @@ async fn get_token(
         }
     };
 
-    let expiry = None;
+    let expiry = Some(now_timestamp() + USER_TOKEN_EXPIRY_SECONDS);
     let token = issue_user_token(&state, user_id, expiry).await?;
 
     Ok((StatusCode::OK, Json(GetTokenResponse { token })))
@@ -1155,7 +1157,14 @@ mod tests {
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let router = Server::new(state.clone(), ServerConfig { http_addr: addr }).build_router();
+        let router = Server::new(
+            state.clone(),
+            ServerConfig {
+                http_addr: addr,
+                max_http_body_size: crate::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+            },
+        )
+        .build_router();
         let server_task = tokio::spawn(async move {
             axum::serve(
                 listener,
@@ -1262,6 +1271,39 @@ mod tests {
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         let body: ErrorResponse = response.json().await.unwrap();
         assert_eq!(body.error, "Forbidden");
+
+        node.server_task.abort();
+        node.net.shutdown().await;
+        oidc_task.abort();
+    }
+
+    #[tokio::test]
+    async fn issued_user_token_carries_bounded_expiry() {
+        let issuer = "https://issuer.example";
+        let kid = "main-key";
+        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
+        let node = spawn_test_node(provider, true).await;
+
+        let (_registered, aruna_token) = register_via_oidc(
+            &node,
+            issuer,
+            kid,
+            &signing_key,
+            "expiry-subject",
+            "Expiry Alice",
+            None,
+        )
+        .await;
+
+        let payload = aruna_token.split('.').nth(1).unwrap();
+        let claims: TokenClaims = serde_json::from_slice(
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(payload)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(claims.exp, claims.iat + super::USER_TOKEN_EXPIRY_SECONDS);
 
         node.server_task.abort();
         node.net.shutdown().await;

--- a/api/src/s3/cors.rs
+++ b/api/src/s3/cors.rs
@@ -1,5 +1,6 @@
+use crate::cors::{S3_PREFLIGHT_VARY, append_vary_headers};
 use aruna_core::structs::{BucketCorsConfiguration, BucketCorsRule};
-use http::header::{HeaderName, HeaderValue, VARY};
+use http::header::{HeaderName, HeaderValue};
 use http::{Method, StatusCode};
 use s3s::HttpResponse;
 use s3s::dto::{CORSConfiguration, CORSRule, GetBucketCorsOutput};
@@ -17,9 +18,6 @@ pub(crate) const MAX_AGE_HEADER: &str = "access-control-max-age";
 
 const WILDCARD: &str = "*";
 const VALID_CORS_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
-
-pub(crate) const PREFLIGHT_VARY: &[&str] =
-    &[ORIGIN_HEADER, REQUEST_METHOD_HEADER, REQUEST_HEADERS_HEADER];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MatchedCorsRule {
@@ -284,14 +282,14 @@ pub(crate) fn build_preflight_response(matched_rule: MatchedCorsRule) -> HttpRes
             &max_age_seconds.to_string(),
         );
     }
-    append_vary_headers(response.headers_mut(), PREFLIGHT_VARY);
+    append_vary_headers(response.headers_mut(), S3_PREFLIGHT_VARY);
     response
 }
 
 pub(crate) fn build_preflight_forbidden_response() -> HttpResponse {
     let mut response = HttpResponse::new(s3s::Body::empty());
     *response.status_mut() = StatusCode::FORBIDDEN;
-    append_vary_headers(response.headers_mut(), PREFLIGHT_VARY);
+    append_vary_headers(response.headers_mut(), S3_PREFLIGHT_VARY);
     response
 }
 
@@ -329,39 +327,10 @@ fn append_header<T>(response: &mut http::Response<T>, name: HeaderName, value: &
     }
 }
 
-fn append_vary_headers(headers: &mut http::HeaderMap, values: &[&str]) {
-    let mut vary_values = headers
-        .get(VARY)
-        .and_then(|value| value.to_str().ok())
-        .map(|value| {
-            value
-                .split(',')
-                .map(str::trim)
-                .filter(|entry| !entry.is_empty())
-                .map(str::to_owned)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    for value in values {
-        if !vary_values
-            .iter()
-            .any(|existing| existing.eq_ignore_ascii_case(value))
-        {
-            vary_values.push((*value).to_string());
-        }
-    }
-
-    if !vary_values.is_empty()
-        && let Ok(value) = HeaderValue::from_str(&vary_values.join(", "))
-    {
-        headers.insert(VARY, value);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http::header::VARY;
 
     #[test]
     fn converts_cors_configuration_between_dto_and_core() {

--- a/api/src/s3/cors.rs
+++ b/api/src/s3/cors.rs
@@ -358,3 +358,192 @@ fn append_vary_headers(headers: &mut http::HeaderMap, values: &[&str]) {
         headers.insert(VARY, value);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_cors_configuration_between_dto_and_core() {
+        let dto = CORSConfiguration {
+            cors_rules: vec![CORSRule {
+                allowed_headers: Some(vec!["content-type".to_string(), "x-amz-meta-*".to_string()]),
+                allowed_methods: vec!["GET".to_string(), "PUT".to_string()],
+                allowed_origins: vec!["https://example.org".to_string()],
+                expose_headers: Some(vec!["etag".to_string()]),
+                id: Some("rule-1".to_string()),
+                max_age_seconds: Some(60),
+            }],
+        };
+
+        let core = dto_to_bucket_cors(dto.clone()).unwrap();
+        assert_eq!(core.rules.len(), 1);
+        assert_eq!(core.rules[0].allowed_methods, vec!["GET", "PUT"]);
+        assert_eq!(core.rules[0].allowed_origins, vec!["https://example.org"]);
+
+        let output = bucket_cors_to_get_output(core);
+        let roundtrip = CORSConfiguration {
+            cors_rules: output.cors_rules.unwrap(),
+        };
+        assert_eq!(roundtrip, dto);
+    }
+
+    #[test]
+    fn rejects_invalid_cors_configuration() {
+        let err = dto_to_bucket_cors(CORSConfiguration { cors_rules: vec![] }).unwrap_err();
+        assert_eq!(err.code(), &s3s::S3ErrorCode::MalformedXML);
+
+        let err = dto_to_bucket_cors(CORSConfiguration {
+            cors_rules: vec![CORSRule {
+                allowed_headers: None,
+                allowed_methods: vec!["OPTIONS".to_string()],
+                allowed_origins: vec!["https://example.org".to_string()],
+                expose_headers: None,
+                id: None,
+                max_age_seconds: None,
+            }],
+        })
+        .unwrap_err();
+        assert_eq!(err.code(), &s3s::S3ErrorCode::MalformedXML);
+    }
+
+    #[test]
+    fn matches_preflight_rules_with_case_insensitive_header_checks() {
+        let config = BucketCorsConfiguration {
+            rules: vec![BucketCorsRule {
+                id: None,
+                allowed_origins: vec!["https://*.example.org".to_string()],
+                allowed_methods: vec!["GET".to_string(), "PUT".to_string()],
+                allowed_headers: vec!["content-type".to_string(), "x-amz-meta-*".to_string()],
+                expose_headers: vec![],
+                max_age_seconds: Some(300),
+            }],
+        };
+
+        let matched = match_preflight_rule(
+            &config,
+            "https://bucket.example.org",
+            "PUT",
+            &parse_requested_headers("Content-Type, X-Amz-Meta-Test"),
+        )
+        .unwrap();
+
+        assert_eq!(matched.allow_origin, "https://bucket.example.org");
+        assert_eq!(
+            matched.allow_headers,
+            vec!["content-type", "x-amz-meta-test"]
+        );
+        assert_eq!(matched.max_age_seconds, Some(300));
+    }
+
+    #[test]
+    fn matches_actual_rules_with_wildcard_origin() {
+        let config = BucketCorsConfiguration {
+            rules: vec![BucketCorsRule {
+                id: None,
+                allowed_origins: vec!["*".to_string()],
+                allowed_methods: vec!["GET".to_string()],
+                allowed_headers: vec![],
+                expose_headers: vec!["etag".to_string()],
+                max_age_seconds: None,
+            }],
+        };
+
+        let matched = match_actual_rule(&config, "https://example.org", &Method::GET).unwrap();
+
+        assert_eq!(matched.allow_origin, "*");
+        assert_eq!(matched.expose_headers, vec!["etag"]);
+    }
+
+    #[test]
+    fn rejects_preflight_when_requested_header_is_not_allowed() {
+        let config = BucketCorsConfiguration {
+            rules: vec![BucketCorsRule {
+                id: None,
+                allowed_origins: vec!["https://example.org".to_string()],
+                allowed_methods: vec!["PUT".to_string()],
+                allowed_headers: vec!["content-type".to_string()],
+                expose_headers: vec![],
+                max_age_seconds: None,
+            }],
+        };
+
+        let matched = match_preflight_rule(
+            &config,
+            "https://example.org",
+            "PUT",
+            &parse_requested_headers("x-custom-header"),
+        );
+
+        assert!(matched.is_none());
+    }
+
+    fn matched_rule() -> MatchedCorsRule {
+        MatchedCorsRule {
+            allow_origin: "https://example.org".to_string(),
+            allow_methods: vec!["GET".to_string(), "PUT".to_string()],
+            allow_headers: vec!["content-type".to_string(), "x-test".to_string()],
+            expose_headers: vec!["etag".to_string()],
+            max_age_seconds: Some(60),
+        }
+    }
+
+    #[test]
+    fn builds_preflight_success_response_with_expected_headers() {
+        let response = build_preflight_response(matched_rule());
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            response.headers()["access-control-allow-origin"],
+            "https://example.org"
+        );
+        assert_eq!(
+            response.headers()["access-control-allow-methods"],
+            "GET, PUT"
+        );
+        assert_eq!(
+            response.headers()["access-control-allow-headers"],
+            "content-type, x-test"
+        );
+        assert_eq!(response.headers()["access-control-max-age"], "60");
+        assert_eq!(
+            response.headers()[VARY],
+            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"
+        );
+    }
+
+    #[test]
+    fn builds_preflight_failure_response_without_allow_headers() {
+        let response = build_preflight_forbidden_response();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .is_none()
+        );
+        assert_eq!(
+            response.headers()[VARY],
+            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"
+        );
+    }
+
+    #[test]
+    fn injects_actual_cors_headers_and_preserves_existing_vary_entries() {
+        let mut response = HttpResponse::new(s3s::Body::empty());
+        *response.status_mut() = StatusCode::OK;
+        response
+            .headers_mut()
+            .insert(VARY, HeaderValue::from_static("Accept-Encoding"));
+
+        inject_actual_cors_headers(&mut response, matched_rule());
+
+        assert_eq!(
+            response.headers()["access-control-allow-origin"],
+            "https://example.org"
+        );
+        assert_eq!(response.headers()["access-control-expose-headers"], "etag");
+        assert_eq!(response.headers()[VARY], "Accept-Encoding, Origin");
+    }
+}

--- a/api/src/s3/cors.rs
+++ b/api/src/s3/cors.rs
@@ -1,20 +1,10 @@
 use crate::cors::{S3_PREFLIGHT_VARY, append_vary_headers};
 use aruna_core::structs::{BucketCorsConfiguration, BucketCorsRule};
-use http::header::{HeaderName, HeaderValue};
+use http::header::{self, HeaderName, HeaderValue};
 use http::{Method, StatusCode};
 use s3s::HttpResponse;
 use s3s::dto::{CORSConfiguration, CORSRule, GetBucketCorsOutput};
 use s3s::{S3Error, s3_error};
-
-pub(crate) const ORIGIN_HEADER: &str = "Origin";
-pub(crate) const REQUEST_METHOD_HEADER: &str = "Access-Control-Request-Method";
-pub(crate) const REQUEST_HEADERS_HEADER: &str = "Access-Control-Request-Headers";
-
-pub(crate) const ALLOW_ORIGIN_HEADER: &str = "access-control-allow-origin";
-pub(crate) const ALLOW_METHODS_HEADER: &str = "access-control-allow-methods";
-pub(crate) const ALLOW_HEADERS_HEADER: &str = "access-control-allow-headers";
-pub(crate) const EXPOSE_HEADERS_HEADER: &str = "access-control-expose-headers";
-pub(crate) const MAX_AGE_HEADER: &str = "access-control-max-age";
 
 const WILDCARD: &str = "*";
 const VALID_CORS_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
@@ -271,14 +261,14 @@ pub(crate) fn build_preflight_response(matched_rule: MatchedCorsRule) -> HttpRes
     if !matched_rule.allow_headers.is_empty() {
         append_header(
             &mut response,
-            HeaderName::from_static(ALLOW_HEADERS_HEADER),
+            header::ACCESS_CONTROL_ALLOW_HEADERS,
             &matched_rule.allow_headers.join(", "),
         );
     }
     if let Some(max_age_seconds) = matched_rule.max_age_seconds {
         append_header(
             &mut response,
-            HeaderName::from_static(MAX_AGE_HEADER),
+            header::ACCESS_CONTROL_MAX_AGE,
             &max_age_seconds.to_string(),
         );
     }
@@ -301,22 +291,22 @@ pub(crate) fn inject_actual_cors_headers(
     if !matched_rule.expose_headers.is_empty() {
         append_header(
             response,
-            HeaderName::from_static(EXPOSE_HEADERS_HEADER),
+            header::ACCESS_CONTROL_EXPOSE_HEADERS,
             &matched_rule.expose_headers.join(", "),
         );
     }
-    append_vary_headers(response.headers_mut(), &[ORIGIN_HEADER]);
+    append_vary_headers(response.headers_mut(), &[header::ORIGIN]);
 }
 
 fn append_allow_origin_and_methods(response: &mut HttpResponse, matched_rule: &MatchedCorsRule) {
     append_header(
         response,
-        HeaderName::from_static(ALLOW_ORIGIN_HEADER),
+        header::ACCESS_CONTROL_ALLOW_ORIGIN,
         &matched_rule.allow_origin,
     );
     append_header(
         response,
-        HeaderName::from_static(ALLOW_METHODS_HEADER),
+        header::ACCESS_CONTROL_ALLOW_METHODS,
         &matched_rule.allow_methods.join(", "),
     );
 }
@@ -477,7 +467,7 @@ mod tests {
         assert_eq!(response.headers()["access-control-max-age"], "60");
         assert_eq!(
             response.headers()[VARY],
-            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"
+            "origin, access-control-request-method, access-control-request-headers"
         );
     }
 
@@ -494,7 +484,7 @@ mod tests {
         );
         assert_eq!(
             response.headers()[VARY],
-            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"
+            "origin, access-control-request-method, access-control-request-headers"
         );
     }
 
@@ -513,6 +503,6 @@ mod tests {
             "https://example.org"
         );
         assert_eq!(response.headers()["access-control-expose-headers"], "etag");
-        assert_eq!(response.headers()[VARY], "Accept-Encoding, Origin");
+        assert_eq!(response.headers()[VARY], "Accept-Encoding, origin");
     }
 }

--- a/api/src/s3/cors.rs
+++ b/api/src/s3/cors.rs
@@ -1,0 +1,360 @@
+use aruna_core::structs::{BucketCorsConfiguration, BucketCorsRule};
+use http::header::{HeaderName, HeaderValue, VARY};
+use http::{Method, StatusCode};
+use s3s::HttpResponse;
+use s3s::dto::{CORSConfiguration, CORSRule, GetBucketCorsOutput};
+use s3s::{S3Error, s3_error};
+
+pub(crate) const ORIGIN_HEADER: &str = "Origin";
+pub(crate) const REQUEST_METHOD_HEADER: &str = "Access-Control-Request-Method";
+pub(crate) const REQUEST_HEADERS_HEADER: &str = "Access-Control-Request-Headers";
+
+pub(crate) const ALLOW_ORIGIN_HEADER: &str = "access-control-allow-origin";
+pub(crate) const ALLOW_METHODS_HEADER: &str = "access-control-allow-methods";
+pub(crate) const ALLOW_HEADERS_HEADER: &str = "access-control-allow-headers";
+pub(crate) const EXPOSE_HEADERS_HEADER: &str = "access-control-expose-headers";
+pub(crate) const MAX_AGE_HEADER: &str = "access-control-max-age";
+
+const WILDCARD: &str = "*";
+const VALID_CORS_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
+
+pub(crate) const PREFLIGHT_VARY: &[&str] =
+    &[ORIGIN_HEADER, REQUEST_METHOD_HEADER, REQUEST_HEADERS_HEADER];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MatchedCorsRule {
+    pub allow_origin: String,
+    pub allow_methods: Vec<String>,
+    pub allow_headers: Vec<String>,
+    pub expose_headers: Vec<String>,
+    pub max_age_seconds: Option<i32>,
+}
+
+pub(crate) fn dto_to_bucket_cors(
+    input: CORSConfiguration,
+) -> Result<BucketCorsConfiguration, S3Error> {
+    if input.cors_rules.is_empty() {
+        return Err(s3_error!(
+            MalformedXML,
+            "CORS configuration must contain at least one rule"
+        ));
+    }
+
+    let rules = input
+        .cors_rules
+        .into_iter()
+        .map(dto_rule_to_bucket_rule)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(BucketCorsConfiguration { rules })
+}
+
+pub(crate) fn bucket_cors_to_get_output(config: BucketCorsConfiguration) -> GetBucketCorsOutput {
+    let cors_rules = config
+        .rules
+        .into_iter()
+        .map(bucket_rule_to_dto_rule)
+        .collect();
+
+    GetBucketCorsOutput {
+        cors_rules: Some(cors_rules),
+    }
+}
+
+pub(crate) fn match_preflight_rule(
+    config: &BucketCorsConfiguration,
+    origin: &str,
+    requested_method: &str,
+    requested_headers: &[String],
+) -> Option<MatchedCorsRule> {
+    config.rules.iter().find_map(|rule| {
+        if !origin_matches(rule, origin)
+            || !method_matches(rule, requested_method)
+            || !headers_match(rule, requested_headers)
+        {
+            return None;
+        }
+
+        Some(MatchedCorsRule {
+            allow_origin: matched_origin(rule, origin),
+            allow_methods: rule.allowed_methods.clone(),
+            allow_headers: matched_allowed_headers(rule, requested_headers),
+            expose_headers: rule.expose_headers.clone(),
+            max_age_seconds: rule.max_age_seconds,
+        })
+    })
+}
+
+pub(crate) fn match_actual_rule(
+    config: &BucketCorsConfiguration,
+    origin: &str,
+    method: &Method,
+) -> Option<MatchedCorsRule> {
+    let method = method.as_str();
+
+    config.rules.iter().find_map(|rule| {
+        if !origin_matches(rule, origin) || !method_matches(rule, method) {
+            return None;
+        }
+
+        Some(MatchedCorsRule {
+            allow_origin: matched_origin(rule, origin),
+            allow_methods: rule.allowed_methods.clone(),
+            allow_headers: rule.allowed_headers.clone(),
+            expose_headers: rule.expose_headers.clone(),
+            max_age_seconds: rule.max_age_seconds,
+        })
+    })
+}
+
+pub(crate) fn parse_requested_headers(raw_headers: &str) -> Vec<String> {
+    raw_headers
+        .split(',')
+        .map(str::trim)
+        .filter(|header| !header.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
+}
+
+fn dto_rule_to_bucket_rule(rule: CORSRule) -> Result<BucketCorsRule, S3Error> {
+    if rule.allowed_methods.is_empty() || rule.allowed_origins.is_empty() {
+        return Err(s3_error!(
+            MalformedXML,
+            "Each CORS rule must contain allowed methods and origins"
+        ));
+    }
+    if rule
+        .max_age_seconds
+        .is_some_and(|max_age_seconds| max_age_seconds < 0)
+    {
+        return Err(s3_error!(
+            MalformedXML,
+            "CORS max age seconds must not be negative"
+        ));
+    }
+
+    let allowed_methods = rule
+        .allowed_methods
+        .into_iter()
+        .map(normalize_method)
+        .collect::<Result<Vec<_>, _>>()?;
+    let allowed_origins = rule
+        .allowed_origins
+        .into_iter()
+        .map(|origin| normalize_non_empty(origin, "CORS allowed origin"))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(BucketCorsRule {
+        id: rule.id,
+        allowed_origins,
+        allowed_methods,
+        allowed_headers: normalize_optional_values(rule.allowed_headers, "CORS allowed header")?,
+        expose_headers: normalize_optional_values(rule.expose_headers, "CORS expose header")?,
+        max_age_seconds: rule.max_age_seconds,
+    })
+}
+
+fn bucket_rule_to_dto_rule(rule: BucketCorsRule) -> CORSRule {
+    CORSRule {
+        allowed_headers: (!rule.allowed_headers.is_empty())
+            .then_some(rule.allowed_headers.into_iter().collect()),
+        allowed_methods: rule.allowed_methods.into_iter().collect(),
+        allowed_origins: rule.allowed_origins.into_iter().collect(),
+        expose_headers: (!rule.expose_headers.is_empty())
+            .then_some(rule.expose_headers.into_iter().collect()),
+        id: rule.id,
+        max_age_seconds: rule.max_age_seconds,
+    }
+}
+
+fn normalize_method(method: String) -> Result<String, S3Error> {
+    let method = normalize_non_empty(method, "CORS allowed method")?.to_ascii_uppercase();
+    if VALID_CORS_METHODS.contains(&method.as_str()) {
+        Ok(method)
+    } else {
+        Err(s3_error!(MalformedXML, "Invalid CORS method `{method}`"))
+    }
+}
+
+fn normalize_optional_values(
+    values: Option<Vec<String>>,
+    field_name: &'static str,
+) -> Result<Vec<String>, S3Error> {
+    values
+        .unwrap_or_default()
+        .into_iter()
+        .map(|value| normalize_non_empty(value, field_name))
+        .collect()
+}
+
+fn normalize_non_empty(value: String, field_name: &'static str) -> Result<String, S3Error> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        Err(s3_error!(MalformedXML, "{field_name} must not be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn origin_matches(rule: &BucketCorsRule, origin: &str) -> bool {
+    rule.allowed_origins
+        .iter()
+        .any(|allowed| pattern_matches(allowed, origin, false))
+}
+
+fn method_matches(rule: &BucketCorsRule, method: &str) -> bool {
+    rule.allowed_methods
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(method))
+}
+
+fn headers_match(rule: &BucketCorsRule, requested_headers: &[String]) -> bool {
+    requested_headers
+        .iter()
+        .all(|requested| header_allowed(rule, requested))
+}
+
+fn header_allowed(rule: &BucketCorsRule, requested_header: &str) -> bool {
+    if rule.allowed_headers.is_empty() {
+        return false;
+    }
+
+    rule.allowed_headers
+        .iter()
+        .any(|allowed| pattern_matches(allowed, requested_header, true))
+}
+
+fn matched_allowed_headers(rule: &BucketCorsRule, requested_headers: &[String]) -> Vec<String> {
+    if requested_headers.is_empty() {
+        return rule.allowed_headers.clone();
+    }
+
+    requested_headers.to_vec()
+}
+
+fn matched_origin(rule: &BucketCorsRule, origin: &str) -> String {
+    if rule
+        .allowed_origins
+        .iter()
+        .any(|allowed| allowed == WILDCARD)
+    {
+        WILDCARD.to_string()
+    } else {
+        origin.to_string()
+    }
+}
+
+fn pattern_matches(pattern: &str, value: &str, case_insensitive: bool) -> bool {
+    if case_insensitive {
+        return wildcard_match(&pattern.to_ascii_lowercase(), &value.to_ascii_lowercase());
+    }
+    wildcard_match(pattern, value)
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    if pattern == WILDCARD {
+        return true;
+    }
+
+    match pattern.split_once(WILDCARD) {
+        Some((prefix, suffix)) => {
+            value.starts_with(prefix)
+                && value.ends_with(suffix)
+                && value.len() >= prefix.len() + suffix.len()
+        }
+        None => pattern == value,
+    }
+}
+
+pub(crate) fn build_preflight_response(matched_rule: MatchedCorsRule) -> HttpResponse {
+    let mut response = HttpResponse::new(s3s::Body::empty());
+    *response.status_mut() = StatusCode::NO_CONTENT;
+    append_allow_origin_and_methods(&mut response, &matched_rule);
+    if !matched_rule.allow_headers.is_empty() {
+        append_header(
+            &mut response,
+            HeaderName::from_static(ALLOW_HEADERS_HEADER),
+            &matched_rule.allow_headers.join(", "),
+        );
+    }
+    if let Some(max_age_seconds) = matched_rule.max_age_seconds {
+        append_header(
+            &mut response,
+            HeaderName::from_static(MAX_AGE_HEADER),
+            &max_age_seconds.to_string(),
+        );
+    }
+    append_vary_headers(response.headers_mut(), PREFLIGHT_VARY);
+    response
+}
+
+pub(crate) fn build_preflight_forbidden_response() -> HttpResponse {
+    let mut response = HttpResponse::new(s3s::Body::empty());
+    *response.status_mut() = StatusCode::FORBIDDEN;
+    append_vary_headers(response.headers_mut(), PREFLIGHT_VARY);
+    response
+}
+
+pub(crate) fn inject_actual_cors_headers(
+    response: &mut HttpResponse,
+    matched_rule: MatchedCorsRule,
+) {
+    append_allow_origin_and_methods(response, &matched_rule);
+    if !matched_rule.expose_headers.is_empty() {
+        append_header(
+            response,
+            HeaderName::from_static(EXPOSE_HEADERS_HEADER),
+            &matched_rule.expose_headers.join(", "),
+        );
+    }
+    append_vary_headers(response.headers_mut(), &[ORIGIN_HEADER]);
+}
+
+fn append_allow_origin_and_methods(response: &mut HttpResponse, matched_rule: &MatchedCorsRule) {
+    append_header(
+        response,
+        HeaderName::from_static(ALLOW_ORIGIN_HEADER),
+        &matched_rule.allow_origin,
+    );
+    append_header(
+        response,
+        HeaderName::from_static(ALLOW_METHODS_HEADER),
+        &matched_rule.allow_methods.join(", "),
+    );
+}
+
+fn append_header<T>(response: &mut http::Response<T>, name: HeaderName, value: &str) {
+    if let Ok(value) = HeaderValue::from_str(value) {
+        response.headers_mut().insert(name, value);
+    }
+}
+
+fn append_vary_headers(headers: &mut http::HeaderMap, values: &[&str]) {
+    let mut vary_values = headers
+        .get(VARY)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    for value in values {
+        if !vary_values
+            .iter()
+            .any(|existing| existing.eq_ignore_ascii_case(value))
+        {
+            vary_values.push((*value).to_string());
+        }
+    }
+
+    if !vary_values.is_empty()
+        && let Ok(value) = HeaderValue::from_str(&vary_values.join(", "))
+    {
+        headers.insert(VARY, value);
+    }
+}

--- a/api/src/s3/error.rs
+++ b/api/src/s3/error.rs
@@ -1,6 +1,9 @@
 use crate::s3::checksum::checksum_mismatch_error;
 use aruna_core::errors::{SourceConnectorResolutionError, StagingSourceError};
 use aruna_operations::s3::abort_multipart_upload::AbortMultipartUploadError;
+use aruna_operations::s3::bucket_cors::{
+    DeleteBucketCorsError, GetBucketCorsError, PutBucketCorsError,
+};
 use aruna_operations::s3::complete_multipart_upload::CompleteMultipartUploadError;
 use aruna_operations::s3::create_bucket::CreateBucketError;
 use aruna_operations::s3::create_multipart_upload::CreateMultipartUploadError;
@@ -62,6 +65,10 @@ fn replication_configuration_not_found_error() -> S3Error {
         ReplicationConfigurationNotFoundError,
         "Replication configuration not found"
     )
+}
+
+fn cors_configuration_not_found_error() -> S3Error {
+    s3_error!(NoSuchCORSConfiguration, "CORS configuration not found")
 }
 
 fn checksum_mismatch_s3_error(algorithm: &'static str, operation: &'static str) -> S3Error {
@@ -237,6 +244,34 @@ impl IntoS3Error for DeleteBucketError {
 impl IntoS3Error for PutBucketReplicationError {
     fn into_s3_error(self) -> S3Error {
         internal_error(self)
+    }
+}
+
+impl IntoS3Error for PutBucketCorsError {
+    fn into_s3_error(self) -> S3Error {
+        match self {
+            PutBucketCorsError::NotFound => bucket_not_found_error(),
+            err => internal_error(err),
+        }
+    }
+}
+
+impl IntoS3Error for GetBucketCorsError {
+    fn into_s3_error(self) -> S3Error {
+        match self {
+            GetBucketCorsError::BucketNotFound => bucket_not_found_error(),
+            GetBucketCorsError::CorsNotFound => cors_configuration_not_found_error(),
+            err => internal_error(err),
+        }
+    }
+}
+
+impl IntoS3Error for DeleteBucketCorsError {
+    fn into_s3_error(self) -> S3Error {
+        match self {
+            DeleteBucketCorsError::NotFound => bucket_not_found_error(),
+            err => internal_error(err),
+        }
     }
 }
 

--- a/api/src/s3/mod.rs
+++ b/api/src/s3/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod checksum;
+mod cors;
 mod error;
 pub mod s3_server;
 pub mod s3_service;

--- a/api/src/s3/s3_server.rs
+++ b/api/src/s3/s3_server.rs
@@ -1,11 +1,17 @@
 use super::auth::AuthProvider;
+use super::cors::{
+    ORIGIN_HEADER, REQUEST_HEADERS_HEADER, REQUEST_METHOD_HEADER,
+    build_preflight_forbidden_response, build_preflight_response, inject_actual_cors_headers,
+    match_actual_rule, match_preflight_rule, parse_requested_headers,
+};
 use super::s3_service::ArunaS3Service;
 use crate::cors::CorsConfig;
 use crate::error::S3ServerError;
 use crate::telemetry::{emit_request_completed, make_request_span};
 use aruna_core::NodeId;
-use aruna_core::structs::RealmId;
-use aruna_operations::driver::DriverContext;
+use aruna_core::structs::{BucketCorsConfiguration, RealmId};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::s3::get_bucket_info::{GetBucketInfoError, GetBucketInfoOperation};
 use futures_core::future::BoxFuture;
 use http::{Method, Request, StatusCode, header};
 use hyper::body::Incoming;
@@ -30,12 +36,16 @@ pub struct S3Server {
     address: String,
     s3service: S3Service,
     cors: CorsConfig,
+    domain: String,
+    driver_ctx: Arc<DriverContext>,
 }
 
 #[derive(Clone)]
 pub struct WrappingService {
     shared: S3Service, // Aruna specific implementation of S3 trait
     cors: CorsConfig,
+    domain: String,
+    driver_ctx: Arc<DriverContext>,
 }
 
 impl S3Server {
@@ -49,6 +59,7 @@ impl S3Server {
         cors: CorsConfig,
     ) -> Result<Self, S3ServerError> {
         let s3service = ArunaS3Service::new(driver_ctx.clone(), realm_id, node_id).await;
+        let hostname = hostname.into();
 
         let auth = AuthProvider {
             driver_ctx: driver_ctx.clone(),
@@ -58,7 +69,7 @@ impl S3Server {
 
         let service = {
             let mut b = S3ServiceBuilder::new(s3service.clone());
-            b.set_host(SingleDomain::new(&hostname.into())?);
+            b.set_host(SingleDomain::new(&hostname)?);
             b.set_auth(auth.clone());
             b.set_access(auth);
             b.set_validation(AwsNameValidation::new());
@@ -69,6 +80,8 @@ impl S3Server {
             address: address.into(),
             s3service: service,
             cors,
+            domain: hostname,
+            driver_ctx,
         })
     }
 
@@ -80,6 +93,8 @@ impl S3Server {
         let service = WrappingService {
             shared: self.s3service,
             cors: self.cors,
+            domain: self.domain,
+            driver_ctx: self.driver_ctx,
         };
         let connection = ConnBuilder::new(TokioExecutor::new());
 
@@ -122,31 +137,6 @@ impl Service<Request<Incoming>> for WrappingService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn call(&self, req: Request<Incoming>) -> Self::Future {
-        let origin = req.headers().get(header::ORIGIN).cloned();
-
-        // Answer CORS preflight before s3s signature validation: an unsigned
-        // OPTIONS request must not fail with 403.
-        if req.method() == Method::OPTIONS
-            && let Some(origin) = origin.as_ref()
-        {
-            let requested_headers = req
-                .headers()
-                .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
-                .cloned();
-            let mut response = http::Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(s3s::Body::empty())
-                .expect("static response must build");
-            if let Some(cors_headers) = self
-                .cors
-                .s3_preflight_headers(origin, requested_headers.as_ref())
-            {
-                response.headers_mut().extend(cors_headers);
-            }
-            return Box::pin(async move { Ok(response) });
-        }
-
-        // Default S3 operation call
         let (parts, body) = req.into_parts();
         let method = parts.method.clone();
         let path = parts.uri.path().to_string();
@@ -162,13 +152,99 @@ impl Service<Request<Incoming>> for WrappingService {
                 "Received S3 request"
             );
         }
+        let host = parts
+            .headers
+            .get(header::HOST)
+            .and_then(|value| value.to_str().ok());
+        let bucket = extract_bucket_name(host, &path, &self.domain);
+        let origin = parts
+            .headers
+            .get(ORIGIN_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        let origin_header = parts.headers.get(header::ORIGIN).cloned();
+        let requested_method = parts
+            .headers
+            .get(REQUEST_METHOD_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        let requested_headers_value = parts
+            .headers
+            .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+            .cloned();
+        let requested_headers = parts
+            .headers
+            .get(REQUEST_HEADERS_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(parse_requested_headers)
+            .unwrap_or_default();
         let s3s_request = s3s::HttpRequest::from_parts(parts, body.into());
         let shared = self.shared.clone();
         let cors = self.cors.clone();
+        let driver_ctx = self.driver_ctx.clone();
         Box::pin(async move {
+            let bucket_cors = match load_bucket_cors_config(driver_ctx, bucket).await {
+                Ok(bucket_cors) => bucket_cors,
+                Err(error) => {
+                    span.record("status_code", 500);
+                    let _guard = span.enter();
+                    error!(
+                        event = "request.failed",
+                        protocol = "s3",
+                        latency_ms = started.elapsed().as_millis() as u64,
+                        error = ?error,
+                        "Failed to query bucket CORS configuration"
+                    );
+                    return Err(HttpError::new(error.into()));
+                }
+            };
+
+            // Answer CORS preflight before s3s signature validation: an unsigned
+            // OPTIONS request must not fail with 403.
+            if method == Method::OPTIONS
+                && let Some(origin_header) = origin_header.as_ref()
+            {
+                if let Some(config) = bucket_cors.as_ref() {
+                    let response = requested_method.as_deref().map_or_else(
+                        build_preflight_forbidden_response,
+                        |requested_method| match match_preflight_rule(
+                            config,
+                            origin.as_deref().unwrap_or_default(),
+                            requested_method,
+                            &requested_headers,
+                        ) {
+                            Some(matched_rule) => build_preflight_response(matched_rule),
+                            None => build_preflight_forbidden_response(),
+                        },
+                    );
+                    emit_request_completed(&span, "s3", response.status().as_u16(), started);
+                    return Ok(response);
+                }
+
+                let mut response = http::Response::builder()
+                    .status(StatusCode::NO_CONTENT)
+                    .body(s3s::Body::empty())
+                    .expect("static response must build");
+                if let Some(cors_headers) =
+                    cors.s3_preflight_headers(origin_header, requested_headers_value.as_ref())
+                {
+                    response.headers_mut().extend(cors_headers);
+                }
+                emit_request_completed(&span, "s3", response.status().as_u16(), started);
+                return Ok(response);
+            }
+
             let mut result = shared.call(s3s_request).instrument(span.clone()).await;
             if let Ok(response) = &mut result {
-                cors.apply_s3_response_headers(origin.as_ref(), response.headers_mut());
+                if let Some(config) = bucket_cors.as_ref() {
+                    if let Some(origin) = origin.as_deref()
+                        && let Some(matched_rule) = match_actual_rule(config, origin, &method)
+                    {
+                        inject_actual_cors_headers(response, matched_rule);
+                    }
+                } else {
+                    cors.apply_s3_response_headers(origin_header.as_ref(), response.headers_mut());
+                }
             }
             match &result {
                 Ok(response) => {
@@ -188,5 +264,92 @@ impl Service<Request<Incoming>> for WrappingService {
             }
             result
         })
+    }
+}
+
+fn extract_bucket_name(host: Option<&str>, path: &str, domain: &str) -> Option<String> {
+    if let Some(host) = host
+        && let Some(bucket) = virtual_hosted_bucket(host, domain)
+    {
+        return Some(bucket);
+    }
+
+    path.trim_start_matches('/')
+        .split('/')
+        .find(|segment| !segment.is_empty())
+        .map(str::to_owned)
+}
+
+fn virtual_hosted_bucket(host: &str, domain: &str) -> Option<String> {
+    let host = host.split(':').next().unwrap_or(host);
+    let domain = domain.split(':').next().unwrap_or(domain);
+    let prefix = host.strip_suffix(domain)?.strip_suffix('.')?;
+    (!prefix.is_empty()).then(|| prefix.to_owned())
+}
+
+async fn load_bucket_cors_config(
+    driver_ctx: Arc<DriverContext>,
+    bucket: Option<String>,
+) -> Result<Option<BucketCorsConfiguration>, GetBucketInfoError> {
+    let Some(bucket) = bucket else {
+        return Ok(None);
+    };
+
+    match drive(GetBucketInfoOperation::new(bucket), driver_ctx.as_ref())
+        .await
+        .and_then(|result| result.transpose())
+    {
+        Ok(Some(bucket_info)) => Ok(bucket_info.cors_configuration),
+        Ok(None) | Err(GetBucketInfoError::NotFound) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_bucket_name_from_path_style_request() {
+        assert_eq!(
+            extract_bucket_name(
+                Some("s3.example.com"),
+                "/bucket-name/object.txt",
+                "s3.example.com"
+            ),
+            Some("bucket-name".to_string())
+        );
+        assert_eq!(
+            extract_bucket_name(Some("s3.example.com"), "/bucket-name", "s3.example.com"),
+            Some("bucket-name".to_string())
+        );
+        assert_eq!(
+            extract_bucket_name(None, "/bucket-name", "s3.example.com"),
+            Some("bucket-name".to_string())
+        );
+        assert_eq!(
+            extract_bucket_name(Some("s3.example.com"), "/", "s3.example.com"),
+            None
+        );
+    }
+
+    #[test]
+    fn extracts_bucket_name_from_virtual_hosted_request() {
+        assert_eq!(
+            extract_bucket_name(
+                Some("bucket-name.s3.example.com"),
+                "/object.txt",
+                "s3.example.com"
+            ),
+            Some("bucket-name".to_string())
+        );
+        assert_eq!(
+            extract_bucket_name(
+                Some("bucket-name.s3.example.com:9000"),
+                "/object.txt",
+                "s3.example.com:9000"
+            ),
+            Some("bucket-name".to_string())
+        );
     }
 }

--- a/api/src/s3/s3_server.rs
+++ b/api/src/s3/s3_server.rs
@@ -1,6 +1,5 @@
 use super::auth::AuthProvider;
 use super::cors::{
-    ORIGIN_HEADER, REQUEST_HEADERS_HEADER, REQUEST_METHOD_HEADER,
     build_preflight_forbidden_response, build_preflight_response, inject_actual_cors_headers,
     match_actual_rule, match_preflight_rule, parse_requested_headers,
 };
@@ -157,17 +156,20 @@ impl Service<Request<Incoming>> for WrappingService {
             .get(header::HOST)
             .and_then(|value| value.to_str().ok());
         let bucket = extract_bucket_name(host, &path, &self.domain);
-        let origin_header = parts.headers.get(ORIGIN_HEADER).cloned();
+        let origin_header = parts.headers.get(header::ORIGIN).cloned();
         let origin = origin_header
             .as_ref()
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
         let requested_method = parts
             .headers
-            .get(REQUEST_METHOD_HEADER)
+            .get(header::ACCESS_CONTROL_REQUEST_METHOD)
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let requested_headers_value = parts.headers.get(REQUEST_HEADERS_HEADER).cloned();
+        let requested_headers_value = parts
+            .headers
+            .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+            .cloned();
         let requested_headers = requested_headers_value
             .as_ref()
             .and_then(|value| value.to_str().ok())

--- a/api/src/s3/s3_server.rs
+++ b/api/src/s3/s3_server.rs
@@ -178,20 +178,24 @@ impl Service<Request<Incoming>> for WrappingService {
         let cors = self.cors.clone();
         let driver_ctx = self.driver_ctx.clone();
         Box::pin(async move {
-            let bucket_cors = match load_bucket_cors_config(driver_ctx, bucket).await {
-                Ok(bucket_cors) => bucket_cors,
-                Err(error) => {
-                    span.record("status_code", 500);
-                    let _guard = span.enter();
-                    error!(
-                        event = "request.failed",
-                        protocol = "s3",
-                        latency_ms = started.elapsed().as_millis() as u64,
-                        error = ?error,
-                        "Failed to query bucket CORS configuration"
-                    );
-                    return Err(HttpError::new(error.into()));
+            let bucket_cors = if origin_header.is_some() {
+                match load_bucket_cors_config(driver_ctx, bucket).await {
+                    Ok(bucket_cors) => bucket_cors,
+                    Err(error) => {
+                        span.record("status_code", 500);
+                        let _guard = span.enter();
+                        error!(
+                            event = "request.failed",
+                            protocol = "s3",
+                            latency_ms = started.elapsed().as_millis() as u64,
+                            error = ?error,
+                            "Failed to query bucket CORS configuration"
+                        );
+                        return Err(HttpError::new(error.into()));
+                    }
                 }
+            } else {
+                None
             };
 
             // Answer CORS preflight before s3s signature validation: an unsigned

--- a/api/src/s3/s3_server.rs
+++ b/api/src/s3/s3_server.rs
@@ -157,24 +157,19 @@ impl Service<Request<Incoming>> for WrappingService {
             .get(header::HOST)
             .and_then(|value| value.to_str().ok());
         let bucket = extract_bucket_name(host, &path, &self.domain);
-        let origin = parts
-            .headers
-            .get(ORIGIN_HEADER)
+        let origin_header = parts.headers.get(ORIGIN_HEADER).cloned();
+        let origin = origin_header
+            .as_ref()
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let origin_header = parts.headers.get(header::ORIGIN).cloned();
         let requested_method = parts
             .headers
             .get(REQUEST_METHOD_HEADER)
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let requested_headers_value = parts
-            .headers
-            .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
-            .cloned();
-        let requested_headers = parts
-            .headers
-            .get(REQUEST_HEADERS_HEADER)
+        let requested_headers_value = parts.headers.get(REQUEST_HEADERS_HEADER).cloned();
+        let requested_headers = requested_headers_value
+            .as_ref()
             .and_then(|value| value.to_str().ok())
             .map(parse_requested_headers)
             .unwrap_or_default();

--- a/api/src/s3/s3_server.rs
+++ b/api/src/s3/s3_server.rs
@@ -1,12 +1,13 @@
 use super::auth::AuthProvider;
 use super::s3_service::ArunaS3Service;
+use crate::cors::CorsConfig;
 use crate::error::S3ServerError;
 use crate::telemetry::{emit_request_completed, make_request_span};
 use aruna_core::NodeId;
 use aruna_core::structs::RealmId;
 use aruna_operations::driver::DriverContext;
 use futures_core::future::BoxFuture;
-use http::Request;
+use http::{Method, Request, StatusCode, header};
 use hyper::body::Incoming;
 use hyper::service::Service;
 use hyper_util::rt::TokioExecutor;
@@ -28,11 +29,13 @@ use tracing::{Instrument, error, info, trace};
 pub struct S3Server {
     address: String,
     s3service: S3Service,
+    cors: CorsConfig,
 }
 
 #[derive(Clone)]
 pub struct WrappingService {
     shared: S3Service, // Aruna specific implementation of S3 trait
+    cors: CorsConfig,
 }
 
 impl S3Server {
@@ -43,6 +46,7 @@ impl S3Server {
         driver_ctx: Arc<DriverContext>,
         realm_id: RealmId,
         node_id: NodeId,
+        cors: CorsConfig,
     ) -> Result<Self, S3ServerError> {
         let s3service = ArunaS3Service::new(driver_ctx.clone(), realm_id, node_id).await;
 
@@ -64,6 +68,7 @@ impl S3Server {
         Ok(Self {
             address: address.into(),
             s3service: service,
+            cors,
         })
     }
 
@@ -74,6 +79,7 @@ impl S3Server {
         let local_addr = listener.local_addr()?;
         let service = WrappingService {
             shared: self.s3service,
+            cors: self.cors,
         };
         let connection = ConnBuilder::new(TokioExecutor::new());
 
@@ -116,7 +122,29 @@ impl Service<Request<Incoming>> for WrappingService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn call(&self, req: Request<Incoming>) -> Self::Future {
-        //TODO: CORS
+        let origin = req.headers().get(header::ORIGIN).cloned();
+
+        // Answer CORS preflight before s3s signature validation: an unsigned
+        // OPTIONS request must not fail with 403.
+        if req.method() == Method::OPTIONS
+            && let Some(origin) = origin.as_ref()
+        {
+            let requested_headers = req
+                .headers()
+                .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+                .cloned();
+            let mut response = http::Response::builder()
+                .status(StatusCode::NO_CONTENT)
+                .body(s3s::Body::empty())
+                .expect("static response must build");
+            if let Some(cors_headers) = self
+                .cors
+                .s3_preflight_headers(origin, requested_headers.as_ref())
+            {
+                response.headers_mut().extend(cors_headers);
+            }
+            return Box::pin(async move { Ok(response) });
+        }
 
         // Default S3 operation call
         let (parts, body) = req.into_parts();
@@ -136,8 +164,12 @@ impl Service<Request<Incoming>> for WrappingService {
         }
         let s3s_request = s3s::HttpRequest::from_parts(parts, body.into());
         let shared = self.shared.clone();
+        let cors = self.cors.clone();
         Box::pin(async move {
-            let result = shared.call(s3s_request).instrument(span.clone()).await;
+            let mut result = shared.call(s3s_request).instrument(span.clone()).await;
+            if let Ok(response) = &mut result {
+                cors.apply_s3_response_headers(origin.as_ref(), response.headers_mut());
+            }
             match &result {
                 Ok(response) => {
                     emit_request_completed(&span, "s3", response.status().as_u16(), started)

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -577,6 +577,7 @@ impl S3 for ArunaS3Service {
         drive(operation, &self.state)
             .await
             .and_then(|result| result.transpose())
+                cors_configuration: None,
             .map_err(IntoS3Error::into_s3_error)?
             .ok_or_else(|| s3_error!(InternalError, "Failed to create bucket"))?;
 
@@ -1902,6 +1903,7 @@ mod tests {
         )
         .await;
 
+            cors_configuration: None,
         let mut extensions = Extensions::new();
         extensions.insert(test_user_access(group_id, realm_id));
         extensions.insert(test_bucket_info(group_id, created_by));

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -1093,7 +1093,10 @@ impl S3 for ArunaS3Service {
         &self,
         _req: S3Request<GetObjectAttributesInput>,
     ) -> S3Result<S3Response<GetObjectAttributesOutput>> {
-        unimplemented!()
+        Err(s3_error!(
+            NotImplemented,
+            "GetObjectAttributes is not implemented"
+        ))
     }
 
     #[tracing::instrument(err, skip(self, req))]

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -4,6 +4,7 @@ use crate::s3::checksum::{
     ApplyChecksums, ChecksumSelection, UploadChecksumRequest, checksum_mode_enabled,
     encode_checksums, parse_upload_checksum_request,
 };
+use crate::s3::cors::{bucket_cors_to_get_output, dto_to_bucket_cors};
 use crate::s3::error::IntoS3Error;
 use crate::s3::util::{
     convert_input, multipart_checksum_type_from_s3, parse_completed_part,
@@ -23,6 +24,9 @@ use aruna_operations::replication::queue::{
 };
 use aruna_operations::s3::abort_multipart_upload::{
     AbortMultipartUploadInput as AMUI, AbortMultipartUploadOperation,
+};
+use aruna_operations::s3::bucket_cors::{
+    DeleteBucketCorsOperation, GetBucketCorsOperation, PutBucketCorsOperation,
 };
 use aruna_operations::s3::complete_multipart_upload::{
     CompleteMultipartUploadInput as CMUI, CompleteMultipartUploadOperation,
@@ -58,15 +62,17 @@ use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use s3s::dto::{
     AbortMultipartUploadInput, AbortMultipartUploadOutput, Bucket, CommonPrefix,
     CompleteMultipartUploadInput, CompleteMultipartUploadOutput, CreateBucketInput,
-    CreateBucketOutput, CreateMultipartUploadInput, CreateMultipartUploadOutput, DeleteBucketInput,
-    DeleteBucketOutput, DeleteBucketReplicationInput, DeleteBucketReplicationOutput,
-    DeleteMarkerReplication, DeleteMarkerReplicationStatus, DeleteObjectInput, DeleteObjectOutput,
-    Destination, ETag, EncodingType, GetBucketReplicationInput, GetBucketReplicationOutput,
-    GetObjectAttributesInput, GetObjectAttributesOutput, GetObjectInput, GetObjectOutput,
-    HeadObjectInput, HeadObjectOutput, LastModified, ListBucketsInput, ListBucketsOutput,
-    ListObjectsV2Input, ListObjectsV2Output, Object, Owner, PutBucketReplicationInput,
-    PutBucketReplicationOutput, PutObjectInput, PutObjectOutput, ReplicationConfiguration,
-    ReplicationRule, ReplicationRuleStatus, StreamingBlob, UploadPartInput, UploadPartOutput,
+    CreateBucketOutput, CreateMultipartUploadInput, CreateMultipartUploadOutput,
+    DeleteBucketCorsInput, DeleteBucketCorsOutput, DeleteBucketInput, DeleteBucketOutput,
+    DeleteBucketReplicationInput, DeleteBucketReplicationOutput, DeleteMarkerReplication,
+    DeleteMarkerReplicationStatus, DeleteObjectInput, DeleteObjectOutput, Destination, ETag,
+    EncodingType, GetBucketCorsInput, GetBucketCorsOutput, GetBucketReplicationInput,
+    GetBucketReplicationOutput, GetObjectAttributesInput, GetObjectAttributesOutput,
+    GetObjectInput, GetObjectOutput, HeadObjectInput, HeadObjectOutput, LastModified,
+    ListBucketsInput, ListBucketsOutput, ListObjectsV2Input, ListObjectsV2Output, Object, Owner,
+    PutBucketCorsInput, PutBucketCorsOutput, PutBucketReplicationInput, PutBucketReplicationOutput,
+    PutObjectInput, PutObjectOutput, ReplicationConfiguration, ReplicationRule,
+    ReplicationRuleStatus, StreamingBlob, UploadPartInput, UploadPartOutput,
 };
 use s3s::{S3, S3ErrorCode, S3Request, S3Response, S3Result, s3_error};
 use std::fmt::Debug;
@@ -571,13 +577,13 @@ impl S3 for ArunaS3Service {
                 group_id: user_access.group_id,
                 created_at: SystemTime::now(),
                 created_by: user_access.user_identity,
+                cors_configuration: None,
             },
         );
 
         drive(operation, &self.state)
             .await
             .and_then(|result| result.transpose())
-                cors_configuration: None,
             .map_err(IntoS3Error::into_s3_error)?
             .ok_or_else(|| s3_error!(InternalError, "Failed to create bucket"))?;
 
@@ -633,6 +639,78 @@ impl S3 for ArunaS3Service {
             owner: None,
             prefix: req.input.prefix,
         }))
+    }
+
+    #[tracing::instrument(err, skip(self, req))]
+    async fn put_bucket_cors(
+        &self,
+        req: S3Request<PutBucketCorsInput>,
+    ) -> S3Result<S3Response<PutBucketCorsOutput>> {
+        debug!(bucket = %req.input.bucket, "Received PUT BUCKET CORS Request");
+
+        let _user_access = req.extensions.get::<UserAccess>().cloned().ok_or_else(|| {
+            error!(error = "Missing user context");
+            s3_error!(UnexpectedContent, "Missing user context")
+        })?;
+        let config = dto_to_bucket_cors(req.input.cors_configuration.clone())?;
+
+        drive(
+            PutBucketCorsOperation::new(req.input.bucket.clone(), config),
+            &self.state,
+        )
+        .await
+        .and_then(|result| result.transpose())
+        .map_err(IntoS3Error::into_s3_error)?
+        .ok_or_else(|| s3_error!(InternalError, "Failed to put bucket CORS configuration"))?;
+
+        Ok(S3Response::new(PutBucketCorsOutput::default()))
+    }
+
+    #[tracing::instrument(err, skip(self, req))]
+    async fn get_bucket_cors(
+        &self,
+        req: S3Request<GetBucketCorsInput>,
+    ) -> S3Result<S3Response<GetBucketCorsOutput>> {
+        debug!(bucket = %req.input.bucket, "Received GET BUCKET CORS Request");
+
+        let _user_access = req.extensions.get::<UserAccess>().cloned().ok_or_else(|| {
+            error!(error = "Missing user context");
+            s3_error!(UnexpectedContent, "Missing user context")
+        })?;
+        let config = drive(
+            GetBucketCorsOperation::new(req.input.bucket.clone()),
+            &self.state,
+        )
+        .await
+        .and_then(|result| result.transpose())
+        .map_err(IntoS3Error::into_s3_error)?
+        .ok_or_else(|| s3_error!(InternalError, "Failed to get bucket CORS configuration"))?;
+
+        Ok(S3Response::new(bucket_cors_to_get_output(config)))
+    }
+
+    #[tracing::instrument(err, skip(self, req))]
+    async fn delete_bucket_cors(
+        &self,
+        req: S3Request<DeleteBucketCorsInput>,
+    ) -> S3Result<S3Response<DeleteBucketCorsOutput>> {
+        debug!(bucket = %req.input.bucket, "Received DELETE BUCKET CORS Request");
+
+        let _user_access = req.extensions.get::<UserAccess>().cloned().ok_or_else(|| {
+            error!(error = "Missing user context");
+            s3_error!(UnexpectedContent, "Missing user context")
+        })?;
+
+        drive(
+            DeleteBucketCorsOperation::new(req.input.bucket.clone()),
+            &self.state,
+        )
+        .await
+        .and_then(|result| result.transpose())
+        .map_err(IntoS3Error::into_s3_error)?
+        .ok_or_else(|| s3_error!(InternalError, "Failed to delete bucket CORS configuration"))?;
+
+        Ok(S3Response::new(DeleteBucketCorsOutput::default()))
     }
 
     #[tracing::instrument(err, skip(self, req))]
@@ -1825,6 +1903,7 @@ mod tests {
             group_id,
             created_at: UNIX_EPOCH,
             created_by,
+            cors_configuration: None,
         }
     }
 
@@ -1903,7 +1982,6 @@ mod tests {
         )
         .await;
 
-            cors_configuration: None,
         let mut extensions = Extensions::new();
         extensions.insert(test_user_access(group_id, realm_id));
         extensions.insert(test_bucket_info(group_id, created_by));

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 
-const MAX_HTTP_BODY_SIZE: usize = 1024 * 1024;
+pub const DEFAULT_MAX_HTTP_BODY_SIZE: usize = 1024 * 1024;
 
 #[derive(Clone, Debug)]
 pub struct Server {
@@ -19,6 +19,7 @@ pub struct Server {
 #[derive(Clone, Debug)]
 pub struct ServerConfig {
     pub http_addr: SocketAddr,
+    pub max_http_body_size: usize,
 }
 
 impl Server {
@@ -37,7 +38,7 @@ impl Server {
                 axum::routing::get(|| async { Redirect::permanent("/swagger-ui") }),
             )
             .nest("/api/v1", api_v1)
-            .layer(DefaultBodyLimit::max(MAX_HTTP_BODY_SIZE))
+            .layer(DefaultBodyLimit::max(self.config.max_http_body_size))
             .merge(swagger_ui())
     }
 

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,3 +1,4 @@
+use crate::cors::CorsConfig;
 use crate::error::ServerSetupError;
 use crate::routes::rest_router;
 pub(crate) use crate::server_state::{ServerState, swagger_ui};
@@ -20,6 +21,7 @@ pub struct Server {
 pub struct ServerConfig {
     pub http_addr: SocketAddr,
     pub max_http_body_size: usize,
+    pub cors: CorsConfig,
 }
 
 impl Server {
@@ -32,14 +34,18 @@ impl Server {
 
         // Build the root router with body size limit for REST API
 
-        Router::new()
+        let mut router = Router::new()
             .route(
                 "/",
                 axum::routing::get(|| async { Redirect::permanent("/swagger-ui") }),
             )
             .nest("/api/v1", api_v1)
             .layer(DefaultBodyLimit::max(self.config.max_http_body_size))
-            .merge(swagger_ui())
+            .merge(swagger_ui());
+        if let Some(cors_layer) = self.config.cors.rest_layer() {
+            router = router.layer(cors_layer);
+        }
+        router
     }
 
     pub async fn run(self) -> Result<(), ServerSetupError> {

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -354,7 +354,13 @@ mod tests {
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let server = Server::new(state, ServerConfig { http_addr: addr });
+        let server = Server::new(
+            state,
+            ServerConfig {
+                http_addr: addr,
+                max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+            },
+        );
         let server_task = tokio::spawn(async move {
             server.run_with_listener(listener).await.unwrap();
         });

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -359,6 +359,7 @@ mod tests {
             ServerConfig {
                 http_addr: addr,
                 max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+                cors: aruna_api::cors::CorsConfig::default(),
             },
         );
         let server_task = tokio::spawn(async move {

--- a/aruna-doctor/src/storage.rs
+++ b/aruna-doctor/src/storage.rs
@@ -715,6 +715,7 @@ mod tests {
                         group_id: group.0.group_id,
                         created_at: SystemTime::now(),
                         created_by: realm_admin,
+                        cors_configuration: None,
                     },
                 ),
                 context.as_ref(),

--- a/aruna-doctor/src/tokens.rs
+++ b/aruna-doctor/src/tokens.rs
@@ -816,6 +816,7 @@ mod tests {
             ServerConfig {
                 http_addr: addr,
                 max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+                cors: aruna_api::cors::CorsConfig::default(),
             },
         )
         .build_router();

--- a/aruna-doctor/src/tokens.rs
+++ b/aruna-doctor/src/tokens.rs
@@ -811,7 +811,14 @@ mod tests {
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let router = Server::new(state, ServerConfig { http_addr: addr }).build_router();
+        let router = Server::new(
+            state,
+            ServerConfig {
+                http_addr: addr,
+                max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+            },
+        )
+        .build_router();
         let server_task = tokio::spawn(async move {
             axum::serve(
                 listener,

--- a/aruna/src/config.rs
+++ b/aruna/src/config.rs
@@ -58,6 +58,7 @@ pub struct Config {
     pub blob_transfer_idle_timeout_secs: u64,
     pub http_socket_addr: SocketAddr,
     pub max_http_body_size: usize,
+    pub cors_allowed_origins: Vec<String>,
     pub p2p_socket_addr: SocketAddr,
     pub max_concurrent_uni_streams: Option<u64>,
     pub max_concurrent_bidi_streams: Option<u64>,
@@ -247,6 +248,7 @@ pub async fn load() -> Result<(Config, StorageHandle), SetupError> {
         .map(|value| value.parse::<usize>())
         .transpose()?
         .unwrap_or(aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE);
+    let cors_allowed_origins = parse_list_env("CORS_ALLOWED_ORIGINS");
     let p2p_socket_addr = SocketAddr::from_str(
         &dotenvy::var("P2P_SOCKET_ADDRESS").unwrap_or_else(|_| http_socket_addr.to_string()),
     )?;
@@ -352,6 +354,7 @@ pub async fn load() -> Result<(Config, StorageHandle), SetupError> {
             blob_transfer_idle_timeout_secs,
             http_socket_addr,
             max_http_body_size,
+            cors_allowed_origins,
             p2p_socket_addr,
             max_concurrent_uni_streams,
             max_concurrent_bidi_streams,

--- a/aruna/src/config.rs
+++ b/aruna/src/config.rs
@@ -57,6 +57,7 @@ pub struct Config {
     pub blob_control_plane_io_timeout_secs: u64,
     pub blob_transfer_idle_timeout_secs: u64,
     pub http_socket_addr: SocketAddr,
+    pub max_http_body_size: usize,
     pub p2p_socket_addr: SocketAddr,
     pub max_concurrent_uni_streams: Option<u64>,
     pub max_concurrent_bidi_streams: Option<u64>,
@@ -241,6 +242,11 @@ pub async fn load() -> Result<(Config, StorageHandle), SetupError> {
         .transpose()?
         .unwrap_or(30 * 60);
     let http_socket_addr = SocketAddr::from_str(&dotenvy::var("SOCKET_ADDRESS")?)?;
+    let max_http_body_size = dotenvy::var("MAX_HTTP_BODY_SIZE")
+        .ok()
+        .map(|value| value.parse::<usize>())
+        .transpose()?
+        .unwrap_or(aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE);
     let p2p_socket_addr = SocketAddr::from_str(
         &dotenvy::var("P2P_SOCKET_ADDRESS").unwrap_or_else(|_| http_socket_addr.to_string()),
     )?;
@@ -345,6 +351,7 @@ pub async fn load() -> Result<(Config, StorageHandle), SetupError> {
             blob_control_plane_io_timeout_secs,
             blob_transfer_idle_timeout_secs,
             http_socket_addr,
+            max_http_body_size,
             p2p_socket_addr,
             max_concurrent_uni_streams,
             max_concurrent_bidi_streams,

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -258,6 +258,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let server_config = ServerConfig {
         http_addr: config.http_socket_addr,
+        max_http_body_size: config.max_http_body_size,
     };
     let server = Server::new(state.clone(), server_config);
 

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -7,6 +7,7 @@ use aruna::bootstrap::{
 use aruna::config::{StartupMode, load, mark_node_state_complete, mark_onboarding_phase};
 use aruna::telemetry::{init_tracing, shutdown_tracing};
 use aruna_api::auth::OidcValidator;
+use aruna_api::cors::CorsConfig;
 use aruna_api::s3::s3_server::S3Server;
 use aruna_api::server::{Server, ServerConfig};
 use aruna_api::server_state::ServerState;
@@ -256,9 +257,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         .await,
     );
 
+    let cors = CorsConfig::new(config.cors_allowed_origins.clone());
     let server_config = ServerConfig {
         http_addr: config.http_socket_addr,
         max_http_body_size: config.max_http_body_size,
+        cors: cors.clone(),
     };
     let server = Server::new(state.clone(), server_config);
 
@@ -269,6 +272,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         driver_ctx.clone(),
         config.realm_id,
         config.node_id,
+        cors,
     )
     .await
     .unwrap();

--- a/aruna/tests/cors.rs
+++ b/aruna/tests/cors.rs
@@ -1,0 +1,151 @@
+mod shared;
+
+use reqwest::StatusCode;
+use reqwest::header;
+use shared::{TEST_CORS_ORIGIN, TestResult, spawn_full_seed_node, spawn_seed_node};
+
+const DISALLOWED_ORIGIN: &str = "http://evil.test";
+
+#[tokio::test]
+async fn rest_preflight_and_actual_requests_carry_cors_headers() -> TestResult<()> {
+    let seed = spawn_seed_node().await?;
+    let client = reqwest::Client::new();
+
+    let preflight = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{}/api/v1/info", seed.base_url),
+        )
+        .header(header::ORIGIN, TEST_CORS_ORIGIN)
+        .header("access-control-request-method", "GET")
+        .header("access-control-request-headers", "authorization")
+        .send()
+        .await?;
+    assert!(preflight.status().is_success());
+    assert_eq!(
+        preflight
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok()),
+        Some(TEST_CORS_ORIGIN)
+    );
+    let allow_headers = preflight
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    assert!(allow_headers.contains("authorization"));
+
+    let actual = client
+        .get(format!("{}/api/v1/info", seed.base_url))
+        .header(header::ORIGIN, TEST_CORS_ORIGIN)
+        .send()
+        .await?;
+    assert!(actual.status().is_success());
+    assert_eq!(
+        actual
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok()),
+        Some(TEST_CORS_ORIGIN)
+    );
+
+    let denied = client
+        .get(format!("{}/api/v1/info", seed.base_url))
+        .header(header::ORIGIN, DISALLOWED_ORIGIN)
+        .send()
+        .await?;
+    assert!(
+        denied
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none()
+    );
+
+    seed.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn s3_preflight_succeeds_unsigned_and_responses_expose_headers() -> TestResult<()> {
+    let seed = spawn_full_seed_node().await?;
+    let s3 = seed.s3.as_ref().expect("full seed node has S3");
+    let client = reqwest::Client::new();
+
+    // Unsigned preflight must be answered before signature validation.
+    let preflight = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{}/some-bucket/some/key", s3.endpoint_url),
+        )
+        .header(header::ORIGIN, TEST_CORS_ORIGIN)
+        .header("access-control-request-method", "PUT")
+        .header("access-control-request-headers", "authorization,x-amz-date")
+        .send()
+        .await?;
+    assert_eq!(preflight.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        preflight
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok()),
+        Some(TEST_CORS_ORIGIN)
+    );
+    let allow_methods = preflight
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_METHODS)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    assert!(allow_methods.contains("PUT"));
+    assert_eq!(
+        preflight
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .and_then(|value| value.to_str().ok()),
+        Some("authorization,x-amz-date")
+    );
+
+    // Preflight from a disallowed origin completes without CORS headers.
+    let denied = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{}/some-bucket/some/key", s3.endpoint_url),
+        )
+        .header(header::ORIGIN, DISALLOWED_ORIGIN)
+        .header("access-control-request-method", "PUT")
+        .send()
+        .await?;
+    assert_eq!(denied.status(), StatusCode::NO_CONTENT);
+    assert!(
+        denied
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none()
+    );
+
+    // Real (unsigned, hence rejected) requests still carry CORS headers so the
+    // browser can read the error response.
+    let unauthorized = client
+        .get(format!("{}/some-bucket/some/key", s3.endpoint_url))
+        .header(header::ORIGIN, TEST_CORS_ORIGIN)
+        .send()
+        .await?;
+    assert!(!unauthorized.status().is_success());
+    assert_eq!(
+        unauthorized
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok()),
+        Some(TEST_CORS_ORIGIN)
+    );
+    let exposed = unauthorized
+        .headers()
+        .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    assert!(exposed.contains("etag"));
+
+    seed.shutdown().await;
+    Ok(())
+}

--- a/aruna/tests/oidc_registration.rs
+++ b/aruna/tests/oidc_registration.rs
@@ -261,6 +261,7 @@ async fn spawn_test_node(provider: OidcProviderConfig) -> TestNode {
         ServerConfig {
             http_addr: addr,
             max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+            cors: aruna_api::cors::CorsConfig::default(),
         },
     )
     .build_router();

--- a/aruna/tests/oidc_registration.rs
+++ b/aruna/tests/oidc_registration.rs
@@ -256,7 +256,14 @@ async fn spawn_test_node(provider: OidcProviderConfig) -> TestNode {
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    let router = Server::new(state, ServerConfig { http_addr: addr }).build_router();
+    let router = Server::new(
+        state,
+        ServerConfig {
+            http_addr: addr,
+            max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+        },
+    )
+    .build_router();
     let server_task = tokio::spawn(async move {
         axum::serve(
             listener,

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -744,7 +744,13 @@ async fn spawn_rest_server(
         Arc::new(ServerState::new(context, realm_id, node_id, capabilities, false, None).await);
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
-    let server = Server::new(state, ServerConfig { http_addr: addr });
+    let server = Server::new(
+        state,
+        ServerConfig {
+            http_addr: addr,
+            max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+        },
+    );
     let router = server.build_router();
     let server_task = tokio::spawn(async move {
         axum::serve(

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -4,6 +4,7 @@ use aruna::bootstrap::{
     announce_core_documents, fetch_core_onboarding_documents, realm_bootstrap_exists,
 };
 use aruna::config::{Config, load, mark_node_state_complete, mark_onboarding_phase};
+use aruna_api::cors::CorsConfig;
 use aruna_api::routes::credentials::{
     CreateS3CredentialsRequest, CreateS3CredentialsResponse, CreateS3PathRestriction,
 };
@@ -734,6 +735,12 @@ async fn announce_realm_presence(
     Ok(())
 }
 
+pub const TEST_CORS_ORIGIN: &str = "http://portal.test";
+
+fn test_cors_config() -> CorsConfig {
+    CorsConfig::new(vec![TEST_CORS_ORIGIN.to_string()])
+}
+
 async fn spawn_rest_server(
     context: Arc<DriverContext>,
     realm_id: RealmId,
@@ -749,6 +756,7 @@ async fn spawn_rest_server(
         ServerConfig {
             http_addr: addr,
             max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
+            cors: test_cors_config(),
         },
     );
     let router = server.build_router();
@@ -786,8 +794,15 @@ async fn spawn_s3_server(
     let bind_addr = listener.local_addr()?;
     let address = bind_addr.to_string();
     let host = format!("localhost:{}", bind_addr.port());
-    let s3_server =
-        S3Server::new(address.as_str(), host.clone(), context, realm_id, node_id).await?;
+    let s3_server = S3Server::new(
+        address.as_str(),
+        host.clone(),
+        context,
+        realm_id,
+        node_id,
+        test_cors_config(),
+    )
+    .await?;
     let (_addr, task) = s3_server.run_with_listener(listener)?;
     Ok((
         S3Endpoint {

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -167,10 +167,36 @@ impl BackendLocation {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BucketCorsConfiguration {
+    pub rules: Vec<BucketCorsRule>,
+}
+
+impl BucketCorsConfiguration {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
+        Ok(postcard::to_allocvec(self)?)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
+        Ok(postcard::from_bytes(bytes)?)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BucketCorsRule {
+    pub id: Option<String>,
+    pub allowed_origins: Vec<String>,
+    pub allowed_methods: Vec<String>,
+    pub allowed_headers: Vec<String>,
+    pub expose_headers: Vec<String>,
+    pub max_age_seconds: Option<i32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BucketInfo {
     pub group_id: Ulid,
     pub created_at: SystemTime,
     pub created_by: UserId,
+    pub cors_configuration: Option<BucketCorsConfiguration>,
 }
 
 impl BucketInfo {
@@ -571,8 +597,9 @@ impl UserAccess {
 #[cfg(test)]
 mod tests {
     use super::{
-        BlobHeadKey, BlobVersion, CurrentVersionPointer, HashPathIndexKey,
-        blob_bucket_permission_path, blob_group_permission_path, blob_object_permission_path,
+        BlobHeadKey, BlobVersion, BucketCorsConfiguration, BucketCorsRule, CurrentVersionPointer,
+        HashPathIndexKey, blob_bucket_permission_path, blob_group_permission_path,
+        blob_object_permission_path,
     };
     use crate::NodeId;
     use crate::structs::{
@@ -742,5 +769,23 @@ mod tests {
         assert!(deleted.blob_hash().is_none());
         assert!(!deleted.is_materialized());
         assert!(deleted.is_deleted());
+    }
+
+    #[test]
+    fn bucket_cors_configuration_roundtrip_preserves_rules() {
+        let config = BucketCorsConfiguration {
+            rules: vec![BucketCorsRule {
+                id: Some("rule-1".to_string()),
+                allowed_origins: vec!["https://example.org".to_string()],
+                allowed_methods: vec!["GET".to_string(), "PUT".to_string()],
+                allowed_headers: vec!["authorization".to_string()],
+                expose_headers: vec!["etag".to_string()],
+                max_age_seconds: Some(600),
+            }],
+        };
+
+        let restored = BucketCorsConfiguration::from_bytes(&config.to_bytes().unwrap()).unwrap();
+
+        assert_eq!(config, restored);
     }
 }

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -4,10 +4,20 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aruna_core::NodeId;
+use aruna_core::effects::{IterStart, StorageEffect};
 use aruna_core::errors::AuthorizationError;
+use aruna_core::events::{Event, StorageEvent};
 use aruna_core::id::short_display_id;
+use aruna_core::keyspaces::{
+    METADATA_EVENT_LOG_KEYSPACE, METADATA_GRAPH_LIFECYCLE_KEYSPACE,
+    METADATA_PENDING_PROJECTION_KEYSPACE,
+};
 use aruna_core::metadata::{
-    MetadataError, MetadataQueryResults, MetadataRoCratePage, MetadataSearchHit,
+    MetadataCreateEventRecord, MetadataError, MetadataGraphLifecycleRecord, MetadataQueryResults,
+    MetadataRoCratePage, MetadataSearchHit,
+};
+use aruna_core::storage_entries::{
+    metadata_event_log_key, metadata_graph_lifecycle_key, metadata_pending_projection_target,
 };
 use aruna_core::structs::{AuthContext, MetadataRegistryRecord, Permission, RealmId};
 use aruna_core::telemetry::record_elapsed_ms;
@@ -28,7 +38,7 @@ use crate::get_metadata_document::{
 use crate::get_realm_nodes::GetRealmNodesOperation;
 use crate::list_groups::ListGroupOperation;
 use crate::list_metadata_documents::ListMetadataDocumentsOperation;
-use crate::metadata::repository::StorageReadError;
+use crate::metadata::repository::{LIST_METADATA_PAGE_SIZE, StorageReadError};
 
 const DEFAULT_LIST_METADATA_LIMIT: usize = 50;
 const MAX_LIST_METADATA_LIMIT: usize = 1_000;
@@ -198,14 +208,20 @@ pub async fn list_visible_metadata_documents(
     let offset = request.offset.unwrap_or(0);
 
     let mut records = Vec::new();
+    let include_pending_projection = request.include_summary;
     if let Some(group_id) = request.group_id {
-        records.extend(load_group_metadata_records(context, group_id).await?);
+        records.extend(
+            load_group_metadata_records(context, group_id, include_pending_projection).await?,
+        );
     } else {
         let groups = drive(ListGroupOperation::new(), context)
             .await
             .map_err(|error| MetadataApiError::Internal(error.to_string()))?;
         for group in groups {
-            records.extend(load_group_metadata_records(context, group.group_id).await?);
+            records.extend(
+                load_group_metadata_records(context, group.group_id, include_pending_projection)
+                    .await?,
+            );
         }
     }
 
@@ -237,9 +253,14 @@ pub async fn list_visible_metadata_documents(
         )
         .await;
         for (record, summary) in selected.into_iter().zip(summaries) {
+            let rocrate_summary_jsonld = match summary {
+                Ok(summary) => Some(summary),
+                Err(MetadataApiError::ServiceUnavailable) => None,
+                Err(error) => return Err(error),
+            };
             documents.push(ListedMetadataDocument {
                 record,
-                rocrate_summary_jsonld: Some(summary?),
+                rocrate_summary_jsonld,
             });
         }
     } else {
@@ -403,10 +424,11 @@ pub async fn load_metadata_realm_nodes(
 async fn load_group_metadata_records(
     context: &DriverContext,
     group_id: GroupId,
+    include_pending_projection: bool,
 ) -> Result<Vec<MetadataRegistryRecord>, MetadataApiError> {
     // Listing remains eventually consistent: the handle-owned visibility cache
     // serves stale snapshots while one refill updates the operation-owned read path.
-    if let Some(metadata_handle) = context.metadata_handle.as_ref() {
+    if !include_pending_projection && let Some(metadata_handle) = context.metadata_handle.as_ref() {
         match metadata_handle
             .list_cached_registry_records_for_group(group_id)
             .await
@@ -421,9 +443,164 @@ async fn load_group_metadata_records(
         }
     }
 
-    drive(ListMetadataDocumentsOperation::new(group_id), context)
+    let mut records = drive(ListMetadataDocumentsOperation::new(group_id), context)
         .await
-        .map_err(|err| MetadataApiError::Internal(err.to_string()))
+        .map_err(|err| MetadataApiError::Internal(err.to_string()))?;
+
+    if include_pending_projection {
+        merge_pending_metadata_records(
+            &mut records,
+            load_pending_group_metadata_records(context, group_id).await?,
+        );
+        records.sort_by_key(|record| record.document_id);
+    }
+
+    Ok(records)
+}
+
+async fn load_pending_group_metadata_records(
+    context: &DriverContext,
+    group_id: GroupId,
+) -> Result<Vec<MetadataRegistryRecord>, MetadataApiError> {
+    let mut records = Vec::new();
+    let mut start_after = None;
+
+    loop {
+        let page = context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: METADATA_PENDING_PROJECTION_KEYSPACE.to_string(),
+                prefix: None,
+                start: start_after.take().map(IterStart::After),
+                limit: LIST_METADATA_PAGE_SIZE,
+                txn_id: None,
+            })
+            .await;
+        let (values, next_start_after) = match page {
+            Event::Storage(StorageEvent::IterResult {
+                values,
+                next_start_after,
+            }) => (values, next_start_after),
+            Event::Storage(StorageEvent::Error { error }) => {
+                return Err(MetadataApiError::Internal(error.to_string()));
+            }
+            other => return Err(MetadataApiError::Internal(format!("{other:?}"))),
+        };
+
+        for (key, _) in values {
+            let Some((document_id, event_id)) = metadata_pending_projection_target(key.as_ref())
+            else {
+                continue;
+            };
+            let Some(event) = read_metadata_create_event(context, document_id, event_id).await?
+            else {
+                continue;
+            };
+            let record = event.record;
+            if record.group_id != group_id {
+                continue;
+            }
+            if metadata_graph_is_deleted(context, &record.graph_iri).await? {
+                continue;
+            }
+            records.push(record);
+        }
+
+        if next_start_after.is_none() {
+            break;
+        }
+        start_after = next_start_after;
+    }
+
+    Ok(records)
+}
+
+async fn read_metadata_create_event(
+    context: &DriverContext,
+    document_id: Ulid,
+    event_id: Ulid,
+) -> Result<Option<MetadataCreateEventRecord>, MetadataApiError> {
+    let value = match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: METADATA_EVENT_LOG_KEYSPACE.to_string(),
+            key: metadata_event_log_key(document_id, event_id),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => value,
+        Event::Storage(StorageEvent::Error { error }) => {
+            return Err(MetadataApiError::Internal(error.to_string()));
+        }
+        other => return Err(MetadataApiError::Internal(format!("{other:?}"))),
+    };
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    let event: MetadataCreateEventRecord = postcard::from_bytes(&value)
+        .map_err(|error| MetadataApiError::Internal(error.to_string()))?;
+    if event.record.document_id != document_id || event.event_id != event_id {
+        return Err(MetadataApiError::Internal(format!(
+            "metadata create event log target {document_id}/{event_id} did not match payload {}/{}",
+            event.record.document_id, event.event_id
+        )));
+    }
+    Ok(Some(event))
+}
+
+async fn metadata_graph_is_deleted(
+    context: &DriverContext,
+    graph_iri: &str,
+) -> Result<bool, MetadataApiError> {
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: METADATA_GRAPH_LIFECYCLE_KEYSPACE.to_string(),
+            key: metadata_graph_lifecycle_key(graph_iri),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(value), ..
+        }) => {
+            let record: MetadataGraphLifecycleRecord = postcard::from_bytes(&value)
+                .map_err(|error| MetadataApiError::Internal(error.to_string()))?;
+            Ok(record.is_deleted())
+        }
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(false),
+        Event::Storage(StorageEvent::Error { error }) => {
+            Err(MetadataApiError::Internal(error.to_string()))
+        }
+        other => Err(MetadataApiError::Internal(format!("{other:?}"))),
+    }
+}
+
+fn merge_pending_metadata_records(
+    records: &mut Vec<MetadataRegistryRecord>,
+    pending_records: Vec<MetadataRegistryRecord>,
+) {
+    let mut positions = records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| (record.document_id, index))
+        .collect::<HashMap<_, _>>();
+
+    for pending_record in pending_records {
+        if let Some(&index) = positions.get(&pending_record.document_id) {
+            let existing_record = &records[index];
+            if (pending_record.updated_at_ms, pending_record.last_event_id)
+                > (existing_record.updated_at_ms, existing_record.last_event_id)
+            {
+                records[index] = pending_record;
+            }
+        } else {
+            positions.insert(pending_record.document_id, records.len());
+            records.push(pending_record);
+        }
+    }
 }
 
 async fn load_record_by_document(

--- a/operations/src/replication/incoming_version_replication.rs
+++ b/operations/src/replication/incoming_version_replication.rs
@@ -1235,6 +1235,7 @@ mod tests {
             group_id,
             created_at: SystemTime::now(),
             created_by: test_user_id(),
+            cors_configuration: None,
         }
     }
 

--- a/operations/src/replication/queue.rs
+++ b/operations/src/replication/queue.rs
@@ -1432,6 +1432,7 @@ mod tests {
             group_id: Ulid::from_parts(2, 2),
             created_at: SystemTime::UNIX_EPOCH,
             created_by: user(),
+            cors_configuration: None,
         };
         match storage
             .send_storage_effect(StorageEffect::Write {

--- a/operations/src/replication/version_replication.rs
+++ b/operations/src/replication/version_replication.rs
@@ -1586,6 +1586,7 @@ mod tests {
             group_id: Ulid::new(),
             created_at: SystemTime::now(),
             created_by: test_user_id(),
+            cors_configuration: None,
         }
     }
 

--- a/operations/src/s3/bucket_cors.rs
+++ b/operations/src/s3/bucket_cors.rs
@@ -1,0 +1,318 @@
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::S3_BUCKET_KEYSPACE;
+use aruna_core::operation::Operation;
+use aruna_core::structs::{BucketCorsConfiguration, BucketInfo};
+use aruna_core::types::{Effects, Key};
+use smallvec::smallvec;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum PutBucketCorsState {
+    Init,
+    StartTransaction,
+    ReadBucket,
+    WriteBucket,
+    CommitTransaction,
+    Finish,
+    Error,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum PutBucketCorsError {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error("Bucket not found")]
+    NotFound,
+    #[error("No transaction found")]
+    NoTransactionFound,
+    #[error("Unexpected event in state {state:?}: expected {expected}, got {received:?}")]
+    InvalidStateEvent {
+        state: &'static str,
+        expected: &'static str,
+        received: Event,
+    },
+}
+
+#[derive(Debug, PartialEq)]
+pub struct PutBucketCorsOperation {
+    bucket: String,
+    config: BucketCorsConfiguration,
+    state: PutBucketCorsState,
+    txn_id: Option<ulid::Ulid>,
+    output: Option<Result<BucketCorsConfiguration, PutBucketCorsError>>,
+}
+
+impl PutBucketCorsOperation {
+    pub fn new(bucket: String, config: BucketCorsConfiguration) -> Self {
+        Self {
+            bucket,
+            config,
+            state: PutBucketCorsState::Init,
+            txn_id: None,
+            output: None,
+        }
+    }
+
+    fn fail(&mut self, err: PutBucketCorsError) -> Effects {
+        self.state = PutBucketCorsState::Error;
+        self.output = Some(Err(err));
+        self.abort()
+    }
+
+    fn write_key(&self) -> Key {
+        self.bucket.as_bytes().to_vec().into()
+    }
+
+    fn state_name(&self) -> &'static str {
+        match self.state {
+            PutBucketCorsState::Init => "Init",
+            PutBucketCorsState::StartTransaction => "StartTransaction",
+            PutBucketCorsState::ReadBucket => "ReadBucket",
+            PutBucketCorsState::WriteBucket => "WriteBucket",
+            PutBucketCorsState::CommitTransaction => "CommitTransaction",
+            PutBucketCorsState::Finish => "Finish",
+            PutBucketCorsState::Error => "Error",
+        }
+    }
+}
+
+impl Operation for PutBucketCorsOperation {
+    type Output = Option<Result<BucketCorsConfiguration, PutBucketCorsError>>;
+    type Error = PutBucketCorsError;
+
+    fn start(&mut self) -> Effects {
+        self.state = PutBucketCorsState::StartTransaction;
+        smallvec![Effect::Storage(StorageEffect::StartTransaction {
+            read: false,
+        })]
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        match self.state {
+            PutBucketCorsState::Init => self.start(),
+            PutBucketCorsState::StartTransaction => {
+                let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = event else {
+                    return self.fail(PutBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::TransactionStarted)",
+                        received: event,
+                    });
+                };
+                self.txn_id = Some(txn_id);
+                self.state = PutBucketCorsState::ReadBucket;
+                smallvec![Effect::Storage(StorageEffect::Read {
+                    key_space: S3_BUCKET_KEYSPACE.to_string(),
+                    key: self.write_key(),
+                    txn_id: Some(txn_id),
+                })]
+            }
+            PutBucketCorsState::ReadBucket => {
+                let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+                    return self.fail(PutBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::ReadResult)",
+                        received: event,
+                    });
+                };
+                let Some(txn_id) = self.txn_id else {
+                    return self.fail(PutBucketCorsError::NoTransactionFound);
+                };
+                let Some(bytes) = value else {
+                    return self.fail(PutBucketCorsError::NotFound);
+                };
+                let mut bucket_info = match BucketInfo::from_bytes(&bytes) {
+                    Ok(info) => info,
+                    Err(err) => return self.fail(err.into()),
+                };
+                bucket_info.cors_configuration = Some(self.config.clone());
+                let value = match bucket_info.to_bytes() {
+                    Ok(value) => value,
+                    Err(err) => return self.fail(err.into()),
+                };
+                self.state = PutBucketCorsState::WriteBucket;
+                smallvec![Effect::Storage(StorageEffect::Write {
+                    key_space: S3_BUCKET_KEYSPACE.to_string(),
+                    key: self.write_key(),
+                    value: value.into(),
+                    txn_id: Some(txn_id),
+                })]
+            }
+            PutBucketCorsState::WriteBucket => {
+                let Event::Storage(StorageEvent::WriteResult { .. }) = event else {
+                    return self.fail(PutBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::WriteResult)",
+                        received: event,
+                    });
+                };
+                let Some(txn_id) = self.txn_id else {
+                    return self.fail(PutBucketCorsError::NoTransactionFound);
+                };
+                self.state = PutBucketCorsState::CommitTransaction;
+                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+            }
+            PutBucketCorsState::CommitTransaction => {
+                let Event::Storage(StorageEvent::TransactionCommitted { .. }) = event else {
+                    return self.fail(PutBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::TransactionCommitted)",
+                        received: event,
+                    });
+                };
+                self.txn_id = None;
+                self.state = PutBucketCorsState::Finish;
+                self.output = Some(Ok(self.config.clone()));
+                smallvec![]
+            }
+            PutBucketCorsState::Finish => smallvec![],
+            PutBucketCorsState::Error => smallvec![],
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            PutBucketCorsState::Finish | PutBucketCorsState::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        if self.state == PutBucketCorsState::Error
+            && let Some(Err(err)) = self.output
+        {
+            return Err(err);
+        }
+        Ok(self.output)
+    }
+
+    fn abort(&mut self) -> Effects {
+        self.txn_id.map_or_else(smallvec::SmallVec::new, |txn_id| {
+            smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })]
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum GetBucketCorsState {
+    Init,
+    ReadBucket,
+    Finish,
+    Error,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum GetBucketCorsError {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error("Bucket not found")]
+    BucketNotFound,
+    #[error("Bucket CORS configuration not found")]
+    CorsNotFound,
+    #[error("Unexpected event in state {state:?}: expected {expected}, got {received:?}")]
+    InvalidStateEvent {
+        state: &'static str,
+        expected: &'static str,
+        received: Event,
+    },
+}
+
+#[derive(Debug, PartialEq)]
+pub struct GetBucketCorsOperation {
+    bucket: String,
+    state: GetBucketCorsState,
+    output: Option<Result<BucketCorsConfiguration, GetBucketCorsError>>,
+}
+
+impl GetBucketCorsOperation {
+    pub fn new(bucket: String) -> Self {
+        Self {
+            bucket,
+            state: GetBucketCorsState::Init,
+            output: None,
+        }
+    }
+
+    fn fail(&mut self, err: GetBucketCorsError) -> Effects {
+        self.state = GetBucketCorsState::Error;
+        self.output = Some(Err(err));
+        smallvec![]
+    }
+
+    fn state_name(&self) -> &'static str {
+        match self.state {
+            GetBucketCorsState::Init => "Init",
+            GetBucketCorsState::ReadBucket => "ReadBucket",
+            GetBucketCorsState::Finish => "Finish",
+            GetBucketCorsState::Error => "Error",
+        }
+    }
+}
+
+impl Operation for GetBucketCorsOperation {
+    type Output = Option<Result<BucketCorsConfiguration, GetBucketCorsError>>;
+    type Error = GetBucketCorsError;
+
+    fn start(&mut self) -> Effects {
+        self.state = GetBucketCorsState::ReadBucket;
+        smallvec![Effect::Storage(StorageEffect::Read {
+            key_space: S3_BUCKET_KEYSPACE.to_string(),
+            key: self.bucket.as_bytes().to_vec().into(),
+            txn_id: None,
+        })]
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        match self.state {
+            GetBucketCorsState::Init => self.start(),
+            GetBucketCorsState::ReadBucket => {
+                let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+                    return self.fail(GetBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::ReadResult)",
+                        received: event,
+                    });
+                };
+
+                self.state = GetBucketCorsState::Finish;
+                self.output = Some(match value {
+                    Some(bytes) => match BucketInfo::from_bytes(&bytes) {
+                        Ok(info) => info
+                            .cors_configuration
+                            .ok_or(GetBucketCorsError::CorsNotFound),
+                        Err(err) => Err(GetBucketCorsError::ConversionError(err)),
+                    },
+                    None => Err(GetBucketCorsError::BucketNotFound),
+                });
+                smallvec![]
+            }
+            GetBucketCorsState::Finish => smallvec![],
+            GetBucketCorsState::Error => self.abort(),
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            GetBucketCorsState::Finish | GetBucketCorsState::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        if self.state == GetBucketCorsState::Error
+            && let Some(Err(err)) = self.output
+        {
+            return Err(err);
+        }
+        Ok(self.output)
+    }
+
+    fn abort(&mut self) -> Effects {
+        smallvec![]
+    }
+}

--- a/operations/src/s3/bucket_cors.rs
+++ b/operations/src/s3/bucket_cors.rs
@@ -316,3 +316,381 @@ impl Operation for GetBucketCorsOperation {
         smallvec![]
     }
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum DeleteBucketCorsState {
+    Init,
+    StartTransaction,
+    ReadBucket,
+    WriteBucket,
+    CommitTransaction,
+    Finish,
+    Error,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum DeleteBucketCorsError {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error("Bucket not found")]
+    NotFound,
+    #[error("No transaction found")]
+    NoTransactionFound,
+    #[error("Unexpected event in state {state:?}: expected {expected}, got {received:?}")]
+    InvalidStateEvent {
+        state: &'static str,
+        expected: &'static str,
+        received: Event,
+    },
+}
+
+#[derive(Debug, PartialEq)]
+pub struct DeleteBucketCorsOperation {
+    bucket: String,
+    state: DeleteBucketCorsState,
+    txn_id: Option<ulid::Ulid>,
+    output: Option<Result<(), DeleteBucketCorsError>>,
+}
+
+impl DeleteBucketCorsOperation {
+    pub fn new(bucket: String) -> Self {
+        Self {
+            bucket,
+            state: DeleteBucketCorsState::Init,
+            txn_id: None,
+            output: None,
+        }
+    }
+
+    fn fail(&mut self, err: DeleteBucketCorsError) -> Effects {
+        self.state = DeleteBucketCorsState::Error;
+        self.output = Some(Err(err));
+        self.abort()
+    }
+
+    fn write_key(&self) -> Key {
+        self.bucket.as_bytes().to_vec().into()
+    }
+
+    fn state_name(&self) -> &'static str {
+        match self.state {
+            DeleteBucketCorsState::Init => "Init",
+            DeleteBucketCorsState::StartTransaction => "StartTransaction",
+            DeleteBucketCorsState::ReadBucket => "ReadBucket",
+            DeleteBucketCorsState::WriteBucket => "WriteBucket",
+            DeleteBucketCorsState::CommitTransaction => "CommitTransaction",
+            DeleteBucketCorsState::Finish => "Finish",
+            DeleteBucketCorsState::Error => "Error",
+        }
+    }
+}
+
+impl Operation for DeleteBucketCorsOperation {
+    type Output = Option<Result<(), DeleteBucketCorsError>>;
+    type Error = DeleteBucketCorsError;
+
+    fn start(&mut self) -> Effects {
+        self.state = DeleteBucketCorsState::StartTransaction;
+        smallvec![Effect::Storage(StorageEffect::StartTransaction {
+            read: false,
+        })]
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        match self.state {
+            DeleteBucketCorsState::Init => self.start(),
+            DeleteBucketCorsState::StartTransaction => {
+                let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = event else {
+                    return self.fail(DeleteBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::TransactionStarted)",
+                        received: event,
+                    });
+                };
+                self.txn_id = Some(txn_id);
+                self.state = DeleteBucketCorsState::ReadBucket;
+                smallvec![Effect::Storage(StorageEffect::Read {
+                    key_space: S3_BUCKET_KEYSPACE.to_string(),
+                    key: self.write_key(),
+                    txn_id: Some(txn_id),
+                })]
+            }
+            DeleteBucketCorsState::ReadBucket => {
+                let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+                    return self.fail(DeleteBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::ReadResult)",
+                        received: event,
+                    });
+                };
+                let Some(txn_id) = self.txn_id else {
+                    return self.fail(DeleteBucketCorsError::NoTransactionFound);
+                };
+                let Some(bytes) = value else {
+                    return self.fail(DeleteBucketCorsError::NotFound);
+                };
+                let mut bucket_info = match BucketInfo::from_bytes(&bytes) {
+                    Ok(info) => info,
+                    Err(err) => return self.fail(err.into()),
+                };
+                bucket_info.cors_configuration = None;
+                let value = match bucket_info.to_bytes() {
+                    Ok(value) => value,
+                    Err(err) => return self.fail(err.into()),
+                };
+                self.state = DeleteBucketCorsState::WriteBucket;
+                smallvec![Effect::Storage(StorageEffect::Write {
+                    key_space: S3_BUCKET_KEYSPACE.to_string(),
+                    key: self.write_key(),
+                    value: value.into(),
+                    txn_id: Some(txn_id),
+                })]
+            }
+            DeleteBucketCorsState::WriteBucket => {
+                let Event::Storage(StorageEvent::WriteResult { .. }) = event else {
+                    return self.fail(DeleteBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::WriteResult)",
+                        received: event,
+                    });
+                };
+                let Some(txn_id) = self.txn_id else {
+                    return self.fail(DeleteBucketCorsError::NoTransactionFound);
+                };
+                self.state = DeleteBucketCorsState::CommitTransaction;
+                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+            }
+            DeleteBucketCorsState::CommitTransaction => {
+                let Event::Storage(StorageEvent::TransactionCommitted { .. }) = event else {
+                    return self.fail(DeleteBucketCorsError::InvalidStateEvent {
+                        state: self.state_name(),
+                        expected: "Event::Storage(StorageEvent::TransactionCommitted)",
+                        received: event,
+                    });
+                };
+                self.txn_id = None;
+                self.state = DeleteBucketCorsState::Finish;
+                self.output = Some(Ok(()));
+                smallvec![]
+            }
+            DeleteBucketCorsState::Finish => smallvec![],
+            DeleteBucketCorsState::Error => smallvec![],
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            DeleteBucketCorsState::Finish | DeleteBucketCorsState::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        if self.state == DeleteBucketCorsState::Error
+            && let Some(Err(err)) = self.output
+        {
+            return Err(err);
+        }
+        Ok(self.output)
+    }
+
+    fn abort(&mut self) -> Effects {
+        self.txn_id.map_or_else(smallvec::SmallVec::new, |txn_id| {
+            smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })]
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DeleteBucketCorsError, DeleteBucketCorsOperation, GetBucketCorsError,
+        GetBucketCorsOperation, PutBucketCorsError, PutBucketCorsOperation,
+    };
+    use crate::driver::{DriverContext, drive};
+    use aruna_core::effects::StorageEffect;
+    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::keyspaces::S3_BUCKET_KEYSPACE;
+    use aruna_core::structs::{BucketCorsConfiguration, BucketCorsRule, BucketInfo};
+    use aruna_storage::storage;
+    use std::time::SystemTime;
+    use tempfile::tempdir;
+    use ulid::Ulid;
+
+    fn make_context() -> DriverContext {
+        let temp_dir = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(temp_dir.path().to_str().unwrap()).unwrap();
+        std::mem::forget(temp_dir);
+        DriverContext {
+            storage_handle,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        }
+    }
+
+    fn bucket_info(cors_configuration: Option<BucketCorsConfiguration>) -> BucketInfo {
+        BucketInfo {
+            group_id: Ulid::new(),
+            created_at: SystemTime::UNIX_EPOCH,
+            created_by: Default::default(),
+            cors_configuration,
+        }
+    }
+
+    fn sample_cors() -> BucketCorsConfiguration {
+        BucketCorsConfiguration {
+            rules: vec![BucketCorsRule {
+                id: Some("rule-1".into()),
+                allowed_origins: vec!["https://example.org".into()],
+                allowed_methods: vec!["GET".into(), "PUT".into()],
+                allowed_headers: vec!["content-type".into()],
+                expose_headers: vec!["etag".into()],
+                max_age_seconds: Some(300),
+            }],
+        }
+    }
+
+    async fn write_bucket(context: &DriverContext, bucket: &str, info: &BucketInfo) {
+        let txn = context
+            .storage_handle
+            .send_storage_effect(StorageEffect::StartTransaction { read: false })
+            .await;
+        let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = txn else {
+            panic!("unexpected event");
+        };
+        let event = context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: S3_BUCKET_KEYSPACE.to_string(),
+                key: bucket.as_bytes().to_vec().into(),
+                value: info.to_bytes().unwrap().into(),
+                txn_id: Some(txn_id),
+            })
+            .await;
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+        let event = context
+            .storage_handle
+            .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
+            .await;
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::TransactionCommitted { .. })
+        ));
+    }
+
+    async fn read_bucket(context: &DriverContext, bucket: &str) -> BucketInfo {
+        let event = context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Read {
+                key_space: S3_BUCKET_KEYSPACE.to_string(),
+                key: bucket.as_bytes().to_vec().into(),
+                txn_id: None,
+            })
+            .await;
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            panic!("unexpected event");
+        };
+        BucketInfo::from_bytes(&value.unwrap()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn roundtrips_bucket_cors_configuration() {
+        let context = make_context();
+        let bucket = "my-bucket";
+        let original = bucket_info(None);
+        write_bucket(&context, bucket, &original).await;
+
+        let config = sample_cors();
+        let stored = drive(
+            PutBucketCorsOperation::new(bucket.to_string(), config.clone()),
+            &context,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+        assert_eq!(stored, config);
+
+        let persisted = read_bucket(&context, bucket).await;
+        assert_eq!(persisted.group_id, original.group_id);
+        assert_eq!(persisted.created_at, original.created_at);
+        assert_eq!(persisted.created_by, original.created_by);
+        assert_eq!(persisted.cors_configuration, Some(config.clone()));
+
+        let fetched = drive(GetBucketCorsOperation::new(bucket.to_string()), &context)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched, config);
+
+        let deleted = drive(DeleteBucketCorsOperation::new(bucket.to_string()), &context)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(deleted, Ok(()));
+
+        let cleared = read_bucket(&context, bucket).await;
+        assert_eq!(cleared.group_id, original.group_id);
+        assert_eq!(cleared.created_at, original.created_at);
+        assert_eq!(cleared.created_by, original.created_by);
+        assert_eq!(cleared.cors_configuration, None);
+
+        let missing_cors = drive(GetBucketCorsOperation::new(bucket.to_string()), &context)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(missing_cors, GetBucketCorsError::CorsNotFound);
+
+        let deleted_again = drive(DeleteBucketCorsOperation::new(bucket.to_string()), &context)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(deleted_again, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_bucket_and_missing_config() {
+        let bucket = "missing-bucket".to_string();
+
+        let context = make_context();
+        let put_missing = drive(
+            PutBucketCorsOperation::new(bucket.clone(), sample_cors()),
+            &context,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(put_missing, PutBucketCorsError::NotFound);
+
+        let get_missing = drive(GetBucketCorsOperation::new(bucket.clone()), &context)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(get_missing, GetBucketCorsError::BucketNotFound);
+
+        let delete_missing = drive(DeleteBucketCorsOperation::new(bucket.clone()), &context)
+            .await
+            .unwrap_err();
+        assert_eq!(delete_missing, DeleteBucketCorsError::NotFound);
+
+        let context = make_context();
+        write_bucket(&context, &bucket, &bucket_info(None)).await;
+
+        let get_no_config = drive(GetBucketCorsOperation::new(bucket.clone()), &context)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(get_no_config, GetBucketCorsError::CorsNotFound);
+    }
+}

--- a/operations/src/s3/create_bucket.rs
+++ b/operations/src/s3/create_bucket.rs
@@ -234,6 +234,7 @@ mod test {
             group_id: Ulid::new(),
             created_at: SystemTime::now(),
             created_by: Default::default(),
+            cors_configuration: None,
         };
 
         let result = drive(

--- a/operations/src/s3/delete_bucket.rs
+++ b/operations/src/s3/delete_bucket.rs
@@ -351,6 +351,7 @@ mod test {
                     group_id: Ulid::new(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
+                    cors_configuration: None,
                 }
                 .to_bytes()
                 .unwrap()
@@ -412,6 +413,7 @@ mod test {
                     group_id: Ulid::new(),
                     created_at: SystemTime::now(),
                     created_by: aruna_core::UserId::nil(RealmId::from_bytes([0u8; 32])),
+                    cors_configuration: None,
                 }
                 .to_bytes()
                 .unwrap()
@@ -486,6 +488,7 @@ mod test {
                     group_id: Ulid::new(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
+                    cors_configuration: None,
                 }
                 .to_bytes()
                 .unwrap()
@@ -547,6 +550,7 @@ mod test {
                     group_id: Ulid::new(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
+                    cors_configuration: None,
                 }
                 .to_bytes()
                 .unwrap()

--- a/operations/src/s3/list_buckets.rs
+++ b/operations/src/s3/list_buckets.rs
@@ -207,6 +207,7 @@ mod test {
                     group_id,
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
+                    cors_configuration: None,
                 },
             ),
             (
@@ -215,6 +216,7 @@ mod test {
                     group_id,
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
+                    cors_configuration: None,
                 },
             ),
             (
@@ -223,6 +225,7 @@ mod test {
                     group_id: Ulid::new(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
+                    cors_configuration: None,
                 },
             ),
         ] {

--- a/operations/src/s3/mod.rs
+++ b/operations/src/s3/mod.rs
@@ -1,4 +1,5 @@
 pub mod abort_multipart_upload;
+pub mod bucket_cors;
 pub mod complete_multipart_upload;
 pub mod create_bucket;
 pub mod create_multipart_upload;


### PR DESCRIPTION
This PR adds CORS support for browser-based access to Aruna through both the REST API and S3 interface. It also integrates bucket-level S3 CORS configuration support from `feat/bucket-cors`.

## Changes

- Add configurable REST CORS handling.
- Add S3 CORS handling for unsigned preflight requests before signature validation.
- Add CORS headers to S3 responses so browser clients can read relevant response headers.
- Add bucket-level CORS configuration stored in `BucketInfo`. (This includes the changes from the branch `feat/bucket_cors`)
- Implement S3 `PutBucketCors`, `GetBucketCors`, and `DeleteBucketCors`.
- Add CORS matching/conversion helpers and focused tests.
- Include the API quick fixes needed for portal integration.

## Fixed Issues

Fixes #242
Fixes #244