### PR TITLE
Feat/usage stats: First iteration of usage stats

### DIFF
--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -575,8 +575,10 @@ fn map_remove_member_error(error: RemoveUserFromGroupError) -> ServerError {
     params(("id" = String, Path, description = "Group id")),
     responses(
         (status = 200, description = "Group storage usage", body = crate::routes::info::UsageResponse),
+        (status = 400, description = "Invalid group id", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
-        (status = 403, description = "Forbidden", body = ErrorResponse)
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Group not found", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -3,7 +3,7 @@ use crate::server_state::ServerState;
 use aruna_core::UserId;
 use aruna_core::errors::{AuthorizationError, StorageError};
 use aruna_core::structs::{
-    Actor, AuthContext, Group, GroupAuthorizationDocument, Permission, Role,
+    Actor, AuthContext, Group, GroupAuthorizationDocument, Permission, Role, usage_group_key,
 };
 use aruna_core::types::RoleId;
 use aruna_operations::add_group_role::{
@@ -42,6 +42,7 @@ use utoipa::{OpenApi, ToSchema};
         create_group,
         list_groups,
         get_group,
+        get_group_usage,
         list_group_members,
         add_group_member,
         remove_group_member,
@@ -57,6 +58,7 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/groups", post(create_group))
         .route("/groups", get(list_groups))
         .route("/groups/{id}", get(get_group))
+        .route("/groups/{id}/usage", get(get_group_usage))
         .route(
             "/groups/{id}/members",
             get(list_group_members).post(add_group_member),
@@ -564,6 +566,35 @@ fn map_remove_member_error(error: RemoveUserFromGroupError) -> ServerError {
         }
         other => ServerError::InternalError(other.to_string()),
     }
+}
+
+#[utoipa::path(
+    get,
+    path = "/groups/{id}/usage",
+    tag = "groups",
+    params(("id" = String, Path, description = "Group id")),
+    responses(
+        (status = 200, description = "Group storage usage", body = crate::routes::info::UsageResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse)
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn get_group_usage(
+    State(state): State<Arc<ServerState>>,
+    Extension(auth): Extension<Option<AuthContext>>,
+    Path(group_id): Path<String>,
+) -> ServerResult<(StatusCode, Json<crate::routes::info::UsageResponse>)> {
+    let auth = auth.ok_or(ServerError::Unauthorized)?;
+    let group_id = parse_group_id(&group_id)?;
+    let (_, auth_doc) = load_group(&state, group_id).await?;
+    if !is_group_member(&auth_doc, auth.user_id) {
+        return Err(ServerError::Forbidden);
+    }
+
+    let counters =
+        crate::routes::info::load_usage_counters(&state, usage_group_key(group_id)).await?;
+    Ok((StatusCode::OK, Json(counters.into())))
 }
 
 #[utoipa::path(

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -5,10 +5,10 @@ use aruna_core::alpn::Alpn;
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
-use aruna_core::keyspaces::{REALM_KEYSPACE, USAGE_STATS_KEYSPACE};
+use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
 use aruna_core::structs::{ConnectionAddressStatus, PeerConnectionStatus, RequestSummaryState};
-use aruna_core::structs::{Realm, RealmConfigDocument, RealmNodeKind};
-use aruna_core::structs::{USAGE_GLOBAL_KEY, UsageCounters};
+use aruna_core::structs::{RealmConfigDocument, RealmNodeKind};
+use aruna_core::structs::{USAGE_GLOBAL_KEY, UsageCounters, usage_global_shard_keys};
 use aruna_operations::driver::drive;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
@@ -316,6 +316,10 @@ impl From<UsageCounters> for UsageResponse {
 }
 
 pub async fn load_usage_counters(state: &ServerState, key: Vec<u8>) -> ServerResult<UsageCounters> {
+    if key.as_slice() == USAGE_GLOBAL_KEY {
+        return load_global_usage_counters(state).await;
+    }
+
     match state
         .get_ctx()
         .storage_handle
@@ -332,6 +336,60 @@ pub async fn load_usage_counters(state: &ServerState, key: Vec<u8>) -> ServerRes
             .map_err(|error| ServerError::InternalError(error.to_string())),
         Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
             Ok(UsageCounters::default())
+        }
+        Event::Storage(StorageEvent::Error { error }) => {
+            Err(ServerError::InternalError(error.to_string()))
+        }
+        other => Err(ServerError::InternalError(format!(
+            "unexpected storage event: {other:?}"
+        ))),
+    }
+}
+
+async fn load_global_usage_counters(state: &ServerState) -> ServerResult<UsageCounters> {
+    let mut reads = usage_global_shard_keys()
+        .into_iter()
+        .map(|key| (USAGE_STATS_KEYSPACE.to_string(), key.into()))
+        .collect::<Vec<_>>();
+    reads.push((
+        USAGE_STATS_KEYSPACE.to_string(),
+        USAGE_GLOBAL_KEY.to_vec().into(),
+    ));
+
+    match state
+        .get_ctx()
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::BatchRead {
+            reads,
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::BatchReadResult { values }) => {
+            let mut total = UsageCounters::default();
+            let mut saw_shard = false;
+            let mut legacy = None;
+            let shard_count = values.len().saturating_sub(1);
+            for (index, (_, value)) in values.into_iter().enumerate() {
+                let Some(bytes) = value else {
+                    continue;
+                };
+                let counters = UsageCounters::from_bytes(&bytes)
+                    .map_err(|error| ServerError::InternalError(error.to_string()))?;
+                if index < shard_count {
+                    saw_shard = true;
+                    total
+                        .add(&counters)
+                        .map_err(|error| ServerError::InternalError(error.to_string()))?;
+                } else {
+                    legacy = Some(counters);
+                }
+            }
+            if saw_shard {
+                Ok(total)
+            } else {
+                Ok(legacy.unwrap_or_default())
+            }
         }
         Event::Storage(StorageEvent::Error { error }) => {
             Err(ServerError::InternalError(error.to_string()))

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -2,17 +2,14 @@ use crate::error::{ServerError, ServerResult};
 pub use crate::server_state::PortalStatus;
 use crate::server_state::ServerState;
 use aruna_core::alpn::Alpn;
-use aruna_core::effects::{Effect, StorageEffect};
-use aruna_core::events::{Event, StorageEvent};
-use aruna_core::handle::Handle;
-use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
 use aruna_core::structs::{ConnectionAddressStatus, PeerConnectionStatus, RequestSummaryState};
 use aruna_core::structs::{RealmConfigDocument, RealmNodeKind};
-use aruna_core::structs::{USAGE_GLOBAL_KEY, UsageCounters, usage_global_shard_keys};
+use aruna_core::structs::{USAGE_GLOBAL_KEY, UsageCounters};
 use aruna_operations::driver::drive;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::status::load_node_observability_status;
+use aruna_operations::usage_stats::LoadUsageCountersOperation;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::get;
@@ -316,88 +313,9 @@ impl From<UsageCounters> for UsageResponse {
 }
 
 pub async fn load_usage_counters(state: &ServerState, key: Vec<u8>) -> ServerResult<UsageCounters> {
-    if key.as_slice() == USAGE_GLOBAL_KEY {
-        return load_global_usage_counters(state).await;
-    }
-
-    match state
-        .get_ctx()
-        .storage_handle
-        .send_effect(Effect::Storage(StorageEffect::Read {
-            key_space: USAGE_STATS_KEYSPACE.to_string(),
-            key: key.into(),
-            txn_id: None,
-        }))
+    drive(LoadUsageCountersOperation::new(key), &state.get_ctx())
         .await
-    {
-        Event::Storage(StorageEvent::ReadResult {
-            value: Some(bytes), ..
-        }) => UsageCounters::from_bytes(&bytes)
-            .map_err(|error| ServerError::InternalError(error.to_string())),
-        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
-            Ok(UsageCounters::default())
-        }
-        Event::Storage(StorageEvent::Error { error }) => {
-            Err(ServerError::InternalError(error.to_string()))
-        }
-        other => Err(ServerError::InternalError(format!(
-            "unexpected storage event: {other:?}"
-        ))),
-    }
-}
-
-async fn load_global_usage_counters(state: &ServerState) -> ServerResult<UsageCounters> {
-    let mut reads = usage_global_shard_keys()
-        .into_iter()
-        .map(|key| (USAGE_STATS_KEYSPACE.to_string(), key.into()))
-        .collect::<Vec<_>>();
-    reads.push((
-        USAGE_STATS_KEYSPACE.to_string(),
-        USAGE_GLOBAL_KEY.to_vec().into(),
-    ));
-
-    match state
-        .get_ctx()
-        .storage_handle
-        .send_effect(Effect::Storage(StorageEffect::BatchRead {
-            reads,
-            txn_id: None,
-        }))
-        .await
-    {
-        Event::Storage(StorageEvent::BatchReadResult { values }) => {
-            let mut total = UsageCounters::default();
-            let mut saw_shard = false;
-            let mut legacy = None;
-            let shard_count = values.len().saturating_sub(1);
-            for (index, (_, value)) in values.into_iter().enumerate() {
-                let Some(bytes) = value else {
-                    continue;
-                };
-                let counters = UsageCounters::from_bytes(&bytes)
-                    .map_err(|error| ServerError::InternalError(error.to_string()))?;
-                if index < shard_count {
-                    saw_shard = true;
-                    total
-                        .add(&counters)
-                        .map_err(|error| ServerError::InternalError(error.to_string()))?;
-                } else {
-                    legacy = Some(counters);
-                }
-            }
-            if saw_shard {
-                Ok(total)
-            } else {
-                Ok(legacy.unwrap_or_default())
-            }
-        }
-        Event::Storage(StorageEvent::Error { error }) => {
-            Err(ServerError::InternalError(error.to_string()))
-        }
-        other => Err(ServerError::InternalError(format!(
-            "unexpected storage event: {other:?}"
-        ))),
-    }
+        .map_err(|error| ServerError::InternalError(error.to_string()))
 }
 
 #[utoipa::path(

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -2,8 +2,13 @@ use crate::error::{ServerError, ServerResult};
 pub use crate::server_state::PortalStatus;
 use crate::server_state::ServerState;
 use aruna_core::alpn::Alpn;
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::{REALM_KEYSPACE, USAGE_STATS_KEYSPACE};
 use aruna_core::structs::{ConnectionAddressStatus, PeerConnectionStatus, RequestSummaryState};
-use aruna_core::structs::{RealmConfigDocument, RealmNodeKind};
+use aruna_core::structs::{Realm, RealmConfigDocument, RealmNodeKind};
+use aruna_core::structs::{USAGE_GLOBAL_KEY, UsageCounters};
 use aruna_operations::driver::drive;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
@@ -22,7 +27,7 @@ use utoipa::{OpenApi, ToSchema};
 #[derive(OpenApi)]
 #[openapi(
     tags((name = "info", description = "Node information endpoints")),
-    paths(get_info, get_realm_info)
+    paths(get_info, get_realm_info, get_usage)
 )]
 pub struct InfoApiDoc;
 
@@ -30,6 +35,7 @@ pub fn router() -> Router<Arc<ServerState>> {
     Router::new()
         .route("/info", get(get_info))
         .route("/info/realm", get(get_realm_info))
+        .route("/info/usage", get(get_usage))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -286,6 +292,69 @@ pub async fn get_realm_info(
         interface_services_status(&state).await,
     )?;
     Ok((StatusCode::OK, Json(response)))
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct UsageResponse {
+    pub buckets: u64,
+    pub objects: u64,
+    pub stored_blobs: u64,
+    pub stored_bytes: u64,
+    pub logical_bytes: u64,
+}
+
+impl From<UsageCounters> for UsageResponse {
+    fn from(counters: UsageCounters) -> Self {
+        Self {
+            buckets: counters.buckets,
+            objects: counters.objects,
+            stored_blobs: counters.stored_blobs,
+            stored_bytes: counters.stored_bytes,
+            logical_bytes: counters.logical_bytes,
+        }
+    }
+}
+
+pub async fn load_usage_counters(state: &ServerState, key: Vec<u8>) -> ServerResult<UsageCounters> {
+    match state
+        .get_ctx()
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Read {
+            key_space: USAGE_STATS_KEYSPACE.to_string(),
+            key: key.into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(bytes), ..
+        }) => UsageCounters::from_bytes(&bytes)
+            .map_err(|error| ServerError::InternalError(error.to_string())),
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
+            Ok(UsageCounters::default())
+        }
+        Event::Storage(StorageEvent::Error { error }) => {
+            Err(ServerError::InternalError(error.to_string()))
+        }
+        other => Err(ServerError::InternalError(format!(
+            "unexpected storage event: {other:?}"
+        ))),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/info/usage",
+    tag = "info",
+    responses(
+        (status = 200, description = "Aggregate storage usage on this node", body = UsageResponse)
+    )
+)]
+pub async fn get_usage(
+    State(state): State<Arc<ServerState>>,
+) -> ServerResult<(StatusCode, Json<UsageResponse>)> {
+    let counters = load_usage_counters(&state, USAGE_GLOBAL_KEY.to_vec()).await?;
+    Ok((StatusCode::OK, Json(UsageResponse::from(counters))))
 }
 
 fn map_realm_info_response(

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -349,14 +349,14 @@ async fn ensure_usage_counters(
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
-    use aruna_core::structs::USAGE_GLOBAL_KEY;
+    use aruna_core::structs::usage_global_shard_key;
     use aruna_operations::usage_stats::RebuildUsageStatsOperation;
 
     let event = driver_ctx
         .storage_handle
         .send_storage_effect(StorageEffect::Read {
             key_space: USAGE_STATS_KEYSPACE.to_string(),
-            key: USAGE_GLOBAL_KEY.to_vec().into(),
+            key: usage_global_shard_key(0).into(),
             txn_id: None,
         })
         .await;

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -235,6 +235,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
+    ensure_usage_counters(driver_ctx.as_ref()).await?;
+
     drive(
         AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
             realm_id: config.realm_id,
@@ -338,6 +340,34 @@ async fn shutdown_runtime(
     if let Err(error) = storage_handle.sync_all().await {
         error!(error = %error, "Failed to sync storage during shutdown");
     }
+}
+
+/// Builds the maintained usage counters once for stores that predate them.
+async fn ensure_usage_counters(
+    driver_ctx: &DriverContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use aruna_core::effects::StorageEffect;
+    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
+    use aruna_core::structs::USAGE_GLOBAL_KEY;
+    use aruna_operations::usage_stats::RebuildUsageStatsOperation;
+
+    let event = driver_ctx
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: USAGE_STATS_KEYSPACE.to_string(),
+            key: USAGE_GLOBAL_KEY.to_vec().into(),
+            txn_id: None,
+        })
+        .await;
+
+    if matches!(
+        event,
+        Event::Storage(StorageEvent::ReadResult { value: None, .. })
+    ) {
+        drive(RebuildUsageStatsOperation::new(), driver_ctx).await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -112,6 +112,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         task_handle: Some(task_handle.clone()),
     });
 
+    ensure_usage_counters(driver_ctx.as_ref()).await?;
+
     initialize_net_incoming(driver_ctx.clone());
     initialize_task_incoming(driver_ctx.clone(), task_handle).await;
 
@@ -235,8 +237,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    ensure_usage_counters(driver_ctx.as_ref()).await?;
-
     drive(
         AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
             realm_id: config.realm_id,
@@ -342,30 +342,48 @@ async fn shutdown_runtime(
     }
 }
 
-/// Builds the maintained usage counters once for stores that predate them.
+/// Ensures the maintained usage counter shards exist before background writes start.
 async fn ensure_usage_counters(
     driver_ctx: &DriverContext,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
-    use aruna_core::structs::usage_global_shard_key;
+    use aruna_core::structs::usage_global_shard_keys;
     use aruna_operations::usage_stats::RebuildUsageStatsOperation;
 
+    let shard_keys = usage_global_shard_keys();
     let event = driver_ctx
         .storage_handle
-        .send_storage_effect(StorageEffect::Read {
-            key_space: USAGE_STATS_KEYSPACE.to_string(),
-            key: usage_global_shard_key(0).into(),
+        .send_storage_effect(StorageEffect::BatchRead {
+            reads: shard_keys
+                .iter()
+                .map(|key| (USAGE_STATS_KEYSPACE.to_string(), key.clone().into()))
+                .collect(),
             txn_id: None,
         })
         .await;
 
-    if matches!(
-        event,
-        Event::Storage(StorageEvent::ReadResult { value: None, .. })
-    ) {
-        drive(RebuildUsageStatsOperation::new(), driver_ctx).await?;
+    match event {
+        Event::Storage(StorageEvent::BatchReadResult { values }) => {
+            if values.len() != shard_keys.len() {
+                return Err(format!(
+                    "usage counter probe returned {} values for {} shards",
+                    values.len(),
+                    shard_keys.len()
+                )
+                .into());
+            }
+            if values.iter().any(|(_, value)| value.is_none()) {
+                drive(RebuildUsageStatsOperation::new(), driver_ctx).await?;
+            }
+        }
+        Event::Storage(StorageEvent::Error { error }) => {
+            return Err(format!("usage counter probe failed: {error}").into());
+        }
+        other => {
+            return Err(format!("usage counter probe received unexpected event: {other:?}").into());
+        }
     }
     Ok(())
 }
@@ -374,8 +392,22 @@ async fn ensure_usage_counters(
 mod tests {
     use super::*;
     use aruna_core::effects::StorageEffect;
-    use aruna_core::events::StorageEvent;
+    use aruna_core::errors::StorageError;
+    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
+    use aruna_core::structs::{UsageCounters, usage_global_shard_keys};
     use std::thread;
+    use tempfile::tempdir;
+
+    fn test_driver_ctx(storage_handle: StorageHandle) -> DriverContext {
+        DriverContext {
+            storage_handle,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        }
+    }
 
     #[tokio::test]
     async fn shutdown_runtime_syncs_storage_without_net() {
@@ -390,6 +422,82 @@ mod tests {
 
         shutdown_runtime(None, None, &storage_handle).await;
 
+        worker.join().expect("storage responder should finish");
+    }
+
+    #[tokio::test]
+    async fn ensure_usage_counters_rebuilds_missing_shards() {
+        let temp = tempdir().expect("temp dir");
+        let storage_handle = aruna_storage::FjallStorage::open(
+            temp.path().to_str().expect("temp path should be utf8"),
+        )
+        .expect("storage opens");
+        let driver_ctx = test_driver_ctx(storage_handle.clone());
+
+        ensure_usage_counters(&driver_ctx).await.unwrap();
+
+        for key in usage_global_shard_keys() {
+            let event = storage_handle
+                .send_storage_effect(StorageEffect::Read {
+                    key_space: USAGE_STATS_KEYSPACE.to_string(),
+                    key: key.into(),
+                    txn_id: None,
+                })
+                .await;
+            let Event::Storage(StorageEvent::ReadResult {
+                value: Some(bytes), ..
+            }) = event
+            else {
+                panic!("expected rebuilt usage shard, got {event:?}");
+            };
+            assert_eq!(
+                UsageCounters::from_bytes(bytes.as_ref()).unwrap(),
+                UsageCounters::default()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_usage_counters_returns_probe_errors() {
+        let (storage_handle, receiver) = StorageHandle::new();
+        let worker = thread::spawn(move || {
+            let (effect, response_tx, _span, _queued_at) = receiver
+                .recv()
+                .expect("usage counter ensure should probe storage");
+            assert!(matches!(effect, StorageEffect::BatchRead { .. }));
+            response_tx.send(StorageEvent::Error {
+                error: StorageError::ReadError,
+            });
+        });
+        let driver_ctx = test_driver_ctx(storage_handle);
+
+        let error = ensure_usage_counters(&driver_ctx)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("usage counter probe failed"));
+        worker.join().expect("storage responder should finish");
+    }
+
+    #[tokio::test]
+    async fn ensure_usage_counters_rejects_unexpected_probe_events() {
+        let (storage_handle, receiver) = StorageHandle::new();
+        let worker = thread::spawn(move || {
+            let (effect, response_tx, _span, _queued_at) = receiver
+                .recv()
+                .expect("usage counter ensure should probe storage");
+            assert!(matches!(effect, StorageEffect::BatchRead { .. }));
+            response_tx.send(StorageEvent::SyncAllFinished);
+        });
+        let driver_ctx = test_driver_ctx(storage_handle);
+
+        let error = ensure_usage_counters(&driver_ctx)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("usage counter probe received unexpected event"));
         worker.join().expect("storage responder should finish");
     }
 }

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -40,6 +40,7 @@ pub const S3_MULTIPART_UPLOAD_PART_KEYSPACE: &str = "s3_multipart_upload_parts";
 pub const BLOB_REPLICATION_JOB_KEYSPACE: &str = "blob_replication_jobs";
 pub const BLOB_LIVE_REPLICATION_OBLIGATION_KEYSPACE: &str = "blob_live_replication_obligations";
 pub const REFERENCE_METADATA_REFRESH_JOB_KEYSPACE: &str = "reference_metadata_refresh_jobs";
+pub const USAGE_STATS_KEYSPACE: &str = "usage_stats";
 
 pub const SOURCE_CONNECTOR_INDEX_KEYSPACE: &str = "source_connector_index";
 pub const SOURCE_CONNECTOR_SECRET_KEYSPACE: &str = "source_connector_secret";

--- a/core/src/structs/mod.rs
+++ b/core/src/structs/mod.rs
@@ -11,6 +11,7 @@ mod source_connector;
 mod staging;
 #[allow(clippy::module_inception)]
 mod structs;
+mod usage;
 
 pub use blob::*;
 pub use group::*;
@@ -23,3 +24,4 @@ pub use source_access::*;
 pub use source_connector::*;
 pub use staging::*;
 pub use structs::*;
+pub use usage::*;

--- a/core/src/structs/usage.rs
+++ b/core/src/structs/usage.rs
@@ -1,0 +1,98 @@
+use crate::errors::ConversionError;
+use crate::types::GroupId;
+use serde::{Deserialize, Serialize};
+
+pub const USAGE_GLOBAL_KEY: &[u8] = b"global";
+
+pub fn usage_group_key(group_id: GroupId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(6 + 16);
+    key.extend_from_slice(b"group/");
+    key.extend_from_slice(&group_id.to_bytes());
+    key
+}
+
+/// Maintained usage aggregates. `stored_*` fields track physical,
+/// content-addressed blobs and are only meaningful on the global counter;
+/// `logical_bytes` sums live version sizes and is the per-group quota basis.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct UsageCounters {
+    pub buckets: u64,
+    pub objects: u64,
+    pub stored_blobs: u64,
+    pub stored_bytes: u64,
+    pub logical_bytes: u64,
+}
+
+impl UsageCounters {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
+        Ok(postcard::to_allocvec(self)?)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
+        Ok(postcard::from_bytes(bytes)?)
+    }
+
+    pub fn apply(&mut self, delta: &UsageDelta) {
+        self.buckets = apply_delta(self.buckets, delta.buckets);
+        self.objects = apply_delta(self.objects, delta.objects);
+        self.stored_blobs = apply_delta(self.stored_blobs, delta.stored_blobs);
+        self.stored_bytes = apply_delta(self.stored_bytes, delta.stored_bytes);
+        self.logical_bytes = apply_delta(self.logical_bytes, delta.logical_bytes);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct UsageDelta {
+    pub buckets: i64,
+    pub objects: i64,
+    pub stored_blobs: i64,
+    pub stored_bytes: i64,
+    pub logical_bytes: i64,
+}
+
+impl UsageDelta {
+    pub fn is_zero(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+fn apply_delta(value: u64, delta: i64) -> u64 {
+    if delta >= 0 {
+        value.saturating_add(delta as u64)
+    } else {
+        value.saturating_sub(delta.unsigned_abs())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_saturates_at_zero() {
+        let mut counters = UsageCounters {
+            objects: 1,
+            ..Default::default()
+        };
+        counters.apply(&UsageDelta {
+            objects: -5,
+            logical_bytes: 10,
+            ..Default::default()
+        });
+        assert_eq!(counters.objects, 0);
+        assert_eq!(counters.logical_bytes, 10);
+    }
+
+    #[test]
+    fn counters_round_trip() {
+        let counters = UsageCounters {
+            buckets: 1,
+            objects: 2,
+            stored_blobs: 3,
+            stored_bytes: 4,
+            logical_bytes: 5,
+        };
+        let bytes = counters.to_bytes().unwrap();
+        assert_eq!(UsageCounters::from_bytes(&bytes).unwrap(), counters);
+    }
+}

--- a/core/src/structs/usage.rs
+++ b/core/src/structs/usage.rs
@@ -1,8 +1,32 @@
 use crate::errors::ConversionError;
 use crate::types::GroupId;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 pub const USAGE_GLOBAL_KEY: &[u8] = b"global";
+pub const USAGE_GLOBAL_SHARD_COUNT: usize = 64;
+
+pub fn usage_global_shard_index(group_id: GroupId) -> usize {
+    group_id
+        .to_bytes()
+        .iter()
+        .fold(0u8, |shard, byte| shard ^ byte) as usize
+        % USAGE_GLOBAL_SHARD_COUNT
+}
+
+pub fn usage_global_shard_key(shard: usize) -> Vec<u8> {
+    format!("global/{shard:02}").into_bytes()
+}
+
+pub fn usage_global_key_for_group(group_id: GroupId) -> Vec<u8> {
+    usage_global_shard_key(usage_global_shard_index(group_id))
+}
+
+pub fn usage_global_shard_keys() -> Vec<Vec<u8>> {
+    (0..USAGE_GLOBAL_SHARD_COUNT)
+        .map(usage_global_shard_key)
+        .collect()
+}
 
 pub fn usage_group_key(group_id: GroupId) -> Vec<u8> {
     let mut key = Vec::with_capacity(6 + 16);
@@ -13,7 +37,7 @@ pub fn usage_group_key(group_id: GroupId) -> Vec<u8> {
 
 /// Maintained usage aggregates. `stored_*` fields track physical,
 /// content-addressed blobs and are only meaningful on the global counter;
-/// `logical_bytes` sums live version sizes and is the per-group quota basis.
+/// `logical_bytes` sums materialized version sizes and is the per-group quota basis.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct UsageCounters {
     pub buckets: u64,
@@ -32,12 +56,34 @@ impl UsageCounters {
         Ok(postcard::from_bytes(bytes)?)
     }
 
-    pub fn apply(&mut self, delta: &UsageDelta) {
-        self.buckets = apply_delta(self.buckets, delta.buckets);
-        self.objects = apply_delta(self.objects, delta.objects);
-        self.stored_blobs = apply_delta(self.stored_blobs, delta.stored_blobs);
-        self.stored_bytes = apply_delta(self.stored_bytes, delta.stored_bytes);
-        self.logical_bytes = apply_delta(self.logical_bytes, delta.logical_bytes);
+    pub fn apply(&mut self, delta: &UsageDelta) -> Result<(), UsageCounterError> {
+        let buckets = apply_delta("buckets", self.buckets, delta.buckets)?;
+        let objects = apply_delta("objects", self.objects, delta.objects)?;
+        let stored_blobs = apply_delta("stored_blobs", self.stored_blobs, delta.stored_blobs)?;
+        let stored_bytes = apply_delta("stored_bytes", self.stored_bytes, delta.stored_bytes)?;
+        let logical_bytes = apply_delta("logical_bytes", self.logical_bytes, delta.logical_bytes)?;
+
+        self.buckets = buckets;
+        self.objects = objects;
+        self.stored_blobs = stored_blobs;
+        self.stored_bytes = stored_bytes;
+        self.logical_bytes = logical_bytes;
+        Ok(())
+    }
+
+    pub fn add(&mut self, other: &Self) -> Result<(), UsageCounterError> {
+        let buckets = add_counter("buckets", self.buckets, other.buckets)?;
+        let objects = add_counter("objects", self.objects, other.objects)?;
+        let stored_blobs = add_counter("stored_blobs", self.stored_blobs, other.stored_blobs)?;
+        let stored_bytes = add_counter("stored_bytes", self.stored_bytes, other.stored_bytes)?;
+        let logical_bytes = add_counter("logical_bytes", self.logical_bytes, other.logical_bytes)?;
+
+        self.buckets = buckets;
+        self.objects = objects;
+        self.stored_blobs = stored_blobs;
+        self.stored_bytes = stored_bytes;
+        self.logical_bytes = logical_bytes;
+        Ok(())
     }
 }
 
@@ -56,12 +102,43 @@ impl UsageDelta {
     }
 }
 
-fn apply_delta(value: u64, delta: i64) -> u64 {
+#[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
+pub enum UsageCounterError {
+    #[error("usage counter {field} would underflow: {value} + ({delta})")]
+    Underflow {
+        field: &'static str,
+        value: u64,
+        delta: i64,
+    },
+    #[error("usage counter {field} would overflow: {value} + {delta}")]
+    Overflow {
+        field: &'static str,
+        value: u64,
+        delta: u64,
+    },
+}
+
+fn apply_delta(field: &'static str, value: u64, delta: i64) -> Result<u64, UsageCounterError> {
     if delta >= 0 {
-        value.saturating_add(delta as u64)
+        add_counter(field, value, delta as u64)
     } else {
-        value.saturating_sub(delta.unsigned_abs())
+        let amount = delta.unsigned_abs();
+        value
+            .checked_sub(amount)
+            .ok_or(UsageCounterError::Underflow {
+                field,
+                value,
+                delta,
+            })
     }
+}
+
+fn add_counter(field: &'static str, value: u64, delta: u64) -> Result<u64, UsageCounterError> {
+    value.checked_add(delta).ok_or(UsageCounterError::Overflow {
+        field,
+        value,
+        delta,
+    })
 }
 
 #[cfg(test)]
@@ -69,18 +146,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn apply_saturates_at_zero() {
+    fn apply_rejects_underflow() {
         let mut counters = UsageCounters {
             objects: 1,
             ..Default::default()
         };
-        counters.apply(&UsageDelta {
+        let error = counters.apply(&UsageDelta {
             objects: -5,
             logical_bytes: 10,
             ..Default::default()
         });
-        assert_eq!(counters.objects, 0);
-        assert_eq!(counters.logical_bytes, 10);
+        assert!(matches!(
+            error,
+            Err(UsageCounterError::Underflow {
+                field: "objects",
+                value: 1,
+                delta: -5,
+            })
+        ));
+        assert_eq!(counters.objects, 1);
+        assert_eq!(counters.logical_bytes, 0);
+    }
+
+    #[test]
+    fn apply_updates_all_counters() {
+        let mut counters = UsageCounters::default();
+        counters
+            .apply(&UsageDelta {
+                buckets: 1,
+                objects: 2,
+                stored_blobs: 3,
+                stored_bytes: 4,
+                logical_bytes: 5,
+            })
+            .unwrap();
+
+        assert_eq!(counters.buckets, 1);
+        assert_eq!(counters.objects, 2);
+        assert_eq!(counters.stored_blobs, 3);
+        assert_eq!(counters.stored_bytes, 4);
+        assert_eq!(counters.logical_bytes, 5);
     }
 
     #[test]

--- a/operations/src/lib.rs
+++ b/operations/src/lib.rs
@@ -62,4 +62,5 @@ pub mod task_persistence;
 pub mod telemetry;
 pub mod update_metadata_document;
 pub mod update_user;
+pub mod usage_stats;
 pub mod user_subject_index;

--- a/operations/src/s3/complete_multipart_upload.rs
+++ b/operations/src/s3/complete_multipart_upload.rs
@@ -3,13 +3,15 @@ use crate::blob::blob_keyspace_helper::{
     write_blob_location_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
+use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
 use aruna_blob::hash::Hasher;
 use aruna_core::effects::{BlobEffect, DhtEffect, Effect, NetEffect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{BlobEvent, DhtEvent, Event, NetEvent, StorageEvent};
 use aruna_core::keyspaces::{
-    BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, S3_MULTIPART_OBJECT_METADATA_KEYSPACE,
-    S3_MULTIPART_UPLOAD_KEYSPACE, S3_MULTIPART_UPLOAD_PART_KEYSPACE,
+    BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE,
+    S3_MULTIPART_OBJECT_METADATA_KEYSPACE, S3_MULTIPART_UPLOAD_KEYSPACE,
+    S3_MULTIPART_UPLOAD_PART_KEYSPACE,
 };
 use aruna_core::operation::Operation;
 use aruna_core::structs::checksum::{ChecksumAlgorithm, ExpectedChecksum, HASH_MD5};
@@ -17,7 +19,7 @@ use aruna_core::structs::{
     AuthContext, BackendLocation, BlobHeadKey, BlobVersion, CurrentVersionPointer,
     MultipartChecksumType, MultipartObjectMetadataKey, MultipartObjectPart, MultipartObjectSummary,
     MultipartUpload, MultipartUploadPart, MultipartUploadPartKey, MultipartUploadStatus, RealmId,
-    VersionKey,
+    UsageDelta, VersionKey,
 };
 use aruna_core::types::{Effects, NodeId, TxnId, UserId};
 use smallvec::smallvec;
@@ -39,12 +41,14 @@ pub enum CompleteMultipartUploadState {
     CheckHashLookup,
     WriteBlobLocation,
     ReadObjectLookup,
+    ReadLivenessVersion,
     WriteBlobHead,
     WriteHashPathIndex,
     WriteBlobVersionRecord,
     WriteObjectMetadata,
     DeleteUploadRecords,
     WriteLiveReplicationObligation,
+    UpdateUsage,
     CommitFinalizeTransaction,
     RegisterBlobInDht,
     CleanupDuplicate,
@@ -90,6 +94,8 @@ pub enum CompleteMultipartUploadError {
     MissingPartEtag,
     #[error("part etag mismatch")]
     PartEtagMismatch,
+    #[error(transparent)]
+    UsageUpdateError(#[from] UsageUpdateError),
     #[error("CompleteMultipartUpload failed")]
     CompleteMultipartUploadFailed,
 }
@@ -136,6 +142,9 @@ pub struct CompleteMultipartUploadOperation {
     version_id: Option<Ulid>,
     version_created_at: Option<SystemTime>,
     existing_pointer: Option<CurrentVersionPointer>,
+    new_blob: bool,
+    was_live: bool,
+    usage_update: Option<UsageCounterUpdate>,
     cleanup_part_index: usize,
     pending_error: Option<CompleteMultipartUploadError>,
     output: Option<Result<CompleteMultipartUploadResult, CompleteMultipartUploadError>>,
@@ -155,6 +164,9 @@ impl CompleteMultipartUploadOperation {
             version_id: None,
             version_created_at: None,
             existing_pointer: None,
+            new_blob: false,
+            was_live: false,
+            usage_update: None,
             cleanup_part_index: 0,
             pending_error: None,
             output: None,
@@ -439,7 +451,10 @@ impl CompleteMultipartUploadOperation {
                     return self.schedule_error(CompleteMultipartUploadError::ConversionError(err));
                 }
             },
-            None => Some(composed_location),
+            None => {
+                self.new_blob = true;
+                Some(composed_location)
+            }
         };
 
         self.write_blob_location()
@@ -505,6 +520,33 @@ impl CompleteMultipartUploadOperation {
             Err(err) => return self.schedule_error(err.into()),
         };
         self.existing_pointer = existing;
+        let existing_pointer = self.existing_pointer.clone();
+        if let Some(pointer) = existing_pointer.as_ref() {
+            let key = match VersionKey::new(&self.input.bucket, &self.input.key, pointer.version_id)
+                .to_bytes()
+            {
+                Ok(key) => key.into(),
+                Err(err) => return self.schedule_error(err.into()),
+            };
+            self.state = CompleteMultipartUploadState::ReadLivenessVersion;
+            return smallvec![Effect::Storage(StorageEffect::Read {
+                key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                key,
+                txn_id: self.txn_id,
+            })];
+        }
+        self.write_current_lookup(existing_pointer.as_ref())
+    }
+
+    fn handle_liveness_version_read(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            return self.schedule_error(CompleteMultipartUploadError::InvalidOperationState);
+        };
+
+        self.was_live = value
+            .and_then(|value| BlobVersion::from_bytes(value.as_ref()).ok())
+            .is_some_and(|version| !version.is_deleted());
+
         let existing_pointer = self.existing_pointer.clone();
         self.write_current_lookup(existing_pointer.as_ref())
     }
@@ -745,8 +787,52 @@ impl CompleteMultipartUploadOperation {
         let Some(txn_id) = self.txn_id else {
             return self.schedule_error(CompleteMultipartUploadError::NoTransactionFound);
         };
-        self.state = CompleteMultipartUploadState::CommitFinalizeTransaction;
-        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+        let Some(group_id) = self.upload_record.as_ref().map(|record| record.group_id) else {
+            return self
+                .schedule_error(CompleteMultipartUploadError::CompleteMultipartUploadFailed);
+        };
+        let Some(size) = self
+            .final_location
+            .as_ref()
+            .map(|location| i64::try_from(location.blob_size).unwrap_or(i64::MAX))
+        else {
+            return self
+                .schedule_error(CompleteMultipartUploadError::CompleteMultipartUploadFailed);
+        };
+
+        let group_delta = UsageDelta {
+            objects: if self.was_live { 0 } else { 1 },
+            logical_bytes: size,
+            ..Default::default()
+        };
+        let global_delta = UsageDelta {
+            stored_blobs: if self.new_blob { 1 } else { 0 },
+            stored_bytes: if self.new_blob { size } else { 0 },
+            ..group_delta
+        };
+        let mut update = UsageCounterUpdate::with_global(group_id, group_delta, global_delta);
+        self.state = CompleteMultipartUploadState::UpdateUsage;
+        let effects = update.start(txn_id);
+        self.usage_update = Some(update);
+        effects
+    }
+
+    fn handle_usage_update(&mut self, event: Event) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.schedule_error(CompleteMultipartUploadError::NoTransactionFound);
+        };
+        let Some(update) = self.usage_update.as_mut() else {
+            return self
+                .schedule_error(CompleteMultipartUploadError::CompleteMultipartUploadFailed);
+        };
+        match update.step(event, txn_id) {
+            Ok(Some(effects)) => effects,
+            Ok(None) => {
+                self.state = CompleteMultipartUploadState::CommitFinalizeTransaction;
+                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+            }
+            Err(err) => self.schedule_error(err.into()),
+        }
     }
 
     fn handle_finalize_committed(&mut self, event: Event) -> Effects {
@@ -976,6 +1062,9 @@ impl Operation for CompleteMultipartUploadOperation {
                 self.handle_blob_location_written(event)
             }
             CompleteMultipartUploadState::ReadObjectLookup => self.handle_object_lookup_read(event),
+            CompleteMultipartUploadState::ReadLivenessVersion => {
+                self.handle_liveness_version_read(event)
+            }
             CompleteMultipartUploadState::WriteBlobHead => self.handle_blob_head_written(event),
             CompleteMultipartUploadState::WriteHashPathIndex => {
                 self.handle_hash_path_index_written(event)
@@ -992,6 +1081,7 @@ impl Operation for CompleteMultipartUploadOperation {
             CompleteMultipartUploadState::WriteLiveReplicationObligation => {
                 self.handle_live_replication_obligation_written(event)
             }
+            CompleteMultipartUploadState::UpdateUsage => self.handle_usage_update(event),
             CompleteMultipartUploadState::CommitFinalizeTransaction => {
                 self.handle_finalize_committed(event)
             }

--- a/operations/src/s3/create_bucket.rs
+++ b/operations/src/s3/create_bucket.rs
@@ -1,9 +1,10 @@
+use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::S3_BUCKET_KEYSPACE;
 use aruna_core::operation::Operation;
-use aruna_core::structs::BucketInfo;
+use aruna_core::structs::{BucketInfo, UsageDelta};
 use aruna_core::types::Effects;
 use smallvec::smallvec;
 use thiserror::Error;
@@ -14,6 +15,7 @@ pub enum CreateBucketState {
     StartTransaction,
     CheckExists,
     CreateBucket,
+    UpdateUsage,
     CommitTransaction,
     Finish,
     Error,
@@ -40,6 +42,8 @@ pub enum CreateBucketError {
         expected: &'static str,
         received: Event,
     },
+    #[error(transparent)]
+    UsageUpdateError(#[from] UsageUpdateError),
     #[error("CreateBucket failed")]
     CreateBucketFailed,
 }
@@ -50,6 +54,7 @@ pub struct CreateBucketOperation {
     bucket_info: BucketInfo,
     state: CreateBucketState,
     txn_id: Option<ulid::Ulid>,
+    usage_update: Option<UsageCounterUpdate>,
     output: Option<Result<BucketInfo, CreateBucketError>>,
 }
 
@@ -60,6 +65,7 @@ impl CreateBucketOperation {
             bucket_info,
             state: CreateBucketState::Init,
             txn_id: None,
+            usage_update: None,
             output: None,
         }
     }
@@ -144,8 +150,34 @@ impl CreateBucketOperation {
         let Some(txn_id) = self.txn_id else {
             return self.emit_error(CreateBucketError::NoTransactionFound);
         };
-        self.state = CreateBucketState::CommitTransaction;
-        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+        let mut update = UsageCounterUpdate::for_group(
+            self.bucket_info.group_id,
+            UsageDelta {
+                buckets: 1,
+                ..Default::default()
+            },
+        );
+        self.state = CreateBucketState::UpdateUsage;
+        let effects = update.start(txn_id);
+        self.usage_update = Some(update);
+        effects
+    }
+
+    fn handle_usage_update(&mut self, event: Event) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(CreateBucketError::NoTransactionFound);
+        };
+        let Some(update) = self.usage_update.as_mut() else {
+            return self.emit_error(CreateBucketError::CreateBucketFailed);
+        };
+        match update.step(event, txn_id) {
+            Ok(Some(effects)) => effects,
+            Ok(None) => {
+                self.state = CreateBucketState::CommitTransaction;
+                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+            }
+            Err(err) => self.emit_error(err.into()),
+        }
     }
 
     fn handle_transaction_committed(&mut self, event: Event) -> Effects {
@@ -178,6 +210,7 @@ impl Operation for CreateBucketOperation {
             CreateBucketState::StartTransaction => self.handle_transaction_started(event),
             CreateBucketState::CheckExists => self.handle_bucket_checked(event),
             CreateBucketState::CreateBucket => self.handle_bucket_created(event),
+            CreateBucketState::UpdateUsage => self.handle_usage_update(event),
             CreateBucketState::CommitTransaction => self.handle_transaction_committed(event),
             CreateBucketState::Finish => smallvec![],
             CreateBucketState::Error => self.abort(),

--- a/operations/src/s3/delete_bucket.rs
+++ b/operations/src/s3/delete_bucket.rs
@@ -1,3 +1,4 @@
+use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
@@ -6,8 +7,8 @@ use aruna_core::keyspaces::{
     S3_MULTIPART_UPLOAD_KEYSPACE,
 };
 use aruna_core::operation::Operation;
-use aruna_core::structs::{BlobHeadKey, BucketInfo, MultipartUpload, VersionKey};
-use aruna_core::types::{Effects, TxnId};
+use aruna_core::structs::{BlobHeadKey, BucketInfo, MultipartUpload, UsageDelta, VersionKey};
+use aruna_core::types::{Effects, GroupId, TxnId};
 use smallvec::smallvec;
 use thiserror::Error;
 
@@ -20,6 +21,7 @@ pub enum DeleteBucketState {
     CheckVersions,
     CheckMultipartUploads,
     DeleteBucket,
+    UpdateUsage,
     CommitTransaction,
     Finish,
     Error,
@@ -43,6 +45,8 @@ pub enum DeleteBucketError {
         expected: &'static str,
         received: Event,
     },
+    #[error(transparent)]
+    UsageUpdateError(#[from] UsageUpdateError),
     #[error("DeleteBucket failed")]
     DeleteBucketFailed,
 }
@@ -52,6 +56,8 @@ pub struct DeleteBucketOperation {
     bucket: String,
     state: DeleteBucketState,
     txn_id: Option<TxnId>,
+    group_id: Option<GroupId>,
+    usage_update: Option<UsageCounterUpdate>,
     output: Option<Result<(), DeleteBucketError>>,
 }
 
@@ -63,6 +69,8 @@ impl DeleteBucketOperation {
             bucket,
             state: DeleteBucketState::Init,
             txn_id: None,
+            group_id: None,
+            usage_update: None,
             output: None,
         }
     }
@@ -110,8 +118,9 @@ impl DeleteBucketOperation {
         let Some(value) = value else {
             return self.emit_error(DeleteBucketError::NotFound);
         };
-        if let Err(err) = BucketInfo::from_bytes(value.as_ref()) {
-            return self.emit_error(err.into());
+        match BucketInfo::from_bytes(value.as_ref()) {
+            Ok(info) => self.group_id = Some(info.group_id),
+            Err(err) => return self.emit_error(err.into()),
         }
 
         let prefix = match BlobHeadKey::bucket_prefix(&self.bucket) {
@@ -226,9 +235,38 @@ impl DeleteBucketOperation {
         let Some(txn_id) = self.txn_id else {
             return self.emit_error(DeleteBucketError::TransactionMissing);
         };
+        let Some(group_id) = self.group_id else {
+            return self.emit_error(DeleteBucketError::DeleteBucketFailed);
+        };
 
-        self.state = DeleteBucketState::CommitTransaction;
-        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+        let mut update = UsageCounterUpdate::for_group(
+            group_id,
+            UsageDelta {
+                buckets: -1,
+                ..Default::default()
+            },
+        );
+        self.state = DeleteBucketState::UpdateUsage;
+        let effects = update.start(txn_id);
+        self.usage_update = Some(update);
+        effects
+    }
+
+    fn handle_usage_update(&mut self, event: Event) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(DeleteBucketError::TransactionMissing);
+        };
+        let Some(update) = self.usage_update.as_mut() else {
+            return self.emit_error(DeleteBucketError::DeleteBucketFailed);
+        };
+        match update.step(event, txn_id) {
+            Ok(Some(effects)) => effects,
+            Ok(None) => {
+                self.state = DeleteBucketState::CommitTransaction;
+                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+            }
+            Err(err) => self.emit_error(err.into()),
+        }
     }
 
     fn handle_transaction_committed(&mut self, event: Event) -> Effects {
@@ -266,6 +304,7 @@ impl Operation for DeleteBucketOperation {
                 self.handle_multipart_uploads_checked(event)
             }
             DeleteBucketState::DeleteBucket => self.handle_bucket_deleted(event),
+            DeleteBucketState::UpdateUsage => self.handle_usage_update(event),
             DeleteBucketState::CommitTransaction => self.handle_transaction_committed(event),
             DeleteBucketState::Finish => smallvec![],
             DeleteBucketState::Error => smallvec![],

--- a/operations/src/s3/delete_bucket.rs
+++ b/operations/src/s3/delete_bucket.rs
@@ -339,6 +339,7 @@ impl Operation for DeleteBucketOperation {
 mod test {
     use super::*;
     use crate::driver::{DriverContext, drive};
+    use crate::s3::create_bucket::CreateBucketOperation;
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{
@@ -382,22 +383,22 @@ mod test {
         };
 
         let bucket = "bucket-a".to_string();
-        let _ = storage_handle
-            .send_storage_effect(StorageEffect::Write {
-                key_space: S3_BUCKET_KEYSPACE.to_string(),
-                key: bucket.clone().into(),
-                value: BucketInfo {
+        drive(
+            CreateBucketOperation::new(
+                bucket.clone(),
+                BucketInfo {
                     group_id: Ulid::new(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
                     cors_configuration: None,
-                }
-                .to_bytes()
-                .unwrap()
-                .into(),
-                txn_id: None,
-            })
-            .await;
+                },
+            ),
+            &driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
 
         let result = drive(DeleteBucketOperation::new(bucket.clone()), &driver_ctx)
             .await
@@ -444,22 +445,22 @@ mod test {
         };
 
         let bucket = "bucket-a".to_string();
-        let _ = storage_handle
-            .send_storage_effect(StorageEffect::Write {
-                key_space: S3_BUCKET_KEYSPACE.to_string(),
-                key: bucket.clone().into(),
-                value: BucketInfo {
+        drive(
+            CreateBucketOperation::new(
+                bucket.clone(),
+                BucketInfo {
                     group_id: Ulid::new(),
                     created_at: SystemTime::now(),
                     created_by: aruna_core::UserId::nil(RealmId::from_bytes([0u8; 32])),
                     cors_configuration: None,
-                }
-                .to_bytes()
-                .unwrap()
-                .into(),
-                txn_id: None,
-            })
-            .await;
+                },
+            ),
+            &driver_ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
         let _ = storage_handle
             .send_storage_effect(StorageEffect::Write {
                 key_space: S3_BUCKET_REPLICATION_KEYSPACE.to_string(),

--- a/operations/src/s3/delete_object.rs
+++ b/operations/src/s3/delete_object.rs
@@ -3,16 +3,18 @@ use crate::blob::blob_keyspace_helper::{
     delete_hash_path_index_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
+use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
-    BLOB_HEAD_KEYSPACE, BLOB_VERSIONS_KEYSPACE, S3_MULTIPART_OBJECT_METADATA_KEYSPACE,
+    BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE,
+    S3_MULTIPART_OBJECT_METADATA_KEYSPACE,
 };
 use aruna_core::operation::Operation;
 use aruna_core::structs::{
-    AuthContext, BlobHeadKey, BlobVersion, CurrentVersionPointer, MultipartObjectMetadataKey,
-    RealmId, VersionKey,
+    AuthContext, BackendLocation, BlobHeadKey, BlobVersion, CurrentVersionPointer,
+    MultipartObjectMetadataKey, RealmId, UsageDelta, VersionKey,
 };
 use aruna_core::types::{Effects, GroupId, Key, NodeId, UserId};
 use smallvec::smallvec;
@@ -26,8 +28,10 @@ pub enum DeleteObjectState {
     Init,
     StartTransaction,
     ReadTargetVersion,
+    ReadTargetLocation,
     ReadAllVersions,
     ReadCurrentLookup,
+    ReadLivenessVersion,
     ApplyHeadTransition,
     DeleteTargetHashPathIndex,
     DeleteTargetVersion,
@@ -36,6 +40,7 @@ pub enum DeleteObjectState {
     DeleteMultipartPart,
     WriteBlobVersion,
     WriteLiveReplicationObligation,
+    UpdateUsage,
     CommitTransaction,
     Finish,
     Error,
@@ -80,6 +85,8 @@ pub enum DeleteObjectError {
     NoSuchVersion,
     #[error("Invalid operation state")]
     InvalidOperationState,
+    #[error(transparent)]
+    UsageUpdateError(#[from] UsageUpdateError),
     #[error("DeleteObject failed")]
     DeleteObjectFailed,
 }
@@ -118,6 +125,9 @@ pub struct DeleteObjectOperation {
     deleted_version_created_at: Option<SystemTime>,
     multipart_part_keys: Vec<Key>,
     multipart_delete_index: usize,
+    target_size: Option<u64>,
+    live_before_marker: bool,
+    usage_update: Option<UsageCounterUpdate>,
     output: Option<Result<DeleteObjectResult, DeleteObjectError>>,
 }
 
@@ -139,6 +149,9 @@ impl DeleteObjectOperation {
             deleted_version_created_at: None,
             multipart_part_keys: Vec::new(),
             multipart_delete_index: 0,
+            target_size: None,
+            live_before_marker: false,
+            usage_update: None,
             output: None,
         }
     }
@@ -248,8 +261,35 @@ impl DeleteObjectOperation {
             Ok(version) => version,
             Err(err) => return self.emit_error(err.into()),
         };
-        self.target_version = Some(VersionSummary::from_blob_version(version_id, &version));
+        let summary = VersionSummary::from_blob_version(version_id, &version);
+        let materialized_hash = summary.materialized_hash;
+        self.target_version = Some(summary);
 
+        if let Some(hash) = materialized_hash {
+            self.state = DeleteObjectState::ReadTargetLocation;
+            return smallvec![Effect::Storage(StorageEffect::Read {
+                key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                key: hash.to_vec().into(),
+                txn_id: self.txn_id,
+            })];
+        }
+
+        self.read_all_versions()
+    }
+
+    fn handle_target_location_read(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            return self.emit_error(DeleteObjectError::InvalidOperationState);
+        };
+
+        self.target_size = value
+            .and_then(|value| BackendLocation::from_bytes(value.as_ref()).ok())
+            .map(|location| location.blob_size);
+
+        self.read_all_versions()
+    }
+
+    fn read_all_versions(&mut self) -> Effects {
         self.state = DeleteObjectState::ReadAllVersions;
         let prefix = match VersionKey::object_prefix(&self.input.bucket, &self.input.key) {
             Ok(prefix) => prefix.into(),
@@ -333,8 +373,40 @@ impl DeleteObjectOperation {
             self.handle_version_delete_current_lookup(target_version_id, existing.as_ref())
         } else {
             self.pending_new_current_hash = None;
+            if let Some(pointer) = existing.as_ref() {
+                let key =
+                    match VersionKey::new(&self.input.bucket, &self.input.key, pointer.version_id)
+                        .to_bytes()
+                    {
+                        Ok(key) => key.into(),
+                        Err(err) => return self.emit_error(err.into()),
+                    };
+                self.state = DeleteObjectState::ReadLivenessVersion;
+                return smallvec![Effect::Storage(StorageEffect::Read {
+                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                    key,
+                    txn_id: self.txn_id,
+                })];
+            }
+            self.live_before_marker = false;
             self.write_tombstone_current_lookup(version_id, existing.as_ref())
         }
+    }
+
+    fn handle_liveness_version_read(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            return self.emit_error(DeleteObjectError::InvalidOperationState);
+        };
+
+        self.live_before_marker = value
+            .and_then(|value| BlobVersion::from_bytes(value.as_ref()).ok())
+            .is_some_and(|version| !version.is_deleted());
+
+        let Some(version_id) = self.version_id else {
+            return self.emit_error(DeleteObjectError::InvalidOperationState);
+        };
+        let existing = self.existing_pointer.clone();
+        self.write_tombstone_current_lookup(version_id, existing.as_ref())
     }
 
     fn handle_version_delete_current_lookup(
@@ -483,17 +555,79 @@ impl DeleteObjectOperation {
         self.delete_next_multipart_part()
     }
 
+    fn usage_delta(&self) -> UsageDelta {
+        if let Some(target) = self.target_version.as_ref() {
+            let pointed_at_target = self
+                .existing_pointer
+                .as_ref()
+                .is_some_and(|pointer| pointer.version_id == target.version_id);
+            let objects = if pointed_at_target {
+                let live_before = !target.is_deleted();
+                let live_after = self
+                    .latest_remaining
+                    .as_ref()
+                    .is_some_and(|latest| !latest.is_deleted());
+                i64::from(live_after) - i64::from(live_before)
+            } else {
+                0
+            };
+            let logical_bytes = match (target.materialized_hash, self.target_size) {
+                (Some(_), Some(size)) => -i64::try_from(size).unwrap_or(i64::MAX),
+                _ => 0,
+            };
+            UsageDelta {
+                objects,
+                logical_bytes,
+                ..Default::default()
+            }
+        } else {
+            UsageDelta {
+                objects: if self.live_before_marker { -1 } else { 0 },
+                ..Default::default()
+            }
+        }
+    }
+
+    fn start_usage_update(&mut self) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(DeleteObjectError::NoTransactionFound);
+        };
+        let delta = self.usage_delta();
+        let mut update = UsageCounterUpdate::for_group(self.input.group_id, delta);
+        if update.is_noop() {
+            self.state = DeleteObjectState::CommitTransaction;
+            return smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })];
+        }
+        self.state = DeleteObjectState::UpdateUsage;
+        let effects = update.start(txn_id);
+        self.usage_update = Some(update);
+        effects
+    }
+
+    fn handle_usage_update(&mut self, event: Event) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(DeleteObjectError::NoTransactionFound);
+        };
+        let Some(update) = self.usage_update.as_mut() else {
+            return self.emit_error(DeleteObjectError::DeleteObjectFailed);
+        };
+        match update.step(event, txn_id) {
+            Ok(Some(effects)) => effects,
+            Ok(None) => {
+                self.state = DeleteObjectState::CommitTransaction;
+                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+            }
+            Err(err) => self.emit_error(err.into()),
+        }
+    }
+
     fn delete_next_multipart_part(&mut self) -> Effects {
         let Some(key) = self
             .multipart_part_keys
             .get(self.multipart_delete_index)
             .cloned()
         else {
-            let Some(txn_id) = self.txn_id else {
-                return self.emit_error(DeleteObjectError::NoTransactionFound);
-            };
-            self.state = DeleteObjectState::CommitTransaction;
-            return smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })];
+            return self.start_usage_update();
         };
 
         self.state = DeleteObjectState::DeleteMultipartPart;
@@ -584,11 +718,7 @@ impl DeleteObjectOperation {
             return self.emit_error(DeleteObjectError::InvalidOperationState);
         };
 
-        let Some(txn_id) = self.txn_id else {
-            return self.emit_error(DeleteObjectError::NoTransactionFound);
-        };
-        self.state = DeleteObjectState::CommitTransaction;
-        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+        self.start_usage_update()
     }
 
     fn handle_transaction_committed(&mut self, event: Event) -> Effects {
@@ -638,8 +768,10 @@ impl Operation for DeleteObjectOperation {
             DeleteObjectState::Init => self.handle_init(),
             DeleteObjectState::StartTransaction => self.handle_transaction_started(event),
             DeleteObjectState::ReadTargetVersion => self.handle_target_version_read(event),
+            DeleteObjectState::ReadTargetLocation => self.handle_target_location_read(event),
             DeleteObjectState::ReadAllVersions => self.handle_all_versions_read(event),
             DeleteObjectState::ReadCurrentLookup => self.handle_current_lookup_read(event),
+            DeleteObjectState::ReadLivenessVersion => self.handle_liveness_version_read(event),
             DeleteObjectState::ApplyHeadTransition => self.handle_head_transition_applied(event),
             DeleteObjectState::DeleteTargetHashPathIndex => {
                 self.handle_target_hash_path_deleted(event)
@@ -654,6 +786,7 @@ impl Operation for DeleteObjectOperation {
             DeleteObjectState::WriteLiveReplicationObligation => {
                 self.handle_live_replication_obligation_written(event)
             }
+            DeleteObjectState::UpdateUsage => self.handle_usage_update(event),
             DeleteObjectState::CommitTransaction => self.handle_transaction_committed(event),
             DeleteObjectState::Finish => smallvec![],
             DeleteObjectState::Error => self.abort(),

--- a/operations/src/s3/put_object.rs
+++ b/operations/src/s3/put_object.rs
@@ -3,16 +3,17 @@ use crate::blob::blob_keyspace_helper::{
     write_blob_location_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
+use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
 use aruna_core::effects::{BlobEffect, DhtEffect, Effect, NetEffect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{BlobEvent, DhtEvent, Event, NetEvent, StorageEvent};
-use aruna_core::keyspaces::{BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE};
+use aruna_core::keyspaces::{BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE};
 use aruna_core::operation::Operation;
 use aruna_core::stream::{BackendStream, StreamError};
 use aruna_core::structs::checksum::ExpectedChecksum;
 use aruna_core::structs::{
     AuthContext, BackendLocation, BlobHeadKey, BlobVersion, CurrentVersionPointer, RealmId,
-    VersionKey, VersionSourceBinding,
+    UsageDelta, VersionKey, VersionSourceBinding,
 };
 use aruna_core::types::{Effects, GroupId, NodeId, UserId};
 use bytes::Bytes;
@@ -29,10 +30,12 @@ pub enum PutObjectState {
     CheckHashLookup,
     CreateBlobLocation,
     ReadObjectLookup,
+    ReadLivenessVersion,
     WriteBlobHead,
     WriteHashPathIndex,
     CreateBlobVersionRecord,
     WriteLiveReplicationObligation,
+    UpdateUsage,
     CommitTransaction,
     RegisterBlobInDht,
     CleanupDuplicate,
@@ -62,6 +65,8 @@ pub enum PutObjectError {
     ChecksumMismatch(&'static str),
     #[error(transparent)]
     ConversionError(#[from] ConversionError),
+    #[error(transparent)]
+    UsageUpdateError(#[from] UsageUpdateError),
     #[error("Something went wrong ...")]
     PutObjectFailed,
 }
@@ -102,6 +107,9 @@ pub struct PutObjectOperation {
     written_location: Option<BackendLocation>,
     cleanup_location: Option<BackendLocation>,
     existing_pointer: Option<CurrentVersionPointer>,
+    new_blob: bool,
+    was_live: bool,
+    usage_update: Option<UsageCounterUpdate>,
     pending_error: Option<PutObjectError>,
     output: Option<Result<BackendLocation, PutObjectError>>,
 }
@@ -116,6 +124,9 @@ impl PutObjectOperation {
             written_location: None,
             cleanup_location: None,
             existing_pointer: None,
+            new_blob: false,
+            was_live: false,
+            usage_update: None,
             pending_error: None,
             output: None,
         }
@@ -218,6 +229,7 @@ impl PutObjectOperation {
                 self.create_blob_location()
             }
             None => {
+                self.new_blob = true;
                 self.output = Some(Ok(written_location.clone()));
                 self.create_blob_location()
             }
@@ -294,6 +306,37 @@ impl PutObjectOperation {
             Err(err) => return self.emit_error(PutObjectError::ConversionError(err)),
         };
         self.existing_pointer = existing;
+        let existing_pointer = self.existing_pointer.clone();
+        if let Some(pointer) = existing_pointer.as_ref() {
+            let key = match VersionKey::new(
+                self.config.request.bucket.clone(),
+                self.config.request.key.clone(),
+                pointer.version_id,
+            )
+            .to_bytes()
+            {
+                Ok(key) => key.into(),
+                Err(err) => return self.emit_error(PutObjectError::ConversionError(err)),
+            };
+            self.state = PutObjectState::ReadLivenessVersion;
+            return smallvec![Effect::Storage(StorageEffect::Read {
+                key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                key,
+                txn_id: self.txn_id,
+            })];
+        }
+        self.write_current_lookup(existing_pointer.as_ref())
+    }
+
+    fn handle_liveness_version_read(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            return self.emit_error(PutObjectError::InvalidOperationState);
+        };
+
+        self.was_live = value
+            .and_then(|value| BlobVersion::from_bytes(value.as_ref()).ok())
+            .is_some_and(|version| !version.is_deleted());
+
         let existing_pointer = self.existing_pointer.clone();
         self.write_current_lookup(existing_pointer.as_ref())
     }
@@ -425,13 +468,51 @@ impl PutObjectOperation {
     fn handle_live_replication_obligation_written(&mut self, event: Event) -> Effects {
         if let Event::Storage(StorageEvent::WriteResult { .. }) = event {
             if let Some(txn_id) = self.txn_id {
-                self.state = PutObjectState::CommitTransaction;
-                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+                let Some(location) = self.get_output().cloned() else {
+                    return self.emit_error(PutObjectError::MissingOutput);
+                };
+                let size = i64::try_from(location.blob_size).unwrap_or(i64::MAX);
+                let group_delta = UsageDelta {
+                    objects: if self.was_live { 0 } else { 1 },
+                    logical_bytes: size,
+                    ..Default::default()
+                };
+                let global_delta = UsageDelta {
+                    stored_blobs: if self.new_blob { 1 } else { 0 },
+                    stored_bytes: if self.new_blob { size } else { 0 },
+                    ..group_delta
+                };
+                let mut update = UsageCounterUpdate::with_global(
+                    self.config.group_id,
+                    group_delta,
+                    global_delta,
+                );
+                self.state = PutObjectState::UpdateUsage;
+                let effects = update.start(txn_id);
+                self.usage_update = Some(update);
+                effects
             } else {
                 self.emit_error(PutObjectError::NoTransactionFound)
             }
         } else {
             self.emit_error(PutObjectError::InvalidOperationState)
+        }
+    }
+
+    fn handle_usage_update(&mut self, event: Event) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(PutObjectError::NoTransactionFound);
+        };
+        let Some(update) = self.usage_update.as_mut() else {
+            return self.emit_error(PutObjectError::PutObjectFailed);
+        };
+        match update.step(event, txn_id) {
+            Ok(Some(effects)) => effects,
+            Ok(None) => {
+                self.state = PutObjectState::CommitTransaction;
+                smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+            }
+            Err(err) => self.emit_error(err.into()),
         }
     }
 
@@ -561,6 +642,7 @@ impl Operation for PutObjectOperation {
             PutObjectState::CheckHashLookup => self.handle_hash_lookup_checked(event),
             PutObjectState::CreateBlobLocation => self.handle_blob_location_created(event),
             PutObjectState::ReadObjectLookup => self.handle_object_lookup_read(event),
+            PutObjectState::ReadLivenessVersion => self.handle_liveness_version_read(event),
             PutObjectState::WriteBlobHead => self.handle_blob_head_written(event),
             PutObjectState::WriteHashPathIndex => self.handle_hash_path_index_created(event),
             PutObjectState::CreateBlobVersionRecord => {
@@ -569,6 +651,7 @@ impl Operation for PutObjectOperation {
             PutObjectState::WriteLiveReplicationObligation => {
                 self.handle_live_replication_obligation_written(event)
             }
+            PutObjectState::UpdateUsage => self.handle_usage_update(event),
             PutObjectState::CommitTransaction => self.handle_transaction_committed(event),
             PutObjectState::RegisterBlobInDht => self.handle_blob_registered_in_dht(event),
             PutObjectState::CleanupDuplicate => self.handle_duplicate_cleanup(event),
@@ -1062,7 +1145,15 @@ mod test {
             key: vec![0].into(),
             value: Some(existing.to_bytes().unwrap().into()),
         }));
+        let [Effect::Storage(StorageEffect::Read { key_space, .. })] = effects.as_slice() else {
+            panic!("expected liveness version read")
+        };
+        assert_eq!(key_space, BLOB_VERSIONS_KEYSPACE);
 
+        let effects = op.handle_liveness_version_read(Event::Storage(StorageEvent::ReadResult {
+            key: vec![0].into(),
+            value: None,
+        }));
         let [Effect::Storage(StorageEffect::Write { value, .. })] = effects.as_slice() else {
             panic!("expected current pointer write")
         };

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -1,0 +1,762 @@
+use aruna_core::effects::{Effect, IterStart, StorageEffect};
+use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::{
+    BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE, S3_BUCKET_KEYSPACE, USAGE_STATS_KEYSPACE,
+};
+use aruna_core::operation::Operation;
+use aruna_core::structs::{
+    BackendLocation, BlobVersion, BlobVersionState, BucketInfo, USAGE_GLOBAL_KEY, UsageCounters,
+    UsageDelta, VersionKey, usage_group_key,
+};
+use aruna_core::types::{Effects, GroupId, Key, TxnId, Value};
+use smallvec::smallvec;
+use std::collections::HashMap;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum UsageUpdateError {
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error("usage counter update received unexpected event: {0:?}")]
+    UnexpectedEvent(Event),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum UsageUpdatePhase {
+    Pending,
+    Reading,
+    Writing,
+    Done,
+}
+
+/// Embeddable read-modify-write of the maintained usage counters. Hosts run
+/// it inside their own transaction right before the commit so counter changes
+/// are atomic with the data they account for.
+#[derive(Clone, Debug, PartialEq)]
+pub struct UsageCounterUpdate {
+    entries: Vec<(Vec<u8>, UsageDelta)>,
+    phase: UsageUpdatePhase,
+}
+
+impl UsageCounterUpdate {
+    pub fn for_group(group_id: GroupId, delta: UsageDelta) -> Self {
+        Self {
+            entries: vec![
+                (USAGE_GLOBAL_KEY.to_vec(), delta),
+                (usage_group_key(group_id), delta),
+            ],
+            phase: UsageUpdatePhase::Pending,
+        }
+    }
+
+    pub fn with_global(
+        group_id: GroupId,
+        group_delta: UsageDelta,
+        global_delta: UsageDelta,
+    ) -> Self {
+        Self {
+            entries: vec![
+                (USAGE_GLOBAL_KEY.to_vec(), global_delta),
+                (usage_group_key(group_id), group_delta),
+            ],
+            phase: UsageUpdatePhase::Pending,
+        }
+    }
+
+    pub fn is_noop(&self) -> bool {
+        self.entries.iter().all(|(_, delta)| delta.is_zero())
+    }
+
+    pub fn start(&mut self, txn_id: TxnId) -> Effects {
+        self.phase = UsageUpdatePhase::Reading;
+        smallvec![Effect::Storage(StorageEffect::BatchRead {
+            reads: self
+                .entries
+                .iter()
+                .map(|(key, _)| (USAGE_STATS_KEYSPACE.to_string(), key.clone().into()))
+                .collect(),
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    /// Returns `Ok(Some(effects))` while more storage work is needed and
+    /// `Ok(None)` once the counters are written.
+    pub fn step(
+        &mut self,
+        event: Event,
+        txn_id: TxnId,
+    ) -> Result<Option<Effects>, UsageUpdateError> {
+        match (&self.phase, event) {
+            (
+                UsageUpdatePhase::Reading,
+                Event::Storage(StorageEvent::BatchReadResult { values }),
+            ) => {
+                let mut writes = Vec::with_capacity(self.entries.len());
+                for ((key, delta), (_, value)) in self.entries.iter().zip(values) {
+                    let mut counters = match value {
+                        Some(value) => UsageCounters::from_bytes(value.as_ref())?,
+                        None => UsageCounters::default(),
+                    };
+                    counters.apply(delta);
+                    writes.push((
+                        USAGE_STATS_KEYSPACE.to_string(),
+                        key.clone().into(),
+                        counters.to_bytes()?.into(),
+                    ));
+                }
+                self.phase = UsageUpdatePhase::Writing;
+                Ok(Some(smallvec![Effect::Storage(
+                    StorageEffect::BatchWrite {
+                        writes,
+                        txn_id: Some(txn_id),
+                    }
+                )]))
+            }
+            (UsageUpdatePhase::Writing, Event::Storage(StorageEvent::BatchWriteResult { .. })) => {
+                self.phase = UsageUpdatePhase::Done;
+                Ok(None)
+            }
+            (_, received) => Err(UsageUpdateError::UnexpectedEvent(received)),
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.phase == UsageUpdatePhase::Done
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RebuildUsageStatsState {
+    Init,
+    ScanBuckets,
+    ScanBlobs,
+    ScanVersions,
+    StartWriteTransaction,
+    WriteCounters,
+    CommitTransaction,
+    Finish,
+    Error,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum RebuildUsageStatsError {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error("State [{state:?}] invalid: expected [{expected:?}] - received [{received:?}]")]
+    InvalidStateEvent {
+        state: RebuildUsageStatsState,
+        expected: &'static str,
+        received: Event,
+    },
+    #[error("RebuildUsageStats failed")]
+    RebuildFailed,
+}
+
+/// Recomputes all usage counters from the underlying keyspaces and writes
+/// them in one transaction. Runs at startup when counters are missing and
+/// doubles as a repair tool; it is not safe to run concurrently with writes.
+/// An object counts as live when its newest version is not a delete marker,
+/// matching the pointer transitions the write operations maintain.
+#[derive(Debug, PartialEq)]
+pub struct RebuildUsageStatsOperation {
+    state: RebuildUsageStatsState,
+    txn_id: Option<TxnId>,
+    bucket_groups: HashMap<String, GroupId>,
+    blob_sizes: HashMap<Vec<u8>, u64>,
+    current_object: Option<(String, String)>,
+    current_newest: Option<(ulid::Ulid, bool)>,
+    global: UsageCounters,
+    groups: HashMap<GroupId, UsageCounters>,
+    output: Option<Result<UsageCounters, RebuildUsageStatsError>>,
+}
+
+impl Default for RebuildUsageStatsOperation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RebuildUsageStatsOperation {
+    const SCAN_LIMIT: usize = 1_000;
+
+    pub fn new() -> Self {
+        Self {
+            state: RebuildUsageStatsState::Init,
+            txn_id: None,
+            bucket_groups: HashMap::new(),
+            blob_sizes: HashMap::new(),
+            current_object: None,
+            current_newest: None,
+            global: UsageCounters::default(),
+            groups: HashMap::new(),
+            output: None,
+        }
+    }
+
+    fn emit_error(&mut self, error: RebuildUsageStatsError) -> Effects {
+        self.state = RebuildUsageStatsState::Error;
+        self.output = Some(Err(error));
+        smallvec![]
+    }
+
+    fn iter_effect(&self, key_space: &str, start_after: Option<Key>) -> Effect {
+        Effect::Storage(StorageEffect::Iter {
+            key_space: key_space.to_string(),
+            prefix: None,
+            start: start_after.map(IterStart::After),
+            limit: Self::SCAN_LIMIT,
+            txn_id: None,
+        })
+    }
+
+    fn scan_keyspace(&self) -> Option<&'static str> {
+        match self.state {
+            RebuildUsageStatsState::ScanBuckets => Some(S3_BUCKET_KEYSPACE),
+            RebuildUsageStatsState::ScanBlobs => Some(BLOB_LOCATIONS_KEYSPACE),
+            RebuildUsageStatsState::ScanVersions => Some(BLOB_VERSIONS_KEYSPACE),
+            _ => None,
+        }
+    }
+
+    fn group_entry(&mut self, group_id: GroupId) -> &mut UsageCounters {
+        self.groups.entry(group_id).or_default()
+    }
+
+    fn finalize_current_object(&mut self) {
+        let Some((bucket, _)) = self.current_object.take() else {
+            return;
+        };
+        let live = self
+            .current_newest
+            .take()
+            .is_some_and(|(_, deleted)| !deleted);
+        if !live {
+            return;
+        }
+        self.global.objects += 1;
+        if let Some(group_id) = self.bucket_groups.get(&bucket).copied() {
+            self.group_entry(group_id).objects += 1;
+        }
+    }
+
+    fn consume_values(&mut self, values: &[(Key, Value)]) -> Result<(), ConversionError> {
+        match self.state {
+            RebuildUsageStatsState::ScanBuckets => {
+                for (key, value) in values {
+                    let info = BucketInfo::from_bytes(value.as_ref())?;
+                    let bucket = String::from_utf8(key.to_vec())?;
+                    self.global.buckets += 1;
+                    self.group_entry(info.group_id).buckets += 1;
+                    self.bucket_groups.insert(bucket, info.group_id);
+                }
+            }
+            RebuildUsageStatsState::ScanBlobs => {
+                for (key, value) in values {
+                    let location = BackendLocation::from_bytes(value.as_ref())?;
+                    if location.staging || location.partial {
+                        continue;
+                    }
+                    self.global.stored_blobs += 1;
+                    self.global.stored_bytes =
+                        self.global.stored_bytes.saturating_add(location.blob_size);
+                    self.blob_sizes.insert(key.to_vec(), location.blob_size);
+                }
+            }
+            RebuildUsageStatsState::ScanVersions => {
+                for (key, value) in values {
+                    let version = BlobVersion::from_bytes(value.as_ref())?;
+                    let version_key = VersionKey::from_bytes(key.as_ref())?;
+                    let object = (version_key.bucket.clone(), version_key.key.clone());
+                    if self.current_object.as_ref() != Some(&object) {
+                        self.finalize_current_object();
+                        self.current_object = Some(object);
+                    }
+                    let deleted = version.is_deleted();
+                    if self
+                        .current_newest
+                        .is_none_or(|(newest, _)| version_key.version_id > newest)
+                    {
+                        self.current_newest = Some((version_key.version_id, deleted));
+                    }
+
+                    let BlobVersionState::Materialized { blob_hash, .. } = version.state else {
+                        continue;
+                    };
+                    let Some(size) = self.blob_sizes.get(blob_hash.as_slice()).copied() else {
+                        continue;
+                    };
+                    self.global.logical_bytes = self.global.logical_bytes.saturating_add(size);
+                    if let Some(group_id) = self.bucket_groups.get(&version_key.bucket).copied() {
+                        let group = self.group_entry(group_id);
+                        group.logical_bytes = group.logical_bytes.saturating_add(size);
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn next_scan(&mut self) -> Effects {
+        let next = match self.state {
+            RebuildUsageStatsState::ScanBuckets => RebuildUsageStatsState::ScanBlobs,
+            RebuildUsageStatsState::ScanBlobs => RebuildUsageStatsState::ScanVersions,
+            RebuildUsageStatsState::ScanVersions => {
+                self.finalize_current_object();
+                self.state = RebuildUsageStatsState::StartWriteTransaction;
+                return smallvec![Effect::Storage(StorageEffect::StartTransaction {
+                    read: false
+                })];
+            }
+            _ => return self.emit_error(RebuildUsageStatsError::RebuildFailed),
+        };
+        self.state = next;
+        let key_space = match self.scan_keyspace() {
+            Some(key_space) => key_space,
+            None => return self.emit_error(RebuildUsageStatsError::RebuildFailed),
+        };
+        smallvec![self.iter_effect(key_space, None)]
+    }
+
+    fn handle_page(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::IterResult {
+            values,
+            next_start_after,
+        }) = event
+        else {
+            return self.emit_error(RebuildUsageStatsError::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::IterResult)",
+                received: event,
+            });
+        };
+
+        if let Err(err) = self.consume_values(&values) {
+            return self.emit_error(err.into());
+        }
+
+        if let Some(start_after) = next_start_after {
+            let key_space = match self.scan_keyspace() {
+                Some(key_space) => key_space,
+                None => return self.emit_error(RebuildUsageStatsError::RebuildFailed),
+            };
+            return smallvec![self.iter_effect(key_space, Some(start_after))];
+        }
+
+        self.next_scan()
+    }
+
+    fn handle_write_transaction_started(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = event else {
+            return self.emit_error(RebuildUsageStatsError::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::TransactionStarted)",
+                received: event,
+            });
+        };
+        self.txn_id = Some(txn_id);
+
+        let mut writes = Vec::with_capacity(1 + self.groups.len());
+        let global = match self.global.to_bytes() {
+            Ok(bytes) => bytes,
+            Err(err) => return self.emit_error(err.into()),
+        };
+        writes.push((
+            USAGE_STATS_KEYSPACE.to_string(),
+            USAGE_GLOBAL_KEY.to_vec().into(),
+            global.into(),
+        ));
+        for (group_id, counters) in &self.groups {
+            let bytes = match counters.to_bytes() {
+                Ok(bytes) => bytes,
+                Err(err) => return self.emit_error(err.into()),
+            };
+            writes.push((
+                USAGE_STATS_KEYSPACE.to_string(),
+                usage_group_key(*group_id).into(),
+                bytes.into(),
+            ));
+        }
+
+        self.state = RebuildUsageStatsState::WriteCounters;
+        smallvec![Effect::Storage(StorageEffect::BatchWrite {
+            writes,
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    fn handle_counters_written(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::BatchWriteResult { .. }) = event else {
+            return self.emit_error(RebuildUsageStatsError::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::BatchWriteResult)",
+                received: event,
+            });
+        };
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(RebuildUsageStatsError::RebuildFailed);
+        };
+        self.state = RebuildUsageStatsState::CommitTransaction;
+        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+    }
+
+    fn handle_transaction_committed(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::TransactionCommitted { .. }) = event else {
+            return self.emit_error(RebuildUsageStatsError::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::TransactionCommitted)",
+                received: event,
+            });
+        };
+        self.state = RebuildUsageStatsState::Finish;
+        self.output = Some(Ok(self.global));
+        smallvec![]
+    }
+}
+
+impl Operation for RebuildUsageStatsOperation {
+    type Output = Option<Result<UsageCounters, RebuildUsageStatsError>>;
+    type Error = RebuildUsageStatsError;
+
+    fn start(&mut self) -> Effects {
+        self.state = RebuildUsageStatsState::ScanBuckets;
+        smallvec![self.iter_effect(S3_BUCKET_KEYSPACE, None)]
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        if let Event::Storage(StorageEvent::Error { error }) = event {
+            return self.emit_error(RebuildUsageStatsError::StorageError(error));
+        }
+
+        match self.state {
+            RebuildUsageStatsState::Init => self.start(),
+            RebuildUsageStatsState::ScanBuckets
+            | RebuildUsageStatsState::ScanBlobs
+            | RebuildUsageStatsState::ScanVersions => self.handle_page(event),
+            RebuildUsageStatsState::StartWriteTransaction => {
+                self.handle_write_transaction_started(event)
+            }
+            RebuildUsageStatsState::WriteCounters => self.handle_counters_written(event),
+            RebuildUsageStatsState::CommitTransaction => self.handle_transaction_committed(event),
+            RebuildUsageStatsState::Finish | RebuildUsageStatsState::Error => smallvec![],
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            RebuildUsageStatsState::Finish | RebuildUsageStatsState::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        if self.state == RebuildUsageStatsState::Error {
+            if let Some(Err(error)) = self.output {
+                return Err(error);
+            }
+            return Err(RebuildUsageStatsError::RebuildFailed);
+        }
+        Ok(self.output)
+    }
+
+    fn abort(&mut self) -> Effects {
+        match self.txn_id {
+            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
+            None => smallvec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::{DriverContext, drive};
+    use crate::s3::create_bucket::CreateBucketOperation;
+    use aruna_core::structs::{BlobHeadKey, BucketInfo, CurrentVersionPointer};
+    use std::time::SystemTime;
+    use tempfile::tempdir;
+    use ulid::Ulid;
+
+    fn test_ctx(root: &str) -> DriverContext {
+        DriverContext {
+            storage_handle: aruna_storage::FjallStorage::open(root).unwrap(),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        }
+    }
+
+    fn location(blob_size: u64, staging: bool, partial: bool) -> BackendLocation {
+        BackendLocation {
+            root: "/tmp".to_string(),
+            storage_bucket: "bucket".to_string(),
+            backend_path: "path".to_string(),
+            ulid: Ulid::new(),
+            compressed: false,
+            encrypted: false,
+            created_at: SystemTime::now(),
+            created_by: Default::default(),
+            staging,
+            partial,
+            blob_size,
+            hashes: std::collections::HashMap::new(),
+        }
+    }
+
+    async fn read_counters(ctx: &DriverContext, key: Vec<u8>) -> UsageCounters {
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Read {
+                key_space: USAGE_STATS_KEYSPACE.to_string(),
+                key: key.into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::ReadResult {
+                value: Some(bytes), ..
+            }) => UsageCounters::from_bytes(&bytes).unwrap(),
+            Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
+                UsageCounters::default()
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn counter_update_applies_deltas_with_synthetic_events() {
+        let group_id = Ulid::new();
+        let txn_id = Ulid::new();
+        let mut update = UsageCounterUpdate::for_group(
+            group_id,
+            UsageDelta {
+                objects: 1,
+                logical_bytes: 42,
+                ..Default::default()
+            },
+        );
+
+        let effects = update.start(txn_id);
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::BatchRead { reads, .. })] if reads.len() == 2
+        ));
+
+        let existing = UsageCounters {
+            objects: 5,
+            logical_bytes: 100,
+            ..Default::default()
+        };
+        let effects = update
+            .step(
+                Event::Storage(StorageEvent::BatchReadResult {
+                    values: vec![
+                        (
+                            USAGE_GLOBAL_KEY.to_vec().into(),
+                            Some(existing.to_bytes().unwrap().into()),
+                        ),
+                        (usage_group_key(group_id).into(), None),
+                    ],
+                }),
+                txn_id,
+            )
+            .unwrap()
+            .unwrap();
+
+        let [Effect::Storage(StorageEffect::BatchWrite { writes, .. })] = effects.as_slice() else {
+            panic!("expected counter batch write");
+        };
+        let global = UsageCounters::from_bytes(writes[0].2.as_ref()).unwrap();
+        assert_eq!(global.objects, 6);
+        assert_eq!(global.logical_bytes, 142);
+        let group = UsageCounters::from_bytes(writes[1].2.as_ref()).unwrap();
+        assert_eq!(group.objects, 1);
+        assert_eq!(group.logical_bytes, 42);
+
+        let done = update
+            .step(
+                Event::Storage(StorageEvent::BatchWriteResult {
+                    entries: Vec::new(),
+                }),
+                txn_id,
+            )
+            .unwrap();
+        assert!(done.is_none());
+        assert!(update.is_done());
+    }
+
+    #[tokio::test]
+    async fn create_bucket_maintains_usage_counters() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let group_id = Ulid::new();
+
+        drive(
+            CreateBucketOperation::new(
+                "counted".to_string(),
+                BucketInfo {
+                    group_id,
+                    created_at: SystemTime::now(),
+                    created_by: Default::default(),
+                },
+            ),
+            &ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        let global = read_counters(&ctx, USAGE_GLOBAL_KEY.to_vec()).await;
+        assert_eq!(global.buckets, 1);
+        let group = read_counters(&ctx, usage_group_key(group_id)).await;
+        assert_eq!(group.buckets, 1);
+    }
+
+    #[tokio::test]
+    async fn rebuild_counts_live_objects_logical_and_stored_bytes() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let group_a = Ulid::new();
+        let group_b = Ulid::new();
+
+        let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::StartTransaction { read: false })
+            .await
+        else {
+            panic!("failed to start transaction");
+        };
+
+        for (bucket, group_id) in [("alpha", group_a), ("beta", group_b)] {
+            let info = BucketInfo {
+                group_id,
+                created_at: SystemTime::now(),
+                created_by: Default::default(),
+            };
+            ctx.storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: S3_BUCKET_KEYSPACE.to_string(),
+                    key: bucket.as_bytes().to_vec().into(),
+                    value: info.to_bytes().unwrap().into(),
+                    txn_id: Some(txn_id),
+                })
+                .await;
+        }
+
+        // Two completed blobs plus one staging blob that must not count.
+        let live = location(100, false, false);
+        let shared = location(40, false, false);
+        let staged = location(7, true, false);
+        let mut hashes = Vec::new();
+        for (index, loc) in [&live, &shared, &staged].into_iter().enumerate() {
+            let hash = [index as u8 + 1; 32];
+            hashes.push(hash);
+            ctx.storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_LOCATIONS_KEYSPACE.to_string(),
+                    key: hash.to_vec().into(),
+                    value: loc.to_bytes().unwrap().into(),
+                    txn_id: Some(txn_id),
+                })
+                .await;
+        }
+
+        // alpha/live.txt: one materialized version, live.
+        // alpha/gone.txt: materialized version superseded by a delete marker.
+        // beta/shared.bin: two materialized versions of the shared blob.
+        let mut write_version = async |bucket: &str, key: &str, version: BlobVersion| {
+            let version_id = Ulid::new();
+            ctx.storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+                    key: VersionKey::new(bucket, key, version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    value: version.to_bytes().unwrap().into(),
+                    txn_id: Some(txn_id),
+                })
+                .await;
+            version_id
+        };
+
+        let now = SystemTime::now();
+        let user = Default::default();
+        write_version(
+            "alpha",
+            "live.txt",
+            BlobVersion::materialized(hashes[0], now, user, None),
+        )
+        .await;
+        write_version(
+            "alpha",
+            "gone.txt",
+            BlobVersion::materialized(hashes[1], now, user, None),
+        )
+        .await;
+        write_version("alpha", "gone.txt", BlobVersion::deleted(now, user)).await;
+        write_version(
+            "beta",
+            "shared.bin",
+            BlobVersion::materialized(hashes[1], now, user, None),
+        )
+        .await;
+        let beta_head = write_version(
+            "beta",
+            "shared.bin",
+            BlobVersion::materialized(hashes[1], now, user, None),
+        )
+        .await;
+
+        ctx.storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: aruna_core::keyspaces::BLOB_HEAD_KEYSPACE.to_string(),
+                key: BlobHeadKey::new("beta", "shared.bin")
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                value: CurrentVersionPointer::new(beta_head)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+                txn_id: Some(txn_id),
+            })
+            .await;
+
+        ctx.storage_handle
+            .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
+            .await;
+
+        let global = drive(RebuildUsageStatsOperation::new(), &ctx)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        // live.txt and shared.bin are live; gone.txt ends on a delete marker.
+        assert_eq!(global.buckets, 2);
+        assert_eq!(global.objects, 2);
+        assert_eq!(global.stored_blobs, 2);
+        assert_eq!(global.stored_bytes, 140);
+        // 100 + 40 + 40 + 40: every materialized version counts logically.
+        assert_eq!(global.logical_bytes, 220);
+
+        let stored_global = read_counters(&ctx, USAGE_GLOBAL_KEY.to_vec()).await;
+        assert_eq!(stored_global, global);
+
+        let alpha = read_counters(&ctx, usage_group_key(group_a)).await;
+        assert_eq!(alpha.buckets, 1);
+        assert_eq!(alpha.objects, 1);
+        assert_eq!(alpha.logical_bytes, 140);
+
+        let beta = read_counters(&ctx, usage_group_key(group_b)).await;
+        assert_eq!(beta.buckets, 1);
+        assert_eq!(beta.objects, 1);
+        assert_eq!(beta.logical_bytes, 80);
+    }
+}

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -2,22 +2,26 @@ use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
-    BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE, S3_BUCKET_KEYSPACE, USAGE_STATS_KEYSPACE,
+    BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE, S3_BUCKET_KEYSPACE,
+    USAGE_STATS_KEYSPACE,
 };
 use aruna_core::operation::Operation;
 use aruna_core::structs::{
-    BackendLocation, BlobVersion, BlobVersionState, BucketInfo, USAGE_GLOBAL_KEY, UsageCounters,
-    UsageDelta, VersionKey, usage_group_key,
+    BackendLocation, BlobHeadKey, BlobVersion, BlobVersionState, BucketInfo, CurrentVersionPointer,
+    USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta, VersionKey,
+    usage_global_key_for_group, usage_global_shard_index, usage_global_shard_key, usage_group_key,
 };
 use aruna_core::types::{Effects, GroupId, Key, TxnId, Value};
 use smallvec::smallvec;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum UsageUpdateError {
     #[error(transparent)]
     ConversionError(#[from] ConversionError),
+    #[error(transparent)]
+    CounterError(#[from] UsageCounterError),
     #[error("usage counter update received unexpected event: {0:?}")]
     UnexpectedEvent(Event),
 }
@@ -43,7 +47,7 @@ impl UsageCounterUpdate {
     pub fn for_group(group_id: GroupId, delta: UsageDelta) -> Self {
         Self {
             entries: vec![
-                (USAGE_GLOBAL_KEY.to_vec(), delta),
+                (usage_global_key_for_group(group_id), delta),
                 (usage_group_key(group_id), delta),
             ],
             phase: UsageUpdatePhase::Pending,
@@ -57,7 +61,7 @@ impl UsageCounterUpdate {
     ) -> Self {
         Self {
             entries: vec![
-                (USAGE_GLOBAL_KEY.to_vec(), global_delta),
+                (usage_global_key_for_group(group_id), global_delta),
                 (usage_group_key(group_id), group_delta),
             ],
             phase: UsageUpdatePhase::Pending,
@@ -98,7 +102,7 @@ impl UsageCounterUpdate {
                         Some(value) => UsageCounters::from_bytes(value.as_ref())?,
                         None => UsageCounters::default(),
                     };
-                    counters.apply(delta);
+                    counters.apply(delta)?;
                     writes.push((
                         USAGE_STATS_KEYSPACE.to_string(),
                         key.clone().into(),
@@ -131,9 +135,12 @@ pub enum RebuildUsageStatsState {
     Init,
     ScanBuckets,
     ScanBlobs,
+    ScanHeads,
     ScanVersions,
+    ScanCounters,
     StartWriteTransaction,
     WriteCounters,
+    DeleteStaleCounters,
     CommitTransaction,
     Finish,
     Error,
@@ -145,6 +152,8 @@ pub enum RebuildUsageStatsError {
     StorageError(#[from] StorageError),
     #[error(transparent)]
     ConversionError(#[from] ConversionError),
+    #[error(transparent)]
+    CounterError(#[from] UsageCounterError),
     #[error("State [{state:?}] invalid: expected [{expected:?}] - received [{received:?}]")]
     InvalidStateEvent {
         state: RebuildUsageStatsState,
@@ -158,18 +167,20 @@ pub enum RebuildUsageStatsError {
 /// Recomputes all usage counters from the underlying keyspaces and writes
 /// them in one transaction. Runs at startup when counters are missing and
 /// doubles as a repair tool; it is not safe to run concurrently with writes.
-/// An object counts as live when its newest version is not a delete marker,
-/// matching the pointer transitions the write operations maintain.
+/// An object counts as live when its current head points at a non-delete
+/// version, matching the pointer transitions the write operations maintain.
 #[derive(Debug, PartialEq)]
 pub struct RebuildUsageStatsOperation {
     state: RebuildUsageStatsState,
     txn_id: Option<TxnId>,
     bucket_groups: HashMap<String, GroupId>,
     blob_sizes: HashMap<Vec<u8>, u64>,
-    current_object: Option<(String, String)>,
-    current_newest: Option<(ulid::Ulid, bool)>,
+    current_versions: HashMap<(String, String), ulid::Ulid>,
     global: UsageCounters,
+    global_shards: Vec<UsageCounters>,
     groups: HashMap<GroupId, UsageCounters>,
+    existing_counter_keys: Vec<Vec<u8>>,
+    stale_counter_deletes: Vec<(String, Key)>,
     output: Option<Result<UsageCounters, RebuildUsageStatsError>>,
 }
 
@@ -188,10 +199,12 @@ impl RebuildUsageStatsOperation {
             txn_id: None,
             bucket_groups: HashMap::new(),
             blob_sizes: HashMap::new(),
-            current_object: None,
-            current_newest: None,
+            current_versions: HashMap::new(),
             global: UsageCounters::default(),
+            global_shards: vec![UsageCounters::default(); USAGE_GLOBAL_SHARD_COUNT],
             groups: HashMap::new(),
+            existing_counter_keys: Vec::new(),
+            stale_counter_deletes: Vec::new(),
             output: None,
         }
     }
@@ -216,7 +229,9 @@ impl RebuildUsageStatsOperation {
         match self.state {
             RebuildUsageStatsState::ScanBuckets => Some(S3_BUCKET_KEYSPACE),
             RebuildUsageStatsState::ScanBlobs => Some(BLOB_LOCATIONS_KEYSPACE),
+            RebuildUsageStatsState::ScanHeads => Some(BLOB_HEAD_KEYSPACE),
             RebuildUsageStatsState::ScanVersions => Some(BLOB_VERSIONS_KEYSPACE),
+            RebuildUsageStatsState::ScanCounters => Some(USAGE_STATS_KEYSPACE),
             _ => None,
         }
     }
@@ -225,31 +240,23 @@ impl RebuildUsageStatsOperation {
         self.groups.entry(group_id).or_default()
     }
 
-    fn finalize_current_object(&mut self) {
-        let Some((bucket, _)) = self.current_object.take() else {
-            return;
-        };
-        let live = self
-            .current_newest
-            .take()
-            .is_some_and(|(_, deleted)| !deleted);
-        if !live {
-            return;
-        }
-        self.global.objects += 1;
-        if let Some(group_id) = self.bucket_groups.get(&bucket).copied() {
-            self.group_entry(group_id).objects += 1;
-        }
+    fn global_shard_entry(&mut self, group_id: GroupId) -> &mut UsageCounters {
+        &mut self.global_shards[usage_global_shard_index(group_id)]
     }
 
-    fn consume_values(&mut self, values: &[(Key, Value)]) -> Result<(), ConversionError> {
+    fn consume_values(&mut self, values: &[(Key, Value)]) -> Result<(), RebuildUsageStatsError> {
         match self.state {
             RebuildUsageStatsState::ScanBuckets => {
                 for (key, value) in values {
                     let info = BucketInfo::from_bytes(value.as_ref())?;
-                    let bucket = String::from_utf8(key.to_vec())?;
-                    self.global.buckets += 1;
-                    self.group_entry(info.group_id).buckets += 1;
+                    let bucket = String::from_utf8(key.to_vec()).map_err(ConversionError::from)?;
+                    let delta = UsageCounters {
+                        buckets: 1,
+                        ..Default::default()
+                    };
+                    self.global.add(&delta)?;
+                    self.group_entry(info.group_id).add(&delta)?;
+                    self.global_shard_entry(info.group_id).add(&delta)?;
                     self.bucket_groups.insert(bucket, info.group_id);
                 }
             }
@@ -259,10 +266,22 @@ impl RebuildUsageStatsOperation {
                     if location.staging || location.partial {
                         continue;
                     }
-                    self.global.stored_blobs += 1;
-                    self.global.stored_bytes =
-                        self.global.stored_bytes.saturating_add(location.blob_size);
+                    let delta = UsageCounters {
+                        stored_blobs: 1,
+                        stored_bytes: location.blob_size,
+                        ..Default::default()
+                    };
+                    self.global.add(&delta)?;
+                    self.global_shards[0].add(&delta)?;
                     self.blob_sizes.insert(key.to_vec(), location.blob_size);
+                }
+            }
+            RebuildUsageStatsState::ScanHeads => {
+                for (key, value) in values {
+                    let head_key = BlobHeadKey::from_bytes(key.as_ref())?;
+                    let pointer = CurrentVersionPointer::from_bytes(value.as_ref())?;
+                    self.current_versions
+                        .insert((head_key.bucket, head_key.key), pointer.version_id);
                 }
             }
             RebuildUsageStatsState::ScanVersions => {
@@ -270,16 +289,24 @@ impl RebuildUsageStatsOperation {
                     let version = BlobVersion::from_bytes(value.as_ref())?;
                     let version_key = VersionKey::from_bytes(key.as_ref())?;
                     let object = (version_key.bucket.clone(), version_key.key.clone());
-                    if self.current_object.as_ref() != Some(&object) {
-                        self.finalize_current_object();
-                        self.current_object = Some(object);
-                    }
-                    let deleted = version.is_deleted();
                     if self
-                        .current_newest
-                        .is_none_or(|(newest, _)| version_key.version_id > newest)
+                        .current_versions
+                        .get(&object)
+                        .is_some_and(|version_id| *version_id == version_key.version_id)
+                        && !version.is_deleted()
                     {
-                        self.current_newest = Some((version_key.version_id, deleted));
+                        let delta = UsageCounters {
+                            objects: 1,
+                            ..Default::default()
+                        };
+                        self.global.add(&delta)?;
+                        if let Some(group_id) = self.bucket_groups.get(&version_key.bucket).copied()
+                        {
+                            self.group_entry(group_id).add(&delta)?;
+                            self.global_shard_entry(group_id).add(&delta)?;
+                        } else {
+                            self.global_shards[0].add(&delta)?;
+                        }
                     }
 
                     let BlobVersionState::Materialized { blob_hash, .. } = version.state else {
@@ -288,12 +315,22 @@ impl RebuildUsageStatsOperation {
                     let Some(size) = self.blob_sizes.get(blob_hash.as_slice()).copied() else {
                         continue;
                     };
-                    self.global.logical_bytes = self.global.logical_bytes.saturating_add(size);
+                    let delta = UsageCounters {
+                        logical_bytes: size,
+                        ..Default::default()
+                    };
+                    self.global.add(&delta)?;
                     if let Some(group_id) = self.bucket_groups.get(&version_key.bucket).copied() {
-                        let group = self.group_entry(group_id);
-                        group.logical_bytes = group.logical_bytes.saturating_add(size);
+                        self.group_entry(group_id).add(&delta)?;
+                        self.global_shard_entry(group_id).add(&delta)?;
+                    } else {
+                        self.global_shards[0].add(&delta)?;
                     }
                 }
+            }
+            RebuildUsageStatsState::ScanCounters => {
+                self.existing_counter_keys
+                    .extend(values.iter().map(|(key, _)| key.to_vec()));
             }
             _ => {}
         }
@@ -303,9 +340,10 @@ impl RebuildUsageStatsOperation {
     fn next_scan(&mut self) -> Effects {
         let next = match self.state {
             RebuildUsageStatsState::ScanBuckets => RebuildUsageStatsState::ScanBlobs,
-            RebuildUsageStatsState::ScanBlobs => RebuildUsageStatsState::ScanVersions,
-            RebuildUsageStatsState::ScanVersions => {
-                self.finalize_current_object();
+            RebuildUsageStatsState::ScanBlobs => RebuildUsageStatsState::ScanHeads,
+            RebuildUsageStatsState::ScanHeads => RebuildUsageStatsState::ScanVersions,
+            RebuildUsageStatsState::ScanVersions => RebuildUsageStatsState::ScanCounters,
+            RebuildUsageStatsState::ScanCounters => {
                 self.state = RebuildUsageStatsState::StartWriteTransaction;
                 return smallvec![Effect::Storage(StorageEffect::StartTransaction {
                     read: false
@@ -335,7 +373,7 @@ impl RebuildUsageStatsOperation {
         };
 
         if let Err(err) = self.consume_values(&values) {
-            return self.emit_error(err.into());
+            return self.emit_error(err);
         }
 
         if let Some(start_after) = next_start_after {
@@ -359,27 +397,32 @@ impl RebuildUsageStatsOperation {
         };
         self.txn_id = Some(txn_id);
 
-        let mut writes = Vec::with_capacity(1 + self.groups.len());
-        let global = match self.global.to_bytes() {
-            Ok(bytes) => bytes,
-            Err(err) => return self.emit_error(err.into()),
-        };
-        writes.push((
-            USAGE_STATS_KEYSPACE.to_string(),
-            USAGE_GLOBAL_KEY.to_vec().into(),
-            global.into(),
-        ));
-        for (group_id, counters) in &self.groups {
+        let mut writes = Vec::with_capacity(USAGE_GLOBAL_SHARD_COUNT + self.groups.len());
+        let mut write_keys = HashSet::with_capacity(USAGE_GLOBAL_SHARD_COUNT + self.groups.len());
+        for (shard, counters) in self.global_shards.iter().enumerate() {
+            let key = usage_global_shard_key(shard);
             let bytes = match counters.to_bytes() {
                 Ok(bytes) => bytes,
                 Err(err) => return self.emit_error(err.into()),
             };
-            writes.push((
-                USAGE_STATS_KEYSPACE.to_string(),
-                usage_group_key(*group_id).into(),
-                bytes.into(),
-            ));
+            write_keys.insert(key.clone());
+            writes.push((USAGE_STATS_KEYSPACE.to_string(), key.into(), bytes.into()));
         }
+        for (group_id, counters) in &self.groups {
+            let key = usage_group_key(*group_id);
+            let bytes = match counters.to_bytes() {
+                Ok(bytes) => bytes,
+                Err(err) => return self.emit_error(err.into()),
+            };
+            write_keys.insert(key.clone());
+            writes.push((USAGE_STATS_KEYSPACE.to_string(), key.into(), bytes.into()));
+        }
+        self.stale_counter_deletes = self
+            .existing_counter_keys
+            .iter()
+            .filter(|key| !write_keys.contains(*key))
+            .map(|key| (USAGE_STATS_KEYSPACE.to_string(), key.clone().into()))
+            .collect();
 
         self.state = RebuildUsageStatsState::WriteCounters;
         smallvec![Effect::Storage(StorageEffect::BatchWrite {
@@ -393,6 +436,28 @@ impl RebuildUsageStatsOperation {
             return self.emit_error(RebuildUsageStatsError::InvalidStateEvent {
                 state: self.state.clone(),
                 expected: "Event::Storage(StorageEvent::BatchWriteResult)",
+                received: event,
+            });
+        };
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(RebuildUsageStatsError::RebuildFailed);
+        };
+        if !self.stale_counter_deletes.is_empty() {
+            self.state = RebuildUsageStatsState::DeleteStaleCounters;
+            return smallvec![Effect::Storage(StorageEffect::BatchDelete {
+                deletes: std::mem::take(&mut self.stale_counter_deletes),
+                txn_id: Some(txn_id),
+            })];
+        }
+        self.state = RebuildUsageStatsState::CommitTransaction;
+        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+    }
+
+    fn handle_stale_counters_deleted(&mut self, event: Event) -> Effects {
+        let Event::Storage(StorageEvent::BatchDeleteResult { .. }) = event else {
+            return self.emit_error(RebuildUsageStatsError::InvalidStateEvent {
+                state: self.state.clone(),
+                expected: "Event::Storage(StorageEvent::BatchDeleteResult)",
                 received: event,
             });
         };
@@ -435,11 +500,16 @@ impl Operation for RebuildUsageStatsOperation {
             RebuildUsageStatsState::Init => self.start(),
             RebuildUsageStatsState::ScanBuckets
             | RebuildUsageStatsState::ScanBlobs
-            | RebuildUsageStatsState::ScanVersions => self.handle_page(event),
+            | RebuildUsageStatsState::ScanHeads
+            | RebuildUsageStatsState::ScanVersions
+            | RebuildUsageStatsState::ScanCounters => self.handle_page(event),
             RebuildUsageStatsState::StartWriteTransaction => {
                 self.handle_write_transaction_started(event)
             }
             RebuildUsageStatsState::WriteCounters => self.handle_counters_written(event),
+            RebuildUsageStatsState::DeleteStaleCounters => {
+                self.handle_stale_counters_deleted(event)
+            }
             RebuildUsageStatsState::CommitTransaction => self.handle_transaction_committed(event),
             RebuildUsageStatsState::Finish | RebuildUsageStatsState::Error => smallvec![],
         }
@@ -475,7 +545,9 @@ mod tests {
     use super::*;
     use crate::driver::{DriverContext, drive};
     use crate::s3::create_bucket::CreateBucketOperation;
-    use aruna_core::structs::{BlobHeadKey, BucketInfo, CurrentVersionPointer};
+    use aruna_core::structs::{
+        BlobHeadKey, BucketInfo, CurrentVersionPointer, usage_global_shard_keys,
+    };
     use std::time::SystemTime;
     use tempfile::tempdir;
     use ulid::Ulid;
@@ -507,7 +579,7 @@ mod tests {
         }
     }
 
-    async fn read_counters(ctx: &DriverContext, key: Vec<u8>) -> UsageCounters {
+    async fn read_optional_counters(ctx: &DriverContext, key: Vec<u8>) -> Option<UsageCounters> {
         match ctx
             .storage_handle
             .send_storage_effect(StorageEffect::Read {
@@ -519,12 +591,22 @@ mod tests {
         {
             Event::Storage(StorageEvent::ReadResult {
                 value: Some(bytes), ..
-            }) => UsageCounters::from_bytes(&bytes).unwrap(),
-            Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
-                UsageCounters::default()
-            }
+            }) => Some(UsageCounters::from_bytes(&bytes).unwrap()),
+            Event::Storage(StorageEvent::ReadResult { value: None, .. }) => None,
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    async fn read_counters(ctx: &DriverContext, key: Vec<u8>) -> UsageCounters {
+        read_optional_counters(ctx, key).await.unwrap_or_default()
+    }
+
+    async fn read_global_counters(ctx: &DriverContext) -> UsageCounters {
+        let mut total = UsageCounters::default();
+        for key in usage_global_shard_keys() {
+            total.add(&read_counters(ctx, key).await).unwrap();
+        }
+        total
     }
 
     #[test]
@@ -556,7 +638,7 @@ mod tests {
                 Event::Storage(StorageEvent::BatchReadResult {
                     values: vec![
                         (
-                            USAGE_GLOBAL_KEY.to_vec().into(),
+                            usage_global_key_for_group(group_id).into(),
                             Some(existing.to_bytes().unwrap().into()),
                         ),
                         (usage_group_key(group_id).into(), None),
@@ -602,6 +684,7 @@ mod tests {
                     group_id,
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
+                    cors_configuration: None,
                 },
             ),
             &ctx,
@@ -611,7 +694,7 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        let global = read_counters(&ctx, USAGE_GLOBAL_KEY.to_vec()).await;
+        let global = read_global_counters(&ctx).await;
         assert_eq!(global.buckets, 1);
         let group = read_counters(&ctx, usage_group_key(group_id)).await;
         assert_eq!(group.buckets, 1);
@@ -637,6 +720,7 @@ mod tests {
                 group_id,
                 created_at: SystemTime::now(),
                 created_by: Default::default(),
+                cors_configuration: None,
             };
             ctx.storage_handle
                 .send_storage_effect(StorageEffect::Write {
@@ -669,7 +753,7 @@ mod tests {
         // alpha/live.txt: one materialized version, live.
         // alpha/gone.txt: materialized version superseded by a delete marker.
         // beta/shared.bin: two materialized versions of the shared blob.
-        let mut write_version = async |bucket: &str, key: &str, version: BlobVersion| {
+        let write_version = async |bucket: &str, key: &str, version: BlobVersion| {
             let version_id = Ulid::new();
             ctx.storage_handle
                 .send_storage_effect(StorageEffect::Write {
@@ -684,10 +768,23 @@ mod tests {
                 .await;
             version_id
         };
+        let write_head = async |bucket: &str, key: &str, version_id: Ulid| {
+            ctx.storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: BLOB_HEAD_KEYSPACE.to_string(),
+                    key: BlobHeadKey::new(bucket, key).to_bytes().unwrap().into(),
+                    value: CurrentVersionPointer::new(version_id)
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    txn_id: Some(txn_id),
+                })
+                .await;
+        };
 
         let now = SystemTime::now();
         let user = Default::default();
-        write_version(
+        let alpha_live_head = write_version(
             "alpha",
             "live.txt",
             BlobVersion::materialized(hashes[0], now, user, None),
@@ -699,7 +796,8 @@ mod tests {
             BlobVersion::materialized(hashes[1], now, user, None),
         )
         .await;
-        write_version("alpha", "gone.txt", BlobVersion::deleted(now, user)).await;
+        let alpha_gone_head =
+            write_version("alpha", "gone.txt", BlobVersion::deleted(now, user)).await;
         write_version(
             "beta",
             "shared.bin",
@@ -713,20 +811,9 @@ mod tests {
         )
         .await;
 
-        ctx.storage_handle
-            .send_storage_effect(StorageEffect::Write {
-                key_space: aruna_core::keyspaces::BLOB_HEAD_KEYSPACE.to_string(),
-                key: BlobHeadKey::new("beta", "shared.bin")
-                    .to_bytes()
-                    .unwrap()
-                    .into(),
-                value: CurrentVersionPointer::new(beta_head)
-                    .to_bytes()
-                    .unwrap()
-                    .into(),
-                txn_id: Some(txn_id),
-            })
-            .await;
+        write_head("alpha", "live.txt", alpha_live_head).await;
+        write_head("alpha", "gone.txt", alpha_gone_head).await;
+        write_head("beta", "shared.bin", beta_head).await;
 
         ctx.storage_handle
             .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
@@ -746,7 +833,7 @@ mod tests {
         // 100 + 40 + 40 + 40: every materialized version counts logically.
         assert_eq!(global.logical_bytes, 220);
 
-        let stored_global = read_counters(&ctx, USAGE_GLOBAL_KEY.to_vec()).await;
+        let stored_global = read_global_counters(&ctx).await;
         assert_eq!(stored_global, global);
 
         let alpha = read_counters(&ctx, usage_group_key(group_a)).await;
@@ -758,5 +845,61 @@ mod tests {
         assert_eq!(beta.buckets, 1);
         assert_eq!(beta.objects, 1);
         assert_eq!(beta.logical_bytes, 80);
+    }
+
+    #[tokio::test]
+    async fn rebuild_removes_stale_usage_counter_keys() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let stale_group = Ulid::new();
+        let stale_key = usage_group_key(stale_group);
+
+        ctx.storage_handle
+            .send_storage_effect(StorageEffect::BatchWrite {
+                writes: vec![
+                    (
+                        USAGE_STATS_KEYSPACE.to_string(),
+                        stale_key.clone().into(),
+                        UsageCounters {
+                            buckets: 9,
+                            ..Default::default()
+                        }
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    ),
+                    (
+                        USAGE_STATS_KEYSPACE.to_string(),
+                        b"global".to_vec().into(),
+                        UsageCounters {
+                            objects: 9,
+                            ..Default::default()
+                        }
+                        .to_bytes()
+                        .unwrap()
+                        .into(),
+                    ),
+                ],
+                txn_id: None,
+            })
+            .await;
+
+        drive(RebuildUsageStatsOperation::new(), &ctx)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert!(read_optional_counters(&ctx, stale_key).await.is_none());
+        assert!(
+            read_optional_counters(&ctx, b"global".to_vec())
+                .await
+                .is_none()
+        );
+        assert!(
+            read_optional_counters(&ctx, usage_global_shard_key(0))
+                .await
+                .is_some()
+        );
     }
 }

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -225,14 +225,10 @@ impl Operation for LoadUsageCountersOperation {
     fn start(&mut self) -> Effects {
         if self.key.as_slice() == USAGE_GLOBAL_KEY {
             self.state = LoadUsageCountersState::ReadGlobal;
-            let mut reads = usage_global_shard_keys()
+            let reads = usage_global_shard_keys()
                 .into_iter()
                 .map(|key| (USAGE_STATS_KEYSPACE.to_string(), key.into()))
                 .collect::<Vec<_>>();
-            reads.push((
-                USAGE_STATS_KEYSPACE.to_string(),
-                USAGE_GLOBAL_KEY.to_vec().into(),
-            ));
             smallvec![Effect::Storage(StorageEffect::BatchRead {
                 reads,
                 txn_id: None,
@@ -277,28 +273,16 @@ fn sum_global_usage_counters(
     values: Vec<(Key, Option<Value>)>,
 ) -> Result<UsageCounters, LoadUsageCountersError> {
     let mut total = UsageCounters::default();
-    let mut saw_shard = false;
-    let mut legacy = None;
-    let shard_count = values.len().saturating_sub(1);
 
-    for (index, (_, value)) in values.into_iter().enumerate() {
+    for (_, value) in values {
         let Some(bytes) = value else {
             continue;
         };
         let counters = UsageCounters::from_bytes(bytes.as_ref())?;
-        if index < shard_count {
-            saw_shard = true;
-            total.add(&counters)?;
-        } else {
-            legacy = Some(counters);
-        }
+        total.add(&counters)?;
     }
 
-    if saw_shard {
-        Ok(total)
-    } else {
-        Ok(legacy.unwrap_or_default())
-    }
+    Ok(total)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -918,13 +902,8 @@ mod tests {
             logical_bytes: 7,
             ..Default::default()
         };
-        let legacy = UsageCounters {
-            buckets: 99,
-            ..Default::default()
-        };
         write_counters(&ctx, usage_global_shard_key(0), shard_zero).await;
         write_counters(&ctx, usage_global_shard_key(1), shard_one).await;
-        write_counters(&ctx, USAGE_GLOBAL_KEY.to_vec(), legacy).await;
 
         let loaded = drive(
             LoadUsageCountersOperation::new(USAGE_GLOBAL_KEY.to_vec()),
@@ -937,16 +916,24 @@ mod tests {
         expected.add(&shard_one).unwrap();
         assert_eq!(loaded, expected);
 
-        let legacy_temp = tempdir().unwrap();
-        let legacy_ctx = test_ctx(legacy_temp.path().to_str().unwrap());
-        write_counters(&legacy_ctx, USAGE_GLOBAL_KEY.to_vec(), legacy).await;
+        let stale_global_temp = tempdir().unwrap();
+        let stale_global_ctx = test_ctx(stale_global_temp.path().to_str().unwrap());
+        write_counters(
+            &stale_global_ctx,
+            USAGE_GLOBAL_KEY.to_vec(),
+            UsageCounters {
+                buckets: 99,
+                ..Default::default()
+            },
+        )
+        .await;
         let loaded = drive(
             LoadUsageCountersOperation::new(USAGE_GLOBAL_KEY.to_vec()),
-            &legacy_ctx,
+            &stale_global_ctx,
         )
         .await
         .unwrap();
-        assert_eq!(loaded, legacy);
+        assert_eq!(loaded, UsageCounters::default());
     }
 
     #[tokio::test]

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -8,8 +8,9 @@ use aruna_core::keyspaces::{
 use aruna_core::operation::Operation;
 use aruna_core::structs::{
     BackendLocation, BlobHeadKey, BlobVersion, BlobVersionState, BucketInfo, CurrentVersionPointer,
-    USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta, VersionKey,
-    usage_global_key_for_group, usage_global_shard_index, usage_global_shard_key, usage_group_key,
+    USAGE_GLOBAL_KEY, USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta,
+    VersionKey, usage_global_key_for_group, usage_global_shard_index, usage_global_shard_key,
+    usage_global_shard_keys, usage_group_key,
 };
 use aruna_core::types::{Effects, GroupId, Key, TxnId, Value};
 use smallvec::smallvec;
@@ -127,6 +128,176 @@ impl UsageCounterUpdate {
 
     pub fn is_done(&self) -> bool {
         self.phase == UsageUpdatePhase::Done
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum LoadUsageCountersState {
+    Init,
+    ReadCounter,
+    ReadGlobal,
+    Finish,
+    Error,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum LoadUsageCountersError {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error(transparent)]
+    CounterError(#[from] UsageCounterError),
+    #[error(
+        "usage counter read received unexpected event in state {state:?}: expected {expected}, got {received:?}"
+    )]
+    UnexpectedEvent {
+        state: String,
+        expected: &'static str,
+        received: Event,
+    },
+    #[error("usage counter read did not finish")]
+    NotFinished,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct LoadUsageCountersOperation {
+    key: Vec<u8>,
+    state: LoadUsageCountersState,
+    output: Option<Result<UsageCounters, LoadUsageCountersError>>,
+}
+
+impl LoadUsageCountersOperation {
+    pub fn new(key: Vec<u8>) -> Self {
+        Self {
+            key,
+            state: LoadUsageCountersState::Init,
+            output: None,
+        }
+    }
+
+    fn finish(&mut self, result: Result<UsageCounters, LoadUsageCountersError>) -> Effects {
+        self.state = if result.is_ok() {
+            LoadUsageCountersState::Finish
+        } else {
+            LoadUsageCountersState::Error
+        };
+        self.output = Some(result);
+        smallvec![]
+    }
+
+    fn unexpected_event(&mut self, expected: &'static str, received: Event) -> Effects {
+        self.finish(Err(LoadUsageCountersError::UnexpectedEvent {
+            state: format!("{:?}", self.state),
+            expected,
+            received,
+        }))
+    }
+
+    fn handle_counter_read(&mut self, event: Event) -> Effects {
+        match event {
+            Event::Storage(StorageEvent::ReadResult {
+                value: Some(bytes), ..
+            }) => self.finish(UsageCounters::from_bytes(&bytes).map_err(Into::into)),
+            Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
+                self.finish(Ok(UsageCounters::default()))
+            }
+            Event::Storage(StorageEvent::Error { error }) => self.finish(Err(error.into())),
+            other => self.unexpected_event("storage read result", other),
+        }
+    }
+
+    fn handle_global_read(&mut self, event: Event) -> Effects {
+        match event {
+            Event::Storage(StorageEvent::BatchReadResult { values }) => {
+                self.finish(sum_global_usage_counters(values))
+            }
+            Event::Storage(StorageEvent::Error { error }) => self.finish(Err(error.into())),
+            other => self.unexpected_event("storage batch read result", other),
+        }
+    }
+}
+
+impl Operation for LoadUsageCountersOperation {
+    type Output = UsageCounters;
+    type Error = LoadUsageCountersError;
+
+    fn start(&mut self) -> Effects {
+        if self.key.as_slice() == USAGE_GLOBAL_KEY {
+            self.state = LoadUsageCountersState::ReadGlobal;
+            let mut reads = usage_global_shard_keys()
+                .into_iter()
+                .map(|key| (USAGE_STATS_KEYSPACE.to_string(), key.into()))
+                .collect::<Vec<_>>();
+            reads.push((
+                USAGE_STATS_KEYSPACE.to_string(),
+                USAGE_GLOBAL_KEY.to_vec().into(),
+            ));
+            smallvec![Effect::Storage(StorageEffect::BatchRead {
+                reads,
+                txn_id: None,
+            })]
+        } else {
+            self.state = LoadUsageCountersState::ReadCounter;
+            smallvec![Effect::Storage(StorageEffect::Read {
+                key_space: USAGE_STATS_KEYSPACE.to_string(),
+                key: self.key.clone().into(),
+                txn_id: None,
+            })]
+        }
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        match self.state {
+            LoadUsageCountersState::ReadCounter => self.handle_counter_read(event),
+            LoadUsageCountersState::ReadGlobal => self.handle_global_read(event),
+            LoadUsageCountersState::Init
+            | LoadUsageCountersState::Finish
+            | LoadUsageCountersState::Error => smallvec![],
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            LoadUsageCountersState::Finish | LoadUsageCountersState::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        self.output.ok_or(LoadUsageCountersError::NotFinished)?
+    }
+
+    fn abort(&mut self) -> Effects {
+        smallvec![]
+    }
+}
+
+fn sum_global_usage_counters(
+    values: Vec<(Key, Option<Value>)>,
+) -> Result<UsageCounters, LoadUsageCountersError> {
+    let mut total = UsageCounters::default();
+    let mut saw_shard = false;
+    let mut legacy = None;
+    let shard_count = values.len().saturating_sub(1);
+
+    for (index, (_, value)) in values.into_iter().enumerate() {
+        let Some(bytes) = value else {
+            continue;
+        };
+        let counters = UsageCounters::from_bytes(bytes.as_ref())?;
+        if index < shard_count {
+            saw_shard = true;
+            total.add(&counters)?;
+        } else {
+            legacy = Some(counters);
+        }
+    }
+
+    if saw_shard {
+        Ok(total)
+    } else {
+        Ok(legacy.unwrap_or_default())
     }
 }
 
@@ -609,6 +780,22 @@ mod tests {
         total
     }
 
+    async fn write_counters(ctx: &DriverContext, key: Vec<u8>, counters: UsageCounters) {
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: USAGE_STATS_KEYSPACE.to_string(),
+                key: key.into(),
+                value: counters.to_bytes().unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
     #[test]
     fn counter_update_applies_deltas_with_synthetic_events() {
         let group_id = Ulid::new();
@@ -698,6 +885,68 @@ mod tests {
         assert_eq!(global.buckets, 1);
         let group = read_counters(&ctx, usage_group_key(group_id)).await;
         assert_eq!(group.buckets, 1);
+    }
+
+    #[tokio::test]
+    async fn load_usage_counters_reads_group_and_global_counters() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let group_id = Ulid::new();
+        let group = UsageCounters {
+            buckets: 1,
+            objects: 2,
+            logical_bytes: 3,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_group_key(group_id), group).await;
+
+        let loaded = drive(
+            LoadUsageCountersOperation::new(usage_group_key(group_id)),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert_eq!(loaded, group);
+
+        let shard_zero = UsageCounters {
+            buckets: 4,
+            stored_bytes: 5,
+            ..Default::default()
+        };
+        let shard_one = UsageCounters {
+            objects: 6,
+            logical_bytes: 7,
+            ..Default::default()
+        };
+        let legacy = UsageCounters {
+            buckets: 99,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_shard_key(0), shard_zero).await;
+        write_counters(&ctx, usage_global_shard_key(1), shard_one).await;
+        write_counters(&ctx, USAGE_GLOBAL_KEY.to_vec(), legacy).await;
+
+        let loaded = drive(
+            LoadUsageCountersOperation::new(USAGE_GLOBAL_KEY.to_vec()),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        let mut expected = UsageCounters::default();
+        expected.add(&shard_zero).unwrap();
+        expected.add(&shard_one).unwrap();
+        assert_eq!(loaded, expected);
+
+        let legacy_temp = tempdir().unwrap();
+        let legacy_ctx = test_ctx(legacy_temp.path().to_str().unwrap());
+        write_counters(&legacy_ctx, USAGE_GLOBAL_KEY.to_vec(), legacy).await;
+        let loaded = drive(
+            LoadUsageCountersOperation::new(USAGE_GLOBAL_KEY.to_vec()),
+            &legacy_ctx,
+        )
+        .await
+        .unwrap();
+        assert_eq!(loaded, legacy);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds maintained usage accounting for buckets, objects, stored blobs, stored bytes, and logical bytes. Counters are updated atomically in the S3 write transactions that change storage state, exposed through node and group usage endpoints, and rebuilt at startup for stores that predate the new counter keyspace.

## Changes

- Adds a `usage_stats` keyspace with serialized `UsageCounters` and `UsageDelta` structs.
- Stores per-group usage counters and sharded global counters to avoid a single global hot key.
- Adds counter overflow and underflow checks so invalid deltas fail without partially mutating counters.
- Adds an embeddable `UsageCounterUpdate` operation that read-modify-writes counters inside the host transaction.
- Updates S3 bucket creation and deletion paths to maintain bucket counters.
- Updates object put, multipart completion, and object deletion paths to maintain object and logical-byte counters.
- Tracks global physical storage usage through stored blob and stored byte counters while keeping per-group quota basis on logical bytes.
- Adds `RebuildUsageStatsOperation` to recompute counters from bucket, blob-location, object-head, and object-version keyspaces.
- Removes stale usage counter keys during rebuild, including the legacy unsharded global counter.
- Runs a startup rebuild when the usage counter keyspace is missing, which backfills existing stores once before serving requests.
- Adds `GET /api/v1/info/usage` for node aggregate usage.
- Adds `GET /api/v1/groups/{id}/usage` for authenticated group members to read group usage.
- Adds OpenAPI schemas for the usage responses and endpoints.
- Keeps global usage reads compatible with the legacy `global` counter if no sharded counters exist.

## GitHub Issues

- Partially addresses #249 by adding the usage keyspace, transactional counter updates for bucket/object write paths, startup backfill, and usage reads. This PR does not add quota configuration, realm-replicated quota policy, admin quota endpoints, or sync-layer distribution.
- Partially addresses #250 by adding the current usage reporting endpoint and recount/rebuild foundation. This PR does not add quota enforcement, warning notifications, history snapshots, portal UI, or periodic drift telemetry.

## Notes

- Replication ingest is intentionally not wired to usage counter updates so accepted writes are counted only once on the node that owns the write transaction.
- `stored_blobs` and `stored_bytes` describe physical content-addressed blobs and are meaningful for global node usage.
- `logical_bytes` sums materialized version sizes and is the per-group quota accounting basis.
- Startup rebuild only runs when the first global shard is missing; future repair or periodic recount scheduling remains follow-up work.