### PR TITLE
Feat/group self service: Let users create their own groups

### DIFF
--- a/api/src/routes/connectors.rs
+++ b/api/src/routes/connectors.rs
@@ -653,6 +653,7 @@ mod tests {
             group_id,
             realm_id,
             roles: group_auth.roles.keys().copied().collect(),
+            owner: user_id,
         };
         let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
 

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -313,7 +313,8 @@ impl From<(Group, GroupAuthorizationDocument)> for GroupInfoResponse {
         (status = 201, description = "Group created", body = CreateGroupResponse),
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
-        (status = 403, description = "Forbidden", body = ErrorResponse)
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 409, description = "Group creation conflict", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -13,9 +13,10 @@ use aruna_operations::add_user_to_group::{
     AddUserToGroupError, AddUserToGroupInput, AddUserToGroupOperation,
 };
 use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
-use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
+use aruna_operations::create_group::{CreateGroupConfig, CreateGroupError, CreateGroupOperation};
 use aruna_operations::driver::drive;
 use aruna_operations::get_group::{GetGroupConfig, GetGroupError, GetGroupOperation};
+use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::list_groups::ListGroupOperation;
 use aruna_operations::remove_group_role::{
     RemoveGroupRoleConfig, RemoveGroupRoleError, RemoveGroupRoleOperation,
@@ -329,7 +330,7 @@ pub async fn create_group(
         return Err(ServerError::Forbidden);
     }
 
-    let allowed = drive(
+    let is_realm_admin = drive(
         CheckPermissionsOperation::new(CheckPermissionsConfig {
             auth_context: auth.clone(),
             path: format!("/{realm_id}/admin/groups"),
@@ -345,9 +346,20 @@ pub async fn create_group(
         | AuthorizationError::AuthDocNotFound => ServerError::Forbidden,
         _ => ServerError::InternalError(err.to_string()),
     })?;
-    if !allowed {
-        return Err(ServerError::Forbidden);
-    }
+
+    // Self-service path: any unrestricted realm member may create groups,
+    // capped by the realm quota config; realm admins are exempt.
+    let owner_cap = if is_realm_admin {
+        None
+    } else {
+        if auth.path_restrictions.is_some() {
+            return Err(ServerError::Forbidden);
+        }
+        let realm_config = drive(GetRealmConfigOperation::new(realm_id), &state.get_ctx())
+            .await
+            .map_err(|err| ServerError::InternalError(err.to_string()))?;
+        realm_config.quota.max_groups_for(&auth.user_id)
+    };
 
     trace!(
         event = "request.group.create.authorized",
@@ -373,12 +385,18 @@ pub async fn create_group(
                 realm_id,
             },
             display_name: request.name,
+            owner_cap,
         }),
         &state.get_ctx(),
     )
     .instrument(create_span.clone())
     .await
-    .map_err(|err| ServerError::InternalError(err.to_string()))?;
+    .map_err(|err| match err {
+        CreateGroupError::OwnedGroupLimitReached { limit } => {
+            ServerError::Conflict(format!("owned group limit reached ({limit})"))
+        }
+        other => ServerError::InternalError(other.to_string()),
+    })?;
     create_span.record("group_id", field::display(result.0.group_id));
     request_span.record("group_id", field::display(result.0.group_id));
 

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -353,9 +353,6 @@ pub async fn create_group(
     let owner_cap = if is_realm_admin {
         None
     } else {
-        if auth.path_restrictions.is_some() {
-            return Err(ServerError::Forbidden);
-        }
         let realm_config = drive(GetRealmConfigOperation::new(realm_id), &state.get_ctx())
             .await
             .map_err(|err| ServerError::InternalError(err.to_string()))?;

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -1,7 +1,7 @@
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
 use aruna_core::UserId;
-use aruna_core::errors::AuthorizationError;
+use aruna_core::errors::{AuthorizationError, StorageError};
 use aruna_core::structs::{
     Actor, AuthContext, Group, GroupAuthorizationDocument, Permission, Role,
 };
@@ -394,6 +394,9 @@ pub async fn create_group(
     .map_err(|err| match err {
         CreateGroupError::OwnedGroupLimitReached { limit } => {
             ServerError::Conflict(format!("owned group limit reached ({limit})"))
+        }
+        CreateGroupError::StorageError(StorageError::TransactionConflict) => {
+            ServerError::Conflict("concurrent group creation conflict; retry".to_string())
         }
         other => ServerError::InternalError(other.to_string()),
     })?;

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -348,8 +348,8 @@ pub async fn create_group(
         _ => ServerError::InternalError(err.to_string()),
     })?;
 
-    // Self-service path: any unrestricted realm member may create groups,
-    // capped by the realm quota config; realm admins are exempt.
+    // Self-service path: any unrestricted same-realm token subject may create
+    // groups, capped by the realm quota config; realm admins are exempt.
     let owner_cap = if is_realm_admin {
         None
     } else {

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -3084,6 +3084,7 @@ mod tests {
             group_id,
             realm_id,
             roles: group_auth.roles.keys().copied().collect(),
+            owner: user_id,
         };
         let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
         let context = node.state.get_ctx();

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -3305,6 +3305,7 @@ mod tests {
             group_id,
             realm_id,
             roles: group_auth.roles.keys().copied().collect(),
+            owner: user_id,
         };
         let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
 

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -567,12 +567,14 @@ mod tests {
             display_name: "bucket-group".to_string(),
             group_id: bucket_group_id,
             realm_id,
+            owner: user_with_source_read,
             roles: bucket_auth.roles.keys().copied().collect(),
         };
         let source_group = Group {
             display_name: "source-group".to_string(),
             group_id: source_group_id,
             realm_id,
+            owner: user_with_source_read,
             roles: source_auth.roles.keys().copied().collect(),
         };
         let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);

--- a/aruna-doctor/src/explorer.rs
+++ b/aruna-doctor/src/explorer.rs
@@ -1639,6 +1639,7 @@ mod tests {
             group_id,
             realm_id,
             roles: Default::default(),
+            owner: aruna_core::UserId::local(Ulid::new(), realm_id),
         };
 
         {

--- a/aruna-doctor/src/storage.rs
+++ b/aruna-doctor/src/storage.rs
@@ -685,6 +685,7 @@ mod tests {
                         realm_id: config.realm_id,
                     },
                     display_name: "Snapshot Test Group".to_string(),
+                    owner_cap: None,
                 }),
                 context.as_ref(),
             )

--- a/aruna/tests/self_service_groups.rs
+++ b/aruna/tests/self_service_groups.rs
@@ -85,8 +85,27 @@ async fn concurrent_creates_cannot_slip_past_the_cap() -> TestResult<()> {
         .iter()
         .filter(|status| matches!(status, Ok(status) if *status == StatusCode::CREATED))
         .count();
+    let conflicts = statuses
+        .iter()
+        .filter(|status| matches!(status, Ok(status) if *status == StatusCode::CONFLICT))
+        .count();
+    let unexpected: Vec<_> = statuses
+        .iter()
+        .filter(|status| {
+            !matches!(
+                status,
+                Ok(status) if *status == StatusCode::CREATED || *status == StatusCode::CONFLICT
+            )
+        })
+        .collect();
+    assert!(unexpected.is_empty(), "unexpected responses: {statuses:?}");
     assert!(created >= 1, "at least one create succeeds: {statuses:?}");
     assert!(created <= 3, "cap held under concurrency: {statuses:?}");
+    assert_eq!(
+        conflicts,
+        statuses.len() - created,
+        "failed concurrent attempts return conflict: {statuses:?}"
+    );
 
     seed.shutdown().await;
     Ok(())

--- a/aruna/tests/self_service_groups.rs
+++ b/aruna/tests/self_service_groups.rs
@@ -1,0 +1,93 @@
+mod shared;
+
+use aruna_api::routes::groups::CreateGroupRequest;
+use aruna_core::UserId;
+use reqwest::StatusCode;
+use shared::{TestResult, create_bearer_token, spawn_seed_node};
+use ulid::Ulid;
+
+async fn post_group(base_url: &str, token: &str, name: &str) -> TestResult<reqwest::Response> {
+    Ok(reqwest::Client::new()
+        .post(format!("{base_url}/api/v1/groups"))
+        .bearer_auth(token)
+        .json(&CreateGroupRequest {
+            name: name.to_string(),
+        })
+        .send()
+        .await?)
+}
+
+#[tokio::test]
+async fn fresh_user_creates_groups_up_to_the_cap() -> TestResult<()> {
+    let seed = spawn_seed_node().await?;
+    let member_token = create_bearer_token(
+        seed.context.as_ref(),
+        UserId::local(Ulid::new(), seed.realm_id),
+        seed.realm_id,
+        seed.capabilities.clone(),
+    )
+    .await?;
+
+    // The default realm quota caps self-service creation at 3 owned groups.
+    for i in 0..3 {
+        let response = post_group(&seed.base_url, &member_token, &format!("workspace-{i}")).await?;
+        assert_eq!(response.status(), StatusCode::CREATED, "create {i}");
+    }
+    let response = post_group(&seed.base_url, &member_token, "workspace-over-cap").await?;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+
+    // Realm admins are exempt from the cap.
+    let admin_token = create_bearer_token(
+        seed.context.as_ref(),
+        seed.user_id,
+        seed.realm_id,
+        seed.capabilities.clone(),
+    )
+    .await?;
+    for i in 0..4 {
+        let response = post_group(&seed.base_url, &admin_token, &format!("admin-{i}")).await?;
+        assert_eq!(response.status(), StatusCode::CREATED, "admin create {i}");
+    }
+
+    seed.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_creates_cannot_slip_past_the_cap() -> TestResult<()> {
+    let seed = spawn_seed_node().await?;
+    let member_token = create_bearer_token(
+        seed.context.as_ref(),
+        UserId::local(Ulid::new(), seed.realm_id),
+        seed.realm_id,
+        seed.capabilities.clone(),
+    )
+    .await?;
+
+    let attempts: Vec<_> = (0..6)
+        .map(|i| {
+            let base_url = seed.base_url.clone();
+            let token = member_token.clone();
+            tokio::spawn(async move {
+                match post_group(&base_url, &token, &format!("race-{i}")).await {
+                    Ok(response) => Ok(response.status()),
+                    Err(error) => Err(error.to_string()),
+                }
+            })
+        })
+        .collect();
+    let mut statuses = Vec::new();
+    for attempt in attempts {
+        statuses.push(attempt.await?);
+    }
+
+    let created = statuses
+        .iter()
+        .filter(|status| matches!(status, Ok(status) if *status == StatusCode::CREATED))
+        .count();
+    assert!(created >= 1, "at least one create succeeds: {statuses:?}");
+    assert!(created <= 3, "cap held under concurrency: {statuses:?}");
+
+    seed.shutdown().await;
+    Ok(())
+}

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -119,9 +119,10 @@ impl AdminDocumentReducerState {
                 AdminDocumentOperation::GroupCreated {
                     realm_id,
                     display_name,
+                    owner,
                 },
             ) => {
-                self.apply_group_created(event, realm_id, display_name);
+                self.apply_group_created(event, realm_id, display_name, owner);
             }
             (
                 AdminDocumentTarget::Group { .. },
@@ -312,6 +313,17 @@ impl AdminDocumentReducerState {
             .get(GROUP_REALM_ID_PATH)
             .and_then(|version| version.value.as_deref())
             .and_then(|value| RealmId::from_base64(value).ok())
+    }
+
+    pub fn materialized_group_owner(&self) -> Option<UserId> {
+        if !matches!(&self.target, AdminDocumentTarget::Group { .. }) {
+            return None;
+        }
+
+        self.user_subject_ids
+            .get(GROUP_OWNER_PATH)
+            .and_then(|version| version.value.as_deref())
+            .and_then(|value| UserId::from_string(value).ok())
     }
 
     pub fn materialized_group_roles(&self) -> BTreeSet<RoleId> {
@@ -510,6 +522,7 @@ impl AdminDocumentReducerState {
         event: &AdminDocumentEvent,
         realm_id: &RealmId,
         display_name: &str,
+        owner: &UserId,
     ) {
         self.apply_group_field(
             event,
@@ -517,6 +530,7 @@ impl AdminDocumentReducerState {
             Some(display_name.to_string()),
         );
         self.apply_group_field(event, GROUP_REALM_ID_PATH, Some(realm_id.to_string()));
+        self.apply_group_field(event, GROUP_OWNER_PATH, Some(owner.to_string()));
     }
 
     fn apply_group_field(&mut self, event: &AdminDocumentEvent, path: &str, value: Option<String>) {
@@ -805,6 +819,7 @@ impl AdminDocumentReducerState {
 pub const USER_NAME_PATH: &str = "user.name";
 pub const GROUP_DISPLAY_NAME_PATH: &str = "group.display_name";
 pub const GROUP_REALM_ID_PATH: &str = "group.realm_id";
+pub const GROUP_OWNER_PATH: &str = "group.owner";
 pub const REALM_CONFIG_METADATA_REPLICATION_PATH: &str =
     "realm_config.settings.metadata_replication";
 pub const REALM_CONFIG_DISCOVERY_PATH: &str = "realm_config.settings.discovery";
@@ -1200,6 +1215,7 @@ mod tests {
             AdminDocumentOperation::GroupCreated {
                 realm_id,
                 display_name: display_name.to_string(),
+                owner: user_id_with_seed(5),
             },
         )
     }
@@ -1754,9 +1770,10 @@ mod tests {
     }
 
     #[test]
-    fn group_created_materializes_display_name_and_realm_id() {
+    fn group_created_materializes_display_name_realm_id_and_owner() {
         let mut state = group_state();
         let realm_id = realm_id();
+        let owner = user_id_with_seed(5);
 
         state
             .apply(&create_group(1, 1, "Engineering", realm_id))
@@ -1767,6 +1784,7 @@ mod tests {
             Some("Engineering")
         );
         assert_eq!(state.materialized_group_realm_id(), Some(realm_id));
+        assert_eq!(state.materialized_group_owner(), Some(owner));
         assert!(state.conflicts.is_empty());
     }
 
@@ -1858,6 +1876,7 @@ mod tests {
             AdminDocumentOperation::GroupCreated {
                 realm_id: realm_id(),
                 display_name: "Engineering".to_string(),
+                owner: user_id_with_seed(5),
             },
         );
 

--- a/core/src/admin_documents.rs
+++ b/core/src/admin_documents.rs
@@ -146,6 +146,7 @@ pub enum AdminDocumentOperation {
     GroupCreated {
         realm_id: RealmId,
         display_name: String,
+        owner: UserId,
     },
 }
 
@@ -205,12 +206,18 @@ mod tests {
     #[test]
     fn admin_document_operations_roundtrip() {
         let role_id = role_id(1);
-        let user_id = user_id(2);
+        let assigned_user_id = user_id(2);
         let realm_id = RealmId::from_bytes([9; 32]);
         let operations = vec![
             AdminDocumentOperation::GroupRoleAdded { role_id },
-            AdminDocumentOperation::GroupRoleUserAssignmentAdded { role_id, user_id },
-            AdminDocumentOperation::GroupRoleUserAssignmentRemoved { role_id, user_id },
+            AdminDocumentOperation::GroupRoleUserAssignmentAdded {
+                role_id,
+                user_id: assigned_user_id,
+            },
+            AdminDocumentOperation::GroupRoleUserAssignmentRemoved {
+                role_id,
+                user_id: assigned_user_id,
+            },
             AdminDocumentOperation::UserAttributeSet {
                 key: "department".to_string(),
                 value: "biology".to_string(),
@@ -228,8 +235,14 @@ mod tests {
                 subject_id: "subject-1".to_string(),
             },
             AdminDocumentOperation::RealmRoleAdded { role_id },
-            AdminDocumentOperation::RealmRoleUserAssignmentAdded { role_id, user_id },
-            AdminDocumentOperation::RealmRoleUserAssignmentRemoved { role_id, user_id },
+            AdminDocumentOperation::RealmRoleUserAssignmentAdded {
+                role_id,
+                user_id: assigned_user_id,
+            },
+            AdminDocumentOperation::RealmRoleUserAssignmentRemoved {
+                role_id,
+                user_id: assigned_user_id,
+            },
             AdminDocumentOperation::GroupRoleCreated {
                 role: role_definition(role_id),
             },
@@ -256,6 +269,7 @@ mod tests {
             AdminDocumentOperation::GroupCreated {
                 realm_id,
                 display_name: "Engineering".to_string(),
+                owner: user_id(3),
             },
         ];
 
@@ -326,6 +340,7 @@ mod tests {
         let operation = AdminDocumentOperation::GroupCreated {
             realm_id: RealmId::from_bytes([9; 32]),
             display_name: "Engineering".to_string(),
+            owner: user_id(3),
         };
 
         assert_eq!(postcard_roundtrip(operation.clone()), operation);

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -1,5 +1,6 @@
 pub const AUTH_KEYSPACE: &str = "auth";
 pub const GROUP_KEYSPACE: &str = "groups";
+pub const GROUP_OWNER_INDEX_KEYSPACE: &str = "group_owner_index";
 pub const REALM_KEYSPACE: &str = "realms";
 pub const REALM_CONFIG_KEYSPACE: &str = "realm_config";
 pub const METADATA_INDEX_KEYSPACE: &str = "metadata_index";

--- a/core/src/structs/group.rs
+++ b/core/src/structs/group.rs
@@ -13,6 +13,7 @@ pub struct Group {
     pub group_id: GroupId,
     pub realm_id: RealmId,
     pub roles: HashSet<RoleId>,
+    pub owner: UserId,
 }
 
 impl Group {
@@ -22,6 +23,18 @@ impl Group {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
         Ok(postcard::from_bytes(bytes)?)
     }
+}
+
+/// Key in GROUP_OWNER_INDEX_KEYSPACE: owner storage key (realm + user ulid)
+/// followed by the group id, so a prefix scan counts a user's owned groups.
+pub fn group_owner_index_key(owner: UserId, group_id: GroupId) -> Vec<u8> {
+    let mut bytes = owner.to_storage_key();
+    bytes.extend_from_slice(&group_id.to_bytes());
+    bytes
+}
+
+pub fn group_owner_index_prefix(owner: UserId) -> Vec<u8> {
+    owner.to_storage_key()
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -116,6 +129,7 @@ mod test {
             group_id: Ulid::new(),
             realm_id: RealmId([0u8; 32]),
             roles: HashSet::from([Ulid::new(), Ulid::new()]),
+            owner: UserId::local(Ulid::new(), RealmId([0u8; 32])),
         };
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -2,7 +2,7 @@ use crate::NodeId;
 use crate::errors::ConversionError;
 use crate::structs::Actor;
 use crate::structs::structs::{Permission, Role};
-use crate::types::{GroupId, RoleId};
+use crate::types::{GroupId, RoleId, UserId};
 use core::fmt;
 use ed25519_dalek::VerifyingKey;
 use ed25519_dalek::pkcs8::EncodePublicKey;
@@ -161,6 +161,57 @@ pub struct RealmConfigDocument {
     pub oidc_providers: Vec<OidcProviderConfig>,
     pub discovery: RealmDiscoveryConfig,
     pub nodes: Vec<RealmNode>,
+    pub quota: QuotaConfig,
+}
+
+/// Realm-wide quota policy. Lives in the realm config (Class-1, replicated
+/// everywhere) so enforcement is local and group admins cannot raise their
+/// own limits.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct QuotaConfig {
+    pub default_group_quota_bytes: Option<u64>,
+    pub grace_factor_percent: u32,
+    pub warn_threshold_percent: u32,
+    pub group_overrides: Vec<GroupQuotaOverride>,
+    pub max_groups_per_user: Option<u32>,
+    pub user_group_cap_overrides: Vec<UserGroupCapOverride>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct GroupQuotaOverride {
+    pub group_id: GroupId,
+    pub quota_bytes: Option<u64>,
+    pub grace_factor_percent: Option<u32>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct UserGroupCapOverride {
+    pub user_id: UserId,
+    pub max_groups: Option<u32>,
+}
+
+impl Default for QuotaConfig {
+    fn default() -> Self {
+        Self {
+            default_group_quota_bytes: None,
+            grace_factor_percent: 110,
+            warn_threshold_percent: 85,
+            group_overrides: Vec::new(),
+            max_groups_per_user: Some(3),
+            user_group_cap_overrides: Vec::new(),
+        }
+    }
+}
+
+impl QuotaConfig {
+    /// None = unlimited.
+    pub fn max_groups_for(&self, user_id: &UserId) -> Option<u32> {
+        self.user_group_cap_overrides
+            .iter()
+            .find(|over| over.user_id == *user_id)
+            .map(|over| over.max_groups)
+            .unwrap_or(self.max_groups_per_user)
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -270,6 +321,7 @@ impl RealmConfigDocument {
             oidc_providers,
             discovery: default_realm_discovery_config(),
             nodes: Vec::new(),
+            quota: QuotaConfig::default(),
         }
     }
 
@@ -470,6 +522,7 @@ mod test {
             }],
             discovery: default_realm_discovery_config(),
             nodes: Vec::new(),
+            quota: super::QuotaConfig::default(),
         };
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[14u8; 32]).public(),
@@ -511,6 +564,7 @@ mod test {
             oidc_providers: vec![],
             discovery: default_realm_discovery_config(),
             nodes: Vec::new(),
+            quota: super::QuotaConfig::default(),
         };
 
         assert_eq!(

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -5,11 +5,10 @@ use std::time::{Duration, Instant};
 
 use aruna_core::NodeId;
 use aruna_core::admin_document_reducer::{
-    AdminDocumentApplyStatus, AdminDocumentReducerState, GROUP_DISPLAY_NAME_PATH,
-    GROUP_OWNER_PATH, GROUP_REALM_ID_PATH, REALM_CONFIG_DISCOVERY_PATH,
-    REALM_CONFIG_METADATA_REPLICATION_PATH, USER_NAME_PATH, group_role_id_from_path,
-    group_role_path, group_role_user_assignment_from_path, group_role_user_assignment_path,
-    realm_config_node_id_from_path, realm_config_node_path,
+    AdminDocumentApplyStatus, AdminDocumentReducerState, GROUP_DISPLAY_NAME_PATH, GROUP_OWNER_PATH,
+    GROUP_REALM_ID_PATH, REALM_CONFIG_DISCOVERY_PATH, REALM_CONFIG_METADATA_REPLICATION_PATH,
+    USER_NAME_PATH, group_role_id_from_path, group_role_path, group_role_user_assignment_from_path,
+    group_role_user_assignment_path, realm_config_node_id_from_path, realm_config_node_path,
     realm_config_oidc_provider_id_from_path, realm_role_path, realm_role_user_assignment_from_path,
     realm_role_user_assignment_path, user_attribute_path, user_subject_id_path,
 };

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -6,9 +6,10 @@ use std::time::{Duration, Instant};
 use aruna_core::NodeId;
 use aruna_core::admin_document_reducer::{
     AdminDocumentApplyStatus, AdminDocumentReducerState, GROUP_DISPLAY_NAME_PATH,
-    GROUP_REALM_ID_PATH, REALM_CONFIG_DISCOVERY_PATH, REALM_CONFIG_METADATA_REPLICATION_PATH,
-    USER_NAME_PATH, group_role_id_from_path, group_role_path, group_role_user_assignment_from_path,
-    group_role_user_assignment_path, realm_config_node_id_from_path, realm_config_node_path,
+    GROUP_OWNER_PATH, GROUP_REALM_ID_PATH, REALM_CONFIG_DISCOVERY_PATH,
+    REALM_CONFIG_METADATA_REPLICATION_PATH, USER_NAME_PATH, group_role_id_from_path,
+    group_role_path, group_role_user_assignment_from_path, group_role_user_assignment_path,
+    realm_config_node_id_from_path, realm_config_node_path,
     realm_config_oidc_provider_id_from_path, realm_role_path, realm_role_user_assignment_from_path,
     realm_role_user_assignment_path, user_attribute_path, user_subject_id_path,
 };
@@ -24,7 +25,8 @@ use aruna_core::events::{Event, StorageEvent};
 use aruna_core::id::short_display_id;
 use aruna_core::keyspaces::{
     ADMIN_DOCUMENT_STATE_KEYSPACE, DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
-    DOCUMENT_SYNC_REVISION_KEYSPACE, GROUP_KEYSPACE, METADATA_DOCUMENT_LIFECYCLE_KEYSPACE,
+    DOCUMENT_SYNC_REVISION_KEYSPACE, GROUP_KEYSPACE, GROUP_OWNER_INDEX_KEYSPACE,
+    METADATA_DOCUMENT_LIFECYCLE_KEYSPACE,
 };
 use aruna_core::metadata::{
     MetadataCreateEventRecord, MetadataDocumentDeleteRecord, MetadataDocumentLifecycleRecord,
@@ -43,7 +45,7 @@ use aruna_core::storage_entries::{
 };
 use aruna_core::structs::{
     Group, GroupAuthorizationDocument, MetadataRegistryRecord, RealmAuthorizationDocument,
-    RealmConfigDocument, RealmId, Role, User,
+    RealmConfigDocument, RealmId, Role, User, group_owner_index_key,
 };
 use aruna_core::telemetry::duration_ms;
 use aruna_core::types::{RoleId, TxnId, UserId, Value};
@@ -1821,6 +1823,12 @@ fn overlay_group_reducer_materialization(
         group.realm_id = realm_id;
     }
 
+    if !reducer_state.conflicts.contains_key(GROUP_OWNER_PATH)
+        && let Some(owner) = reducer_state.materialized_group_owner()
+    {
+        group.owner = owner;
+    }
+
     overlay_group_role_set_reducer_materialization(group, reducer_state);
 }
 
@@ -1850,6 +1858,7 @@ fn group_metadata_conflicted(reducer_state: &AdminDocumentReducerState) -> bool 
         .conflicts
         .contains_key(GROUP_DISPLAY_NAME_PATH)
         || reducer_state.conflicts.contains_key(GROUP_REALM_ID_PATH)
+        || reducer_state.conflicts.contains_key(GROUP_OWNER_PATH)
 }
 
 fn group_reducer_materialized_group(
@@ -1864,6 +1873,7 @@ fn group_reducer_materialized_group(
         display_name: reducer_state.materialized_group_display_name()?,
         group_id,
         realm_id: reducer_state.materialized_group_realm_id()?,
+        owner: reducer_state.materialized_group_owner()?,
         roles: reducer_state
             .materialized_group_roles()
             .into_iter()
@@ -2042,6 +2052,7 @@ fn realm_config_from_reducer_materialization(
         oidc_providers: Vec::new(),
         discovery,
         nodes: Vec::new(),
+        quota: Default::default(),
     };
     overlay_realm_config_reducer_materialization(&mut config, reducer_state);
     Some(config)
@@ -2379,11 +2390,11 @@ async fn apply_user_admin_document_operation_to_storage(
     storage_batch_delete_and_write_transactionally(storage, deletes, writes).await
 }
 
-async fn group_write_entry_from_reducer(
+async fn group_write_entries_from_reducer(
     storage: &StorageHandle,
     group_id: Ulid,
     reducer_state: &AdminDocumentReducerState,
-) -> Result<Option<(String, ByteView, Value)>> {
+) -> Result<Vec<(String, ByteView, Value)>> {
     let target = DocumentSyncTarget::Group { group_id };
     let group =
         match storage_read_from(storage, GROUP_KEYSPACE.to_string(), target.storage_key()).await? {
@@ -2401,18 +2412,25 @@ async fn group_write_entry_from_reducer(
             }
             None => {
                 let Some(group) = group_reducer_materialized_group(group_id, reducer_state) else {
-                    return Ok(None);
+                    return Ok(Vec::new());
                 };
                 group
             }
         };
 
-    Ok(Some(target_write_entry(
-        target,
-        postcard::to_allocvec(&group)
-            .map_err(|error| NetError::Bootstrap(error.to_string()))?
-            .into(),
-    )))
+    Ok(vec![
+        target_write_entry(
+            target,
+            postcard::to_allocvec(&group)
+                .map_err(|error| NetError::Bootstrap(error.to_string()))?
+                .into(),
+        ),
+        (
+            GROUP_OWNER_INDEX_KEYSPACE.to_string(),
+            group_owner_index_key(group.owner, group.group_id).into(),
+            ByteView::from(Vec::new()),
+        ),
+    ])
 }
 
 async fn apply_group_authorization_admin_document_operation_to_storage(
@@ -2486,7 +2504,7 @@ async fn apply_group_authorization_admin_document_operation_to_storage(
         roles: Default::default(),
     });
     materialize_group_authorization_admin_document_operation(&mut auth_doc, &reducer_state, &event);
-    let group_write = group_write_entry_from_reducer(storage, group_id, &reducer_state).await?;
+    let group_writes = group_write_entries_from_reducer(storage, group_id, &reducer_state).await?;
 
     let mut writes = vec![
         (
@@ -2500,9 +2518,7 @@ async fn apply_group_authorization_admin_document_operation_to_storage(
         admin_document_reducer_state_write_entry(&reducer_state)
             .map_err(|error| NetError::Bootstrap(error.to_string()))?,
     ];
-    if let Some(group_write) = group_write {
-        writes.push(group_write);
-    }
+    writes.extend(group_writes);
     writes.extend(
         admin_document_conflict_write_entries(&reducer_state)
             .map_err(|error| NetError::Bootstrap(error.to_string()))?,
@@ -4898,6 +4914,7 @@ mod tests {
                 AdminDocumentOperation::GroupCreated {
                     realm_id,
                     display_name: "Reduced group".to_string(),
+                    owner: actor.user_id,
                 },
             ),
         )
@@ -4910,8 +4927,18 @@ mod tests {
                 display_name: "Reduced group".to_string(),
                 group_id,
                 realm_id,
+                owner: actor.user_id,
                 roles: HashSet::new(),
             }
+        );
+        assert!(
+            read_storage_value(
+                &storage,
+                GROUP_OWNER_INDEX_KEYSPACE,
+                group_owner_index_key(actor.user_id, group_id).into(),
+            )
+            .await
+            .is_some()
         );
     }
 
@@ -4940,6 +4967,7 @@ mod tests {
                 AdminDocumentOperation::GroupCreated {
                     realm_id,
                     display_name: "Reduced group".to_string(),
+                    owner: actor.user_id,
                 },
             ),
         )
@@ -4995,6 +5023,7 @@ mod tests {
             display_name: "Durable group".to_string(),
             group_id,
             realm_id,
+            owner: actor.user_id,
             roles: HashSet::from([existing_role_id, conflicted_role_id]),
         };
         storage_batch_write_to(
@@ -5152,6 +5181,7 @@ mod tests {
             display_name: "Durable group".to_string(),
             group_id,
             realm_id,
+            owner: actor.user_id,
             roles: HashSet::from([role_id]),
         };
         let auth_doc = GroupAuthorizationDocument {

--- a/operations/src/add_group_role.rs
+++ b/operations/src/add_group_role.rs
@@ -804,6 +804,7 @@ pub mod test {
             group_id,
             realm_id,
             roles: auth_doc.roles.keys().copied().collect(),
+            owner: user_id,
         };
         let auth_context = aruna_core::structs::AuthContext {
             user_id,

--- a/operations/src/add_user_to_group.rs
+++ b/operations/src/add_user_to_group.rs
@@ -1083,6 +1083,7 @@ pub mod test {
                 realm_id,
             },
             display_name: "Test group".to_string(),
+            owner_cap: None,
         };
         let group_operation = CreateGroupOperation::new(group_config.clone());
         let (group, auth_doc) = drive(group_operation, &context).await.unwrap();

--- a/operations/src/check_permissions.rs
+++ b/operations/src/check_permissions.rs
@@ -537,6 +537,7 @@ mod test {
                 realm_id,
             },
             display_name: "Test group".to_string(),
+            owner_cap: None,
         };
 
         let group_operation = CreateGroupOperation::new(group_config.clone());

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -9,14 +9,17 @@ use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
-use aruna_core::keyspaces::{AUTH_KEYSPACE, GROUP_KEYSPACE};
+use aruna_core::keyspaces::{AUTH_KEYSPACE, GROUP_KEYSPACE, GROUP_OWNER_INDEX_KEYSPACE};
 use aruna_core::operation::Operation;
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_write_entry,
 };
-use aruna_core::structs::{Actor, Group, GroupAuthorizationDocument, Role};
+use aruna_core::structs::{
+    Actor, Group, GroupAuthorizationDocument, Role, group_owner_index_key, group_owner_index_prefix,
+};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, UserId, Value};
+use byteview::ByteView;
 use smallvec::smallvec;
 use std::collections::HashSet;
 use thiserror::Error;
@@ -27,6 +30,10 @@ use ulid::Ulid;
 pub struct CreateGroupConfig {
     pub actor: Actor,
     pub display_name: String,
+    /// Maximum number of groups the actor may own; checked inside the write
+    /// transaction so concurrent creates cannot slip past. None = unlimited
+    /// (realm admins are exempt).
+    pub owner_cap: Option<u32>,
 }
 
 #[derive(PartialEq)]
@@ -63,6 +70,43 @@ impl CreateGroupOperation {
             output: None,
         }
     }
+    #[tracing::instrument(name = "group.create.emit_count_owned", level = "debug", skip(self), fields(state = ?self.state))]
+    fn emit_count_owned_groups(&mut self, cap: u32) -> Effects {
+        self.state = CreateGroupState::CountOwnedGroups;
+        smallvec![Effect::Storage(StorageEffect::Iter {
+            key_space: GROUP_OWNER_INDEX_KEYSPACE.to_string(),
+            prefix: Some(group_owner_index_prefix(self.config.actor.user_id).into()),
+            start: None,
+            limit: cap as usize,
+            txn_id: self.txn_id,
+        })]
+    }
+
+    #[tracing::instrument(name = "group.create.handle_count_owned", level = "debug", skip(self, event), fields(state = ?self.state))]
+    fn handle_count_owned_groups(&mut self, event: Event) -> Effects {
+        let got = format!("{event:?}");
+        let Event::Storage(StorageEvent::IterResult { values, .. }) = event else {
+            return self.unexpected_event(
+                CreateGroupState::CountOwnedGroups,
+                "Event::Storage(StorageEvent::IterResult)",
+                got,
+            );
+        };
+        let cap = self.config.owner_cap.unwrap_or(u32::MAX);
+        if values.len() >= cap as usize {
+            let cleanup_effects = self.abort();
+            return self.fail_with_cleanup(
+                CreateGroupError::OwnedGroupLimitReached { limit: cap },
+                cleanup_effects,
+            );
+        }
+        self.state = CreateGroupState::CreateGroup;
+        match self.emit_create_group() {
+            Ok(effects) => effects,
+            Err(err) => self.fail(err),
+        }
+    }
+
     #[tracing::instrument(name = "group.create.emit_group", level = "debug", skip(self), fields(state = ?self.state, group_name = %self.config.display_name))]
     fn emit_create_group(&mut self) -> Result<Effects, CreateGroupError> {
         let group_id = Ulid::new();
@@ -76,6 +120,7 @@ impl CreateGroupOperation {
             display_name: self.config.display_name.clone(),
             group_id,
             realm_id: self.config.actor.realm_id,
+            owner: self.config.actor.user_id,
         };
 
         self.auth_doc = Some(auth_doc);
@@ -261,11 +306,23 @@ impl CreateGroupOperation {
             );
         };
 
-        self.state = CreateGroupState::CreateGroup;
         self.txn_id = Some(txn_id);
-        match self.emit_create_group() {
-            Ok(effects) => effects,
-            Err(err) => self.fail(err),
+        match self.config.owner_cap {
+            Some(0) => {
+                let cleanup_effects = self.abort();
+                self.fail_with_cleanup(
+                    CreateGroupError::OwnedGroupLimitReached { limit: 0 },
+                    cleanup_effects,
+                )
+            }
+            Some(cap) => self.emit_count_owned_groups(cap),
+            None => {
+                self.state = CreateGroupState::CreateGroup;
+                match self.emit_create_group() {
+                    Ok(effects) => effects,
+                    Err(err) => self.fail(err),
+                }
+            }
         }
     }
 
@@ -275,6 +332,39 @@ impl CreateGroupOperation {
         let Event::Storage(StorageEvent::WriteResult { .. }) = event else {
             return self.unexpected_event(
                 CreateGroupState::CreateGroup,
+                "Event::Storage(StorageEvent::WriteResult)",
+                got,
+            );
+        };
+
+        self.state = CreateGroupState::WriteOwnerIndex;
+        match self.emit_write_owner_index() {
+            Ok(effects) => effects,
+            Err(err) => self.fail(err),
+        }
+    }
+
+    #[tracing::instrument(name = "group.create.emit_owner_index", level = "debug", skip(self), fields(state = ?self.state))]
+    fn emit_write_owner_index(&mut self) -> Result<Effects, CreateGroupError> {
+        let group_id = self
+            .group
+            .as_ref()
+            .ok_or(CreateGroupError::GroupNotFound)?
+            .group_id;
+        Ok(smallvec![Effect::Storage(StorageEffect::Write {
+            key_space: GROUP_OWNER_INDEX_KEYSPACE.to_string(),
+            key: group_owner_index_key(self.config.actor.user_id, group_id).into(),
+            value: ByteView::from(Vec::new()),
+            txn_id: self.txn_id,
+        })])
+    }
+
+    #[tracing::instrument(name = "group.create.handle_owner_index_write", level = "debug", skip(self, event), fields(state = ?self.state, event = ?event))]
+    fn handle_write_owner_index(&mut self, event: Event) -> Effects {
+        let got = format!("{event:?}");
+        let Event::Storage(StorageEvent::WriteResult { .. }) = event else {
+            return self.unexpected_event(
+                CreateGroupState::WriteOwnerIndex,
                 "Event::Storage(StorageEvent::WriteResult)",
                 got,
             );
@@ -358,7 +448,9 @@ fn sorted_user_ids(user_ids: &HashSet<UserId>) -> Vec<UserId> {
 pub enum CreateGroupState {
     Init,
     StartTransaction,
+    CountOwnedGroups,
     CreateGroup,
+    WriteOwnerIndex,
     CreateRoles,
     CommitTransaction,
     ScheduleDocumentSyncOutboxDrain,
@@ -382,6 +474,8 @@ pub enum CreateGroupError {
     NoTransactionFound,
     #[error("No group found")]
     GroupNotFound,
+    #[error("owned group limit reached ({limit})")]
+    OwnedGroupLimitReached { limit: u32 },
     #[error("Creating Group did not finish")]
     NotFinished,
     #[error("Unexpected event in state {state:?}: expected {expected}, got {got}")]
@@ -415,7 +509,9 @@ impl Operation for CreateGroupOperation {
 
         match self.state {
             CreateGroupState::StartTransaction => self.handle_start_transaction(event),
+            CreateGroupState::CountOwnedGroups => self.handle_count_owned_groups(event),
             CreateGroupState::CreateGroup => self.handle_create_group(event),
+            CreateGroupState::WriteOwnerIndex => self.handle_write_owner_index(event),
             CreateGroupState::CreateRoles => self.handle_create_roles(event),
             CreateGroupState::CommitTransaction => self.handle_commit_transaction(event),
             CreateGroupState::ScheduleDocumentSyncOutboxDrain => {
@@ -725,6 +821,7 @@ mod test {
                 realm_id,
             },
             display_name: "Test group".to_string(),
+            owner_cap: None,
         };
         let group_operation = CreateGroupOperation::new(group_config.clone());
         let result = drive(group_operation, &context).await.unwrap();
@@ -763,6 +860,71 @@ mod test {
                 .iter()
                 .any(|(_id, role)| { role.name == "viewer" })
         );
+
+        net_handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    pub async fn owner_cap_blocks_creation_at_limit() {
+        let random_path = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(random_path.path().to_str().unwrap()).unwrap();
+        let net_handle = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().unwrap(),
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage_handle.clone(),
+        )
+        .await
+        .unwrap();
+        let task_handle = TaskHandle::new();
+
+        let context = DriverContext {
+            storage_handle,
+            blob_handle: None,
+            net_handle: Some(net_handle.clone()),
+            metadata_handle: None,
+            task_handle: Some(task_handle),
+        };
+
+        let realm_id = aruna_core::structs::RealmId([0u8; 32]);
+        let user_id = UserId::local(Ulid::new(), realm_id);
+        let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
+        let actor = Actor {
+            node_id,
+            user_id,
+            realm_id,
+        };
+
+        let capped = |name: &str| CreateGroupConfig {
+            actor: actor.clone(),
+            display_name: name.to_string(),
+            owner_cap: Some(1),
+        };
+
+        drive(CreateGroupOperation::new(capped("first")), &context)
+            .await
+            .unwrap();
+        let second = drive(CreateGroupOperation::new(capped("second")), &context).await;
+        assert!(matches!(
+            second,
+            Err(crate::create_group::CreateGroupError::OwnedGroupLimitReached { limit: 1 })
+        ));
+
+        // Uncapped (realm admin) creation still works past the limit.
+        drive(
+            CreateGroupOperation::new(CreateGroupConfig {
+                actor: actor.clone(),
+                display_name: "third".to_string(),
+                owner_cap: None,
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
 
         net_handle.shutdown().await;
     }

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -191,6 +191,7 @@ impl CreateGroupOperation {
             AdminDocumentOperation::GroupCreated {
                 realm_id: self.config.actor.realm_id,
                 display_name: self.config.display_name.clone(),
+                owner: self.config.actor.user_id,
             },
         )?);
 
@@ -585,6 +586,7 @@ mod test {
         CreateGroupConfig {
             actor,
             display_name: "Test group".to_string(),
+            owner_cap: None,
         }
     }
 
@@ -620,6 +622,7 @@ mod test {
             group_id: auth_doc.group_id,
             realm_id: actor.realm_id,
             roles: auth_doc.roles.keys().copied().collect(),
+            owner: actor.user_id,
         };
         let mut operation = CreateGroupOperation::new(config(actor));
         operation.txn_id = Some(txn_id);
@@ -721,7 +724,10 @@ mod test {
             AdminDocumentOperation::GroupCreated {
                 realm_id,
                 display_name,
-            } if *realm_id == group.realm_id && display_name == &group.display_name
+                owner,
+            } if *realm_id == group.realm_id
+                && display_name == &group.display_name
+                && *owner == group.owner
         ));
         let role_names = events[1..=auth_doc.roles.len()]
             .iter()

--- a/operations/src/get_group.rs
+++ b/operations/src/get_group.rs
@@ -313,6 +313,7 @@ mod test {
         let group_config = CreateGroupConfig {
             actor,
             display_name: "Test group".to_string(),
+            owner_cap: None,
         };
         let group_operation = CreateGroupOperation::new(group_config.clone());
         let create_result = drive(group_operation, &context).await.unwrap();

--- a/operations/src/list_groups.rs
+++ b/operations/src/list_groups.rs
@@ -283,6 +283,7 @@ mod test {
                     node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
                 },
                 display_name: format!("Test group {i}"),
+                owner_cap: None,
             };
             let group_operation = CreateGroupOperation::new(group_config.clone());
             let create_result = drive(group_operation, &context).await.unwrap();

--- a/operations/src/remove_group_role.rs
+++ b/operations/src/remove_group_role.rs
@@ -764,6 +764,7 @@ pub mod test {
             group_id,
             realm_id,
             roles: HashSet::from([role_id]),
+            owner: user_id,
         };
         let auth_doc = GroupAuthorizationDocument {
             group_id,

--- a/operations/src/remove_group_role.rs
+++ b/operations/src/remove_group_role.rs
@@ -728,6 +728,7 @@ pub mod test {
         let group_operation = CreateGroupOperation::new(CreateGroupConfig {
             actor: actor.clone(),
             display_name: "Test group".to_string(),
+            owner_cap: None,
         });
         let (group, auth_doc) = drive(group_operation, context).await.unwrap();
         (actor, group, auth_doc)

--- a/operations/src/remove_user_from_group.rs
+++ b/operations/src/remove_user_from_group.rs
@@ -740,6 +740,7 @@ pub mod test {
         let group_operation = CreateGroupOperation::new(CreateGroupConfig {
             actor: actor.clone(),
             display_name: "Test group".to_string(),
+            owner_cap: None,
         });
         let (group, auth_doc) = drive(group_operation, context).await.unwrap();
         (actor, group, auth_doc)

--- a/operations/tests/group_replication.rs
+++ b/operations/tests/group_replication.rs
@@ -43,6 +43,7 @@ async fn group_creation_replicates_to_all_realm_nodes() -> Result<(), Box<dyn st
         CreateGroupOperation::new(CreateGroupConfig {
             actor: creator,
             display_name: "replicated group".to_string(),
+            owner_cap: None,
         }),
         nodes[0].context.as_ref(),
     )

--- a/operations/tests/metadata_query_concurrency.rs
+++ b/operations/tests/metadata_query_concurrency.rs
@@ -498,6 +498,7 @@ async fn lazy_visibility_matches_eager_query_and_search_semantics() -> Result<()
         group_id,
         realm_id: REALM,
         roles: group_auth.roles.keys().copied().collect(),
+        owner: member,
     };
     let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(REALM);
     write_value(


### PR DESCRIPTION
Enables self-service group creation for unrestricted same-realm token subjects, with a per-user owner cap enforced during group creation. Realm admins remain exempt from the cap.

## Changes

- Allows non-admin unrestricted same-realm callers to create groups through `POST /groups`.
- Reads the realm quota config during group creation and applies `max_groups_per_user` / user-specific group cap overrides.
- Adds `QuotaConfig` to realm config with a default self-service cap of 3 owned groups per user.
- Adds an `owner` field to group documents and maintains a `group_owner_index` keyspace for prefix-counting owned groups.
- Checks the owner cap inside the create-group storage transaction so local concurrent creates cannot silently pass the configured limit.
- Writes owner-index entries during local group creation and when group documents are materialized from synced admin-document events.
- Extends group admin-document `GroupCreated` events to carry the owner, so synced materialization preserves ownership.
- Maps over-cap creates and local transaction conflicts to `409 Conflict` instead of generic server errors.
- Documents the new `409 Conflict` response for `POST /groups`.
- Updates existing group fixtures and test helpers for the new `owner` / `owner_cap` fields.
- Adds integration coverage for fresh-user self-service group creation, admin cap bypass, and concurrent creates at the cap boundary.

## Known Limitation

- The cap is enforced locally at create time. Concurrent creates accepted by different management/API nodes before owner-index sync may temporarily exceed the cap. This is accepted for this first iteration; a later quota reconciliation or distributed reservation mechanism would be needed for hard realm-wide caps under multi-node write races.

## Related Issues

- Closes #247.
- Related to #249: this includes the minimal quota-config slice needed for the group creation cap, but does not implement usage accounting, byte quotas, or quota admin APIs.
- Builds on #246 / PR #300 group membership management, which added the group/member route and operation foundations this branch rebases onto.