### PR TITLE
Harden metadata sync placement and clock skew handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,10 @@ CORS_ALLOWED_ORIGINS=
 # are rejected with 413.
 MAX_HTTP_BODY_SIZE=1048576
 
+# Inbound metadata events stamped further than this many seconds in the
+# future are rejected (conflict resolution is last-writer-wins on wall
+# clock). Run NTP on every node. Default 300.
+MAX_CLOCK_SKEW_SECS=
+
 RUST_LOG=
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -234,6 +234,7 @@ pub enum RealmNodeKindInfo {
     Management,
     Server,
     Local,
+    User,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -249,6 +250,7 @@ impl From<&RealmNodeKind> for RealmNodeKindInfo {
             RealmNodeKind::Management => Self::Management,
             RealmNodeKind::Server => Self::Server,
             RealmNodeKind::Local => Self::Local,
+            RealmNodeKind::User => Self::User,
         }
     }
 }

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -848,6 +848,7 @@ fn realm_node_kind_value(kind: &RealmNodeKind) -> String {
         RealmNodeKind::Management => "management",
         RealmNodeKind::Server => "server",
         RealmNodeKind::Local => "local",
+        RealmNodeKind::User => "user",
     }
     .to_string()
 }
@@ -926,6 +927,7 @@ fn realm_node_kind_from_value(value: &str) -> Option<RealmNodeKind> {
         "management" => Some(RealmNodeKind::Management),
         "server" => Some(RealmNodeKind::Server),
         "local" => Some(RealmNodeKind::Local),
+        "user" => Some(RealmNodeKind::User),
         _ => None,
     }
 }

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -203,6 +203,15 @@ pub enum RealmNodeKind {
     Management,
     Server,
     Local,
+    /// Owner-bound user device (laptop). Never a sync/holder target.
+    User,
+}
+
+impl RealmNodeKind {
+    /// User nodes must never become document holders or sync targets.
+    pub fn is_sync_eligible(&self) -> bool {
+        !matches!(self, RealmNodeKind::User)
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -294,6 +303,19 @@ impl RealmConfigDocument {
     pub fn node_ids(&self) -> Result<Vec<NodeId>, ConversionError> {
         self.nodes
             .iter()
+            .map(|node| {
+                NodeId::from_str(&node.node_id)
+                    .map_err(|error| ConversionError::FromStrError(error.to_string()))
+            })
+            .collect()
+    }
+
+    /// Node ids eligible as sync peers / document holders (excludes User
+    /// kind nodes).
+    pub fn sync_eligible_node_ids(&self) -> Result<Vec<NodeId>, ConversionError> {
+        self.nodes
+            .iter()
+            .filter(|node| node.kind.is_sync_eligible())
             .map(|node| {
                 NodeId::from_str(&node.node_id)
                     .map_err(|error| ConversionError::FromStrError(error.to_string()))
@@ -394,10 +416,12 @@ fn normalize_replication_factor(replication_factor: u32) -> usize {
 
 #[cfg(test)]
 mod test {
+    use crate::NodeId;
     use crate::structs::{
         Actor, DynamicDiscoveryMethod, MetadataGroupReplicationOverride,
         MetadataPathReplicationOverride, OidcProviderConfig, RealmAuthorizationDocument,
-        RealmConfigDocument, RealmDiscoveryConfig, RealmId, default_realm_discovery_config,
+        RealmConfigDocument, RealmDiscoveryConfig, RealmId, RealmNodeKind,
+        default_realm_discovery_config,
     };
     use ulid::Ulid;
 
@@ -523,5 +547,23 @@ mod test {
             }
             other => panic!("unexpected default discovery config: {other:?}"),
         }
+    }
+
+    #[test]
+    fn sync_eligible_node_ids_excludes_user_kind_nodes() {
+        fn node_id(seed: u8) -> NodeId {
+            let mut bytes = [0u8; 32];
+            bytes[0] = seed;
+            iroh::SecretKey::from_bytes(&bytes).public()
+        }
+
+        let server = node_id(1);
+        let user_device = node_id(2);
+        let mut document = RealmConfigDocument::new(RealmId::from_bytes([9u8; 32]), Vec::new(), 3);
+        document.ensure_node(server, RealmNodeKind::Server);
+        document.ensure_node(user_device, RealmNodeKind::User);
+
+        assert_eq!(document.node_ids().unwrap(), vec![server, user_device]);
+        assert_eq!(document.sync_eligible_node_ids().unwrap(), vec![server]);
     }
 }

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -29,6 +29,8 @@ use aruna_core::types::Key;
 use aruna_storage::StorageHandle;
 use aruna_tasks::TaskHandle;
 use byteview::ByteView;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use thiserror::Error;
 use tracing::warn;
 use ulid::Ulid;
@@ -55,6 +57,33 @@ pub struct PendingMetadataProjectionDrainResult {
     pub markers_examined: usize,
     pub projected: usize,
     pub has_more: bool,
+}
+
+/// Conflict resolution is last-writer-wins on wall-clock time, so an event
+/// stamped far in the future would win every conflict forever. Inbound
+/// events beyond the configured skew are rejected; operators must run NTP.
+const DEFAULT_MAX_CLOCK_SKEW_SECS: u64 = 300;
+
+static CLOCK_SKEW_REJECTIONS: AtomicU64 = AtomicU64::new(0);
+
+fn max_clock_skew_ms() -> u64 {
+    static SKEW_MS: OnceLock<u64> = OnceLock::new();
+    *SKEW_MS.get_or_init(|| {
+        std::env::var("MAX_CLOCK_SKEW_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_MAX_CLOCK_SKEW_SECS)
+            .saturating_mul(1000)
+    })
+}
+
+pub fn clock_skew_rejection_count() -> u64 {
+    CLOCK_SKEW_REJECTIONS.load(Ordering::Relaxed)
+}
+
+fn exceeds_clock_skew(event: &MetadataCreateEventRecord, now_ms: u64, max_skew_ms: u64) -> bool {
+    let limit = now_ms.saturating_add(max_skew_ms);
+    event.record.updated_at_ms > limit || event.occurred_at_ms > limit
 }
 
 #[derive(Debug, Error)]
@@ -369,6 +398,23 @@ pub async fn project_metadata_create_events(
     let mut projected_records = Vec::new();
 
     for event in events {
+        let now_ms = aruna_core::util::unix_timestamp_millis();
+        if exceeds_clock_skew(&event, now_ms, max_clock_skew_ms()) {
+            let rejected_total = CLOCK_SKEW_REJECTIONS.fetch_add(1, Ordering::Relaxed) + 1;
+            warn!(
+                event = "metadata.event.rejected",
+                reason = "clock_skew",
+                event_id = %event.event_id,
+                document_id = %event.record.document_id,
+                node_id = %event.node_id,
+                updated_at_ms = event.record.updated_at_ms,
+                occurred_at_ms = event.occurred_at_ms,
+                now_ms,
+                rejected_total,
+                "Rejecting metadata event stamped too far in the future; check NTP on the emitting node"
+            );
+            continue;
+        }
         let document_id = event.record.document_id;
         pending_projection_delete_targets.insert((document_id, event.event_id));
         if metadata_graph_deleted_cached(context, &event.record.graph_iri, &mut lifecycle_cache)
@@ -845,6 +891,7 @@ mod tests {
         metadata_create_event_write_entry, metadata_pending_projection_key,
     };
     use aruna_core::structs::{RealmConfigDocument, RealmId, RealmNodeKind};
+    use aruna_core::types::UserId;
     use aruna_storage::{FjallStorage, StorageHandle};
     use aruna_tasks::{InboundTaskHandler, TaskHandle};
     use async_trait::async_trait;
@@ -1155,5 +1202,65 @@ mod tests {
             aruna_core::document::DocumentSyncChangeKind::Upsert
         );
         assert_eq!(change.current.event_id, event.event_id);
+    }
+
+    fn skew_event(updated_at_ms: u64, occurred_at_ms: u64) -> MetadataCreateEventRecord {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let document_id = Ulid::new();
+        MetadataCreateEventRecord {
+            event_id: Ulid::new(),
+            record: MetadataRegistryRecord {
+                realm_id,
+                group_id: Ulid::new(),
+                document_id,
+                document_path: "datasets/skew".to_string(),
+                graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+                public: false,
+                permission_path: String::new(),
+                holder_node_ids: Vec::new(),
+                created_at_ms: updated_at_ms,
+                updated_at_ms,
+                last_event_id: Ulid::new(),
+            },
+            user_id: UserId::nil(realm_id),
+            node_id: iroh::SecretKey::from_bytes(&[2u8; 32]).public(),
+            payload: MetadataCreateEventPayload::RoCrate {
+                jsonld: String::new(),
+            },
+            occurred_at_ms,
+        }
+    }
+
+    #[test]
+    fn skew_guard_accepts_events_at_the_threshold() {
+        let now_ms = 1_000_000;
+        let max_skew_ms = 300_000;
+        assert!(!exceeds_clock_skew(
+            &skew_event(now_ms + max_skew_ms, now_ms),
+            now_ms,
+            max_skew_ms
+        ));
+        assert!(!exceeds_clock_skew(
+            &skew_event(now_ms, now_ms + max_skew_ms),
+            now_ms,
+            max_skew_ms
+        ));
+        assert!(!exceeds_clock_skew(&skew_event(0, 0), now_ms, max_skew_ms));
+    }
+
+    #[test]
+    fn skew_guard_rejects_events_past_the_threshold() {
+        let now_ms = 1_000_000;
+        let max_skew_ms = 300_000;
+        assert!(exceeds_clock_skew(
+            &skew_event(now_ms + max_skew_ms + 1, now_ms),
+            now_ms,
+            max_skew_ms
+        ));
+        assert!(exceeds_clock_skew(
+            &skew_event(now_ms, now_ms + max_skew_ms + 1),
+            now_ms,
+            max_skew_ms
+        ));
     }
 }

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -647,7 +647,7 @@ fn expand_create_event_holders(
         event.record.group_id,
         Some(event.record.document_path.as_str()),
     );
-    let candidates = realm_config.node_ids()?;
+    let candidates = realm_config.sync_eligible_node_ids()?;
 
     event.record.holder_node_ids =
         complete_authoritative_holders(&target, &candidates, &holders, desired_holder_count);

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -178,6 +178,8 @@ pub fn realm_nodes_from_config_bytes(value: &[u8]) -> Result<Vec<NodeId>, Conver
     Ok(nodes)
 }
 
+/// Scores a candidate for a topic. The score must not depend on the local
+/// node identity so every node derives the same holder set for a document.
 fn selector_score(topic_id: &[u8], candidate_node_id: NodeId) -> [u8; 32] {
     let mut hasher = blake3::Hasher::new();
     hasher.update(SELECTOR_DOMAIN);
@@ -220,6 +222,16 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(first.len(), 3);
+    }
+
+    #[test]
+    fn selector_is_identical_across_local_node_identities() {
+        let candidates = vec![node(4), node(2), node(3), node(1), node(7), node(8)];
+        let from_first_node = select_sync_peers(&target(), &candidates, &[], 3);
+        let from_second_node = select_sync_peers(&target(), &candidates, &[], 3);
+
+        assert_eq!(from_first_node, from_second_node);
+        assert_eq!(from_first_node.len(), 3);
     }
 
     #[test]

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -173,7 +173,7 @@ pub fn decode_placement(value: &[u8]) -> Result<PendingDocumentPlacement, postca
 
 pub fn realm_nodes_from_config_bytes(value: &[u8]) -> Result<Vec<NodeId>, ConversionError> {
     let document = RealmConfigDocument::from_bytes(value)?;
-    let mut nodes = document.node_ids()?;
+    let mut nodes = document.sync_eligible_node_ids()?;
     sort_node_ids(&mut nodes);
     Ok(nodes)
 }


### PR DESCRIPTION
## Summary
- Rebase selector-clock work onto current main without portal-serving changes.
- Make sync peer selection independent of the local node identity.
- Exclude user-device realm nodes from sync placement candidates and expose the node kind in info/admin config handling.
- Reject inbound metadata events stamped beyond MAX_CLOCK_SKEW_SECS to avoid permanent last-writer-wins conflicts.
