### PR TITLE
Feat/quota config: Admins can now configure quotas

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -33,6 +33,8 @@ pub enum ServerError {
     Conflict(String),
     #[error("Bad request")]
     BadRequest,
+    #[error("{0}")]
+    BadRequestReason(String),
     #[error("Bad gateway")]
     BadGateway,
     #[error("Service unavailable")]
@@ -194,7 +196,7 @@ impl ServerError {
             ServerError::Forbidden => StatusCode::FORBIDDEN,
             ServerError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::Conflict(_) => StatusCode::CONFLICT,
-            ServerError::BadRequest => StatusCode::BAD_REQUEST,
+            ServerError::BadRequest | ServerError::BadRequestReason(_) => StatusCode::BAD_REQUEST,
             ServerError::BadGateway => StatusCode::BAD_GATEWAY,
             ServerError::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
         }
@@ -208,7 +210,7 @@ impl ServerError {
             ServerError::Forbidden => "Forbidden".to_string(),
             ServerError::InternalError(_) => "Internal error".to_string(),
             ServerError::Conflict(_) => "Conflict".to_string(),
-            ServerError::BadRequest => "Bad request".to_string(),
+            ServerError::BadRequest | ServerError::BadRequestReason(_) => "Bad request".to_string(),
             ServerError::BadGateway => "Bad gateway".to_string(),
             ServerError::ServiceUnavailable => "Service unavailable".to_string(),
         }

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -600,10 +600,26 @@ pub async fn get_group_usage(
         aruna_operations::usage_stats::RealmUsageScope::Group(group_id),
     )
     .await?;
-    Ok((
-        StatusCode::OK,
-        Json(crate::routes::info::UsageResponse::new(local, realm)),
-    ))
+
+    // The QuotaGate enforces against the group's realm-wide logical_bytes, so the
+    // warning threshold is evaluated against the same counter.
+    let realm_group_logical_bytes = realm.logical_bytes;
+    let mut response = crate::routes::info::UsageResponse::new(local, realm);
+    // Best effort: omit the quota block rather than failing the request if the
+    // realm config is unavailable.
+    if let Ok(config) = drive(
+        GetRealmConfigOperation::new(state.get_realm_id()),
+        &state.get_ctx(),
+    )
+    .await
+    {
+        response.quota = Some(crate::routes::info::GroupQuotaStatus::resolve(
+            &config.quota,
+            &group_id,
+            realm_group_logical_bytes,
+        ));
+    }
+    Ok((StatusCode::OK, Json(response)))
 }
 
 #[utoipa::path(

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -594,9 +594,16 @@ pub async fn get_group_usage(
         return Err(ServerError::Forbidden);
     }
 
-    let counters =
-        crate::routes::info::load_usage_counters(&state, usage_group_key(group_id)).await?;
-    Ok((StatusCode::OK, Json(counters.into())))
+    let local = crate::routes::info::load_usage_counters(&state, usage_group_key(group_id)).await?;
+    let realm = crate::routes::info::load_realm_usage(
+        &state,
+        aruna_operations::usage_stats::RealmUsageScope::Group(group_id),
+    )
+    .await?;
+    Ok((
+        StatusCode::OK,
+        Json(crate::routes::info::UsageResponse::new(local, realm)),
+    ))
 }
 
 #[utoipa::path(

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -3,6 +3,7 @@ pub use crate::server_state::PortalStatus;
 use crate::server_state::ServerState;
 use aruna_core::UserId;
 use aruna_core::alpn::Alpn;
+use aruna_core::errors::StorageError;
 use aruna_core::structs::{
     Actor, AuthContext, GroupQuotaOverride, Permission, QuotaConfig, UserGroupCapOverride,
 };
@@ -438,7 +439,8 @@ async fn authorize_realm_config_admin(
         (status = 200, description = "Updated realm quota configuration", body = RealmQuotaConfig),
         (status = 400, description = "Invalid quota configuration", body = crate::error::ErrorResponse),
         (status = 403, description = "Caller is not a realm config admin", body = crate::error::ErrorResponse),
-        (status = 404, description = "Realm config not found", body = crate::error::ErrorResponse)
+        (status = 404, description = "Realm config not found", body = crate::error::ErrorResponse),
+        (status = 409, description = "Concurrent quota update conflict", body = crate::error::ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -459,12 +461,19 @@ pub async fn set_realm_quota(
         &state.get_ctx(),
     )
     .await
-    .map_err(|error| match error {
+    .map_err(map_set_realm_quota_error)?;
+    Ok((StatusCode::OK, Json(RealmQuotaConfig::from(stored.quota))))
+}
+
+fn map_set_realm_quota_error(error: SetRealmQuotaError) -> ServerError {
+    match error {
         SetRealmQuotaError::RealmConfigNotFound => ServerError::NotFound,
         SetRealmQuotaError::InvalidQuota { reason } => ServerError::BadRequestReason(reason),
+        SetRealmQuotaError::StorageError(StorageError::TransactionConflict) => {
+            ServerError::Conflict("concurrent realm quota update conflict; retry".to_string())
+        }
         other => ServerError::InternalError(other.to_string()),
-    })?;
-    Ok((StatusCode::OK, Json(RealmQuotaConfig::from(stored.quota))))
+    }
 }
 
 /// Storage usage. The flat fields report this node's local counters (kept for
@@ -494,8 +503,9 @@ pub struct GroupQuotaStatus {
     /// Enforced hard cap (quota x grace). `None` = unlimited.
     pub ceiling_bytes: Option<u64>,
     pub warn_threshold_percent: u32,
-    /// True when the group's realm-wide `logical_bytes` has reached
-    /// `quota_bytes * warn_threshold_percent / 100`; always false when unlimited.
+    /// True when the group's realm-wide `logical_bytes` has reached the
+    /// fractional `quota_bytes * warn_threshold_percent / 100` threshold; always
+    /// false when unlimited.
     pub warning: bool,
 }
 
@@ -510,8 +520,8 @@ impl GroupQuotaStatus {
         let quota_bytes = quota.effective_group_quota_bytes(group_id);
         let warning = match quota_bytes {
             Some(limit) => {
-                let threshold = u128::from(limit) * u128::from(quota.warn_threshold_percent) / 100;
-                u128::from(realm_group_logical_bytes) >= threshold
+                u128::from(realm_group_logical_bytes) * 100
+                    >= u128::from(limit) * u128::from(quota.warn_threshold_percent)
             }
             None => false,
         };
@@ -910,19 +920,21 @@ mod tests {
         BlobServiceStatus, DatabaseServiceStatus, InfoResponse, InterfaceServicesStatus,
         InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind, NodeStatus, PortalStatus,
         RealmQuotaConfig, RequestSummary, ServiceStatus, ServicesStatus, get_info, get_realm_info,
-        get_usage, set_realm_quota,
+        get_usage, map_set_realm_quota_error, set_realm_quota,
     };
     use crate::error::ServerError;
     use crate::openapi::ApiDoc;
     use crate::server_state::ServerState;
     use aruna_core::UserId;
     use aruna_core::effects::StorageEffect;
+    use aruna_core::errors::StorageError;
     use aruna_core::structs::{Actor, AuthContext, NodeCapabilities, QuotaConfig, RealmId};
     use aruna_operations::claim_initial_realm_admin::{
         ClaimInitialRealmAdminInput, ClaimInitialRealmAdminOperation,
     };
     use aruna_operations::create_realm::{CreateRealmConfig, CreateRealmOperation};
     use aruna_operations::driver::{DriverContext, drive};
+    use aruna_operations::set_realm_quota::SetRealmQuotaError;
     use aruna_storage::storage;
     use aruna_tasks::TaskHandle;
     use axum::extract::State;
@@ -1232,10 +1244,45 @@ mod tests {
     }
 
     #[test]
+    fn group_quota_status_uses_fractional_warn_threshold_without_flooring() {
+        let group = Ulid::new();
+        let quota = QuotaConfig {
+            default_group_quota_bytes: Some(3),
+            warn_threshold_percent: 85,
+            ..QuotaConfig::default()
+        };
+
+        let below = super::GroupQuotaStatus::resolve(&quota, &group, 2);
+        assert!(!below.warning);
+        let at = super::GroupQuotaStatus::resolve(&quota, &group, 3);
+        assert!(at.warning);
+
+        let tiny_quota = QuotaConfig {
+            default_group_quota_bytes: Some(1),
+            warn_threshold_percent: 85,
+            ..QuotaConfig::default()
+        };
+        let zero = super::GroupQuotaStatus::resolve(&tiny_quota, &group, 0);
+        assert!(!zero.warning);
+    }
+
+    #[test]
     fn openapi_includes_realm_quota_path() {
         let openapi = ApiDoc::openapi();
 
         assert!(openapi.paths.paths.contains_key("/info/realm/quota"));
+    }
+
+    #[test]
+    fn set_realm_quota_transaction_conflict_maps_to_http_conflict() {
+        let error = map_set_realm_quota_error(SetRealmQuotaError::StorageError(
+            StorageError::TransactionConflict,
+        ));
+
+        assert!(matches!(
+            error,
+            ServerError::Conflict(message) if message.contains("retry")
+        ));
     }
 
     async fn setup_management_state() -> (Arc<ServerState>, RealmId, UserId, TempDir) {

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1336,7 +1336,6 @@ mod tests {
         };
         let mut body = RealmQuotaConfig::from(QuotaConfig::default());
         body.default_group_quota_bytes = Some(4096);
-        body.max_devices_per_user = Some(2);
 
         let (status, Json(stored)) =
             set_realm_quota(State(state.clone()), Extension(Some(auth)), Json(body))
@@ -1344,12 +1343,12 @@ mod tests {
                 .unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(stored.default_group_quota_bytes, Some(4096));
-        assert_eq!(stored.max_devices_per_user, Some(2));
+        assert_eq!(stored.max_devices_per_user, None);
 
         let (status, Json(info)) = get_realm_info(State(state)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(info.quota.default_group_quota_bytes, Some(4096));
-        assert_eq!(info.quota.max_devices_per_user, Some(2));
+        assert_eq!(info.quota.max_devices_per_user, None);
     }
 
     #[tokio::test]
@@ -1386,5 +1385,26 @@ mod tests {
             "body must carry the validation reason, got: {}",
             parsed.error
         );
+    }
+
+    #[tokio::test]
+    async fn set_realm_quota_rejects_unsupported_device_cap() {
+        let (state, realm_id, admin, _tempdir) = setup_management_state().await;
+        let auth = AuthContext {
+            user_id: admin,
+            realm_id,
+            path_restrictions: None,
+        };
+        let mut body = RealmQuotaConfig::from(QuotaConfig::default());
+        body.max_devices_per_user = Some(2);
+
+        let error = set_realm_quota(State(state), Extension(Some(auth)), Json(body))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ServerError::BadRequestReason(reason) if reason.contains("max_devices_per_user")
+        ));
     }
 }

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -230,6 +230,7 @@ pub struct RealmQuotaConfig {
     pub warn_threshold_percent: u32,
     pub group_overrides: Vec<RealmGroupQuotaOverride>,
     pub max_groups_per_user: Option<u32>,
+    /// Redacted from unauthenticated `/info/realm` responses.
     pub user_group_cap_overrides: Vec<RealmUserGroupCapOverride>,
     pub max_devices_per_user: Option<u32>,
 }
@@ -377,10 +378,12 @@ impl From<&RealmNodeKind> for RealmNodeKindInfo {
     responses(
         (status = 200, description = "Realm information", body = RealmInfoResponse),
         (status = 404, description = "Realm config not found", body = crate::error::ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn get_realm_info(
     State(state): State<Arc<ServerState>>,
+    Extension(auth): Extension<Option<AuthContext>>,
 ) -> ServerResult<(StatusCode, Json<RealmInfoResponse>)> {
     let config = drive(
         GetRealmConfigOperation::new(state.get_realm_id()),
@@ -399,6 +402,8 @@ pub async fn get_realm_info(
         config,
         present_nodes,
         interface_services_status(&state).await,
+        auth.as_ref()
+            .is_some_and(|auth| auth.realm_id == state.get_realm_id()),
     )?;
     Ok((StatusCode::OK, Json(response)))
 }
@@ -625,6 +630,7 @@ fn map_realm_info_response(
     config: RealmConfigDocument,
     present_nodes: HashSet<aruna_core::NodeId>,
     interfaces: InterfaceServicesStatus,
+    include_user_quota_overrides: bool,
 ) -> ServerResult<RealmInfoResponse> {
     let discovery = serde_json::to_value(&config.discovery)
         .map_err(|error| ServerError::InternalError(error.to_string()))?;
@@ -654,6 +660,11 @@ fn map_realm_info_response(
         })
         .collect();
 
+    let mut quota = RealmQuotaConfig::from(config.quota);
+    if !include_user_quota_overrides {
+        quota.user_group_cap_overrides.clear();
+    }
+
     Ok(RealmInfoResponse {
         realm_id: config.realm_id.to_string(),
         description: config.description,
@@ -672,7 +683,7 @@ fn map_realm_info_response(
             .collect(),
         discovery,
         nodes,
-        quota: RealmQuotaConfig::from(config.quota),
+        quota,
         interfaces,
     })
 }
@@ -919,8 +930,8 @@ mod tests {
     use super::{
         BlobServiceStatus, DatabaseServiceStatus, InfoResponse, InterfaceServicesStatus,
         InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind, NodeStatus, PortalStatus,
-        RealmQuotaConfig, RequestSummary, ServiceStatus, ServicesStatus, get_info, get_realm_info,
-        get_usage, map_set_realm_quota_error, set_realm_quota,
+        RealmQuotaConfig, RealmUserGroupCapOverride, RequestSummary, ServiceStatus, ServicesStatus,
+        get_info, get_realm_info, get_usage, map_set_realm_quota_error, set_realm_quota,
     };
     use crate::error::ServerError;
     use crate::openapi::ApiDoc;
@@ -1384,18 +1395,60 @@ mod tests {
         let mut body = RealmQuotaConfig::from(QuotaConfig::default());
         body.default_group_quota_bytes = Some(4096);
 
-        let (status, Json(stored)) =
-            set_realm_quota(State(state.clone()), Extension(Some(auth)), Json(body))
-                .await
-                .unwrap();
+        let (status, Json(stored)) = set_realm_quota(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            Json(body),
+        )
+        .await
+        .unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(stored.default_group_quota_bytes, Some(4096));
         assert_eq!(stored.max_devices_per_user, None);
 
-        let (status, Json(info)) = get_realm_info(State(state)).await.unwrap();
+        let (status, Json(info)) = get_realm_info(State(state), Extension(Some(auth)))
+            .await
+            .unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(info.quota.default_group_quota_bytes, Some(4096));
         assert_eq!(info.quota.max_devices_per_user, None);
+    }
+
+    #[tokio::test]
+    async fn get_realm_info_redacts_user_quota_overrides_for_anonymous_callers() {
+        let (state, realm_id, admin, _tempdir) = setup_management_state().await;
+        let auth = AuthContext {
+            user_id: admin,
+            realm_id,
+            path_restrictions: None,
+        };
+        let mut body = RealmQuotaConfig::from(QuotaConfig::default());
+        body.user_group_cap_overrides = vec![RealmUserGroupCapOverride {
+            user_id: admin.to_string(),
+            max_groups: Some(1),
+        }];
+
+        let (_status, Json(_stored)) = set_realm_quota(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            Json(body),
+        )
+        .await
+        .unwrap();
+
+        let (_status, Json(anonymous)) = get_realm_info(State(state.clone()), Extension(None))
+            .await
+            .unwrap();
+        assert!(anonymous.quota.user_group_cap_overrides.is_empty());
+
+        let (_status, Json(authenticated)) = get_realm_info(State(state), Extension(Some(auth)))
+            .await
+            .unwrap();
+        assert_eq!(authenticated.quota.user_group_cap_overrides.len(), 1);
+        assert_eq!(
+            authenticated.quota.user_group_cap_overrides[0].user_id,
+            admin.to_string()
+        );
     }
 
     #[tokio::test]

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1,30 +1,39 @@
 use crate::error::{ServerError, ServerResult};
 pub use crate::server_state::PortalStatus;
 use crate::server_state::ServerState;
+use aruna_core::UserId;
 use aruna_core::alpn::Alpn;
+use aruna_core::structs::{
+    Actor, AuthContext, GroupQuotaOverride, Permission, QuotaConfig, UserGroupCapOverride,
+};
 use aruna_core::structs::{ConnectionAddressStatus, PeerConnectionStatus, RequestSummaryState};
 use aruna_core::structs::{RealmConfigDocument, RealmNodeKind};
 use aruna_core::structs::{USAGE_GLOBAL_KEY, UsageCounters};
+use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use aruna_operations::driver::drive;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
+use aruna_operations::set_realm_quota::{
+    SetRealmQuotaConfig, SetRealmQuotaError, SetRealmQuotaOperation,
+};
 use aruna_operations::status::load_node_observability_status;
 use aruna_operations::usage_stats::LoadUsageCountersOperation;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::routing::get;
-use axum::{Json, Router};
+use axum::routing::{get, put};
+use axum::{Extension, Json, Router};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::warn;
+use ulid::Ulid;
 use utoipa::{OpenApi, ToSchema};
 
 #[derive(OpenApi)]
 #[openapi(
     tags((name = "info", description = "Node information endpoints")),
-    paths(get_info, get_realm_info, get_usage)
+    paths(get_info, get_realm_info, set_realm_quota, get_usage)
 )]
 pub struct InfoApiDoc;
 
@@ -32,6 +41,7 @@ pub fn router() -> Router<Arc<ServerState>> {
     Router::new()
         .route("/info", get(get_info))
         .route("/info/realm", get(get_realm_info))
+        .route("/info/realm/quota", put(set_realm_quota))
         .route("/info/usage", get(get_usage))
 }
 
@@ -206,7 +216,100 @@ pub struct RealmInfoResponse {
     #[schema(value_type = Object)]
     pub discovery: Value,
     pub nodes: Vec<RealmNodeInfoResponse>,
+    pub quota: RealmQuotaConfig,
     pub interfaces: InterfaceServicesStatus,
+}
+
+/// Realm-wide quota policy. Used both as the response for the current settings
+/// and as the replace-semantics request body for updating them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct RealmQuotaConfig {
+    pub default_group_quota_bytes: Option<u64>,
+    pub grace_factor_percent: u32,
+    pub warn_threshold_percent: u32,
+    pub group_overrides: Vec<RealmGroupQuotaOverride>,
+    pub max_groups_per_user: Option<u32>,
+    pub user_group_cap_overrides: Vec<RealmUserGroupCapOverride>,
+    pub max_devices_per_user: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct RealmGroupQuotaOverride {
+    pub group_id: String,
+    pub quota_bytes: Option<u64>,
+    pub grace_factor_percent: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct RealmUserGroupCapOverride {
+    pub user_id: String,
+    pub max_groups: Option<u32>,
+}
+
+impl From<QuotaConfig> for RealmQuotaConfig {
+    fn from(quota: QuotaConfig) -> Self {
+        Self {
+            default_group_quota_bytes: quota.default_group_quota_bytes,
+            grace_factor_percent: quota.grace_factor_percent,
+            warn_threshold_percent: quota.warn_threshold_percent,
+            group_overrides: quota
+                .group_overrides
+                .into_iter()
+                .map(|over| RealmGroupQuotaOverride {
+                    group_id: over.group_id.to_string(),
+                    quota_bytes: over.quota_bytes,
+                    grace_factor_percent: over.grace_factor_percent,
+                })
+                .collect(),
+            max_groups_per_user: quota.max_groups_per_user,
+            user_group_cap_overrides: quota
+                .user_group_cap_overrides
+                .into_iter()
+                .map(|over| RealmUserGroupCapOverride {
+                    user_id: over.user_id.to_string(),
+                    max_groups: over.max_groups,
+                })
+                .collect(),
+            max_devices_per_user: quota.max_devices_per_user,
+        }
+    }
+}
+
+impl RealmQuotaConfig {
+    fn into_quota_config(self) -> ServerResult<QuotaConfig> {
+        let group_overrides = self
+            .group_overrides
+            .into_iter()
+            .map(|over| {
+                Ok(GroupQuotaOverride {
+                    group_id: Ulid::from_string(&over.group_id)
+                        .map_err(|_| ServerError::BadRequest)?,
+                    quota_bytes: over.quota_bytes,
+                    grace_factor_percent: over.grace_factor_percent,
+                })
+            })
+            .collect::<ServerResult<Vec<_>>>()?;
+        let user_group_cap_overrides = self
+            .user_group_cap_overrides
+            .into_iter()
+            .map(|over| {
+                Ok(UserGroupCapOverride {
+                    user_id: UserId::from_string(&over.user_id)
+                        .map_err(|_| ServerError::BadRequest)?,
+                    max_groups: over.max_groups,
+                })
+            })
+            .collect::<ServerResult<Vec<_>>>()?;
+        Ok(QuotaConfig {
+            default_group_quota_bytes: self.default_group_quota_bytes,
+            grace_factor_percent: self.grace_factor_percent,
+            warn_threshold_percent: self.warn_threshold_percent,
+            group_overrides,
+            max_groups_per_user: self.max_groups_per_user,
+            user_group_cap_overrides,
+            max_devices_per_user: self.max_devices_per_user,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -289,6 +392,71 @@ pub async fn get_realm_info(
         interface_services_status(&state).await,
     )?;
     Ok((StatusCode::OK, Json(response)))
+}
+
+async fn authorize_realm_config_admin(
+    state: &Arc<ServerState>,
+    auth: Option<AuthContext>,
+) -> ServerResult<AuthContext> {
+    let auth = auth.ok_or(ServerError::Unauthorized)?;
+    let realm_id = state.get_realm_id();
+    if auth.realm_id != realm_id || !state.is_management_node() {
+        return Err(ServerError::Forbidden);
+    }
+
+    let allowed = drive(
+        CheckPermissionsOperation::new(CheckPermissionsConfig {
+            auth_context: auth.clone(),
+            path: format!("/{realm_id}/admin/config"),
+            required_permission: Permission::WRITE,
+        }),
+        &state.get_ctx(),
+    )
+    .await
+    .map_err(|err| ServerError::InternalError(err.to_string()))?;
+    if !allowed {
+        return Err(ServerError::Forbidden);
+    }
+
+    Ok(auth)
+}
+
+#[utoipa::path(
+    put,
+    path = "/info/realm/quota",
+    tag = "info",
+    request_body = RealmQuotaConfig,
+    responses(
+        (status = 200, description = "Updated realm quota configuration", body = RealmQuotaConfig),
+        (status = 400, description = "Invalid quota configuration", body = crate::error::ErrorResponse),
+        (status = 403, description = "Caller is not a realm config admin", body = crate::error::ErrorResponse),
+        (status = 404, description = "Realm config not found", body = crate::error::ErrorResponse)
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn set_realm_quota(
+    State(state): State<Arc<ServerState>>,
+    Extension(auth): Extension<Option<AuthContext>>,
+    Json(request): Json<RealmQuotaConfig>,
+) -> ServerResult<(StatusCode, Json<RealmQuotaConfig>)> {
+    let auth = authorize_realm_config_admin(&state, auth).await?;
+    let quota = request.into_quota_config()?;
+    let actor = Actor {
+        node_id: state.get_node_id(),
+        user_id: auth.user_id,
+        realm_id: auth.realm_id,
+    };
+    let stored = drive(
+        SetRealmQuotaOperation::new(SetRealmQuotaConfig { actor, quota }),
+        &state.get_ctx(),
+    )
+    .await
+    .map_err(|error| match error {
+        SetRealmQuotaError::RealmConfigNotFound => ServerError::NotFound,
+        SetRealmQuotaError::InvalidQuota { .. } => ServerError::BadRequest,
+        other => ServerError::InternalError(other.to_string()),
+    })?;
+    Ok((StatusCode::OK, Json(RealmQuotaConfig::from(stored.quota))))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -385,6 +553,7 @@ fn map_realm_info_response(
             .collect(),
         discovery,
         nodes,
+        quota: RealmQuotaConfig::from(config.quota),
         interfaces,
     })
 }
@@ -631,20 +800,29 @@ mod tests {
     use super::{
         BlobServiceStatus, DatabaseServiceStatus, InfoResponse, InterfaceServicesStatus,
         InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind, NodeStatus, PortalStatus,
-        RequestSummary, ServiceStatus, ServicesStatus, get_info,
+        RealmQuotaConfig, RequestSummary, ServiceStatus, ServicesStatus, get_info, get_realm_info,
+        set_realm_quota,
     };
+    use crate::error::ServerError;
     use crate::openapi::ApiDoc;
     use crate::server_state::ServerState;
+    use aruna_core::UserId;
     use aruna_core::effects::StorageEffect;
-    use aruna_core::structs::{NodeCapabilities, RealmId};
-    use aruna_operations::driver::DriverContext;
+    use aruna_core::structs::{Actor, AuthContext, NodeCapabilities, QuotaConfig, RealmId};
+    use aruna_operations::claim_initial_realm_admin::{
+        ClaimInitialRealmAdminInput, ClaimInitialRealmAdminOperation,
+    };
+    use aruna_operations::create_realm::{CreateRealmConfig, CreateRealmOperation};
+    use aruna_operations::driver::{DriverContext, drive};
     use aruna_storage::storage;
-    use axum::Json;
+    use aruna_tasks::TaskHandle;
     use axum::extract::State;
     use axum::http::StatusCode;
+    use axum::{Extension, Json};
     use ed25519_dalek::SigningKey;
     use std::sync::Arc;
     use tempfile::{TempDir, tempdir};
+    use ulid::Ulid;
 
     async fn setup_state() -> (Arc<ServerState>, TempDir) {
         let tempdir = tempdir().unwrap();
@@ -825,5 +1003,126 @@ mod tests {
         let openapi = ApiDoc::openapi();
 
         assert!(openapi.paths.paths.contains_key("/info"));
+    }
+
+    #[test]
+    fn openapi_includes_realm_quota_path() {
+        let openapi = ApiDoc::openapi();
+
+        assert!(openapi.paths.paths.contains_key("/info/realm/quota"));
+    }
+
+    async fn setup_management_state() -> (Arc<ServerState>, RealmId, UserId, TempDir) {
+        let tempdir = tempdir().unwrap();
+        let storage_handle = storage::FjallStorage::open(tempdir.path().to_str().unwrap()).unwrap();
+        let driver_ctx = Arc::new(DriverContext {
+            storage_handle,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: Some(TaskHandle::new()),
+        });
+
+        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
+        let realm_signing_key = SigningKey::generate(&mut csprng);
+        let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
+        let user_id = UserId::local(Ulid::new(), realm_id);
+        let node_id = iroh::SecretKey::generate().public();
+
+        drive(
+            CreateRealmOperation::new(CreateRealmConfig {
+                actor: Actor {
+                    node_id,
+                    user_id,
+                    realm_id,
+                },
+                realm_description: "Realm".to_string(),
+                oidc_providers: vec![],
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap();
+        drive(
+            ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
+                actor: Actor {
+                    node_id,
+                    user_id,
+                    realm_id,
+                },
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap();
+
+        let state = Arc::new(
+            ServerState::new(
+                driver_ctx,
+                realm_id,
+                node_id,
+                NodeCapabilities::management_node(realm_signing_key).unwrap(),
+                false,
+                None,
+            )
+            .await,
+        );
+
+        (state, realm_id, user_id, tempdir)
+    }
+
+    #[tokio::test]
+    async fn set_realm_quota_requires_authentication() {
+        let (state, _realm_id, _admin, _tempdir) = setup_management_state().await;
+        let body = RealmQuotaConfig::from(QuotaConfig::default());
+
+        let error = set_realm_quota(State(state), Extension(None), Json(body))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ServerError::Unauthorized));
+    }
+
+    #[tokio::test]
+    async fn set_realm_quota_rejects_non_admin() {
+        let (state, realm_id, _admin, _tempdir) = setup_management_state().await;
+        let stranger = AuthContext {
+            user_id: UserId::local(Ulid::new(), realm_id),
+            realm_id,
+            path_restrictions: None,
+        };
+        let body = RealmQuotaConfig::from(QuotaConfig::default());
+
+        let error = set_realm_quota(State(state), Extension(Some(stranger)), Json(body))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ServerError::Forbidden));
+    }
+
+    #[tokio::test]
+    async fn admin_sets_and_reads_realm_quota() {
+        let (state, realm_id, admin, _tempdir) = setup_management_state().await;
+        let auth = AuthContext {
+            user_id: admin,
+            realm_id,
+            path_restrictions: None,
+        };
+        let mut body = RealmQuotaConfig::from(QuotaConfig::default());
+        body.default_group_quota_bytes = Some(4096);
+        body.max_devices_per_user = Some(2);
+
+        let (status, Json(stored)) =
+            set_realm_quota(State(state.clone()), Extension(Some(auth)), Json(body))
+                .await
+                .unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(stored.default_group_quota_bytes, Some(4096));
+        assert_eq!(stored.max_devices_per_user, Some(2));
+
+        let (status, Json(info)) = get_realm_info(State(state)).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(info.quota.default_group_quota_bytes, Some(4096));
+        assert_eq!(info.quota.max_devices_per_user, Some(2));
     }
 }

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -17,7 +17,7 @@ use aruna_operations::set_realm_quota::{
     SetRealmQuotaConfig, SetRealmQuotaError, SetRealmQuotaOperation,
 };
 use aruna_operations::status::load_node_observability_status;
-use aruna_operations::usage_stats::LoadUsageCountersOperation;
+use aruna_operations::usage_stats::{LoadUsageCountersOperation, RealmUsageScope};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::{get, put};
@@ -459,6 +459,9 @@ pub async fn set_realm_quota(
     Ok((StatusCode::OK, Json(RealmQuotaConfig::from(stored.quota))))
 }
 
+/// Storage usage. The flat fields report this node's local counters (kept for
+/// backward compatibility); `realm` reports the realm-wide total summed across
+/// every node in the realm.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct UsageResponse {
     pub buckets: u64,
@@ -466,9 +469,19 @@ pub struct UsageResponse {
     pub stored_blobs: u64,
     pub stored_bytes: u64,
     pub logical_bytes: u64,
+    pub realm: UsageTotals,
 }
 
-impl From<UsageCounters> for UsageResponse {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct UsageTotals {
+    pub buckets: u64,
+    pub objects: u64,
+    pub stored_blobs: u64,
+    pub stored_bytes: u64,
+    pub logical_bytes: u64,
+}
+
+impl From<UsageCounters> for UsageTotals {
     fn from(counters: UsageCounters) -> Self {
         Self {
             buckets: counters.buckets,
@@ -480,10 +493,32 @@ impl From<UsageCounters> for UsageResponse {
     }
 }
 
+impl UsageResponse {
+    pub fn new(local: UsageCounters, realm: UsageCounters) -> Self {
+        Self {
+            buckets: local.buckets,
+            objects: local.objects,
+            stored_blobs: local.stored_blobs,
+            stored_bytes: local.stored_bytes,
+            logical_bytes: local.logical_bytes,
+            realm: realm.into(),
+        }
+    }
+}
+
 pub async fn load_usage_counters(state: &ServerState, key: Vec<u8>) -> ServerResult<UsageCounters> {
     drive(LoadUsageCountersOperation::new(key), &state.get_ctx())
         .await
         .map_err(|error| ServerError::InternalError(error.to_string()))
+}
+
+pub async fn load_realm_usage(
+    state: &ServerState,
+    scope: RealmUsageScope,
+) -> ServerResult<UsageCounters> {
+    aruna_operations::usage_stats::load_realm_usage(&state.get_ctx(), state.get_node_id(), scope)
+        .await
+        .map_err(ServerError::InternalError)
 }
 
 #[utoipa::path(
@@ -491,14 +526,15 @@ pub async fn load_usage_counters(state: &ServerState, key: Vec<u8>) -> ServerRes
     path = "/info/usage",
     tag = "info",
     responses(
-        (status = 200, description = "Aggregate storage usage on this node", body = UsageResponse)
+        (status = 200, description = "Local and realm-wide storage usage", body = UsageResponse)
     )
 )]
 pub async fn get_usage(
     State(state): State<Arc<ServerState>>,
 ) -> ServerResult<(StatusCode, Json<UsageResponse>)> {
-    let counters = load_usage_counters(&state, USAGE_GLOBAL_KEY.to_vec()).await?;
-    Ok((StatusCode::OK, Json(UsageResponse::from(counters))))
+    let local = load_usage_counters(&state, USAGE_GLOBAL_KEY.to_vec()).await?;
+    let realm = load_realm_usage(&state, RealmUsageScope::Global).await?;
+    Ok((StatusCode::OK, Json(UsageResponse::new(local, realm))))
 }
 
 fn map_realm_info_response(
@@ -801,7 +837,7 @@ mod tests {
         BlobServiceStatus, DatabaseServiceStatus, InfoResponse, InterfaceServicesStatus,
         InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind, NodeStatus, PortalStatus,
         RealmQuotaConfig, RequestSummary, ServiceStatus, ServicesStatus, get_info, get_realm_info,
-        set_realm_quota,
+        get_usage, set_realm_quota,
     };
     use crate::error::ServerError;
     use crate::openapi::ApiDoc;
@@ -1003,6 +1039,57 @@ mod tests {
         let openapi = ApiDoc::openapi();
 
         assert!(openapi.paths.paths.contains_key("/info"));
+    }
+
+    #[tokio::test]
+    async fn get_usage_reports_local_and_realm_totals() {
+        use aruna_core::keyspaces::{USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE};
+        use aruna_core::structs::{
+            NodeUsageSnapshot, UsageCounters, node_usage_global_key, usage_global_shard_key,
+        };
+
+        let (state, _tempdir) = setup_state().await;
+        let ctx = state.get_ctx();
+
+        // This node's live local total.
+        ctx.storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: USAGE_STATS_KEYSPACE.to_string(),
+                key: usage_global_shard_key(0).into(),
+                value: UsageCounters {
+                    buckets: 2,
+                    ..Default::default()
+                }
+                .to_bytes()
+                .unwrap()
+                .into(),
+                txn_id: None,
+            })
+            .await;
+        // A remote node's replicated snapshot.
+        let remote = iroh::SecretKey::from_bytes(&[9u8; 32]).public();
+        ctx.storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+                key: node_usage_global_key(remote).into(),
+                value: NodeUsageSnapshot {
+                    node_id: remote,
+                    counters: UsageCounters {
+                        buckets: 3,
+                        ..Default::default()
+                    },
+                }
+                .to_bytes()
+                .unwrap()
+                .into(),
+                txn_id: None,
+            })
+            .await;
+
+        let (status, Json(response)) = get_usage(State(state)).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(response.buckets, 2, "flat fields report local total");
+        assert_eq!(response.realm.buckets, 5, "realm sums local and remote");
     }
 
     #[test]

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -460,8 +460,9 @@ pub async fn set_realm_quota(
 }
 
 /// Storage usage. The flat fields report this node's local counters (kept for
-/// backward compatibility); `realm` reports the realm-wide total summed across
-/// every node in the realm.
+/// backward compatibility) and are always present. `realm` reports the
+/// realm-wide total summed across every node and is only included for
+/// authenticated callers, so unauthenticated requests never disclose it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct UsageResponse {
     pub buckets: u64,
@@ -469,7 +470,8 @@ pub struct UsageResponse {
     pub stored_blobs: u64,
     pub stored_bytes: u64,
     pub logical_bytes: u64,
-    pub realm: UsageTotals,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub realm: Option<UsageTotals>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -495,13 +497,17 @@ impl From<UsageCounters> for UsageTotals {
 
 impl UsageResponse {
     pub fn new(local: UsageCounters, realm: UsageCounters) -> Self {
+        Self::with_realm(local, Some(realm.into()))
+    }
+
+    pub fn with_realm(local: UsageCounters, realm: Option<UsageTotals>) -> Self {
         Self {
             buckets: local.buckets,
             objects: local.objects,
             stored_blobs: local.stored_blobs,
             stored_bytes: local.stored_bytes,
             logical_bytes: local.logical_bytes,
-            realm: realm.into(),
+            realm,
         }
     }
 }
@@ -526,15 +532,31 @@ pub async fn load_realm_usage(
     path = "/info/usage",
     tag = "info",
     responses(
-        (status = 200, description = "Local and realm-wide storage usage", body = UsageResponse)
-    )
+        (
+            status = 200,
+            description = "Local storage usage always; realm-wide totals only for authenticated callers",
+            body = UsageResponse
+        )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn get_usage(
     State(state): State<Arc<ServerState>>,
+    Extension(auth): Extension<Option<AuthContext>>,
 ) -> ServerResult<(StatusCode, Json<UsageResponse>)> {
     let local = load_usage_counters(&state, USAGE_GLOBAL_KEY.to_vec()).await?;
-    let realm = load_realm_usage(&state, RealmUsageScope::Global).await?;
-    Ok((StatusCode::OK, Json(UsageResponse::new(local, realm))))
+    let realm = match auth {
+        Some(_) => Some(
+            load_realm_usage(&state, RealmUsageScope::Global)
+                .await?
+                .into(),
+        ),
+        None => None,
+    };
+    Ok((
+        StatusCode::OK,
+        Json(UsageResponse::with_realm(local, realm)),
+    ))
 }
 
 fn map_realm_info_response(
@@ -1041,22 +1063,19 @@ mod tests {
         assert!(openapi.paths.paths.contains_key("/info"));
     }
 
-    #[tokio::test]
-    async fn get_usage_reports_local_and_realm_totals() {
+    async fn seed_usage_state(state: &Arc<ServerState>) {
         use aruna_core::keyspaces::{USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE};
         use aruna_core::structs::{
-            NodeUsageSnapshot, UsageCounters, node_usage_global_key, usage_global_shard_key,
+            NodeUsageSnapshot, node_usage_global_key, usage_global_shard_key,
         };
 
-        let (state, _tempdir) = setup_state().await;
         let ctx = state.get_ctx();
-
         // This node's live local total.
         ctx.storage_handle
             .send_storage_effect(StorageEffect::Write {
                 key_space: USAGE_STATS_KEYSPACE.to_string(),
                 key: usage_global_shard_key(0).into(),
-                value: UsageCounters {
+                value: aruna_core::structs::UsageCounters {
                     buckets: 2,
                     ..Default::default()
                 }
@@ -1074,7 +1093,7 @@ mod tests {
                 key: node_usage_global_key(remote).into(),
                 value: NodeUsageSnapshot {
                     node_id: remote,
-                    counters: UsageCounters {
+                    counters: aruna_core::structs::UsageCounters {
                         buckets: 3,
                         ..Default::default()
                     },
@@ -1085,11 +1104,46 @@ mod tests {
                 txn_id: None,
             })
             .await;
+    }
 
-        let (status, Json(response)) = get_usage(State(state)).await.unwrap();
+    fn test_auth_context(state: &Arc<ServerState>) -> AuthContext {
+        AuthContext {
+            user_id: UserId::local(Ulid::new(), state.get_realm_id()),
+            realm_id: state.get_realm_id(),
+            path_restrictions: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn get_usage_reports_realm_totals_for_authenticated_callers() {
+        let (state, _tempdir) = setup_state().await;
+        seed_usage_state(&state).await;
+
+        let auth = test_auth_context(&state);
+        let (status, Json(response)) = get_usage(State(state), Extension(Some(auth)))
+            .await
+            .unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response.buckets, 2, "flat fields report local total");
-        assert_eq!(response.realm.buckets, 5, "realm sums local and remote");
+        let realm = response.realm.expect("authenticated caller sees realm");
+        assert_eq!(realm.buckets, 5, "realm sums local and remote");
+    }
+
+    #[tokio::test]
+    async fn get_usage_omits_realm_totals_for_unauthenticated_callers() {
+        let (state, _tempdir) = setup_state().await;
+        seed_usage_state(&state).await;
+
+        let (status, Json(response)) = get_usage(State(state), Extension(None)).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            response.buckets, 2,
+            "flat local fields stay unauthenticated"
+        );
+        assert!(
+            response.realm.is_none(),
+            "unauthenticated callers must not see realm-wide totals"
+        );
     }
 
     #[test]

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -282,8 +282,12 @@ impl RealmQuotaConfig {
             .into_iter()
             .map(|over| {
                 Ok(GroupQuotaOverride {
-                    group_id: Ulid::from_string(&over.group_id)
-                        .map_err(|_| ServerError::BadRequest)?,
+                    group_id: Ulid::from_string(&over.group_id).map_err(|_| {
+                        ServerError::BadRequestReason(format!(
+                            "invalid group id in group_overrides: {}",
+                            over.group_id
+                        ))
+                    })?,
                     quota_bytes: over.quota_bytes,
                     grace_factor_percent: over.grace_factor_percent,
                 })
@@ -294,8 +298,12 @@ impl RealmQuotaConfig {
             .into_iter()
             .map(|over| {
                 Ok(UserGroupCapOverride {
-                    user_id: UserId::from_string(&over.user_id)
-                        .map_err(|_| ServerError::BadRequest)?,
+                    user_id: UserId::from_string(&over.user_id).map_err(|_| {
+                        ServerError::BadRequestReason(format!(
+                            "invalid user id in user_group_cap_overrides: {}",
+                            over.user_id
+                        ))
+                    })?,
                     max_groups: over.max_groups,
                 })
             })
@@ -453,7 +461,7 @@ pub async fn set_realm_quota(
     .await
     .map_err(|error| match error {
         SetRealmQuotaError::RealmConfigNotFound => ServerError::NotFound,
-        SetRealmQuotaError::InvalidQuota { .. } => ServerError::BadRequest,
+        SetRealmQuotaError::InvalidQuota { reason } => ServerError::BadRequestReason(reason),
         other => ServerError::InternalError(other.to_string()),
     })?;
     Ok((StatusCode::OK, Json(RealmQuotaConfig::from(stored.quota))))
@@ -1342,5 +1350,41 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(info.quota.default_group_quota_bytes, Some(4096));
         assert_eq!(info.quota.max_devices_per_user, Some(2));
+    }
+
+    #[tokio::test]
+    async fn set_realm_quota_surfaces_invalid_reason_in_bad_request_body() {
+        use axum::response::IntoResponse;
+
+        let (state, realm_id, admin, _tempdir) = setup_management_state().await;
+        let auth = AuthContext {
+            user_id: admin,
+            realm_id,
+            path_restrictions: None,
+        };
+        let mut body = RealmQuotaConfig::from(QuotaConfig::default());
+        body.warn_threshold_percent = 0;
+
+        let error = set_realm_quota(State(state), Extension(Some(auth)), Json(body))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ServerError::BadRequestReason(_)));
+
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed: crate::error::ErrorResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            parsed.code.as_deref(),
+            Some("Bad request"),
+            "machine code stays identical to plain BadRequest"
+        );
+        assert!(
+            parsed.error.contains("warn_threshold_percent"),
+            "body must carry the validation reason, got: {}",
+            parsed.error
+        );
     }
 }

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -472,6 +472,48 @@ pub struct UsageResponse {
     pub logical_bytes: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub realm: Option<UsageTotals>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quota: Option<GroupQuotaStatus>,
+}
+
+/// Per-group quota status derived from the realm quota config. Attached only to
+/// the group usage endpoint; `/info/usage` and the plain constructors leave it
+/// `None` so their output is unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct GroupQuotaStatus {
+    /// Effective pre-grace group quota (override else default). `None` = unlimited.
+    pub quota_bytes: Option<u64>,
+    /// Enforced hard cap (quota x grace). `None` = unlimited.
+    pub ceiling_bytes: Option<u64>,
+    pub warn_threshold_percent: u32,
+    /// True when the group's realm-wide `logical_bytes` has reached
+    /// `quota_bytes * warn_threshold_percent / 100`; always false when unlimited.
+    pub warning: bool,
+}
+
+impl GroupQuotaStatus {
+    /// Builds the status from the realm quota config and the group's realm-wide
+    /// `logical_bytes` — the same counter the put-object `QuotaGate` enforces.
+    pub fn resolve(
+        quota: &QuotaConfig,
+        group_id: &aruna_core::types::GroupId,
+        realm_group_logical_bytes: u64,
+    ) -> Self {
+        let quota_bytes = quota.effective_group_quota_bytes(group_id);
+        let warning = match quota_bytes {
+            Some(limit) => {
+                let threshold = u128::from(limit) * u128::from(quota.warn_threshold_percent) / 100;
+                u128::from(realm_group_logical_bytes) >= threshold
+            }
+            None => false,
+        };
+        Self {
+            quota_bytes,
+            ceiling_bytes: quota.effective_group_ceiling(group_id),
+            warn_threshold_percent: quota.warn_threshold_percent,
+            warning,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -508,6 +550,7 @@ impl UsageResponse {
             stored_bytes: local.stored_bytes,
             logical_bytes: local.logical_bytes,
             realm,
+            quota: None,
         }
     }
 }
@@ -1144,6 +1187,40 @@ mod tests {
             response.realm.is_none(),
             "unauthenticated callers must not see realm-wide totals"
         );
+    }
+
+    #[test]
+    fn group_quota_status_reports_warning_and_unlimited() {
+        let group = Ulid::new();
+        let unlimited_group = Ulid::new();
+        let quota = QuotaConfig {
+            default_group_quota_bytes: Some(1_000),
+            grace_factor_percent: 110,
+            warn_threshold_percent: 85,
+            group_overrides: vec![aruna_core::structs::GroupQuotaOverride {
+                group_id: unlimited_group,
+                quota_bytes: None,
+                grace_factor_percent: None,
+            }],
+            ..QuotaConfig::default()
+        };
+
+        // Finite default quota, usage below the 850-byte warn threshold.
+        let below = super::GroupQuotaStatus::resolve(&quota, &group, 800);
+        assert_eq!(below.quota_bytes, Some(1_000));
+        assert_eq!(below.ceiling_bytes, Some(1_100));
+        assert_eq!(below.warn_threshold_percent, 85);
+        assert!(!below.warning);
+
+        // At the threshold the warning fires.
+        let at = super::GroupQuotaStatus::resolve(&quota, &group, 850);
+        assert!(at.warning);
+
+        // An override with quota_bytes: None is unlimited and never warns.
+        let unlimited = super::GroupQuotaStatus::resolve(&quota, &unlimited_group, u64::MAX);
+        assert_eq!(unlimited.quota_bytes, None);
+        assert_eq!(unlimited.ceiling_bytes, None);
+        assert!(!unlimited.warning);
     }
 
     #[test]

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -12,6 +12,7 @@ use aruna_operations::replication::queue::{
     QueueLiveVersionReplicationInput, QueueLiveVersionReplicationOperation,
 };
 use aruna_operations::s3::get_bucket_info::{GetBucketInfoError, GetBucketInfoOperation};
+use aruna_operations::s3::put_object::PutObjectError;
 use aruna_operations::staging::head_source::HeadStagingSourceError;
 use aruna_operations::staging::read_source::ReadStagingSourceError;
 use aruna_operations::staging::reference::{
@@ -316,6 +317,9 @@ fn validate_relative_source_path(source_path: &str) -> ServerResult<()> {
 fn map_snapshot_error(error: MaterializeSnapshotError) -> ServerError {
     match error {
         MaterializeSnapshotError::Read(error) => map_read_staging_error(error),
+        MaterializeSnapshotError::Write(PutObjectError::QuotaExceeded { .. }) => {
+            ServerError::Forbidden
+        }
         MaterializeSnapshotError::Write(error) => ServerError::InternalError(error.to_string()),
     }
 }
@@ -531,6 +535,17 @@ mod tests {
             .is_some(),
             "durable obligation should remain repairable when staging queue kick fails"
         );
+    }
+
+    #[test]
+    fn snapshot_quota_exceeded_maps_to_forbidden() {
+        let error = map_snapshot_error(MaterializeSnapshotError::Write(
+            PutObjectError::QuotaExceeded {
+                limit: 100,
+                usage: 200,
+            },
+        ));
+        assert!(matches!(error, ServerError::Forbidden));
     }
 
     #[test]

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -198,6 +198,8 @@ async fn reference_blob(
     .await?;
     ensure_source_permission(&state, &auth, group_id, connector_id, &request.source_path).await?;
 
+    let quota_ceiling = resolve_group_quota_ceiling(&state, group_id).await?;
+
     let result = stage_reference_blob(
         &state.get_ctx(),
         MaterializeReferenceInput {
@@ -209,6 +211,7 @@ async fn reference_blob(
             source_path: request.source_path,
             bucket: request.bucket.clone(),
             key: request.key.clone(),
+            quota_ceiling,
         },
     )
     .await
@@ -327,8 +330,13 @@ fn map_snapshot_error(error: MaterializeSnapshotError) -> ServerError {
 fn map_reference_error(error: MaterializeReferenceError) -> ServerError {
     match error {
         MaterializeReferenceError::Head(error) => map_head_staging_error(error),
+        MaterializeReferenceError::QuotaExceeded { .. } => ServerError::Forbidden,
         MaterializeReferenceError::Storage(error) => ServerError::InternalError(error.to_string()),
         MaterializeReferenceError::Conversion(error) => {
+            ServerError::InternalError(error.to_string())
+        }
+        MaterializeReferenceError::Usage(error) => ServerError::InternalError(error.to_string()),
+        MaterializeReferenceError::QuotaGate(error) => {
             ServerError::InternalError(error.to_string())
         }
     }
@@ -415,6 +423,7 @@ mod tests {
     use super::*;
     use crate::openapi::ApiDoc;
     use aruna_core::UserId;
+    use aruna_core::document::DocumentSyncTarget;
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{
@@ -423,7 +432,7 @@ mod tests {
     };
     use aruna_core::structs::{
         Actor, Group, GroupAuthorizationDocument, NodeCapabilities, PathRestriction,
-        RealmAuthorizationDocument,
+        RealmAuthorizationDocument, RealmConfigDocument,
     };
     use aruna_operations::driver::DriverContext;
     use aruna_operations::replication::queue::{
@@ -549,6 +558,16 @@ mod tests {
     }
 
     #[test]
+    fn reference_quota_exceeded_maps_to_forbidden() {
+        let error = map_reference_error(MaterializeReferenceError::QuotaExceeded {
+            limit: 100,
+            usage: 200,
+        });
+
+        assert!(matches!(error, ServerError::Forbidden));
+    }
+
+    #[test]
     fn openapi_includes_staging_path() {
         let openapi = ApiDoc::openapi();
 
@@ -613,12 +632,21 @@ mod tests {
             roles: source_auth.roles.keys().copied().collect(),
         };
         let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+        let realm_config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+        let realm_config_target = DocumentSyncTarget::RealmConfig { realm_id };
 
         write_doc(
             &driver_ctx,
             AUTH_KEYSPACE,
             (*realm_id.as_bytes()).into(),
             realm_auth.to_bytes(&actor).unwrap().into(),
+        )
+        .await;
+        write_doc(
+            &driver_ctx,
+            realm_config_target.storage_keyspace(),
+            realm_config_target.storage_key(),
+            realm_config.to_bytes(&actor).unwrap().into(),
         )
         .await;
         write_doc(

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -7,6 +7,7 @@ use crate::server_state::ServerState;
 use aruna_core::errors::{SourceConnectorResolutionError, StagingSourceError};
 use aruna_core::structs::{AuthContext, BucketInfo, Permission};
 use aruna_operations::driver::drive;
+use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::replication::queue::{
     QueueLiveVersionReplicationInput, QueueLiveVersionReplicationOperation,
 };
@@ -131,6 +132,8 @@ async fn snapshot_blob(
     .await?;
     ensure_source_permission(&state, &auth, group_id, connector_id, &request.source_path).await?;
 
+    let quota_ceiling = resolve_group_quota_ceiling(&state, group_id).await?;
+
     let result = stage_snapshot_blob(
         &state.get_ctx(),
         MaterializeSnapshotInput {
@@ -142,6 +145,7 @@ async fn snapshot_blob(
             source_path: request.source_path,
             bucket: request.bucket.clone(),
             key: request.key.clone(),
+            quota_ceiling,
         },
     )
     .await
@@ -222,6 +226,22 @@ async fn reference_blob(
             last_modified: result.source_metadata.last_modified.map(format_system_time),
         }),
     ))
+}
+
+/// Resolves the hard byte ceiling for a group's realm-wide `logical_bytes` from
+/// the realm quota config, mirroring the S3 surface's `resolve_quota_ceiling`.
+/// `None` means the group is unlimited.
+async fn resolve_group_quota_ceiling(
+    state: &ServerState,
+    group_id: ulid::Ulid,
+) -> ServerResult<Option<u64>> {
+    let config = drive(
+        GetRealmConfigOperation::new(state.get_realm_id()),
+        &state.get_ctx(),
+    )
+    .await
+    .map_err(|err| ServerError::InternalError(err.to_string()))?;
+    Ok(config.quota.effective_group_ceiling(&group_id))
 }
 
 async fn load_bucket_info(state: &ServerState, bucket: &str) -> ServerResult<BucketInfo> {

--- a/api/src/s3/error.rs
+++ b/api/src/s3/error.rs
@@ -18,12 +18,24 @@ use aruna_operations::s3::put_bucket_replication::{
 };
 use aruna_operations::s3::put_object::PutObjectError;
 use aruna_operations::s3::upload_part::UploadPartError;
-use s3s::{S3Error, s3_error};
+use s3s::{S3Error, S3ErrorCode, s3_error};
 use std::fmt::Display;
 use tracing::warn;
 
 fn internal_error<E: Display>(err: E) -> S3Error {
     s3_error!(InternalError, "{}", err)
+}
+
+/// A group storage quota rejection. S3 has no standard quota code, so we return a
+/// custom `QuotaExceeded` code with an explicit 403 status, matching the
+/// convention used by S3-compatible object stores.
+fn quota_exceeded_error(limit: u64, usage: u64) -> S3Error {
+    let mut error = S3Error::with_message(
+        S3ErrorCode::Custom("QuotaExceeded".into()),
+        format!("Group storage quota exceeded: {usage} bytes would exceed limit of {limit} bytes"),
+    );
+    error.set_status_code(http::StatusCode::FORBIDDEN);
+    error
 }
 
 fn no_such_upload_error() -> S3Error {
@@ -115,6 +127,7 @@ impl IntoS3Error for PutObjectError {
             PutObjectError::MissingExpectedChecksum(algorithm) => {
                 missing_expected_checksum_s3_error(algorithm, "PutObject")
             }
+            PutObjectError::QuotaExceeded { limit, usage } => quota_exceeded_error(limit, usage),
             err => internal_error(err),
         }
     }
@@ -165,6 +178,9 @@ impl IntoS3Error for CompleteMultipartUploadError {
                     InvalidPart,
                     "The part ETag did not match the uploaded part."
                 )
+            }
+            CompleteMultipartUploadError::QuotaExceeded { limit, usage } => {
+                quota_exceeded_error(limit, usage)
             }
             err => internal_error(err),
         }

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -19,6 +19,7 @@ use aruna_core::structs::{
 };
 use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::replication::queue::{
     QueueLiveVersionReplicationInput, QueueLiveVersionReplicationOperation,
 };
@@ -155,6 +156,22 @@ impl ArunaS3Service {
         )
         .await
         .map_err(|err| s3_error!(InternalError, "{}", err.to_string()))
+    }
+
+    /// Resolves the hard byte ceiling for a group's realm-wide `logical_bytes`
+    /// from the realm quota config, mirroring the create_group pattern of reading
+    /// realm config at the request surface. `None` means the group is unlimited.
+    async fn resolve_quota_ceiling(
+        &self,
+        group_id: aruna_core::types::GroupId,
+    ) -> S3Result<Option<u64>> {
+        let realm_config = drive(GetRealmConfigOperation::new(self.realm_id), &self.state)
+            .await
+            .map_err(|err| {
+                error!(error = %err, "Failed to load realm config for quota enforcement");
+                s3_error!(InternalError, "Failed to load realm quota configuration")
+            })?;
+        Ok(realm_config.quota.effective_group_ceiling(&group_id))
     }
 
     fn parse_replication_targets(
@@ -850,13 +867,15 @@ impl S3 for ArunaS3Service {
         let replication_bucket = req.input.bucket.clone();
         let replication_key = req.input.key.clone();
 
+        let group_id = bucket_info
+            .as_ref()
+            .map(|bucket_info| bucket_info.group_id)
+            .unwrap_or(user_access.group_id);
+        let quota_ceiling = self.resolve_quota_ceiling(group_id).await?;
         let input = convert_input(req.input)?;
         let config = PutObjectConfig {
             user_id: user_access.user_identity,
-            group_id: bucket_info
-                .as_ref()
-                .map(|bucket_info| bucket_info.group_id)
-                .unwrap_or(user_access.group_id),
+            group_id,
             realm_id: self.realm_id,
             node_id: self.node_id,
             request: input,
@@ -864,6 +883,7 @@ impl S3 for ArunaS3Service {
             checksum_type: Some(checksum_request.checksum_type.as_str().to_string()),
             version_source: None,
             exists: false,
+            quota_ceiling,
         };
         let operation = PutObjectOperation::new(config);
 
@@ -999,6 +1019,12 @@ impl S3 for ArunaS3Service {
             error!(error = "Missing user context");
             s3_error!(UnexpectedContent, "Missing user context")
         })?;
+        let bucket_info = req.extensions.get::<BucketInfo>().cloned();
+        let group_id = bucket_info
+            .as_ref()
+            .map(|bucket_info| bucket_info.group_id)
+            .unwrap_or(user_access.group_id);
+        let quota_ceiling = self.resolve_quota_ceiling(group_id).await?;
         let checksum_request = parse_upload_checksum_request(&req.headers)?;
         let upload_id = parse_upload_id(&req.input.upload_id)?;
         let replication_auth = AuthContext {
@@ -1031,6 +1057,7 @@ impl S3 for ArunaS3Service {
             checksum_type: multipart_checksum_type_from_s3(&checksum_request.checksum_type),
             object_size: req.input.mpu_object_size.map(|size| size as u64),
             created_by: user_access.user_identity,
+            quota_ceiling,
         });
 
         let result = drive(operation, &self.state)

--- a/api/src/server_state.rs
+++ b/api/src/server_state.rs
@@ -320,6 +320,7 @@ impl ServerState {
                     realm_signing_key: realm_signing_key.clone(),
                     realm_id: self.realm_id,
                     node_id,
+                    issuer_node_id: self.node_id,
                     now: chrono::Utc::now().timestamp().max(0) as u64,
                     ttl_secs: ONBOARDING_SYNC_TICKET_TTL_SECS,
                 }),

--- a/aruna-doctor/src/explorer.rs
+++ b/aruna-doctor/src/explorer.rs
@@ -566,6 +566,11 @@ enum JsonDocumentSyncTarget {
     MetadataGraphLifecycle {
         graph_iri: String,
     },
+    NodeUsage {
+        realm_id: String,
+        node_id: String,
+        group_id: Option<String>,
+    },
 }
 
 fn json_document_sync_target(target: &DocumentSyncTarget) -> JsonDocumentSyncTarget {
@@ -613,6 +618,15 @@ fn json_document_sync_target(target: &DocumentSyncTarget) -> JsonDocumentSyncTar
                 graph_iri: graph_iri.clone(),
             }
         }
+        DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id,
+            group_id,
+        } => JsonDocumentSyncTarget::NodeUsage {
+            realm_id: realm_id.to_string(),
+            node_id: node_id.to_string(),
+            group_id: group_id.map(|group_id| group_id.to_string()),
+        },
     }
 }
 

--- a/aruna-doctor/src/storage.rs
+++ b/aruna-doctor/src/storage.rs
@@ -742,6 +742,7 @@ mod tests {
                     expected_checksums: vec![],
                     checksum_type: None,
                     version_source: None,
+                    quota_ceiling: None,
                     exists: false,
                 }),
                 context.as_ref(),

--- a/aruna/src/bootstrap.rs
+++ b/aruna/src/bootstrap.rs
@@ -58,7 +58,7 @@ pub async fn announce_core_documents(
     let driver_ctx = driver_ctx.clone();
     let realm_id = *realm_id;
     tokio::spawn(async move {
-        let documents = match core_document_targets(&driver_ctx, realm_id).await {
+        let documents = match core_document_targets(&driver_ctx, node_id, realm_id).await {
             Ok(documents) => documents,
             Err(error) => {
                 warn!(error = %error, "Failed to collect core documents for replication");
@@ -92,11 +92,19 @@ pub async fn announce_core_documents(
 
 async fn core_document_targets(
     driver_ctx: &DriverContext,
+    node_id: NodeId,
     realm_id: aruna_core::structs::RealmId,
 ) -> Result<Vec<DocumentSyncTarget>, Box<dyn std::error::Error>> {
     let mut documents = vec![
         DocumentSyncTarget::RealmAuthorization { realm_id },
         DocumentSyncTarget::RealmConfig { realm_id },
+        // Announce the shared realm-scoped node-usage topic so every realm node
+        // subscribes to it and receives all peers' usage snapshots.
+        DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id,
+            group_id: None,
+        },
     ];
 
     match driver_ctx

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -117,6 +117,20 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     initialize_net_incoming(driver_ctx.clone());
     initialize_task_incoming(driver_ctx.clone(), task_handle).await;
 
+    // Republish a full set of node usage snapshots at startup so realm peers see
+    // this node's totals again after a restart, dirty-marker loss, or a counter
+    // rebuild. Best-effort: failures are retried by the debounced publisher.
+    if let Err(error) = aruna_operations::usage_stats::publish_usage_snapshots(
+        driver_ctx.as_ref(),
+        config.node_id,
+        config.realm_id,
+        true,
+    )
+    .await
+    {
+        warn!(error = %error, "Failed to publish initial node usage snapshots");
+    }
+
     let replayed_metadata_events = replay_metadata_event_log(driver_ctx.as_ref()).await?;
     if replayed_metadata_events > 0 {
         info!(

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -117,20 +117,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     initialize_net_incoming(driver_ctx.clone());
     initialize_task_incoming(driver_ctx.clone(), task_handle).await;
 
-    // Republish a full set of node usage snapshots at startup so realm peers see
-    // this node's totals again after a restart, dirty-marker loss, or a counter
-    // rebuild. Best-effort: failures are retried by the debounced publisher.
-    if let Err(error) = aruna_operations::usage_stats::publish_and_refresh_usage_snapshots(
-        driver_ctx.as_ref(),
-        config.node_id,
-        config.realm_id,
-        true,
-    )
-    .await
-    {
-        warn!(error = %error, "Failed to publish initial node usage snapshots");
-    }
-
     let replayed_metadata_events = replay_metadata_event_log(driver_ctx.as_ref()).await?;
     if replayed_metadata_events > 0 {
         info!(
@@ -264,6 +250,20 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             announce_core_documents(driver_ctx.as_ref(), config.node_id, &config.realm_id, false)
                 .await?;
         }
+    }
+
+    // Republish a full set of node usage snapshots after startup-mode core
+    // document announcement has had a chance to queue the shared node-usage topic
+    // genesis. Best-effort: failures are retried by the debounced publisher.
+    if let Err(error) = aruna_operations::usage_stats::publish_and_refresh_usage_snapshots(
+        driver_ctx.as_ref(),
+        config.node_id,
+        config.realm_id,
+        true,
+    )
+    .await
+    {
+        warn!(error = %error, "Failed to publish initial node usage snapshots");
     }
 
     drive(

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -120,7 +120,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Republish a full set of node usage snapshots at startup so realm peers see
     // this node's totals again after a restart, dirty-marker loss, or a counter
     // rebuild. Best-effort: failures are retried by the debounced publisher.
-    if let Err(error) = aruna_operations::usage_stats::publish_usage_snapshots(
+    if let Err(error) = aruna_operations::usage_stats::publish_and_refresh_usage_snapshots(
         driver_ctx.as_ref(),
         config.node_id,
         config.realm_id,

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -914,7 +914,13 @@ fn realm_discovery_value(discovery: &RealmDiscoveryConfig) -> String {
 }
 
 fn quota_value(quota: &QuotaConfig) -> String {
-    serde_json::to_string(quota).expect("admin document quota config serializes")
+    serde_json::to_string(&supported_quota(quota)).expect("admin document quota config serializes")
+}
+
+fn supported_quota(quota: &QuotaConfig) -> QuotaConfig {
+    let mut quota = quota.clone();
+    quota.max_devices_per_user = None;
+    quota
 }
 
 fn oidc_provider_value(provider: &OidcProviderConfig) -> String {
@@ -1001,7 +1007,9 @@ fn realm_discovery_from_value(value: &str) -> Option<RealmDiscoveryConfig> {
 }
 
 fn quota_from_value(value: &str) -> Option<QuotaConfig> {
-    serde_json::from_str(value).ok()
+    serde_json::from_str(value)
+        .ok()
+        .map(|quota| supported_quota(&quota))
 }
 
 fn realm_node_kind_from_value(value: &str) -> Option<RealmNodeKind> {
@@ -1019,13 +1027,13 @@ mod tests {
     use super::{
         AdminDocumentApplyStatus, AdminDocumentReducerError, AdminDocumentReducerState,
         GROUP_DISPLAY_NAME_PATH, GROUP_REALM_ID_PATH, REALM_CONFIG_DESCRIPTION_PATH,
-        REALM_CONFIG_DISCOVERY_PATH, REALM_CONFIG_METADATA_REPLICATION_PATH, USER_NAME_PATH,
-        group_role_id_from_path, group_role_path, group_role_user_assignment_from_path,
-        group_role_user_assignment_path, metadata_replication_value, oidc_provider_value,
-        realm_config_node_id_from_path, realm_config_node_path,
-        realm_config_oidc_provider_id_from_path, realm_config_oidc_provider_path,
-        realm_discovery_value, realm_role_id_from_path, realm_role_path,
-        realm_role_user_assignment_from_path, realm_role_user_assignment_path,
+        REALM_CONFIG_DISCOVERY_PATH, REALM_CONFIG_METADATA_REPLICATION_PATH,
+        REALM_CONFIG_QUOTA_PATH, USER_NAME_PATH, group_role_id_from_path, group_role_path,
+        group_role_user_assignment_from_path, group_role_user_assignment_path,
+        metadata_replication_value, oidc_provider_value, realm_config_node_id_from_path,
+        realm_config_node_path, realm_config_oidc_provider_id_from_path,
+        realm_config_oidc_provider_path, realm_discovery_value, realm_role_id_from_path,
+        realm_role_path, realm_role_user_assignment_from_path, realm_role_user_assignment_path,
         role_definition_value, user_attribute_path, user_subject_id_path,
     };
     use crate::admin_documents::{
@@ -1033,8 +1041,8 @@ mod tests {
         AdminDocumentRoleDefinition, AdminDocumentTarget,
     };
     use crate::structs::{
-        Actor, MetadataReplicationConfig, OidcProviderConfig, Permission, RealmDiscoveryConfig,
-        RealmId, RealmNodeKind,
+        Actor, MetadataReplicationConfig, OidcProviderConfig, Permission, QuotaConfig,
+        RealmDiscoveryConfig, RealmId, RealmNodeKind,
     };
     use crate::types::{GroupId, RoleId};
     use crate::user_update_validation::UserAttributeValidationError;
@@ -2595,6 +2603,53 @@ mod tests {
             Some("Demo Realm")
         );
         assert!(state.conflicts.is_empty());
+    }
+
+    #[test]
+    fn realm_config_quota_materialization_drops_unsupported_max_devices_per_user() {
+        let mut state = realm_config_state();
+        let quota = QuotaConfig {
+            default_group_quota_bytes: Some(1_000),
+            max_devices_per_user: Some(6),
+            ..QuotaConfig::default()
+        };
+        let expected = QuotaConfig {
+            max_devices_per_user: None,
+            ..quota.clone()
+        };
+
+        state
+            .apply(&realm_config_event(
+                1,
+                node(1),
+                1,
+                AdminDocumentClock::default(),
+                AdminDocumentOperation::RealmConfigQuotaSet {
+                    quota: quota.clone(),
+                },
+            ))
+            .unwrap();
+
+        assert_eq!(
+            state.materialized_realm_config_quota(),
+            Some(expected.clone())
+        );
+
+        let stored_value = state
+            .user_subject_ids
+            .get(REALM_CONFIG_QUOTA_PATH)
+            .and_then(|version| version.value.as_deref())
+            .expect("quota reducer value exists")
+            .to_string();
+        let stored_quota: QuotaConfig = serde_json::from_str(&stored_value).unwrap();
+        assert_eq!(stored_quota, expected);
+
+        state
+            .user_subject_ids
+            .get_mut(REALM_CONFIG_QUOTA_PATH)
+            .expect("quota reducer value exists")
+            .value = Some(serde_json::to_string(&quota).unwrap());
+        assert_eq!(state.materialized_realm_config_quota(), Some(expected));
     }
 
     #[test]

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -920,6 +920,10 @@ fn quota_value(quota: &QuotaConfig) -> String {
 fn supported_quota(quota: &QuotaConfig) -> QuotaConfig {
     let mut quota = quota.clone();
     quota.max_devices_per_user = None;
+    quota.group_overrides.sort_by_key(|over| over.group_id);
+    quota
+        .user_group_cap_overrides
+        .sort_by_key(|over| over.user_id);
     quota
 }
 
@@ -1041,8 +1045,8 @@ mod tests {
         AdminDocumentRoleDefinition, AdminDocumentTarget,
     };
     use crate::structs::{
-        Actor, MetadataReplicationConfig, OidcProviderConfig, Permission, QuotaConfig,
-        RealmDiscoveryConfig, RealmId, RealmNodeKind,
+        Actor, GroupQuotaOverride, MetadataReplicationConfig, OidcProviderConfig, Permission,
+        QuotaConfig, RealmDiscoveryConfig, RealmId, RealmNodeKind, UserGroupCapOverride,
     };
     use crate::types::{GroupId, RoleId};
     use crate::user_update_validation::UserAttributeValidationError;
@@ -2650,6 +2654,89 @@ mod tests {
             .expect("quota reducer value exists")
             .value = Some(serde_json::to_string(&quota).unwrap());
         assert_eq!(state.materialized_realm_config_quota(), Some(expected));
+    }
+
+    #[test]
+    fn realm_config_quota_override_order_is_canonical_for_conflict_detection() {
+        let group_a = Ulid::from_bytes([1; 16]);
+        let group_b = Ulid::from_bytes([2; 16]);
+        let user_a = user_id_with_seed(3);
+        let user_b = user_id_with_seed(4);
+        let expected = QuotaConfig {
+            default_group_quota_bytes: Some(1_000),
+            grace_factor_percent: 125,
+            warn_threshold_percent: 80,
+            group_overrides: vec![
+                GroupQuotaOverride {
+                    group_id: group_a,
+                    quota_bytes: Some(500),
+                    grace_factor_percent: None,
+                },
+                GroupQuotaOverride {
+                    group_id: group_b,
+                    quota_bytes: Some(750),
+                    grace_factor_percent: Some(150),
+                },
+            ],
+            max_groups_per_user: Some(4),
+            user_group_cap_overrides: vec![
+                UserGroupCapOverride {
+                    user_id: user_a,
+                    max_groups: Some(2),
+                },
+                UserGroupCapOverride {
+                    user_id: user_b,
+                    max_groups: Some(3),
+                },
+            ],
+            max_devices_per_user: None,
+        };
+        let reordered = QuotaConfig {
+            group_overrides: expected.group_overrides.iter().cloned().rev().collect(),
+            user_group_cap_overrides: expected
+                .user_group_cap_overrides
+                .iter()
+                .cloned()
+                .rev()
+                .collect(),
+            max_devices_per_user: Some(6),
+            ..expected.clone()
+        };
+
+        let first = realm_config_event(
+            1,
+            node(1),
+            1,
+            AdminDocumentClock::default(),
+            AdminDocumentOperation::RealmConfigQuotaSet {
+                quota: expected.clone(),
+            },
+        );
+        let second = realm_config_event(
+            2,
+            node(2),
+            1,
+            AdminDocumentClock::default(),
+            AdminDocumentOperation::RealmConfigQuotaSet { quota: reordered },
+        );
+
+        let mut state = realm_config_state();
+        state.apply(&first).unwrap();
+        state.apply(&second).unwrap();
+
+        assert!(state.conflicts.is_empty());
+        assert_eq!(
+            state.materialized_realm_config_quota(),
+            Some(expected.clone())
+        );
+
+        let stored_value = state
+            .user_subject_ids
+            .get(REALM_CONFIG_QUOTA_PATH)
+            .and_then(|version| version.value.as_deref())
+            .expect("quota reducer value exists");
+        let stored_quota: QuotaConfig = serde_json::from_str(stored_value).unwrap();
+        assert_eq!(stored_quota, expected);
     }
 
     #[test]

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -11,8 +11,8 @@ use crate::admin_documents::{
     AdminDocumentRoleDefinition, AdminDocumentTarget,
 };
 use crate::structs::{
-    Actor, MetadataReplicationConfig, OidcProviderConfig, RealmDiscoveryConfig, RealmId,
-    RealmNodeKind,
+    Actor, MetadataReplicationConfig, OidcProviderConfig, QuotaConfig, RealmDiscoveryConfig,
+    RealmId, RealmNodeKind,
 };
 use crate::types::{RoleId, UserId};
 use crate::user_update_validation::{
@@ -259,6 +259,12 @@ impl AdminDocumentReducerState {
                     description.clone(),
                 );
             }
+            (
+                AdminDocumentTarget::RealmConfig { .. },
+                AdminDocumentOperation::RealmConfigQuotaSet { quota },
+            ) => {
+                self.apply_realm_config_setting(event, REALM_CONFIG_QUOTA_PATH, quota_value(quota));
+            }
             _ => return Err(AdminDocumentReducerError::UnsupportedTarget),
         }
 
@@ -487,6 +493,17 @@ impl AdminDocumentReducerState {
         self.user_subject_ids
             .get(REALM_CONFIG_DESCRIPTION_PATH)
             .and_then(|version| version.value.clone())
+    }
+
+    pub fn materialized_realm_config_quota(&self) -> Option<QuotaConfig> {
+        if !matches!(&self.target, AdminDocumentTarget::RealmConfig { .. }) {
+            return None;
+        }
+
+        self.user_subject_ids
+            .get(REALM_CONFIG_QUOTA_PATH)
+            .and_then(|version| version.value.as_deref())
+            .and_then(quota_from_value)
     }
 
     fn apply_user_name(&mut self, event: &AdminDocumentEvent, name: &str) {
@@ -844,6 +861,7 @@ pub const REALM_CONFIG_METADATA_REPLICATION_PATH: &str =
     "realm_config.settings.metadata_replication";
 pub const REALM_CONFIG_DISCOVERY_PATH: &str = "realm_config.settings.discovery";
 pub const REALM_CONFIG_DESCRIPTION_PATH: &str = "realm_config.description";
+pub const REALM_CONFIG_QUOTA_PATH: &str = "realm_config.quota";
 
 fn event_observes_dot(event: &AdminDocumentEvent, dot: &AdminDocumentDot) -> bool {
     event.observed.observes(dot)
@@ -893,6 +911,10 @@ fn metadata_replication_value(metadata_replication: &MetadataReplicationConfig) 
 
 fn realm_discovery_value(discovery: &RealmDiscoveryConfig) -> String {
     serde_json::to_string(discovery).expect("admin document realm discovery config serializes")
+}
+
+fn quota_value(quota: &QuotaConfig) -> String {
+    serde_json::to_string(quota).expect("admin document quota config serializes")
 }
 
 fn oidc_provider_value(provider: &OidcProviderConfig) -> String {
@@ -975,6 +997,10 @@ fn metadata_replication_from_value(value: &str) -> Option<MetadataReplicationCon
 }
 
 fn realm_discovery_from_value(value: &str) -> Option<RealmDiscoveryConfig> {
+    serde_json::from_str(value).ok()
+}
+
+fn quota_from_value(value: &str) -> Option<QuotaConfig> {
     serde_json::from_str(value).ok()
 }
 

--- a/core/src/admin_documents.rs
+++ b/core/src/admin_documents.rs
@@ -5,8 +5,8 @@ use ulid::Ulid;
 
 use crate::NodeId;
 use crate::structs::{
-    Actor, MetadataReplicationConfig, OidcProviderConfig, Permission, RealmDiscoveryConfig,
-    RealmId, RealmNodeKind, Role,
+    Actor, MetadataReplicationConfig, OidcProviderConfig, Permission, QuotaConfig,
+    RealmDiscoveryConfig, RealmId, RealmNodeKind, Role,
 };
 use crate::types::{GroupId, RoleId, UserId};
 
@@ -151,6 +151,9 @@ pub enum AdminDocumentOperation {
     RealmConfigDescriptionSet {
         description: String,
     },
+    RealmConfigQuotaSet {
+        quota: QuotaConfig,
+    },
 }
 
 #[cfg(test)]
@@ -158,8 +161,8 @@ mod tests {
     use super::{AdminDocumentOperation, AdminDocumentRoleDefinition, AdminDocumentTarget};
     use crate::NodeId;
     use crate::structs::{
-        MetadataReplicationConfig, OidcProviderConfig, Permission, RealmDiscoveryConfig, RealmId,
-        RealmNodeKind,
+        MetadataReplicationConfig, OidcProviderConfig, Permission, QuotaConfig,
+        RealmDiscoveryConfig, RealmId, RealmNodeKind,
     };
     use crate::types::{GroupId, RoleId, UserId};
     use std::collections::BTreeMap;
@@ -276,6 +279,9 @@ mod tests {
             },
             AdminDocumentOperation::RealmConfigDescriptionSet {
                 description: "Demo Realm".to_string(),
+            },
+            AdminDocumentOperation::RealmConfigQuotaSet {
+                quota: QuotaConfig::default(),
             },
         ];
 

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -8,13 +8,13 @@ use crate::admin_documents::AdminDocumentEvent;
 use crate::keyspaces::{
     AUTH_KEYSPACE, GROUP_KEYSPACE, METADATA_DOCUMENT_LIFECYCLE_KEYSPACE,
     METADATA_EVENT_LOG_KEYSPACE, METADATA_GRAPH_LIFECYCLE_KEYSPACE, METADATA_INDEX_KEYSPACE,
-    REALM_CONFIG_KEYSPACE, USER_KEYSPACE,
+    REALM_CONFIG_KEYSPACE, USAGE_NODE_STATS_KEYSPACE, USER_KEYSPACE,
 };
 use crate::metadata::{MetadataCreateEventRecord, MetadataGraphLifecycleRecord};
 use crate::storage_entries::{
     metadata_document_lifecycle_key, metadata_event_log_key, metadata_graph_lifecycle_key,
 };
-use crate::structs::RealmId;
+use crate::structs::{RealmId, node_usage_global_key, node_usage_group_key};
 use crate::types::{GroupId, Key, UserId};
 use crate::{NodeId, TopicId};
 
@@ -48,6 +48,11 @@ pub enum DocumentSyncTarget {
     },
     MetadataGraphLifecycle {
         graph_iri: String,
+    },
+    NodeUsage {
+        realm_id: RealmId,
+        node_id: NodeId,
+        group_id: Option<GroupId>,
     },
 }
 
@@ -275,6 +280,7 @@ impl DocumentSyncTarget {
             Self::MetadataGraphLifecycle { graph_iri } => {
                 TopicId::metadata(metadata_graph_lifecycle_topic_id(graph_iri))
             }
+            Self::NodeUsage { realm_id, .. } => TopicId::realm(*realm_id),
         }
     }
 
@@ -288,6 +294,7 @@ impl DocumentSyncTarget {
             Self::MetadataCreateEvent { .. } => METADATA_EVENT_LOG_KEYSPACE,
             Self::MetadataDocumentLifecycle { .. } => METADATA_DOCUMENT_LIFECYCLE_KEYSPACE,
             Self::MetadataGraphLifecycle { .. } => METADATA_GRAPH_LIFECYCLE_KEYSPACE,
+            Self::NodeUsage { .. } => USAGE_NODE_STATS_KEYSPACE,
         }
     }
 
@@ -317,6 +324,12 @@ impl DocumentSyncTarget {
                 metadata_document_lifecycle_key(*document_id)
             }
             Self::MetadataGraphLifecycle { graph_iri } => metadata_graph_lifecycle_key(graph_iri),
+            Self::NodeUsage {
+                node_id, group_id, ..
+            } => match group_id {
+                Some(group_id) => ByteView::from(node_usage_group_key(*group_id, *node_id)),
+                None => ByteView::from(node_usage_global_key(*node_id)),
+            },
         }
     }
 
@@ -348,6 +361,9 @@ impl DocumentSyncTarget {
                 bytes.extend_from_slice(b"/metadata-graph-lifecycle/");
                 bytes.extend_from_slice(graph_iri.as_bytes());
             }
+            // No node id in the suffix: every node's usage snapshot flows over a
+            // single shared realm-scoped topic that all realm nodes subscribe to.
+            Self::NodeUsage { .. } => bytes.extend_from_slice(b"/node-usage"),
         }
         irokle::TopicId::hash(bytes)
     }
@@ -695,6 +711,55 @@ mod tests {
     #[test]
     fn document_sync_event_type_id_is_stable() {
         assert_eq!(DocumentSyncEvent::TYPE_ID, "aruna.document.v2");
+    }
+
+    #[test]
+    fn node_usage_targets_share_one_realm_topic_and_map_to_snapshot_keys() {
+        use crate::keyspaces::USAGE_NODE_STATS_KEYSPACE;
+        use crate::structs::{node_usage_global_key, node_usage_group_key};
+
+        let realm_id = test_realm(2);
+        let node_id = test_node(1);
+        let group_id = test_ulid(4);
+
+        let global = DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id,
+            group_id: None,
+        };
+        let group = DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id,
+            group_id: Some(group_id),
+        };
+
+        // Both map onto the realm domain topic and the single shared sync topic.
+        assert_eq!(global.topic_id(), TopicId::realm(realm_id));
+        assert_eq!(global.topic_id(), group.topic_id());
+        assert_eq!(global.sync_topic_id(), group.sync_topic_id());
+
+        // A different node's usage rides the very same shared topic.
+        let other = DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id: test_node(9),
+            group_id: None,
+        };
+        assert_eq!(global.sync_topic_id(), other.sync_topic_id());
+        // But is distinct from the realm-config topic on the same domain.
+        assert_ne!(
+            global.sync_topic_id(),
+            DocumentSyncTarget::RealmConfig { realm_id }.sync_topic_id()
+        );
+
+        assert_eq!(global.storage_keyspace(), USAGE_NODE_STATS_KEYSPACE);
+        assert_eq!(
+            global.storage_key().as_ref(),
+            node_usage_global_key(node_id).as_slice()
+        );
+        assert_eq!(
+            group.storage_key().as_ref(),
+            node_usage_group_key(group_id, node_id).as_slice()
+        );
     }
 
     #[test]

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -41,6 +41,7 @@ pub const BLOB_REPLICATION_JOB_KEYSPACE: &str = "blob_replication_jobs";
 pub const BLOB_LIVE_REPLICATION_OBLIGATION_KEYSPACE: &str = "blob_live_replication_obligations";
 pub const REFERENCE_METADATA_REFRESH_JOB_KEYSPACE: &str = "reference_metadata_refresh_jobs";
 pub const USAGE_STATS_KEYSPACE: &str = "usage_stats";
+pub const USAGE_NODE_STATS_KEYSPACE: &str = "usage_node_stats";
 
 pub const SOURCE_CONNECTOR_INDEX_KEYSPACE: &str = "source_connector_index";
 pub const SOURCE_CONNECTOR_SECRET_KEYSPACE: &str = "source_connector_secret";

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -162,10 +162,6 @@ pub struct QuotaConfig {
     pub group_overrides: Vec<GroupQuotaOverride>,
     pub max_groups_per_user: Option<u32>,
     pub user_group_cap_overrides: Vec<UserGroupCapOverride>,
-    /// Added after the initial `QuotaConfig` shape. `#[serde(default)]` lets JSON
-    /// reducer state persisted before this field materialize; the postcard wire
-    /// shape is handled by the legacy fallback in `RealmConfigDocument::from_bytes`.
-    #[serde(default)]
     pub max_devices_per_user: Option<u32>,
 }
 
@@ -394,17 +390,7 @@ impl RealmConfigDocument {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
-        // Try the current wire shape first; fall back to the pre-`max_devices_per_user`
-        // layout so realm configs persisted by an earlier build still decode. This
-        // repo is pre-GA (issue #286 will add real format versioning), so a minimal
-        // try-then-legacy chain with no on-wire version tag is sufficient.
-        match postcard::from_bytes::<Self>(bytes) {
-            Ok(document) => Ok(document),
-            Err(_) => {
-                let legacy: LegacyRealmConfigDocument = postcard::from_bytes(bytes)?;
-                Ok(legacy.into())
-            }
-        }
+        Ok(postcard::from_bytes(bytes)?)
     }
 
     pub fn reconcile_bytes(
@@ -414,61 +400,6 @@ impl RealmConfigDocument {
     ) -> Result<Vec<u8>, ConversionError> {
         let _ = (current, actor);
         Ok(postcard::to_allocvec(self)?)
-    }
-}
-
-/// Pre-`max_devices_per_user` mirror of [`QuotaConfig`], used only to decode
-/// realm configs persisted before that field existed. Keep field order identical
-/// to the historical layout.
-#[derive(Deserialize)]
-struct LegacyQuotaConfig {
-    default_group_quota_bytes: Option<u64>,
-    grace_factor_percent: u32,
-    warn_threshold_percent: u32,
-    group_overrides: Vec<GroupQuotaOverride>,
-    max_groups_per_user: Option<u32>,
-    user_group_cap_overrides: Vec<UserGroupCapOverride>,
-}
-
-impl From<LegacyQuotaConfig> for QuotaConfig {
-    fn from(legacy: LegacyQuotaConfig) -> Self {
-        Self {
-            default_group_quota_bytes: legacy.default_group_quota_bytes,
-            grace_factor_percent: legacy.grace_factor_percent,
-            warn_threshold_percent: legacy.warn_threshold_percent,
-            group_overrides: legacy.group_overrides,
-            max_groups_per_user: legacy.max_groups_per_user,
-            user_group_cap_overrides: legacy.user_group_cap_overrides,
-            max_devices_per_user: None,
-        }
-    }
-}
-
-/// Pre-`max_devices_per_user` mirror of [`RealmConfigDocument`] (only the `quota`
-/// field differs). Used as the postcard fallback in
-/// [`RealmConfigDocument::from_bytes`].
-#[derive(Deserialize)]
-struct LegacyRealmConfigDocument {
-    realm_id: RealmId,
-    metadata_replication: MetadataReplicationConfig,
-    oidc_providers: Vec<OidcProviderConfig>,
-    discovery: RealmDiscoveryConfig,
-    nodes: Vec<RealmNode>,
-    quota: LegacyQuotaConfig,
-    description: String,
-}
-
-impl From<LegacyRealmConfigDocument> for RealmConfigDocument {
-    fn from(legacy: LegacyRealmConfigDocument) -> Self {
-        Self {
-            realm_id: legacy.realm_id,
-            metadata_replication: legacy.metadata_replication,
-            oidc_providers: legacy.oidc_providers,
-            discovery: legacy.discovery,
-            nodes: legacy.nodes,
-            quota: legacy.quota.into(),
-            description: legacy.description,
-        }
     }
 }
 
@@ -614,81 +545,6 @@ mod test {
         let restored = RealmConfigDocument::from_bytes(&bytes).expect("from bytes");
 
         assert_eq!(document, restored);
-    }
-
-    #[test]
-    fn from_bytes_decodes_legacy_pre_max_devices_quota() {
-        use serde::Serialize;
-
-        #[derive(Serialize)]
-        struct LegacyQuota {
-            default_group_quota_bytes: Option<u64>,
-            grace_factor_percent: u32,
-            warn_threshold_percent: u32,
-            group_overrides: Vec<super::GroupQuotaOverride>,
-            max_groups_per_user: Option<u32>,
-            user_group_cap_overrides: Vec<super::UserGroupCapOverride>,
-        }
-
-        #[derive(Serialize)]
-        struct LegacyDoc {
-            realm_id: RealmId,
-            metadata_replication: super::MetadataReplicationConfig,
-            oidc_providers: Vec<OidcProviderConfig>,
-            discovery: RealmDiscoveryConfig,
-            nodes: Vec<super::RealmNode>,
-            quota: LegacyQuota,
-            description: String,
-        }
-
-        let legacy = LegacyDoc {
-            realm_id: RealmId::from_bytes([3u8; 32]),
-            metadata_replication: super::MetadataReplicationConfig::new(3),
-            oidc_providers: Vec::new(),
-            discovery: default_realm_discovery_config(),
-            nodes: Vec::new(),
-            quota: LegacyQuota {
-                default_group_quota_bytes: Some(4_096),
-                grace_factor_percent: 110,
-                warn_threshold_percent: 85,
-                group_overrides: vec![super::GroupQuotaOverride {
-                    group_id: Ulid::from_bytes([2u8; 16]),
-                    quota_bytes: Some(1_000),
-                    grace_factor_percent: Some(120),
-                }],
-                max_groups_per_user: Some(3),
-                user_group_cap_overrides: Vec::new(),
-            },
-            description: "Legacy Realm".to_string(),
-        };
-
-        let bytes = postcard::to_allocvec(&legacy).expect("legacy postcard encode");
-        let restored = RealmConfigDocument::from_bytes(&bytes).expect("legacy config decodes");
-
-        assert_eq!(restored.realm_id, RealmId::from_bytes([3u8; 32]));
-        assert_eq!(restored.quota.default_group_quota_bytes, Some(4_096));
-        assert_eq!(restored.quota.group_overrides.len(), 1);
-        assert_eq!(restored.quota.max_groups_per_user, Some(3));
-        assert_eq!(restored.quota.max_devices_per_user, None);
-        assert_eq!(restored.description, "Legacy Realm");
-    }
-
-    #[test]
-    fn quota_config_json_tolerates_missing_max_devices_per_user() {
-        // JSON reducer state persisted before `max_devices_per_user` existed must
-        // still materialize via `#[serde(default)]`.
-        let legacy_json = r#"{
-            "default_group_quota_bytes": 4096,
-            "grace_factor_percent": 110,
-            "warn_threshold_percent": 85,
-            "group_overrides": [],
-            "max_groups_per_user": 3,
-            "user_group_cap_overrides": []
-        }"#;
-        let quota: super::QuotaConfig =
-            serde_json::from_str(legacy_json).expect("legacy quota json decodes");
-        assert_eq!(quota.default_group_quota_bytes, Some(4_096));
-        assert_eq!(quota.max_devices_per_user, None);
     }
 
     #[test]

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -202,20 +202,34 @@ impl QuotaConfig {
             .unwrap_or(self.max_groups_per_user)
     }
 
+    /// Resolves the effective pre-grace quota (in bytes) for a group: the group
+    /// override's `quota_bytes` when an override exists — an existing override
+    /// with `quota_bytes: None` means the group is explicitly unlimited — else
+    /// the realm `default_group_quota_bytes`. `None` means unlimited.
+    pub fn effective_group_quota_bytes(&self, group_id: &GroupId) -> Option<u64> {
+        match self
+            .group_overrides
+            .iter()
+            .find(|over| over.group_id == *group_id)
+        {
+            Some(over) => over.quota_bytes,
+            None => self.default_group_quota_bytes,
+        }
+    }
+
     /// Resolves the hard ceiling (in bytes) a group's realm-wide `logical_bytes`
-    /// may reach before writes are rejected: the effective quota (group override
-    /// `quota_bytes` if present, else `default_group_quota_bytes`) scaled by the
-    /// effective grace factor (group override if present, else the global
-    /// `grace_factor_percent`). Returns `None` when no quota applies — i.e. the
-    /// group is unlimited and no gate is enforced.
+    /// may reach before writes are rejected: the effective quota
+    /// (`effective_group_quota_bytes`) scaled by the effective grace factor (group
+    /// override if present, else the global `grace_factor_percent`). Returns
+    /// `None` when no quota applies — an existing override with `quota_bytes: None`
+    /// or no override and no `default_group_quota_bytes` — i.e. the group is
+    /// unlimited and no gate is enforced.
     pub fn effective_group_ceiling(&self, group_id: &GroupId) -> Option<u64> {
         let over = self
             .group_overrides
             .iter()
             .find(|over| over.group_id == *group_id);
-        let quota = over
-            .and_then(|over| over.quota_bytes)
-            .or(self.default_group_quota_bytes)?;
+        let quota = self.effective_group_quota_bytes(group_id)?;
         let grace = over
             .and_then(|over| over.grace_factor_percent)
             .unwrap_or(self.grace_factor_percent);
@@ -573,6 +587,24 @@ mod test {
             ..super::QuotaConfig::default()
         };
         assert_eq!(unlimited.effective_group_ceiling(&other), None);
+
+        // An existing override with quota_bytes: None is explicitly unlimited even
+        // when a finite default exists.
+        let unlimited_override = super::QuotaConfig {
+            default_group_quota_bytes: Some(1_000),
+            grace_factor_percent: 110,
+            group_overrides: vec![super::GroupQuotaOverride {
+                group_id: group,
+                quota_bytes: None,
+                grace_factor_percent: None,
+            }],
+            ..super::QuotaConfig::default()
+        };
+        assert_eq!(unlimited_override.effective_group_ceiling(&group), None);
+        assert_eq!(
+            unlimited_override.effective_group_ceiling(&other),
+            Some(1_100)
+        );
     }
 
     #[test]

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -233,7 +233,8 @@ impl QuotaConfig {
         let grace = over
             .and_then(|over| over.grace_factor_percent)
             .unwrap_or(self.grace_factor_percent);
-        Some(quota.saturating_mul(u64::from(grace)) / 100)
+        let ceiling = u128::from(quota) * u128::from(grace) / 100;
+        Some(ceiling.min(u128::from(u64::MAX)) as u64)
     }
 }
 
@@ -605,6 +606,20 @@ mod test {
             unlimited_override.effective_group_ceiling(&other),
             Some(1_100)
         );
+
+        let huge = super::QuotaConfig {
+            default_group_quota_bytes: Some(u64::MAX),
+            grace_factor_percent: 100,
+            ..super::QuotaConfig::default()
+        };
+        assert_eq!(huge.effective_group_ceiling(&other), Some(u64::MAX));
+
+        let over_huge = super::QuotaConfig {
+            default_group_quota_bytes: Some(u64::MAX),
+            grace_factor_percent: 110,
+            ..super::QuotaConfig::default()
+        };
+        assert_eq!(over_huge.effective_group_ceiling(&other), Some(u64::MAX));
     }
 
     #[test]

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -162,6 +162,10 @@ pub struct QuotaConfig {
     pub group_overrides: Vec<GroupQuotaOverride>,
     pub max_groups_per_user: Option<u32>,
     pub user_group_cap_overrides: Vec<UserGroupCapOverride>,
+    /// Added after the initial `QuotaConfig` shape. `#[serde(default)]` lets JSON
+    /// reducer state persisted before this field materialize; the postcard wire
+    /// shape is handled by the legacy fallback in `RealmConfigDocument::from_bytes`.
+    #[serde(default)]
     pub max_devices_per_user: Option<u32>,
 }
 
@@ -200,6 +204,26 @@ impl QuotaConfig {
             .find(|over| over.user_id == *user_id)
             .map(|over| over.max_groups)
             .unwrap_or(self.max_groups_per_user)
+    }
+
+    /// Resolves the hard ceiling (in bytes) a group's realm-wide `logical_bytes`
+    /// may reach before writes are rejected: the effective quota (group override
+    /// `quota_bytes` if present, else `default_group_quota_bytes`) scaled by the
+    /// effective grace factor (group override if present, else the global
+    /// `grace_factor_percent`). Returns `None` when no quota applies — i.e. the
+    /// group is unlimited and no gate is enforced.
+    pub fn effective_group_ceiling(&self, group_id: &GroupId) -> Option<u64> {
+        let over = self
+            .group_overrides
+            .iter()
+            .find(|over| over.group_id == *group_id);
+        let quota = over
+            .and_then(|over| over.quota_bytes)
+            .or(self.default_group_quota_bytes)?;
+        let grace = over
+            .and_then(|over| over.grace_factor_percent)
+            .unwrap_or(self.grace_factor_percent);
+        Some(quota.saturating_mul(u64::from(grace)) / 100)
     }
 }
 
@@ -370,7 +394,17 @@ impl RealmConfigDocument {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
-        Ok(postcard::from_bytes(bytes)?)
+        // Try the current wire shape first; fall back to the pre-`max_devices_per_user`
+        // layout so realm configs persisted by an earlier build still decode. This
+        // repo is pre-GA (issue #286 will add real format versioning), so a minimal
+        // try-then-legacy chain with no on-wire version tag is sufficient.
+        match postcard::from_bytes::<Self>(bytes) {
+            Ok(document) => Ok(document),
+            Err(_) => {
+                let legacy: LegacyRealmConfigDocument = postcard::from_bytes(bytes)?;
+                Ok(legacy.into())
+            }
+        }
     }
 
     pub fn reconcile_bytes(
@@ -380,6 +414,61 @@ impl RealmConfigDocument {
     ) -> Result<Vec<u8>, ConversionError> {
         let _ = (current, actor);
         Ok(postcard::to_allocvec(self)?)
+    }
+}
+
+/// Pre-`max_devices_per_user` mirror of [`QuotaConfig`], used only to decode
+/// realm configs persisted before that field existed. Keep field order identical
+/// to the historical layout.
+#[derive(Deserialize)]
+struct LegacyQuotaConfig {
+    default_group_quota_bytes: Option<u64>,
+    grace_factor_percent: u32,
+    warn_threshold_percent: u32,
+    group_overrides: Vec<GroupQuotaOverride>,
+    max_groups_per_user: Option<u32>,
+    user_group_cap_overrides: Vec<UserGroupCapOverride>,
+}
+
+impl From<LegacyQuotaConfig> for QuotaConfig {
+    fn from(legacy: LegacyQuotaConfig) -> Self {
+        Self {
+            default_group_quota_bytes: legacy.default_group_quota_bytes,
+            grace_factor_percent: legacy.grace_factor_percent,
+            warn_threshold_percent: legacy.warn_threshold_percent,
+            group_overrides: legacy.group_overrides,
+            max_groups_per_user: legacy.max_groups_per_user,
+            user_group_cap_overrides: legacy.user_group_cap_overrides,
+            max_devices_per_user: None,
+        }
+    }
+}
+
+/// Pre-`max_devices_per_user` mirror of [`RealmConfigDocument`] (only the `quota`
+/// field differs). Used as the postcard fallback in
+/// [`RealmConfigDocument::from_bytes`].
+#[derive(Deserialize)]
+struct LegacyRealmConfigDocument {
+    realm_id: RealmId,
+    metadata_replication: MetadataReplicationConfig,
+    oidc_providers: Vec<OidcProviderConfig>,
+    discovery: RealmDiscoveryConfig,
+    nodes: Vec<RealmNode>,
+    quota: LegacyQuotaConfig,
+    description: String,
+}
+
+impl From<LegacyRealmConfigDocument> for RealmConfigDocument {
+    fn from(legacy: LegacyRealmConfigDocument) -> Self {
+        Self {
+            realm_id: legacy.realm_id,
+            metadata_replication: legacy.metadata_replication,
+            oidc_providers: legacy.oidc_providers,
+            discovery: legacy.discovery,
+            nodes: legacy.nodes,
+            quota: legacy.quota.into(),
+            description: legacy.description,
+        }
     }
 }
 
@@ -525,6 +614,109 @@ mod test {
         let restored = RealmConfigDocument::from_bytes(&bytes).expect("from bytes");
 
         assert_eq!(document, restored);
+    }
+
+    #[test]
+    fn from_bytes_decodes_legacy_pre_max_devices_quota() {
+        use serde::Serialize;
+
+        #[derive(Serialize)]
+        struct LegacyQuota {
+            default_group_quota_bytes: Option<u64>,
+            grace_factor_percent: u32,
+            warn_threshold_percent: u32,
+            group_overrides: Vec<super::GroupQuotaOverride>,
+            max_groups_per_user: Option<u32>,
+            user_group_cap_overrides: Vec<super::UserGroupCapOverride>,
+        }
+
+        #[derive(Serialize)]
+        struct LegacyDoc {
+            realm_id: RealmId,
+            metadata_replication: super::MetadataReplicationConfig,
+            oidc_providers: Vec<OidcProviderConfig>,
+            discovery: RealmDiscoveryConfig,
+            nodes: Vec<super::RealmNode>,
+            quota: LegacyQuota,
+            description: String,
+        }
+
+        let legacy = LegacyDoc {
+            realm_id: RealmId::from_bytes([3u8; 32]),
+            metadata_replication: super::MetadataReplicationConfig::new(3),
+            oidc_providers: Vec::new(),
+            discovery: default_realm_discovery_config(),
+            nodes: Vec::new(),
+            quota: LegacyQuota {
+                default_group_quota_bytes: Some(4_096),
+                grace_factor_percent: 110,
+                warn_threshold_percent: 85,
+                group_overrides: vec![super::GroupQuotaOverride {
+                    group_id: Ulid::from_bytes([2u8; 16]),
+                    quota_bytes: Some(1_000),
+                    grace_factor_percent: Some(120),
+                }],
+                max_groups_per_user: Some(3),
+                user_group_cap_overrides: Vec::new(),
+            },
+            description: "Legacy Realm".to_string(),
+        };
+
+        let bytes = postcard::to_allocvec(&legacy).expect("legacy postcard encode");
+        let restored = RealmConfigDocument::from_bytes(&bytes).expect("legacy config decodes");
+
+        assert_eq!(restored.realm_id, RealmId::from_bytes([3u8; 32]));
+        assert_eq!(restored.quota.default_group_quota_bytes, Some(4_096));
+        assert_eq!(restored.quota.group_overrides.len(), 1);
+        assert_eq!(restored.quota.max_groups_per_user, Some(3));
+        assert_eq!(restored.quota.max_devices_per_user, None);
+        assert_eq!(restored.description, "Legacy Realm");
+    }
+
+    #[test]
+    fn quota_config_json_tolerates_missing_max_devices_per_user() {
+        // JSON reducer state persisted before `max_devices_per_user` existed must
+        // still materialize via `#[serde(default)]`.
+        let legacy_json = r#"{
+            "default_group_quota_bytes": 4096,
+            "grace_factor_percent": 110,
+            "warn_threshold_percent": 85,
+            "group_overrides": [],
+            "max_groups_per_user": 3,
+            "user_group_cap_overrides": []
+        }"#;
+        let quota: super::QuotaConfig =
+            serde_json::from_str(legacy_json).expect("legacy quota json decodes");
+        assert_eq!(quota.default_group_quota_bytes, Some(4_096));
+        assert_eq!(quota.max_devices_per_user, None);
+    }
+
+    #[test]
+    fn effective_group_ceiling_resolves_override_and_grace() {
+        let group = Ulid::from_bytes([1u8; 16]);
+        let other = Ulid::from_bytes([2u8; 16]);
+        let quota = super::QuotaConfig {
+            default_group_quota_bytes: Some(1_000),
+            grace_factor_percent: 110,
+            group_overrides: vec![super::GroupQuotaOverride {
+                group_id: group,
+                quota_bytes: Some(2_000),
+                grace_factor_percent: Some(150),
+            }],
+            ..super::QuotaConfig::default()
+        };
+
+        // Override quota_bytes and grace win for the overridden group.
+        assert_eq!(quota.effective_group_ceiling(&group), Some(3_000));
+        // Default quota and global grace apply otherwise.
+        assert_eq!(quota.effective_group_ceiling(&other), Some(1_100));
+
+        // No default and no override => unlimited (no gate).
+        let unlimited = super::QuotaConfig {
+            default_group_quota_bytes: None,
+            ..super::QuotaConfig::default()
+        };
+        assert_eq!(unlimited.effective_group_ceiling(&other), None);
     }
 
     #[test]

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -162,6 +162,7 @@ pub struct QuotaConfig {
     pub group_overrides: Vec<GroupQuotaOverride>,
     pub max_groups_per_user: Option<u32>,
     pub user_group_cap_overrides: Vec<UserGroupCapOverride>,
+    pub max_devices_per_user: Option<u32>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -186,6 +187,7 @@ impl Default for QuotaConfig {
             group_overrides: Vec::new(),
             max_groups_per_user: Some(3),
             user_group_cap_overrides: Vec::new(),
+            max_devices_per_user: None,
         }
     }
 }

--- a/core/src/structs/usage.rs
+++ b/core/src/structs/usage.rs
@@ -84,6 +84,13 @@ pub fn node_usage_dirty_group_id(key: &[u8]) -> Option<GroupId> {
     Some(GroupId::from_bytes(bytes))
 }
 
+/// Recovers the group id from a `g/<group><node>` per-group snapshot key.
+pub fn node_usage_group_key_group_id(key: &[u8]) -> Option<GroupId> {
+    let tail = key.strip_prefix(NODE_USAGE_GROUP_PREFIX)?;
+    let bytes: [u8; 16] = tail.get(..16)?.try_into().ok()?;
+    Some(GroupId::from_bytes(bytes))
+}
+
 pub fn node_usage_summary_group_key(group_id: GroupId) -> Vec<u8> {
     let mut key = Vec::with_capacity(NODE_USAGE_SUMMARY_GROUP_PREFIX.len() + 16);
     key.extend_from_slice(NODE_USAGE_SUMMARY_GROUP_PREFIX);
@@ -316,6 +323,8 @@ mod tests {
         let group_key = node_usage_group_key(group_id, node_id);
         assert!(group_key.starts_with(&node_usage_group_prefix(group_id)));
         assert_eq!(node_usage_key_node_id(&group_key), Some(node_id));
+        assert_eq!(node_usage_group_key_group_id(&group_key), Some(group_id));
+        assert_eq!(node_usage_group_key_group_id(&global_key), None);
 
         // Group snapshots for one group form a contiguous scan range.
         assert!(group_key.starts_with(NODE_USAGE_GROUP_PREFIX));

--- a/core/src/structs/usage.rs
+++ b/core/src/structs/usage.rs
@@ -129,7 +129,8 @@ pub fn usage_group_key(group_id: GroupId) -> Vec<u8> {
 
 /// Maintained usage aggregates. `stored_*` fields track physical,
 /// content-addressed blobs and are only meaningful on the global counter;
-/// `logical_bytes` sums materialized version sizes and is the per-group quota basis.
+/// `logical_bytes` sums materialized and reference version sizes and is the
+/// per-group quota basis.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct UsageCounters {
     pub buckets: u64,
@@ -181,11 +182,11 @@ impl UsageCounters {
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct UsageDelta {
-    pub buckets: i64,
-    pub objects: i64,
-    pub stored_blobs: i64,
-    pub stored_bytes: i64,
-    pub logical_bytes: i64,
+    pub buckets: i128,
+    pub objects: i128,
+    pub stored_blobs: i128,
+    pub stored_bytes: i128,
+    pub logical_bytes: i128,
 }
 
 impl UsageDelta {
@@ -200,21 +201,31 @@ pub enum UsageCounterError {
     Underflow {
         field: &'static str,
         value: u64,
-        delta: i64,
+        delta: i128,
     },
     #[error("usage counter {field} would overflow: {value} + {delta}")]
     Overflow {
         field: &'static str,
         value: u64,
-        delta: u64,
+        delta: u128,
     },
 }
 
-fn apply_delta(field: &'static str, value: u64, delta: i64) -> Result<u64, UsageCounterError> {
+fn apply_delta(field: &'static str, value: u64, delta: i128) -> Result<u64, UsageCounterError> {
     if delta >= 0 {
-        add_counter(field, value, delta as u64)
+        let amount = u64::try_from(delta).map_err(|_| UsageCounterError::Overflow {
+            field,
+            value,
+            delta: delta as u128,
+        })?;
+        add_counter(field, value, amount)
     } else {
-        let amount = delta.unsigned_abs();
+        let amount =
+            u64::try_from(delta.unsigned_abs()).map_err(|_| UsageCounterError::Underflow {
+                field,
+                value,
+                delta,
+            })?;
         value
             .checked_sub(amount)
             .ok_or(UsageCounterError::Underflow {
@@ -229,7 +240,7 @@ fn add_counter(field: &'static str, value: u64, delta: u64) -> Result<u64, Usage
     value.checked_add(delta).ok_or(UsageCounterError::Overflow {
         field,
         value,
-        delta,
+        delta: u128::from(delta),
     })
 }
 
@@ -278,6 +289,21 @@ mod tests {
         assert_eq!(counters.stored_blobs, 3);
         assert_eq!(counters.stored_bytes, 4);
         assert_eq!(counters.logical_bytes, 5);
+    }
+
+    #[test]
+    fn apply_accepts_delta_larger_than_i64_max() {
+        let mut counters = UsageCounters::default();
+        let large = i128::from(i64::MAX) + 1;
+
+        counters
+            .apply(&UsageDelta {
+                logical_bytes: large,
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert_eq!(counters.logical_bytes, i64::MAX as u64 + 1);
     }
 
     #[test]

--- a/core/src/structs/usage.rs
+++ b/core/src/structs/usage.rs
@@ -1,3 +1,4 @@
+use crate::NodeId;
 use crate::errors::ConversionError;
 use crate::types::GroupId;
 use serde::{Deserialize, Serialize};
@@ -5,6 +6,90 @@ use thiserror::Error;
 
 pub const USAGE_GLOBAL_KEY: &[u8] = b"global";
 pub const USAGE_GLOBAL_SHARD_COUNT: usize = 64;
+
+/// Keys in the node-usage keyspace. Per-node snapshots use fixed-length keys so
+/// their prefixes are unambiguous: `n/` + node id for a node's global total,
+/// `g/` + group id + node id for a node's per-group total (group first so all
+/// nodes' snapshots for one group form a single scan range). Local-only keys use
+/// text prefixes (`dirty/`, `summary/`) that never collide with the binary
+/// snapshot prefixes.
+pub const NODE_USAGE_GLOBAL_PREFIX: &[u8] = b"n/";
+pub const NODE_USAGE_GROUP_PREFIX: &[u8] = b"g/";
+pub const NODE_USAGE_DIRTY_PREFIX: &[u8] = b"dirty/";
+pub const NODE_USAGE_DIRTY_GLOBAL_KEY: &[u8] = b"dirty/global";
+pub const NODE_USAGE_DIRTY_GROUP_PREFIX: &[u8] = b"dirty/group/";
+pub const NODE_USAGE_SUMMARY_GLOBAL_KEY: &[u8] = b"summary/global";
+pub const NODE_USAGE_SUMMARY_GROUP_PREFIX: &[u8] = b"summary/group/";
+
+/// A single node's usage total distributed over the sync layer. Single writer
+/// per key (each node writes only its own snapshots), so ingest is last-write-wins.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeUsageSnapshot {
+    pub node_id: NodeId,
+    pub counters: UsageCounters,
+}
+
+impl NodeUsageSnapshot {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
+        Ok(postcard::to_allocvec(self)?)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
+        Ok(postcard::from_bytes(bytes)?)
+    }
+}
+
+pub fn node_usage_global_key(node_id: NodeId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(NODE_USAGE_GLOBAL_PREFIX.len() + 32);
+    key.extend_from_slice(NODE_USAGE_GLOBAL_PREFIX);
+    key.extend_from_slice(node_id.as_bytes());
+    key
+}
+
+pub fn node_usage_group_prefix(group_id: GroupId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(NODE_USAGE_GROUP_PREFIX.len() + 16);
+    key.extend_from_slice(NODE_USAGE_GROUP_PREFIX);
+    key.extend_from_slice(&group_id.to_bytes());
+    key
+}
+
+pub fn node_usage_group_key(group_id: GroupId, node_id: NodeId) -> Vec<u8> {
+    let mut key = node_usage_group_prefix(group_id);
+    key.extend_from_slice(node_id.as_bytes());
+    key
+}
+
+/// Recovers the owning node id from a snapshot key produced by
+/// [`node_usage_global_key`] or [`node_usage_group_key`].
+pub fn node_usage_key_node_id(key: &[u8]) -> Option<NodeId> {
+    let tail = match key.strip_prefix(NODE_USAGE_GLOBAL_PREFIX) {
+        Some(rest) => rest,
+        None => key.strip_prefix(NODE_USAGE_GROUP_PREFIX)?.get(16..)?,
+    };
+    let bytes: [u8; 32] = tail.try_into().ok()?;
+    NodeId::from_bytes(&bytes).ok()
+}
+
+pub fn node_usage_dirty_group_key(group_id: GroupId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(NODE_USAGE_DIRTY_GROUP_PREFIX.len() + 16);
+    key.extend_from_slice(NODE_USAGE_DIRTY_GROUP_PREFIX);
+    key.extend_from_slice(&group_id.to_bytes());
+    key
+}
+
+/// Recovers the group id from a `dirty/group/<ulid>` marker key.
+pub fn node_usage_dirty_group_id(key: &[u8]) -> Option<GroupId> {
+    let tail = key.strip_prefix(NODE_USAGE_DIRTY_GROUP_PREFIX)?;
+    let bytes: [u8; 16] = tail.try_into().ok()?;
+    Some(GroupId::from_bytes(bytes))
+}
+
+pub fn node_usage_summary_group_key(group_id: GroupId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(NODE_USAGE_SUMMARY_GROUP_PREFIX.len() + 16);
+    key.extend_from_slice(NODE_USAGE_SUMMARY_GROUP_PREFIX);
+    key.extend_from_slice(&group_id.to_bytes());
+    key
+}
 
 pub fn usage_global_shard_index(group_id: GroupId) -> usize {
     group_id
@@ -199,5 +284,44 @@ mod tests {
         };
         let bytes = counters.to_bytes().unwrap();
         assert_eq!(UsageCounters::from_bytes(&bytes).unwrap(), counters);
+    }
+
+    fn node(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    #[test]
+    fn node_usage_snapshot_round_trips() {
+        let snapshot = NodeUsageSnapshot {
+            node_id: node(7),
+            counters: UsageCounters {
+                buckets: 2,
+                logical_bytes: 9,
+                ..Default::default()
+            },
+        };
+        let bytes = snapshot.to_bytes().unwrap();
+        assert_eq!(NodeUsageSnapshot::from_bytes(&bytes).unwrap(), snapshot);
+    }
+
+    #[test]
+    fn node_usage_keys_recover_node_and_group_ids() {
+        let node_id = node(3);
+        let group_id = ulid::Ulid::from_bytes([5u8; 16]);
+
+        let global_key = node_usage_global_key(node_id);
+        assert!(global_key.starts_with(NODE_USAGE_GLOBAL_PREFIX));
+        assert_eq!(node_usage_key_node_id(&global_key), Some(node_id));
+
+        let group_key = node_usage_group_key(group_id, node_id);
+        assert!(group_key.starts_with(&node_usage_group_prefix(group_id)));
+        assert_eq!(node_usage_key_node_id(&group_key), Some(node_id));
+
+        // Group snapshots for one group form a contiguous scan range.
+        assert!(group_key.starts_with(NODE_USAGE_GROUP_PREFIX));
+
+        let dirty_key = node_usage_dirty_group_key(group_id);
+        assert_eq!(node_usage_dirty_group_id(&dirty_key), Some(group_id));
+        assert_eq!(node_usage_dirty_group_id(NODE_USAGE_DIRTY_GLOBAL_KEY), None);
     }
 }

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -22,6 +22,7 @@ pub enum TaskKey {
         peers: Vec<NodeId>,
     },
     DrainDocumentSyncOutbox,
+    PublishUsageSnapshots,
     DrainMetadataProjectionQueue,
     DrainMetadataMaterializationQueue,
     DrainMetadataGraphPruneQueue,

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -4749,6 +4749,10 @@ mod tests {
             }],
             max_devices_per_user: Some(6),
         };
+        let expected_quota = QuotaConfig {
+            max_devices_per_user: None,
+            ..quota.clone()
+        };
 
         // Quota lands before any config doc exists; it must be recorded in the
         // reducer and later carried through realm_config_from_reducer_materialization.
@@ -4788,7 +4792,7 @@ mod tests {
         .expect("realm config settings op bootstraps config doc");
 
         let config = read_realm_config_doc(&storage, realm_id).await;
-        assert_eq!(config.quota, quota);
+        assert_eq!(config.quota, expected_quota);
         assert_eq!(config.metadata_replication, metadata_replication);
     }
 
@@ -8053,12 +8057,14 @@ mod tests {
                         event_id: Ulid::new(),
                         target: target.clone(),
                         change: change(DocumentSyncChangeKind::Delete),
+                        allow_genesis: true,
                     },
                     DocumentSyncPublish::Upsert {
                         event_id: Ulid::new(),
                         target: target.clone(),
                         bytes: snapshot_bytes.clone(),
                         change: change(DocumentSyncChangeKind::Upsert),
+                        allow_genesis: true,
                     },
                 ],
                 Vec::new(),

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -1651,6 +1651,26 @@ impl DocumentSyncService {
                             applied_targets.push(target);
                         }
                     }
+                    DocumentSyncEvent::Delete {
+                        target: target @ DocumentSyncTarget::NodeUsage { .. },
+                        ..
+                    }
+                    | DocumentSyncEvent::AdminOperation {
+                        target: target @ DocumentSyncTarget::NodeUsage { .. },
+                        ..
+                    } => {
+                        // Node-usage snapshots only ever sync as owner-validated
+                        // upserts. A signed Delete or AdminOperation on the shared
+                        // realm topic would otherwise `?`-propagate through the
+                        // generic arm and wedge every peer's reconcile forever, so
+                        // skip it and let the cursor advance past the hostile op.
+                        warn!(
+                            %topic_id,
+                            ?target,
+                            "Skipping unsupported non-upsert node usage document event"
+                        );
+                        continue;
+                    }
                     DocumentSyncEvent::Upsert { ref target, .. }
                     | DocumentSyncEvent::Delete { ref target, .. }
                         if admin_document_target_for_reduced_document(target).is_some() =>
@@ -7973,5 +7993,132 @@ mod tests {
             validate_node_usage_upsert(&DocumentSyncTarget::RealmConfig { realm_id }, &owned_bytes)
                 .is_err()
         );
+    }
+
+    // A forged non-upsert node-usage event (here a signed Delete) on the shared
+    // realm topic must be skipped, not `?`-propagated: otherwise every peer's
+    // reconcile of that topic errors at the op forever and realm usage freezes.
+    #[tokio::test]
+    async fn reconcile_skips_forged_non_upsert_node_usage_event() {
+        use aruna_core::structs::UsageCounters;
+
+        let (_storage_dir, storage) = test_storage();
+        let doc_dir = tempfile::tempdir().expect("doc dir");
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(53).await,
+            storage.clone(),
+            doc_dir.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+        )
+        .expect("document sync service opens");
+
+        let local_node = service.local_node_id().expect("local node id");
+        let realm_id = RealmId::from_bytes([53u8; 32]);
+        let target = DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id: local_node,
+            group_id: None,
+        };
+        let topic_id = target.sync_topic_id();
+
+        let change = |kind| DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id: Ulid::new(),
+                actor: local_node,
+                updated_at_ms: 1,
+            },
+            kind,
+        };
+
+        let snapshot = NodeUsageSnapshot {
+            node_id: local_node,
+            counters: UsageCounters {
+                buckets: 5,
+                ..Default::default()
+            },
+        };
+        let snapshot_bytes = snapshot.to_bytes().expect("snapshot serializes");
+
+        // Hostile Delete first, then a legitimate owner-signed Upsert on the same
+        // topic. Publishing appends both ops and advances the local cursor.
+        let published = service
+            .publish_documents(
+                vec![
+                    DocumentSyncPublish::Delete {
+                        event_id: Ulid::new(),
+                        target: target.clone(),
+                        change: change(DocumentSyncChangeKind::Delete),
+                    },
+                    DocumentSyncPublish::Upsert {
+                        event_id: Ulid::new(),
+                        target: target.clone(),
+                        bytes: snapshot_bytes.clone(),
+                        change: change(DocumentSyncChangeKind::Upsert),
+                    },
+                ],
+                Vec::new(),
+            )
+            .await;
+        assert!(matches!(
+            published,
+            DocumentSyncNetEvent::DocumentsPublished { .. }
+        ));
+
+        // Reset the cursor so reconcile reprocesses both ops exactly as a fresh
+        // peer receiving them via sync would (its cursor has not yet advanced).
+        service
+            .storage_write(
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                topic_cursor_key(topic_id),
+                ByteView::from(
+                    postcard::to_allocvec(&irokle_crate::ActorClock::default())
+                        .expect("clock serializes"),
+                ),
+            )
+            .await
+            .expect("cursor reset");
+
+        // (a) Reconcile completes without error despite the hostile Delete.
+        let result = service
+            .reconcile_document_topics([topic_id])
+            .await
+            .expect("reconcile skips the forged delete instead of wedging");
+
+        // (c) The legitimate upsert on the same topic still applied.
+        assert!(result.targets.contains(&target));
+        let stored = read_storage_value(&storage, target.storage_keyspace(), target.storage_key())
+            .await
+            .expect("node usage snapshot applied");
+        assert_eq!(
+            NodeUsageSnapshot::from_bytes(&stored).expect("snapshot decodes"),
+            snapshot
+        );
+
+        // (b) The cursor advanced past the hostile op.
+        let cursor_bytes = read_storage_value(
+            &storage,
+            DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+            topic_cursor_key(topic_id),
+        )
+        .await
+        .expect("cursor persisted");
+        let cursor: irokle_crate::ActorClock =
+            postcard::from_bytes(&cursor_bytes).expect("cursor decodes");
+        let topic_clock = service
+            .node()
+            .storage()
+            .actor_clock(&topic_id)
+            .expect("topic clock");
+        assert!(
+            cursor.dominates(&topic_clock),
+            "cursor must advance past the hostile op"
+        );
+
+        service.shutdown().await;
     }
 }

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -3842,9 +3842,10 @@ mod tests {
         subject_index_value,
     };
     use aruna_core::structs::{
-        Actor, Group, GroupAuthorizationDocument, MetadataReplicationConfig, OidcProviderConfig,
-        Permission, RealmAuthorizationDocument, RealmConfigDocument, RealmDiscoveryConfig, RealmId,
-        RealmNodeKind, Role, StaticRealmEndpoint,
+        Actor, Group, GroupAuthorizationDocument, GroupQuotaOverride, MetadataReplicationConfig,
+        OidcProviderConfig, Permission, QuotaConfig, RealmAuthorizationDocument,
+        RealmConfigDocument, RealmDiscoveryConfig, RealmId, RealmNodeKind, Role,
+        StaticRealmEndpoint, UserGroupCapOverride,
     };
     use std::collections::{BTreeMap, HashMap, HashSet};
     use std::{env, process::Command};
@@ -4614,6 +4615,76 @@ mod tests {
             reducer_state.materialized_realm_config_discovery(),
             Some(discovery)
         );
+    }
+
+    #[tokio::test]
+    async fn quota_survives_reducer_materialization_without_existing_config_doc() {
+        let (_dir, storage) = test_storage();
+        let realm_id = RealmId::from_bytes([61; 32]);
+        let actor = test_actor(
+            8,
+            UserId::local(Ulid::from_parts(1_384, 1), realm_id),
+            realm_id,
+        );
+        let target = AdminDocumentTarget::RealmConfig { realm_id };
+        let document_target = DocumentSyncTarget::RealmConfig { realm_id };
+        let quota = QuotaConfig {
+            default_group_quota_bytes: Some(9_000),
+            grace_factor_percent: 130,
+            warn_threshold_percent: 70,
+            group_overrides: vec![GroupQuotaOverride {
+                group_id: Ulid::from_parts(1_385, 1),
+                quota_bytes: Some(4_500),
+                grace_factor_percent: Some(140),
+            }],
+            max_groups_per_user: Some(7),
+            user_group_cap_overrides: vec![UserGroupCapOverride {
+                user_id: UserId::local(Ulid::from_parts(1_386, 1), realm_id),
+                max_groups: Some(2),
+            }],
+            max_devices_per_user: Some(6),
+        };
+
+        // Quota lands before any config doc exists; it must be recorded in the
+        // reducer and later carried through realm_config_from_reducer_materialization.
+        apply_admin_document_operation_to_storage(
+            &storage,
+            document_target.clone(),
+            test_admin_event(
+                Ulid::from_parts(1_387, 1),
+                target.clone(),
+                &actor,
+                1,
+                AdminDocumentOperation::RealmConfigQuotaSet {
+                    quota: quota.clone(),
+                },
+            ),
+        )
+        .await
+        .expect("realm config quota op applies");
+
+        let metadata_replication = MetadataReplicationConfig::new(5);
+        let discovery = test_discovery(23, "https://quota-materialization.example:443");
+        apply_admin_document_operation_to_storage(
+            &storage,
+            document_target.clone(),
+            test_admin_event(
+                Ulid::from_parts(1_388, 1),
+                target.clone(),
+                &actor,
+                2,
+                AdminDocumentOperation::RealmConfigSettingsSet {
+                    metadata_replication: metadata_replication.clone(),
+                    discovery: discovery.clone(),
+                },
+            ),
+        )
+        .await
+        .expect("realm config settings op bootstraps config doc");
+
+        let config = read_realm_config_doc(&storage, realm_id).await;
+        assert_eq!(config.quota, quota);
+        assert_eq!(config.metadata_replication, metadata_replication);
     }
 
     #[tokio::test]

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -45,8 +45,9 @@ use aruna_core::storage_entries::{
     subject_index_writes,
 };
 use aruna_core::structs::{
-    Group, GroupAuthorizationDocument, MetadataRegistryRecord, RealmAuthorizationDocument,
-    RealmConfigDocument, RealmId, Role, User, group_owner_index_key,
+    Group, GroupAuthorizationDocument, MetadataRegistryRecord, NodeUsageSnapshot,
+    RealmAuthorizationDocument, RealmConfigDocument, RealmId, Role, User, group_owner_index_key,
+    node_usage_key_node_id,
 };
 use aruna_core::telemetry::duration_ms;
 use aruna_core::types::{RoleId, TxnId, UserId, Value};
@@ -1512,7 +1513,7 @@ impl DocumentSyncService {
             // merged clock is the new applied watermark.
             cursor.merge(&topic_clock);
             let mut deferred_creates = false;
-            for event in events {
+            for (event, actor_id) in events {
                 let target_topic_id = event.target().sync_topic_id();
                 if target_topic_id != topic_id {
                     warn!(
@@ -1523,6 +1524,47 @@ impl DocumentSyncService {
                     continue;
                 }
                 match event {
+                    DocumentSyncEvent::Upsert {
+                        target:
+                            target @ DocumentSyncTarget::NodeUsage {
+                                node_id: snapshot_node,
+                                ..
+                            },
+                        bytes,
+                        change,
+                        ..
+                    } => {
+                        // Node-usage snapshots ride a single shared realm topic
+                        // that every realm publisher can write, so validate that
+                        // the signed publisher owns the claimed node and that the
+                        // payload's own node id matches its target before applying.
+                        // A rejected event is skipped (never `?`) so the cursor
+                        // still advances past it and a forgery cannot wedge the
+                        // topic's reconcile loop.
+                        let expected_actor = irokle_crate::actor_id_for(
+                            topic_id,
+                            node_id_to_peer_id(&snapshot_node),
+                        );
+                        if actor_id != expected_actor {
+                            warn!(
+                                %topic_id,
+                                node_id = %snapshot_node,
+                                "Rejecting node usage snapshot: publisher is not the owning node"
+                            );
+                            continue;
+                        }
+                        if let Err(reason) = validate_node_usage_upsert(&target, &bytes) {
+                            warn!(
+                                %topic_id,
+                                node_id = %snapshot_node,
+                                %reason,
+                                "Rejecting invalid node usage snapshot"
+                            );
+                            continue;
+                        }
+                        self.apply_upsert(target.clone(), bytes, change).await?;
+                        applied_targets.push(target);
+                    }
                     event @ DocumentSyncEvent::Upsert {
                         target: DocumentSyncTarget::MetadataCreateEvent { .. },
                         ..
@@ -1663,18 +1705,22 @@ impl DocumentSyncService {
     }
 
     /// Returns the decoded document events above the applied cursor, reading
-    /// only the unapplied portion of the topic history where possible.
+    /// only the unapplied portion of the topic history where possible. Each
+    /// event is paired with the authenticated `actor_id` of the op that carried
+    /// it: irokle admits an op only after verifying its signature against
+    /// `body.author` and enforcing `actor_id == actor_id_for(topic, author)`, so
+    /// the returned actor id is a trustworthy proxy for the signed publisher.
     fn document_events_after(
         &self,
         topic_id: irokle_crate::TopicId,
         cursor: &irokle_crate::ActorClock,
-    ) -> Result<Vec<DocumentSyncEvent>> {
+    ) -> Result<Vec<(DocumentSyncEvent, irokle_crate::ActorId)>> {
         match self.node.open_topic::<DocumentSyncEvent>(topic_id) {
             Ok(topic) => Ok(topic
                 .history_after(cursor, HistoryOrder::OldestFirst)
                 .map_err(|error| NetError::Bootstrap(error.to_string()))?
                 .into_iter()
-                .map(|record| record.event)
+                .map(|record| (record.event, record.meta.actor_id))
                 .collect()),
             // Topics we hold ops for without being a listed member still
             // reconcile via the full history.
@@ -1691,14 +1737,16 @@ impl DocumentSyncService {
                     if cursor.get(&op.signed.body.actor_id) >= op.signed.body.actor_seq {
                         continue;
                     }
+                    let actor_id = op.signed.body.actor_id;
                     let TopicPayload::Event(envelope) = op.signed.body.payload else {
                         continue;
                     };
-                    events.push(
+                    events.push((
                         envelope
                             .decode_event::<DocumentSyncEvent>()
                             .map_err(|error| NetError::Bootstrap(error.to_string()))?,
-                    );
+                        actor_id,
+                    ));
                 }
                 Ok(events)
             }
@@ -1900,6 +1948,13 @@ impl DocumentSyncService {
                 .apply_metadata_graph_lifecycle(record, bytes)
                 .await
                 .map(|_| ());
+        }
+        if let DocumentSyncTarget::NodeUsage { .. } = target {
+            // Structural guard for the shared node-usage keyspace. The reconcile
+            // loop already validated the signed publisher and this payload, but
+            // re-check the snapshot's self-consistency here so the generic
+            // storage write below can never persist an unvalidated snapshot.
+            validate_node_usage_upsert(&target, &bytes).map_err(NetError::Bootstrap)?;
         }
         self.storage_write(
             target.storage_keyspace().to_string(),
@@ -3469,6 +3524,36 @@ fn metadata_document_delete_write_entries(
 
 fn node_id_to_peer_id(node_id: &NodeId) -> PeerId {
     PeerId::from_bytes(*node_id.as_bytes())
+}
+
+/// Validates the self-consistency of a replicated node-usage snapshot against
+/// its sync target: the payload must decode, its embedded `node_id` must match
+/// the target's node, and the target's derived storage key must attribute back
+/// to that same node. Returns a human-readable reason on rejection. Does not
+/// check the publisher's identity (the caller enforces that against the signed
+/// actor). A zero-counter snapshot is valid: stale-group cleanup publishes them.
+fn validate_node_usage_upsert(
+    target: &DocumentSyncTarget,
+    bytes: &[u8],
+) -> std::result::Result<(), String> {
+    let DocumentSyncTarget::NodeUsage { node_id, .. } = target else {
+        return Err("target is not a node usage snapshot".to_string());
+    };
+    let snapshot = NodeUsageSnapshot::from_bytes(bytes)
+        .map_err(|error| format!("undecodable node usage snapshot: {error}"))?;
+    if snapshot.node_id != *node_id {
+        return Err(format!(
+            "snapshot node id {} does not match target node id {node_id}",
+            snapshot.node_id
+        ));
+    }
+    let key = target.storage_key();
+    if node_usage_key_node_id(key.as_ref()) != Some(*node_id) {
+        return Err(format!(
+            "node usage storage key does not attribute to target node id {node_id}"
+        ));
+    }
+    Ok(())
 }
 
 fn topic_cursor_key(topic_id: irokle_crate::TopicId) -> ByteView {
@@ -7834,5 +7919,59 @@ mod tests {
         );
 
         service.shutdown().await;
+    }
+    #[test]
+    fn validate_node_usage_upsert_accepts_owner_and_rejects_forgeries() {
+        use aruna_core::structs::UsageCounters;
+
+        let node_id = node(7);
+        let realm_id = RealmId::from_bytes([2u8; 32]);
+        let group_id = Ulid::from_bytes([4u8; 16]);
+        let global = DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id,
+            group_id: None,
+        };
+        let group = DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id,
+            group_id: Some(group_id),
+        };
+
+        // The owning node's own snapshot validates as global and per-group.
+        let owned = NodeUsageSnapshot {
+            node_id,
+            counters: UsageCounters {
+                buckets: 3,
+                ..Default::default()
+            },
+        };
+        let owned_bytes = owned.to_bytes().unwrap();
+        assert!(validate_node_usage_upsert(&global, &owned_bytes).is_ok());
+        assert!(validate_node_usage_upsert(&group, &owned_bytes).is_ok());
+
+        // Zero-counter snapshots (stale-group cleanup) are legitimate upserts.
+        let zero = NodeUsageSnapshot {
+            node_id,
+            counters: UsageCounters::default(),
+        };
+        assert!(validate_node_usage_upsert(&global, &zero.to_bytes().unwrap()).is_ok());
+
+        // A snapshot whose embedded node id is a different node is rejected.
+        let misattributed = NodeUsageSnapshot {
+            node_id: node(9),
+            counters: UsageCounters {
+                buckets: 99,
+                ..Default::default()
+            },
+        };
+        assert!(validate_node_usage_upsert(&global, &misattributed.to_bytes().unwrap()).is_err());
+
+        // Undecodable payloads and non node-usage targets are rejected.
+        assert!(validate_node_usage_upsert(&global, b"not-a-snapshot").is_err());
+        assert!(
+            validate_node_usage_upsert(&DocumentSyncTarget::RealmConfig { realm_id }, &owned_bytes)
+                .is_err()
+        );
     }
 }

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -7,9 +7,9 @@ use aruna_core::NodeId;
 use aruna_core::admin_document_reducer::{
     AdminDocumentApplyStatus, AdminDocumentReducerState, GROUP_DISPLAY_NAME_PATH, GROUP_OWNER_PATH,
     GROUP_REALM_ID_PATH, REALM_CONFIG_DESCRIPTION_PATH, REALM_CONFIG_DISCOVERY_PATH,
-    REALM_CONFIG_METADATA_REPLICATION_PATH, USER_NAME_PATH, group_role_id_from_path,
-    group_role_path, group_role_user_assignment_from_path, group_role_user_assignment_path,
-    realm_config_node_id_from_path, realm_config_node_path,
+    REALM_CONFIG_METADATA_REPLICATION_PATH, REALM_CONFIG_QUOTA_PATH, USER_NAME_PATH,
+    group_role_id_from_path, group_role_path, group_role_user_assignment_from_path,
+    group_role_user_assignment_path, realm_config_node_id_from_path, realm_config_node_path,
     realm_config_oidc_provider_id_from_path, realm_role_path, realm_role_user_assignment_from_path,
     realm_role_user_assignment_path, user_attribute_path, user_subject_id_path,
 };
@@ -2215,6 +2215,14 @@ fn overlay_realm_config_reducer_materialization(
         config.description = description;
     }
 
+    if !reducer_state
+        .conflicts
+        .contains_key(REALM_CONFIG_QUOTA_PATH)
+        && let Some(quota) = reducer_state.materialized_realm_config_quota()
+    {
+        config.quota = quota;
+    }
+
     for path in reducer_state.conflicts.keys() {
         if let Some(node_id) = realm_config_node_id_from_path(path) {
             remove_realm_config_node(config, &node_id);
@@ -2263,7 +2271,9 @@ fn realm_config_from_reducer_materialization(
         oidc_providers: Vec::new(),
         discovery,
         nodes: Vec::new(),
-        quota: Default::default(),
+        quota: reducer_state
+            .materialized_realm_config_quota()
+            .unwrap_or_default(),
         description: String::new(),
     };
     overlay_realm_config_reducer_materialization(&mut config, reducer_state);
@@ -2864,9 +2874,10 @@ async fn apply_realm_config_admin_document_operation_to_storage(
             | AdminDocumentOperation::RealmConfigOidcProviderRemoved { .. }
             | AdminDocumentOperation::RealmConfigSettingsSet { .. }
             | AdminDocumentOperation::RealmConfigDescriptionSet { .. }
+            | AdminDocumentOperation::RealmConfigQuotaSet { .. }
     ) {
         return Err(NetError::Bootstrap(
-            "realm config admin operation sync only supports node ensure, OIDC provider updates, settings updates, and description updates"
+            "realm config admin operation sync only supports node ensure, OIDC provider updates, settings updates, description updates, and quota updates"
                 .to_string(),
         ));
     }

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -306,6 +306,22 @@ impl AnnounceTopicOperation {
                     kind: DocumentSyncChangeKind::Upsert,
                 })
             }
+            // Node usage snapshots are single-writer per key and applied as plain
+            // upserts (last event wins), so the change only needs a monotonic
+            // wall-clock generation from this node.
+            DocumentSyncTarget::NodeUsage { .. } => {
+                let now = aruna_core::util::unix_timestamp_millis();
+                Ok(DocumentSyncChange {
+                    base: None,
+                    current: DocumentSyncRevision {
+                        generation: now,
+                        event_id: Ulid::new(),
+                        actor: self.local_node_id,
+                        updated_at_ms: now,
+                    },
+                    kind: DocumentSyncChangeKind::Upsert,
+                })
+            }
         }
     }
 

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -91,6 +91,7 @@ pub async fn bootstrap_onboarding_finalize(
             realm_signing_key: input.realm_signing_key,
             realm_id: input.realm_id,
             node_id: input.node_id,
+            issuer_node_id: input.local_node_id,
             now: input.now,
             ttl_secs: ONBOARDING_SYNC_TICKET_TTL_SECS,
         }),

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -15,7 +15,7 @@ use crate::metadata::prune_queue::process_metadata_graph_tombstones;
 use crate::process_placements::{PlacementConfig, ProcessPlacementsOperation};
 use crate::replication::incoming_version_replication::IncomingVersionReplicationOperation;
 use crate::replication::protocol::VersionReplicationMessage;
-use crate::usage_stats::recompute_realm_usage_summary;
+use crate::usage_stats::refresh_realm_usage_summary_for_targets;
 use aruna_core::alpn::Alpn;
 use aruna_core::document::{
     DocumentSyncEvictedDocument, DocumentSyncReconcileResult, DocumentSyncTarget,
@@ -177,7 +177,7 @@ async fn reconcile_inbound_document_sync_topics(
             error!(error = ?error, "Failed to process pending placements after document sync reconciliation");
         }
     }
-    refresh_realm_usage_summary(context, &net_handle, &targets.targets).await;
+    refresh_realm_usage_summary_for_targets(context, net_handle.node_id(), &targets.targets).await;
     let project_started = Instant::now();
     project_inbound_metadata_create_events(context, targets).await;
     let project_elapsed = project_started.elapsed();
@@ -193,41 +193,6 @@ async fn reconcile_inbound_document_sync_topics(
         total_ms = duration_ms(run_started.elapsed()),
         "Inbound document sync reconcile summary"
     );
-}
-
-/// Refreshes the persisted realm usage summed cache for the scopes touched by an
-/// inbound reconcile. Remote node snapshots landed via the generic apply path, so
-/// this re-sums live local counters plus every node's snapshot for those scopes.
-async fn refresh_realm_usage_summary(
-    context: &Arc<DriverContext>,
-    net_handle: &aruna_net::NetHandle,
-    targets: &[DocumentSyncTarget],
-) {
-    let mut include_global = false;
-    let mut groups = BTreeSet::new();
-    for target in targets {
-        if let DocumentSyncTarget::NodeUsage { group_id, .. } = target {
-            match group_id {
-                Some(group_id) => {
-                    groups.insert(*group_id);
-                }
-                None => include_global = true,
-            }
-        }
-    }
-    if !include_global && groups.is_empty() {
-        return;
-    }
-    if let Err(error) = recompute_realm_usage_summary(
-        context,
-        net_handle.node_id(),
-        include_global,
-        groups.into_iter().collect(),
-    )
-    .await
-    {
-        error!(error = %error, "Failed to refresh realm usage summary after document sync reconciliation");
-    }
 }
 
 pub fn initialize_net_incoming(context: Arc<DriverContext>) {

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -15,6 +15,7 @@ use crate::metadata::prune_queue::process_metadata_graph_tombstones;
 use crate::process_placements::{PlacementConfig, ProcessPlacementsOperation};
 use crate::replication::incoming_version_replication::IncomingVersionReplicationOperation;
 use crate::replication::protocol::VersionReplicationMessage;
+use crate::usage_stats::recompute_realm_usage_summary;
 use aruna_core::alpn::Alpn;
 use aruna_core::document::{
     DocumentSyncEvictedDocument, DocumentSyncReconcileResult, DocumentSyncTarget,
@@ -176,6 +177,7 @@ async fn reconcile_inbound_document_sync_topics(
             error!(error = ?error, "Failed to process pending placements after document sync reconciliation");
         }
     }
+    refresh_realm_usage_summary(context, &net_handle, &targets.targets).await;
     let project_started = Instant::now();
     project_inbound_metadata_create_events(context, targets).await;
     let project_elapsed = project_started.elapsed();
@@ -191,6 +193,41 @@ async fn reconcile_inbound_document_sync_topics(
         total_ms = duration_ms(run_started.elapsed()),
         "Inbound document sync reconcile summary"
     );
+}
+
+/// Refreshes the persisted realm usage summed cache for the scopes touched by an
+/// inbound reconcile. Remote node snapshots landed via the generic apply path, so
+/// this re-sums live local counters plus every node's snapshot for those scopes.
+async fn refresh_realm_usage_summary(
+    context: &Arc<DriverContext>,
+    net_handle: &aruna_net::NetHandle,
+    targets: &[DocumentSyncTarget],
+) {
+    let mut include_global = false;
+    let mut groups = BTreeSet::new();
+    for target in targets {
+        if let DocumentSyncTarget::NodeUsage { group_id, .. } = target {
+            match group_id {
+                Some(group_id) => {
+                    groups.insert(*group_id);
+                }
+                None => include_global = true,
+            }
+        }
+    }
+    if !include_global && groups.is_empty() {
+        return;
+    }
+    if let Err(error) = recompute_realm_usage_summary(
+        context,
+        net_handle.node_id(),
+        include_global,
+        groups.into_iter().collect(),
+    )
+    .await
+    {
+        error!(error = %error, "Failed to refresh realm usage summary after document sync reconciliation");
+    }
 }
 
 pub fn initialize_net_incoming(context: Arc<DriverContext>) {

--- a/operations/src/issue_onboarding_sync_ticket.rs
+++ b/operations/src/issue_onboarding_sync_ticket.rs
@@ -19,7 +19,10 @@ const USER_SYNC_TICKET_PAGE_SIZE: usize = 512;
 pub struct IssueOnboardingSyncTicketInput {
     pub realm_signing_key: SigningKey,
     pub realm_id: RealmId,
+    /// Node the ticket is issued to.
     pub node_id: NodeId,
+    /// Local issuer node that owns the bootstrap node-usage snapshot.
+    pub issuer_node_id: NodeId,
     pub now: u64,
     pub ttl_secs: u64,
 }
@@ -67,6 +70,11 @@ impl IssueOnboardingSyncTicketOperation {
             },
             DocumentSyncTarget::RealmConfig {
                 realm_id: input.realm_id,
+            },
+            DocumentSyncTarget::NodeUsage {
+                realm_id: input.realm_id,
+                node_id: input.issuer_node_id,
+                group_id: None,
             },
         ];
         Self {
@@ -188,6 +196,7 @@ mod tests {
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::USER_KEYSPACE;
+    use aruna_core::operation::Operation;
     use aruna_core::structs::RealmId;
     use aruna_core::types::UserId;
     use aruna_storage::storage;
@@ -195,6 +204,48 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use tempfile::tempdir;
     use ulid::Ulid;
+
+    #[test]
+    fn ticket_includes_shared_node_usage_for_issuer_node() {
+        let realm_signing_key = SigningKey::from_bytes(&[3u8; 32]);
+        let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
+        let joiner_node_id = iroh::SecretKey::from_bytes(&[4u8; 32]).public();
+        let issuer_node_id = iroh::SecretKey::from_bytes(&[5u8; 32]).public();
+        let mut operation =
+            IssueOnboardingSyncTicketOperation::new(IssueOnboardingSyncTicketInput {
+                realm_signing_key,
+                realm_id,
+                node_id: joiner_node_id,
+                issuer_node_id,
+                now: 100,
+                ttl_secs: ONBOARDING_SYNC_TICKET_TTL_SECS,
+            });
+
+        assert_eq!(operation.start().len(), 1);
+        assert!(
+            operation
+                .step(Event::Storage(StorageEvent::IterResult {
+                    values: Vec::new(),
+                    next_start_after: None,
+                }))
+                .is_empty()
+        );
+        let ticket = operation.finalize().unwrap();
+
+        assert_eq!(ticket.payload.node_id, joiner_node_id.to_string());
+        assert_eq!(
+            ticket.payload.documents,
+            vec![
+                DocumentSyncTarget::RealmAuthorization { realm_id },
+                DocumentSyncTarget::RealmConfig { realm_id },
+                DocumentSyncTarget::NodeUsage {
+                    realm_id,
+                    node_id: issuer_node_id,
+                    group_id: None,
+                },
+            ]
+        );
+    }
 
     #[tokio::test]
     async fn ticket_user_discovery_paginates_beyond_ten_thousand() {
@@ -210,6 +261,7 @@ mod tests {
         let realm_signing_key = SigningKey::from_bytes(&[3u8; 32]);
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::from_bytes(&[4u8; 32]).public();
+        let issuer_node_id = iroh::SecretKey::from_bytes(&[5u8; 32]).public();
         let user_count = 10_005usize;
         let writes = (0..user_count)
             .map(|index| {
@@ -238,6 +290,7 @@ mod tests {
                 realm_signing_key,
                 realm_id,
                 node_id,
+                issuer_node_id,
                 now: 100,
                 ttl_secs: ONBOARDING_SYNC_TICKET_TTL_SECS,
             }),
@@ -253,6 +306,16 @@ mod tests {
             .filter(|document| matches!(document, DocumentSyncTarget::User { .. }))
             .count();
         assert_eq!(users, user_count);
-        assert_eq!(ticket.payload.documents.len(), user_count + 2);
+        assert!(
+            ticket
+                .payload
+                .documents
+                .contains(&DocumentSyncTarget::NodeUsage {
+                    realm_id,
+                    node_id: issuer_node_id,
+                    group_id: None,
+                })
+        );
+        assert_eq!(ticket.payload.documents.len(), user_count + 3);
     }
 }

--- a/operations/src/lib.rs
+++ b/operations/src/lib.rs
@@ -53,6 +53,7 @@ pub mod replication;
 pub mod reserve_onboarding_secret;
 pub mod s3;
 pub mod search_users;
+pub mod set_realm_quota;
 pub mod staging;
 pub mod startup;
 pub mod status;

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -174,7 +174,7 @@ impl ReplicateDocumentsOperation {
             )))
         };
 
-        if selected_peers.is_empty() {
+        if selected_peers.is_empty() && !matches!(document, DocumentSyncTarget::NodeUsage { .. }) {
             return match self.emit_placement_update() {
                 Ok(effects) => effects,
                 Err(error) => self.fail(error),
@@ -358,6 +358,14 @@ mod tests {
         }
     }
 
+    fn node_usage_target(realm_id: RealmId, node_id: NodeId) -> DocumentSyncTarget {
+        DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id,
+            group_id: None,
+        }
+    }
+
     #[test]
     fn task_schedule_error_is_non_blocking_after_placement_write() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
@@ -423,6 +431,28 @@ mod tests {
         };
         assert_eq!(record.authoritative_node_id, local_node_id);
         assert_eq!(record.selected_peers, vec![node(2)]);
+    }
+
+    #[test]
+    fn shared_node_usage_publishes_without_remote_peers() {
+        let realm_id = RealmId::from_bytes([7u8; 32]);
+        let local_node_id = node(1);
+        let target = node_usage_target(realm_id, local_node_id);
+        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
+            realm_id,
+            local_node_id,
+            excluded_peers: Vec::new(),
+            documents: vec![target.clone()],
+            allow_genesis: true,
+        });
+        operation.realm_nodes = vec![local_node_id];
+
+        let effects = operation.emit_next_publish();
+
+        assert!(
+            matches!(operation.placement_action, Some(PlacementAction::Write(ref record)) if record.target == target)
+        );
+        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
     }
 
     #[test]

--- a/operations/src/s3/complete_multipart_upload.rs
+++ b/operations/src/s3/complete_multipart_upload.rs
@@ -54,6 +54,7 @@ pub enum CompleteMultipartUploadState {
     RegisterBlobInDht,
     CleanupDuplicate,
     CleanupPartBlobs,
+    AbortFinalizeTransaction,
     ResetUploadTransaction,
     ReadUploadForReset,
     WriteUploadReset,
@@ -192,6 +193,18 @@ impl CompleteMultipartUploadOperation {
 
     fn schedule_error(&mut self, error: CompleteMultipartUploadError) -> Effects {
         self.pending_error = Some(error);
+        // Any open finalize transaction must be aborted before we start the reset
+        // transaction, otherwise the old txn is orphaned in the storage actor and
+        // pins an LSM snapshot forever. The original error is preserved in
+        // `pending_error` and surfaced once cleanup completes.
+        if let Some(txn_id) = self.txn_id.take() {
+            self.state = CompleteMultipartUploadState::AbortFinalizeTransaction;
+            return smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })];
+        }
+        self.continue_error_cleanup()
+    }
+
+    fn continue_error_cleanup(&mut self) -> Effects {
         if self.upload_record.is_some() {
             self.state = CompleteMultipartUploadState::ResetUploadTransaction;
             smallvec![Effect::Storage(StorageEffect::StartTransaction {
@@ -207,6 +220,14 @@ impl CompleteMultipartUploadOperation {
             })]
         } else {
             self.emit_pending_error()
+        }
+    }
+
+    fn handle_abort_finalize_transaction(&mut self, event: Event) -> Effects {
+        match event {
+            Event::Storage(StorageEvent::TransactionAborted { .. })
+            | Event::Storage(StorageEvent::Error { .. }) => self.continue_error_cleanup(),
+            _ => self.emit_error(CompleteMultipartUploadError::InvalidOperationState),
         }
     }
 
@@ -1159,6 +1180,9 @@ impl Operation for CompleteMultipartUploadOperation {
             }
             CompleteMultipartUploadState::CleanupDuplicate => self.handle_duplicate_cleanup(event),
             CompleteMultipartUploadState::CleanupPartBlobs => self.handle_cleanup_part_blob(event),
+            CompleteMultipartUploadState::AbortFinalizeTransaction => {
+                self.handle_abort_finalize_transaction(event)
+            }
             CompleteMultipartUploadState::ResetUploadTransaction => {
                 self.handle_reset_transaction_started(event)
             }
@@ -1270,5 +1294,127 @@ fn composite_digest_for_algorithm(algorithm: ChecksumAlgorithm, bytes: &[u8]) ->
         ChecksumAlgorithm::Crc32 => hashes.crc32.to_vec(),
         ChecksumAlgorithm::Crc32c => hashes.crc32c.to_vec(),
         ChecksumAlgorithm::Crc64Nvme => hashes.crc64nvme.to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finalize_input() -> CompleteMultipartUploadInput {
+        let realm_id = RealmId::from_bytes([3u8; 32]);
+        CompleteMultipartUploadInput {
+            bucket: "bucket".to_string(),
+            key: "object".to_string(),
+            upload_id: Ulid::new(),
+            realm_id,
+            node_id: iroh::SecretKey::from_bytes(&[7u8; 32]).public(),
+            completed_parts: vec![],
+            expected_checksums: vec![],
+            checksum_type: MultipartChecksumType::FullObject,
+            object_size: Some(10),
+            created_by: UserId::local(Ulid::new(), realm_id),
+            quota_ceiling: Some(30),
+        }
+    }
+
+    fn open_upload_record(input: &CompleteMultipartUploadInput) -> MultipartUpload {
+        MultipartUpload {
+            upload_id: input.upload_id,
+            bucket: input.bucket.clone(),
+            key: input.key.clone(),
+            group_id: Ulid::new(),
+            created_by: input.created_by,
+            created_at: SystemTime::now(),
+            status: MultipartUploadStatus::Completing,
+            checksum_hint: None,
+        }
+    }
+
+    // A quota rejection at EnforceQuota leaves the finalize transaction open. It
+    // must be aborted before the reset transaction starts, otherwise the storage
+    // actor orphans the txn and pins an LSM snapshot forever.
+    #[test]
+    fn quota_rejection_aborts_finalize_txn_before_reset() {
+        let input = finalize_input();
+        let record = open_upload_record(&input);
+        let mut op = CompleteMultipartUploadOperation::new(input);
+        let finalize_txn = TxnId::new();
+        op.txn_id = Some(finalize_txn);
+        op.upload_record = Some(record);
+        op.state = CompleteMultipartUploadState::EnforceQuota;
+
+        let effects = op.schedule_error(CompleteMultipartUploadError::QuotaExceeded {
+            limit: 30,
+            usage: 35,
+        });
+
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            effects[0],
+            Effect::Storage(StorageEffect::AbortTransaction { txn_id }) if txn_id == finalize_txn
+        ));
+        assert_eq!(
+            op.state,
+            CompleteMultipartUploadState::AbortFinalizeTransaction
+        );
+        // Cleared so the reset StartTransaction can never overwrite (orphan) it.
+        assert_eq!(op.txn_id, None);
+
+        let effects = op.step(Event::Storage(StorageEvent::TransactionAborted {
+            txn_id: finalize_txn,
+        }));
+
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            effects[0],
+            Effect::Storage(StorageEffect::StartTransaction { read: false })
+        ));
+        assert_eq!(
+            op.state,
+            CompleteMultipartUploadState::ResetUploadTransaction
+        );
+        assert_eq!(
+            op.pending_error,
+            Some(CompleteMultipartUploadError::QuotaExceeded {
+                limit: 30,
+                usage: 35
+            })
+        );
+    }
+
+    // If the finalize-txn abort itself errors, the original quota error must still
+    // be surfaced rather than masked by the abort failure.
+    #[test]
+    fn quota_rejection_abort_failure_preserves_original_error() {
+        let input = finalize_input();
+        let mut op = CompleteMultipartUploadOperation::new(input);
+        let finalize_txn = TxnId::new();
+        op.txn_id = Some(finalize_txn);
+        op.state = CompleteMultipartUploadState::EnforceQuota;
+
+        let effects = op.schedule_error(CompleteMultipartUploadError::QuotaExceeded {
+            limit: 30,
+            usage: 35,
+        });
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            effects[0],
+            Effect::Storage(StorageEffect::AbortTransaction { txn_id }) if txn_id == finalize_txn
+        ));
+
+        let effects = op.step(Event::Storage(StorageEvent::Error {
+            error: StorageError::Timeout,
+        }));
+
+        assert!(effects.is_empty());
+        assert!(op.is_complete());
+        assert_eq!(
+            op.finalize(),
+            Err(CompleteMultipartUploadError::QuotaExceeded {
+                limit: 30,
+                usage: 35
+            })
+        );
     }
 }

--- a/operations/src/s3/complete_multipart_upload.rs
+++ b/operations/src/s3/complete_multipart_upload.rs
@@ -3,7 +3,7 @@ use crate::blob::blob_keyspace_helper::{
     write_blob_location_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
-use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
+use crate::usage_stats::{QuotaGate, QuotaGateError, UsageCounterUpdate, UsageUpdateError};
 use aruna_blob::hash::Hasher;
 use aruna_core::effects::{BlobEffect, DhtEffect, Effect, NetEffect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
@@ -48,6 +48,7 @@ pub enum CompleteMultipartUploadState {
     WriteObjectMetadata,
     DeleteUploadRecords,
     WriteLiveReplicationObligation,
+    EnforceQuota,
     UpdateUsage,
     CommitFinalizeTransaction,
     RegisterBlobInDht,
@@ -96,6 +97,10 @@ pub enum CompleteMultipartUploadError {
     PartEtagMismatch,
     #[error(transparent)]
     UsageUpdateError(#[from] UsageUpdateError),
+    #[error(transparent)]
+    QuotaGateError(#[from] QuotaGateError),
+    #[error("group storage quota exceeded: {usage} bytes would exceed limit of {limit} bytes")]
+    QuotaExceeded { limit: u64, usage: u64 },
     #[error("CompleteMultipartUpload failed")]
     CompleteMultipartUploadFailed,
 }
@@ -119,6 +124,10 @@ pub struct CompleteMultipartUploadInput {
     pub checksum_type: MultipartChecksumType,
     pub object_size: Option<u64>,
     pub created_by: UserId,
+    /// Hard ceiling (bytes) the group's realm-wide `logical_bytes` may reach,
+    /// resolved from the realm quota config at the request surface. `None` =
+    /// unlimited, so no gate is enforced.
+    pub quota_ceiling: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -145,6 +154,7 @@ pub struct CompleteMultipartUploadOperation {
     new_blob: bool,
     was_live: bool,
     usage_update: Option<UsageCounterUpdate>,
+    quota_gate: Option<QuotaGate>,
     cleanup_part_index: usize,
     pending_error: Option<CompleteMultipartUploadError>,
     output: Option<Result<CompleteMultipartUploadResult, CompleteMultipartUploadError>>,
@@ -167,6 +177,7 @@ impl CompleteMultipartUploadOperation {
             new_blob: false,
             was_live: false,
             usage_update: None,
+            quota_gate: None,
             cleanup_part_index: 0,
             pending_error: None,
             output: None,
@@ -810,11 +821,68 @@ impl CompleteMultipartUploadOperation {
             stored_bytes: if self.new_blob { size } else { 0 },
             ..group_delta
         };
-        let mut update = UsageCounterUpdate::with_global(group_id, group_delta, global_delta);
+        self.usage_update = Some(UsageCounterUpdate::with_global(
+            group_id,
+            group_delta,
+            global_delta,
+        ));
+
+        // Enforce the hard group quota before the counters commit. Only a positive
+        // logical-bytes delta can push a group over its ceiling.
+        let object_size = self
+            .final_location
+            .as_ref()
+            .map(|location| location.blob_size)
+            .unwrap_or(0);
+        if let Some(ceiling) = self.input.quota_ceiling
+            && object_size > 0
+        {
+            let mut gate = QuotaGate::new(ceiling, object_size, group_id, self.input.node_id);
+            self.state = CompleteMultipartUploadState::EnforceQuota;
+            let effects = gate.start(txn_id);
+            self.quota_gate = Some(gate);
+            effects
+        } else {
+            self.start_usage_update(txn_id)
+        }
+    }
+
+    fn start_usage_update(&mut self, txn_id: TxnId) -> Effects {
         self.state = CompleteMultipartUploadState::UpdateUsage;
-        let effects = update.start(txn_id);
-        self.usage_update = Some(update);
-        effects
+        match self.usage_update.as_mut() {
+            Some(update) => update.start(txn_id),
+            None => {
+                self.schedule_error(CompleteMultipartUploadError::CompleteMultipartUploadFailed)
+            }
+        }
+    }
+
+    fn handle_enforce_quota(&mut self, event: Event) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.schedule_error(CompleteMultipartUploadError::NoTransactionFound);
+        };
+        let Some(gate) = self.quota_gate.as_mut() else {
+            return self
+                .schedule_error(CompleteMultipartUploadError::CompleteMultipartUploadFailed);
+        };
+        match gate.step(event, txn_id) {
+            Ok(Some(effects)) => effects,
+            Ok(None) => {
+                if gate.is_exceeded() {
+                    let limit = gate.ceiling();
+                    let usage = gate.projected_usage();
+                    // schedule_error resets the upload back to Open and cleans up
+                    // the composed blob, mirroring every other finalize-phase error.
+                    self.schedule_error(CompleteMultipartUploadError::QuotaExceeded {
+                        limit,
+                        usage,
+                    })
+                } else {
+                    self.start_usage_update(txn_id)
+                }
+            }
+            Err(err) => self.schedule_error(err.into()),
+        }
     }
 
     fn handle_usage_update(&mut self, event: Event) -> Effects {
@@ -1081,6 +1149,7 @@ impl Operation for CompleteMultipartUploadOperation {
             CompleteMultipartUploadState::WriteLiveReplicationObligation => {
                 self.handle_live_replication_obligation_written(event)
             }
+            CompleteMultipartUploadState::EnforceQuota => self.handle_enforce_quota(event),
             CompleteMultipartUploadState::UpdateUsage => self.handle_usage_update(event),
             CompleteMultipartUploadState::CommitFinalizeTransaction => {
                 self.handle_finalize_committed(event)

--- a/operations/src/s3/complete_multipart_upload.rs
+++ b/operations/src/s3/complete_multipart_upload.rs
@@ -3,7 +3,10 @@ use crate::blob::blob_keyspace_helper::{
     write_blob_location_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
-use crate::usage_stats::{QuotaGate, QuotaGateError, UsageCounterUpdate, UsageUpdateError};
+use crate::usage_stats::{
+    QuotaGate, QuotaGateError, UsageCounterUpdate, UsageUpdateError,
+    schedule_usage_snapshot_publish_effect,
+};
 use aruna_blob::hash::Hasher;
 use aruna_core::effects::{BlobEffect, DhtEffect, Effect, NetEffect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
@@ -145,6 +148,7 @@ pub struct CompleteMultipartUploadOperation {
     input: CompleteMultipartUploadInput,
     txn_id: Option<TxnId>,
     upload_record: Option<MultipartUpload>,
+    upload_parts: Vec<MultipartUploadPart>,
     resolved_parts: Vec<MultipartUploadPart>,
     composed_location: Option<BackendLocation>,
     final_location: Option<BackendLocation>,
@@ -168,6 +172,7 @@ impl CompleteMultipartUploadOperation {
             input,
             txn_id: None,
             upload_record: None,
+            upload_parts: Vec::new(),
             resolved_parts: Vec::new(),
             composed_location: None,
             final_location: None,
@@ -349,15 +354,18 @@ impl CompleteMultipartUploadOperation {
     fn extract_requested_parts(
         &self,
         values: Vec<(aruna_core::types::Key, aruna_core::types::Value)>,
-    ) -> Result<Vec<MultipartUploadPart>, CompleteMultipartUploadError> {
+    ) -> Result<(Vec<MultipartUploadPart>, Vec<MultipartUploadPart>), CompleteMultipartUploadError>
+    {
         if self.input.completed_parts.is_empty() {
             return Err(CompleteMultipartUploadError::MissingParts);
         }
 
         let mut all_parts = HashMap::new();
+        let mut upload_parts = Vec::new();
         for (key, value) in values {
             let part_key = MultipartUploadPartKey::from_bytes(key.as_ref())?;
             let part_record = MultipartUploadPart::from_bytes(value.as_ref())?;
+            upload_parts.push(part_record.clone());
             all_parts.insert(part_key.part_number, part_record);
         }
 
@@ -385,7 +393,7 @@ impl CompleteMultipartUploadOperation {
             return Err(CompleteMultipartUploadError::InvalidObjectSize);
         }
 
-        Ok(resolved)
+        Ok((resolved, upload_parts))
     }
 
     fn handle_upload_parts_read(&mut self, event: Event) -> Effects {
@@ -393,14 +401,15 @@ impl CompleteMultipartUploadOperation {
             return self.schedule_error(CompleteMultipartUploadError::InvalidOperationState);
         };
 
-        let resolved = match self.extract_requested_parts(values) {
-            Ok(resolved) => resolved,
+        let (resolved, upload_parts) = match self.extract_requested_parts(values) {
+            Ok(parts) => parts,
             Err(err) => return self.schedule_error(err),
         };
         self.composite_hashes = match compute_composite_hashes(&resolved) {
             Ok(hashes) => hashes,
             Err(err) => return self.schedule_error(err),
         };
+        self.upload_parts = upload_parts;
         self.resolved_parts = resolved.clone();
 
         self.state = CompleteMultipartUploadState::ComposeBlob;
@@ -758,8 +767,8 @@ impl CompleteMultipartUploadOperation {
     }
 
     fn delete_upload_records(&mut self) -> Effects {
-        let mut deletes = Vec::with_capacity(self.resolved_parts.len() + 1);
-        for record in &self.resolved_parts {
+        let mut deletes = Vec::with_capacity(self.upload_parts.len() + 1);
+        for record in &self.upload_parts {
             let key = match MultipartUploadPartKey::new(self.input.upload_id, record.part_number)
                 .to_bytes()
             {
@@ -826,7 +835,7 @@ impl CompleteMultipartUploadOperation {
         let Some(size) = self
             .final_location
             .as_ref()
-            .map(|location| i64::try_from(location.blob_size).unwrap_or(i64::MAX))
+            .map(|location| i128::from(location.blob_size))
         else {
             return self
                 .schedule_error(CompleteMultipartUploadError::CompleteMultipartUploadFailed);
@@ -858,7 +867,13 @@ impl CompleteMultipartUploadOperation {
         if let Some(ceiling) = self.input.quota_ceiling
             && object_size > 0
         {
-            let mut gate = QuotaGate::new(ceiling, object_size, group_id, self.input.node_id);
+            let mut gate = QuotaGate::new_for_realm(
+                ceiling,
+                object_size,
+                group_id,
+                self.input.node_id,
+                self.input.realm_id,
+            );
             self.state = CompleteMultipartUploadState::EnforceQuota;
             let effects = gate.start(txn_id);
             self.quota_gate = Some(gate);
@@ -997,7 +1012,7 @@ impl CompleteMultipartUploadOperation {
     }
 
     fn cleanup_next_part_blob(&mut self) -> Effects {
-        let Some(record) = self.resolved_parts.get(self.cleanup_part_index) else {
+        let Some(record) = self.upload_parts.get(self.cleanup_part_index) else {
             self.state = CompleteMultipartUploadState::Finish;
             self.composed_location = None;
             let Some(location) = self.final_location.clone() else {
@@ -1018,7 +1033,7 @@ impl CompleteMultipartUploadOperation {
                 checksum_type: self.input.checksum_type,
                 response_hashes,
             }));
-            return smallvec![];
+            return smallvec![schedule_usage_snapshot_publish_effect()];
         };
 
         self.state = CompleteMultipartUploadState::CleanupPartBlobs;
@@ -1329,6 +1344,84 @@ mod tests {
             status: MultipartUploadStatus::Completing,
             checksum_hint: None,
         }
+    }
+
+    fn part_record(part_number: u16, blob_size: u64) -> MultipartUploadPart {
+        MultipartUploadPart {
+            part_number,
+            location: BackendLocation {
+                root: "/tmp".to_string(),
+                storage_bucket: "multipart".to_string(),
+                backend_path: format!("part-{part_number}"),
+                ulid: Ulid::new(),
+                compressed: false,
+                encrypted: false,
+                created_by: UserId::local(Ulid::new(), RealmId::from_bytes([4u8; 32])),
+                created_at: SystemTime::now(),
+                staging: false,
+                partial: true,
+                blob_size,
+                hashes: HashMap::new(),
+            },
+            created_at: SystemTime::now(),
+        }
+    }
+
+    #[test]
+    fn delete_upload_records_includes_omitted_parts() {
+        let input = finalize_input();
+        let mut op = CompleteMultipartUploadOperation::new(input);
+        op.upload_parts = vec![part_record(1, 10), part_record(2, 20)];
+        op.resolved_parts = vec![op.upload_parts[0].clone()];
+
+        let effects = op.delete_upload_records();
+
+        let [Effect::Storage(StorageEffect::BatchDelete { deletes, .. })] = effects.as_slice()
+        else {
+            panic!("expected batch delete effect");
+        };
+        assert_eq!(deletes.len(), 3);
+        let omitted_key = MultipartUploadPartKey::new(op.input.upload_id, 2)
+            .to_bytes()
+            .unwrap();
+        assert!(deletes.iter().any(|(_, key)| key.as_ref() == omitted_key));
+    }
+
+    #[test]
+    fn cleanup_part_blobs_includes_omitted_parts() {
+        let input = finalize_input();
+        let mut op = CompleteMultipartUploadOperation::new(input);
+        let requested = part_record(1, 10);
+        let omitted = part_record(2, 20);
+        op.final_location = Some(BackendLocation {
+            root: "/tmp".to_string(),
+            storage_bucket: "objects".to_string(),
+            backend_path: "object".to_string(),
+            ulid: Ulid::new(),
+            compressed: false,
+            encrypted: false,
+            created_by: UserId::local(Ulid::new(), RealmId::from_bytes([4u8; 32])),
+            created_at: SystemTime::now(),
+            staging: false,
+            partial: false,
+            blob_size: 10,
+            hashes: HashMap::new(),
+        });
+        op.version_id = Some(Ulid::new());
+        op.upload_parts = vec![requested.clone(), omitted.clone()];
+        op.resolved_parts = vec![requested.clone()];
+
+        let effects = op.begin_cleanup_part_blobs();
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Blob(BlobEffect::Delete { location })] if location == &requested.location
+        ));
+
+        let effects = op.step(Event::Blob(BlobEvent::DeleteFinished));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Blob(BlobEffect::Delete { location })] if location == &omitted.location
+        ));
     }
 
     // A quota rejection at EnforceQuota leaves the finalize transaction open. It

--- a/operations/src/s3/create_bucket.rs
+++ b/operations/src/s3/create_bucket.rs
@@ -1,4 +1,6 @@
-use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
+use crate::usage_stats::{
+    UsageCounterUpdate, UsageUpdateError, schedule_usage_snapshot_publish_effect,
+};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
@@ -192,7 +194,7 @@ impl CreateBucketOperation {
         self.txn_id = None;
         self.state = CreateBucketState::Finish;
         self.output = Some(Ok(self.bucket_info.clone()));
-        smallvec![]
+        smallvec![schedule_usage_snapshot_publish_effect()]
     }
 }
 

--- a/operations/src/s3/delete_bucket.rs
+++ b/operations/src/s3/delete_bucket.rs
@@ -1,4 +1,6 @@
-use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
+use crate::usage_stats::{
+    UsageCounterUpdate, UsageUpdateError, schedule_usage_snapshot_publish_effect,
+};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
@@ -281,7 +283,7 @@ impl DeleteBucketOperation {
         self.txn_id = None;
         self.state = DeleteBucketState::Finish;
         self.output = Some(Ok(()));
-        smallvec![]
+        smallvec![schedule_usage_snapshot_publish_effect()]
     }
 }
 

--- a/operations/src/s3/delete_object.rs
+++ b/operations/src/s3/delete_object.rs
@@ -1086,6 +1086,7 @@ mod test {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             &context,
         )
@@ -1236,6 +1237,7 @@ mod test {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             &context,
         )

--- a/operations/src/s3/delete_object.rs
+++ b/operations/src/s3/delete_object.rs
@@ -3,7 +3,9 @@ use crate::blob::blob_keyspace_helper::{
     delete_hash_path_index_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
-use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
+use crate::usage_stats::{
+    UsageCounterUpdate, UsageUpdateError, schedule_usage_snapshot_publish_effect,
+};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
@@ -13,8 +15,8 @@ use aruna_core::keyspaces::{
 };
 use aruna_core::operation::Operation;
 use aruna_core::structs::{
-    AuthContext, BackendLocation, BlobHeadKey, BlobVersion, CurrentVersionPointer,
-    MultipartObjectMetadataKey, RealmId, UsageDelta, VersionKey,
+    AuthContext, BackendLocation, BlobHeadKey, BlobVersion, BlobVersionState,
+    CurrentVersionPointer, MultipartObjectMetadataKey, RealmId, UsageDelta, VersionKey,
 };
 use aruna_core::types::{Effects, GroupId, Key, NodeId, UserId};
 use smallvec::smallvec;
@@ -56,14 +58,23 @@ enum HeadTransitionContinuation {
 struct VersionSummary {
     version_id: Ulid,
     materialized_hash: Option<[u8; 32]>,
+    logical_size: Option<u64>,
     deleted: bool,
 }
 
 impl VersionSummary {
     fn from_blob_version(version_id: Ulid, version: &BlobVersion) -> Self {
+        let (materialized_hash, logical_size) = match &version.state {
+            BlobVersionState::Materialized { blob_hash, .. } => (Some(*blob_hash), None),
+            BlobVersionState::Reference {
+                cached_metadata, ..
+            } => (None, Some(cached_metadata.content_length)),
+            BlobVersionState::Deleted => (None, None),
+        };
         Self {
             version_id,
-            materialized_hash: version.blob_hash().copied(),
+            materialized_hash,
+            logical_size,
             deleted: version.is_deleted(),
         }
     }
@@ -263,6 +274,7 @@ impl DeleteObjectOperation {
         };
         let summary = VersionSummary::from_blob_version(version_id, &version);
         let materialized_hash = summary.materialized_hash;
+        self.target_size = summary.logical_size;
         self.target_version = Some(summary);
 
         if let Some(hash) = materialized_hash {
@@ -567,14 +579,11 @@ impl DeleteObjectOperation {
                     .latest_remaining
                     .as_ref()
                     .is_some_and(|latest| !latest.is_deleted());
-                i64::from(live_after) - i64::from(live_before)
+                i128::from(u8::from(live_after)) - i128::from(u8::from(live_before))
             } else {
                 0
             };
-            let logical_bytes = match (target.materialized_hash, self.target_size) {
-                (Some(_), Some(size)) => -i64::try_from(size).unwrap_or(i64::MAX),
-                _ => 0,
-            };
+            let logical_bytes = self.target_size.map_or(0, |size| -i128::from(size));
             UsageDelta {
                 objects,
                 logical_bytes,
@@ -738,7 +747,7 @@ impl DeleteObjectOperation {
                     version_id,
                     delete_marker,
                 }));
-                return smallvec![];
+                return smallvec![schedule_usage_snapshot_publish_effect()];
             }
             return self.emit_error(DeleteObjectError::InvalidOperationState);
         };
@@ -748,7 +757,7 @@ impl DeleteObjectOperation {
             version_id,
             delete_marker: true,
         }));
-        smallvec![]
+        smallvec![schedule_usage_snapshot_publish_effect()]
     }
 }
 

--- a/operations/src/s3/put_object.rs
+++ b/operations/src/s3/put_object.rs
@@ -3,7 +3,10 @@ use crate::blob::blob_keyspace_helper::{
     write_blob_location_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
-use crate::usage_stats::{QuotaGate, QuotaGateError, UsageCounterUpdate, UsageUpdateError};
+use crate::usage_stats::{
+    QuotaGate, QuotaGateError, UsageCounterUpdate, UsageUpdateError,
+    schedule_usage_snapshot_publish_effect,
+};
 use aruna_core::effects::{BlobEffect, DhtEffect, Effect, NetEffect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{BlobEvent, DhtEvent, Event, NetEvent, StorageEvent};
@@ -483,7 +486,7 @@ impl PutObjectOperation {
                 let Some(location) = self.get_output().cloned() else {
                     return self.emit_error(PutObjectError::MissingOutput);
                 };
-                let size = i64::try_from(location.blob_size).unwrap_or(i64::MAX);
+                let size = i128::from(location.blob_size);
                 let group_delta = UsageDelta {
                     objects: if self.was_live { 0 } else { 1 },
                     logical_bytes: size,
@@ -506,11 +509,12 @@ impl PutObjectOperation {
                 if let Some(ceiling) = self.config.quota_ceiling
                     && location.blob_size > 0
                 {
-                    let mut gate = QuotaGate::new(
+                    let mut gate = QuotaGate::new_for_realm(
                         ceiling,
                         location.blob_size,
                         self.config.group_id,
                         self.config.node_id,
+                        self.config.realm_id,
                     );
                     self.state = PutObjectState::EnforceQuota;
                     let effects = gate.start(txn_id);
@@ -653,7 +657,7 @@ impl PutObjectOperation {
             smallvec![Effect::Blob(BlobEffect::Delete { location })]
         } else {
             self.state = PutObjectState::Finish;
-            smallvec![]
+            smallvec![schedule_usage_snapshot_publish_effect()]
         }
     }
 
@@ -661,7 +665,7 @@ impl PutObjectOperation {
         match event {
             Event::Blob(BlobEvent::DeleteFinished) | Event::Blob(BlobEvent::Error(_)) => {
                 self.state = PutObjectState::Finish;
-                smallvec![]
+                smallvec![schedule_usage_snapshot_publish_effect()]
             }
             _ => self.emit_error(PutObjectError::InvalidOperationState),
         }

--- a/operations/src/s3/put_object.rs
+++ b/operations/src/s3/put_object.rs
@@ -3,7 +3,7 @@ use crate::blob::blob_keyspace_helper::{
     write_blob_location_effect, write_blob_version_effect,
 };
 use crate::replication::queue::write_live_replication_obligation_effect;
-use crate::usage_stats::{UsageCounterUpdate, UsageUpdateError};
+use crate::usage_stats::{QuotaGate, QuotaGateError, UsageCounterUpdate, UsageUpdateError};
 use aruna_core::effects::{BlobEffect, DhtEffect, Effect, NetEffect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{BlobEvent, DhtEvent, Event, NetEvent, StorageEvent};
@@ -35,6 +35,8 @@ pub enum PutObjectState {
     WriteHashPathIndex,
     CreateBlobVersionRecord,
     WriteLiveReplicationObligation,
+    EnforceQuota,
+    QuotaRejectAbort,
     UpdateUsage,
     CommitTransaction,
     RegisterBlobInDht,
@@ -67,6 +69,10 @@ pub enum PutObjectError {
     ConversionError(#[from] ConversionError),
     #[error(transparent)]
     UsageUpdateError(#[from] UsageUpdateError),
+    #[error(transparent)]
+    QuotaGateError(#[from] QuotaGateError),
+    #[error("group storage quota exceeded: {usage} bytes would exceed limit of {limit} bytes")]
+    QuotaExceeded { limit: u64, usage: u64 },
     #[error("Something went wrong ...")]
     PutObjectFailed,
 }
@@ -90,6 +96,10 @@ pub struct PutObjectConfig {
     pub checksum_type: Option<String>,
     pub exists: bool, //Note: For version shenanigans which will be implemented later
     pub version_source: Option<VersionSourceBinding>,
+    /// Hard ceiling (bytes) the group's realm-wide `logical_bytes` may reach,
+    /// resolved from the realm quota config at the request surface. `None` =
+    /// unlimited, so no gate is enforced.
+    pub quota_ceiling: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -110,6 +120,7 @@ pub struct PutObjectOperation {
     new_blob: bool,
     was_live: bool,
     usage_update: Option<UsageCounterUpdate>,
+    quota_gate: Option<QuotaGate>,
     pending_error: Option<PutObjectError>,
     output: Option<Result<BackendLocation, PutObjectError>>,
 }
@@ -127,6 +138,7 @@ impl PutObjectOperation {
             new_blob: false,
             was_live: false,
             usage_update: None,
+            quota_gate: None,
             pending_error: None,
             output: None,
         }
@@ -482,21 +494,95 @@ impl PutObjectOperation {
                     stored_bytes: if self.new_blob { size } else { 0 },
                     ..group_delta
                 };
-                let mut update = UsageCounterUpdate::with_global(
+                self.usage_update = Some(UsageCounterUpdate::with_global(
                     self.config.group_id,
                     group_delta,
                     global_delta,
-                );
-                self.state = PutObjectState::UpdateUsage;
-                let effects = update.start(txn_id);
-                self.usage_update = Some(update);
-                effects
+                ));
+
+                // Enforce the hard group quota before the counters commit. Only a
+                // positive logical-bytes delta can push a group over its ceiling;
+                // deletes and zero-length writes are never gated.
+                if let Some(ceiling) = self.config.quota_ceiling
+                    && location.blob_size > 0
+                {
+                    let mut gate = QuotaGate::new(
+                        ceiling,
+                        location.blob_size,
+                        self.config.group_id,
+                        self.config.node_id,
+                    );
+                    self.state = PutObjectState::EnforceQuota;
+                    let effects = gate.start(txn_id);
+                    self.quota_gate = Some(gate);
+                    effects
+                } else {
+                    self.start_usage_update(txn_id)
+                }
             } else {
                 self.emit_error(PutObjectError::NoTransactionFound)
             }
         } else {
             self.emit_error(PutObjectError::InvalidOperationState)
         }
+    }
+
+    fn start_usage_update(&mut self, txn_id: Ulid) -> Effects {
+        self.state = PutObjectState::UpdateUsage;
+        match self.usage_update.as_mut() {
+            Some(update) => update.start(txn_id),
+            None => self.emit_error(PutObjectError::PutObjectFailed),
+        }
+    }
+
+    fn handle_enforce_quota(&mut self, event: Event) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.emit_error(PutObjectError::NoTransactionFound);
+        };
+        let Some(gate) = self.quota_gate.as_mut() else {
+            return self.emit_error(PutObjectError::PutObjectFailed);
+        };
+        match gate.step(event, txn_id) {
+            Ok(Some(effects)) => effects,
+            Ok(None) => {
+                if gate.is_exceeded() {
+                    self.pending_error = Some(PutObjectError::QuotaExceeded {
+                        limit: gate.ceiling(),
+                        usage: gate.projected_usage(),
+                    });
+                    self.reject_over_quota()
+                } else {
+                    self.start_usage_update(txn_id)
+                }
+            }
+            Err(err) => self.emit_error(err.into()),
+        }
+    }
+
+    /// Unwinds the pending write after a quota rejection: aborts the open
+    /// transaction, then deletes the orphaned blob, before surfacing the error.
+    fn reject_over_quota(&mut self) -> Effects {
+        self.state = PutObjectState::QuotaRejectAbort;
+        match self.txn_id.take() {
+            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
+            None => self.cleanup_orphan_blob(),
+        }
+    }
+
+    fn handle_quota_reject_abort(&mut self, event: Event) -> Effects {
+        match event {
+            Event::Storage(StorageEvent::TransactionAborted { .. })
+            | Event::Storage(StorageEvent::Error { .. }) => self.cleanup_orphan_blob(),
+            _ => self.emit_error(PutObjectError::InvalidOperationState),
+        }
+    }
+
+    fn cleanup_orphan_blob(&mut self) -> Effects {
+        self.state = PutObjectState::CleanupFailedWrite;
+        self.get_written_location().cloned().map_or_else(
+            || self.emit_pending_error(),
+            |location| smallvec![Effect::Blob(BlobEffect::Delete { location })],
+        )
     }
 
     fn handle_usage_update(&mut self, event: Event) -> Effects {
@@ -651,6 +737,8 @@ impl Operation for PutObjectOperation {
             PutObjectState::WriteLiveReplicationObligation => {
                 self.handle_live_replication_obligation_written(event)
             }
+            PutObjectState::EnforceQuota => self.handle_enforce_quota(event),
+            PutObjectState::QuotaRejectAbort => self.handle_quota_reject_abort(event),
             PutObjectState::UpdateUsage => self.handle_usage_update(event),
             PutObjectState::CommitTransaction => self.handle_transaction_committed(event),
             PutObjectState::RegisterBlobInDht => self.handle_blob_registered_in_dht(event),
@@ -804,6 +892,7 @@ mod test {
             checksum_type: None,
             exists: false,
             version_source: None,
+            quota_ceiling: None,
         };
         let put_operation = PutObjectOperation::new(put_config);
 
@@ -1004,6 +1093,7 @@ mod test {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             &context,
         )
@@ -1030,6 +1120,7 @@ mod test {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             &context,
         )
@@ -1121,6 +1212,7 @@ mod test {
             checksum_type: None,
             exists: false,
             version_source: None,
+            quota_ceiling: None,
         });
         let version_id = Ulid::new();
         op.version_id = Some(version_id);
@@ -1219,6 +1311,7 @@ mod test {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             &context,
         )
@@ -1245,6 +1338,7 @@ mod test {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             &context,
         )
@@ -1400,6 +1494,7 @@ mod test {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             &context,
         )

--- a/operations/src/s3/put_object.rs
+++ b/operations/src/s3/put_object.rs
@@ -613,11 +613,24 @@ impl PutObjectOperation {
     }
 
     fn handle_transaction_committed(&mut self, event: Event) -> Effects {
-        if let Event::Storage(StorageEvent::TransactionCommitted { .. }) = event {
-            self.txn_id = None;
-            self.register_blob_in_dht_or_continue()
-        } else {
-            self.emit_error(PutObjectError::InvalidOperationState)
+        match event {
+            Event::Storage(StorageEvent::TransactionCommitted { .. }) => {
+                self.txn_id = None;
+                self.register_blob_in_dht_or_continue()
+            }
+            Event::Storage(StorageEvent::Error {
+                error: StorageError::TransactionConflict,
+            }) => {
+                self.txn_id = None;
+                self.cleanup_failed_write(PutObjectError::StorageError(
+                    StorageError::TransactionConflict,
+                ))
+            }
+            Event::Storage(StorageEvent::Error { error }) => {
+                self.txn_id = None;
+                self.emit_error(error.into())
+            }
+            _ => self.emit_error(PutObjectError::InvalidOperationState),
         }
     }
 
@@ -987,6 +1000,40 @@ mod test {
         assert!(matches!(
             op.finalize(),
             Err(crate::s3::put_object::PutObjectError::UsageUpdateError(_))
+        ));
+    }
+
+    #[test]
+    fn commit_transaction_conflict_deletes_written_blob_and_returns_conflict() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let group_id = Ulid::new();
+        let node_id = iroh::SecretKey::generate().public();
+        let mut op = PutObjectOperation::new(put_config(realm_id, group_id, node_id));
+        let txn_id = Ulid::new();
+        let location = test_location(op.config.user_id);
+
+        op.state = PutObjectState::CommitTransaction;
+        op.txn_id = Some(txn_id);
+        op.written_location = Some(location.clone());
+
+        let effects = op.step(Event::Storage(StorageEvent::Error {
+            error: StorageError::TransactionConflict,
+        }));
+
+        let [Effect::Blob(BlobEffect::Delete { location: deleted })] = effects.as_slice() else {
+            panic!("expected blob cleanup")
+        };
+        assert_eq!(deleted, &location);
+
+        let effects = op.step(Event::Blob(BlobEvent::DeleteFinished));
+
+        assert!(effects.is_empty());
+        assert!(op.is_complete());
+        assert!(matches!(
+            op.finalize(),
+            Err(crate::s3::put_object::PutObjectError::StorageError(
+                StorageError::TransactionConflict
+            ))
         ));
     }
 

--- a/operations/src/s3/put_object.rs
+++ b/operations/src/s3/put_object.rs
@@ -555,11 +555,14 @@ impl PutObjectOperation {
                     self.start_usage_update(txn_id)
                 }
             }
-            Err(err) => self.emit_error(err.into()),
+            Err(err) => {
+                self.pending_error = Some(err.into());
+                self.reject_over_quota()
+            }
         }
     }
 
-    /// Unwinds the pending write after a quota rejection: aborts the open
+    /// Unwinds the pending write after quota/accounting failure: aborts the open
     /// transaction, then deletes the orphaned blob, before surfacing the error.
     fn reject_over_quota(&mut self) -> Effects {
         self.state = PutObjectState::QuotaRejectAbort;
@@ -598,7 +601,10 @@ impl PutObjectOperation {
                 self.state = PutObjectState::CommitTransaction;
                 smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
             }
-            Err(err) => self.emit_error(err.into()),
+            Err(err) => {
+                self.pending_error = Some(err.into());
+                self.reject_over_quota()
+            }
         }
     }
 
@@ -795,19 +801,24 @@ impl Operation for PutObjectOperation {
 #[cfg(test)]
 mod test {
     use crate::driver::{DriverContext, drive};
-    use crate::s3::put_object::{PutObjectConfig, PutObjectInput, PutObjectOperation};
+    use crate::s3::put_object::{
+        PutObjectConfig, PutObjectInput, PutObjectOperation, PutObjectState,
+    };
+    use crate::usage_stats::{QuotaGate, UsageCounterUpdate};
     use aruna_blob::blob::BlobHandler;
-    use aruna_core::effects::{Effect, StorageEffect};
-    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::effects::{BlobEffect, Effect, StorageEffect};
+    use aruna_core::errors::StorageError;
+    use aruna_core::events::{BlobEvent, Event, StorageEvent};
     use aruna_core::keyspaces::{
         BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE, DHT_KEYSPACE,
         HASH_PATHS_INDEX_KEYSPACE,
     };
+    use aruna_core::operation::Operation;
     use aruna_core::stream::BackendStream;
     use aruna_core::structs::checksum::{ChecksumAlgorithm, ExpectedChecksum};
     use aruna_core::structs::{
         Backend, BackendConfig, BackendLocation, BlobHeadKey, BlobVersion, CurrentVersionPointer,
-        HashPathIndexKey, RealmId, VersionKey,
+        HashPathIndexKey, RealmId, UsageDelta, VersionKey,
     };
     use aruna_net::dht::storage::decode_entries;
     use aruna_net::{NetConfig, NetHandle};
@@ -844,6 +855,135 @@ mod test {
         };
 
         value
+    }
+
+    fn test_location(created_by: aruna_core::UserId) -> BackendLocation {
+        BackendLocation {
+            root: "/tmp".to_string(),
+            storage_bucket: "bucket".to_string(),
+            backend_path: "path".to_string(),
+            ulid: Ulid::new(),
+            compressed: false,
+            encrypted: false,
+            created_by,
+            created_at: std::time::SystemTime::now(),
+            staging: false,
+            partial: false,
+            blob_size: 1,
+            hashes: HashMap::new(),
+        }
+    }
+
+    fn put_config(
+        realm_id: RealmId,
+        group_id: Ulid,
+        node_id: aruna_core::NodeId,
+    ) -> PutObjectConfig {
+        PutObjectConfig {
+            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            group_id,
+            realm_id,
+            node_id,
+            request: PutObjectInput {
+                bucket: "mybucket".to_string(),
+                key: "some-file.txt".to_string(),
+                content_length: None,
+                body: None,
+            },
+            expected_checksums: vec![],
+            checksum_type: None,
+            exists: false,
+            version_source: None,
+            quota_ceiling: Some(1),
+        }
+    }
+
+    #[test]
+    fn quota_gate_error_aborts_transaction_and_deletes_written_blob() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let group_id = Ulid::new();
+        let node_id = iroh::SecretKey::generate().public();
+        let mut op = PutObjectOperation::new(put_config(realm_id, group_id, node_id));
+        let txn_id = Ulid::new();
+        let location = test_location(op.config.user_id);
+
+        op.state = PutObjectState::EnforceQuota;
+        op.txn_id = Some(txn_id);
+        op.written_location = Some(location.clone());
+        op.quota_gate = Some(QuotaGate::new(1, 1, group_id, node_id));
+
+        let effects = op.handle_enforce_quota(Event::Storage(StorageEvent::Error {
+            error: StorageError::Timeout,
+        }));
+
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            effects[0],
+            Effect::Storage(StorageEffect::AbortTransaction { txn_id: observed }) if observed == txn_id
+        ));
+        assert_eq!(op.txn_id, None);
+
+        let effects = op.step(Event::Storage(StorageEvent::TransactionAborted { txn_id }));
+
+        let [Effect::Blob(BlobEffect::Delete { location: deleted })] = effects.as_slice() else {
+            panic!("expected blob cleanup")
+        };
+        assert_eq!(deleted, &location);
+
+        let effects = op.step(Event::Blob(BlobEvent::DeleteFinished));
+
+        assert!(effects.is_empty());
+        assert!(op.is_complete());
+        assert!(matches!(
+            op.finalize(),
+            Err(crate::s3::put_object::PutObjectError::QuotaGateError(_))
+        ));
+    }
+
+    #[test]
+    fn usage_update_error_aborts_transaction_and_deletes_written_blob() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let group_id = Ulid::new();
+        let node_id = iroh::SecretKey::generate().public();
+        let mut op = PutObjectOperation::new(put_config(realm_id, group_id, node_id));
+        let txn_id = Ulid::new();
+        let location = test_location(op.config.user_id);
+
+        op.state = PutObjectState::UpdateUsage;
+        op.txn_id = Some(txn_id);
+        op.written_location = Some(location.clone());
+        op.usage_update = Some(UsageCounterUpdate::with_global(
+            group_id,
+            UsageDelta::default(),
+            UsageDelta::default(),
+        ));
+
+        let effects = op.handle_usage_update(Event::Storage(StorageEvent::Error {
+            error: StorageError::Timeout,
+        }));
+
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            effects[0],
+            Effect::Storage(StorageEffect::AbortTransaction { txn_id: observed }) if observed == txn_id
+        ));
+        assert_eq!(op.txn_id, None);
+
+        let effects = op.step(Event::Storage(StorageEvent::TransactionAborted { txn_id }));
+
+        let [Effect::Blob(BlobEffect::Delete { location: deleted })] = effects.as_slice() else {
+            panic!("expected blob cleanup")
+        };
+        assert_eq!(deleted, &location);
+
+        let effects = op.step(Event::Blob(BlobEvent::DeleteFinished));
+
+        assert!(effects.is_empty());
+        assert!(op.is_complete());
+        assert!(matches!(
+            op.finalize(),
+            Err(crate::s3::put_object::PutObjectError::UsageUpdateError(_))
+        ));
     }
 
     #[tokio::test]

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -191,6 +191,7 @@ impl SetRealmQuotaOperation {
             DocumentSyncOutboxEvent::AdminOperation {
                 event: Box::new(admin_event),
             },
+            false,
         );
         writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         writes.extend(admin_document_conflict_write_entries(&reducer_state)?);

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 
-use aruna_core::admin_document_reducer::{AdminDocumentReducerError, AdminDocumentReducerState};
+use aruna_core::admin_document_reducer::{
+    AdminDocumentReducerError, AdminDocumentReducerState, REALM_CONFIG_QUOTA_PATH,
+};
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
@@ -162,7 +164,11 @@ impl SetRealmQuotaOperation {
                 quota: self.config.quota.clone(),
             },
         )?;
-        document.quota = self.config.quota.clone();
+        // Derive the stored quota from the reducer's materialized state (rather
+        // than assigning the input directly) so the local write path agrees with
+        // the replicated overlay in net/src/irokle.rs: when the quota path is
+        // conflicted, both leave the previously stored quota in place.
+        apply_reducer_quota(&mut document, &reducer_state);
 
         let stale_conflict_deletes = stale_admin_document_conflict_delete_entries(
             previous_reducer_state.as_ref(),
@@ -345,6 +351,24 @@ impl Operation for SetRealmQuotaOperation {
     }
 }
 
+/// Overlays the reducer's materialized quota onto the config document, mirroring
+/// the replicated materialization in `net::irokle`: the stored quota is only
+/// updated from a non-conflicted, materialized value, so a conflicted quota path
+/// leaves the last agreed quota untouched instead of clobbering it with the
+/// caller's input.
+fn apply_reducer_quota(
+    document: &mut RealmConfigDocument,
+    reducer_state: &AdminDocumentReducerState,
+) {
+    if !reducer_state
+        .conflicts
+        .contains_key(REALM_CONFIG_QUOTA_PATH)
+        && let Some(quota) = reducer_state.materialized_realm_config_quota()
+    {
+        document.quota = quota;
+    }
+}
+
 fn validate_quota(quota: &QuotaConfig) -> Result<(), SetRealmQuotaError> {
     if !(1..=100).contains(&quota.warn_threshold_percent) {
         return Err(SetRealmQuotaError::InvalidQuota {
@@ -367,6 +391,15 @@ fn validate_quota(quota: &QuotaConfig) -> Result<(), SetRealmQuotaError> {
         if !seen_groups.insert(over.group_id) {
             return Err(SetRealmQuotaError::InvalidQuota {
                 reason: format!("duplicate group override for group {}", over.group_id),
+            });
+        }
+        if let Some(grace_factor_percent) = over.grace_factor_percent
+            && grace_factor_percent < 100
+        {
+            return Err(SetRealmQuotaError::InvalidQuota {
+                reason: format!(
+                    "group override grace_factor_percent must be at least 100, got {grace_factor_percent}"
+                ),
             });
         }
     }
@@ -573,7 +606,128 @@ mod tests {
     }
 
     #[test]
+    fn validate_quota_rejects_low_override_grace_factor() {
+        let quota = QuotaConfig {
+            group_overrides: vec![GroupQuotaOverride {
+                group_id: Ulid::from_bytes([5; 16]),
+                quota_bytes: Some(1),
+                grace_factor_percent: Some(99),
+            }],
+            ..QuotaConfig::default()
+        };
+        assert!(matches!(
+            validate_quota(&quota),
+            Err(SetRealmQuotaError::InvalidQuota { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_quota_accepts_override_grace_factor_at_or_above_100() {
+        let quota = QuotaConfig {
+            group_overrides: vec![GroupQuotaOverride {
+                group_id: Ulid::from_bytes([5; 16]),
+                quota_bytes: Some(1),
+                grace_factor_percent: Some(100),
+            }],
+            ..QuotaConfig::default()
+        };
+        assert!(validate_quota(&quota).is_ok());
+    }
+
+    #[test]
     fn validate_quota_accepts_default() {
         assert!(validate_quota(&QuotaConfig::default()).is_ok());
+    }
+
+    fn quota_conflict_state(
+        realm_id: RealmId,
+        quota_a: QuotaConfig,
+        quota_b: QuotaConfig,
+    ) -> AdminDocumentReducerState {
+        use aruna_core::admin_documents::{
+            AdminDocumentClock, AdminDocumentEvent, AdminDocumentTarget,
+        };
+
+        fn node(seed: u8) -> aruna_core::NodeId {
+            iroh::SecretKey::from_bytes(&[seed; 32]).public()
+        }
+
+        let target = AdminDocumentTarget::RealmConfig { realm_id };
+        let mut state = AdminDocumentReducerState::new(target.clone());
+        let quota_event =
+            |seed: u8, origin: aruna_core::NodeId, quota: QuotaConfig| AdminDocumentEvent {
+                event_id: Ulid::from_bytes([seed; 16]),
+                target: target.clone(),
+                origin_node_id: origin,
+                origin_seq: 1,
+                observed: AdminDocumentClock::default(),
+                actor: actor(seed, realm_id),
+                op: AdminDocumentOperation::RealmConfigQuotaSet { quota },
+            };
+        // Two concurrent events (neither observes the other) with divergent quota
+        // values conflict on the quota path.
+        state.apply(&quota_event(10, node(1), quota_a)).unwrap();
+        state.apply(&quota_event(11, node(2), quota_b)).unwrap();
+        state
+    }
+
+    #[test]
+    fn apply_reducer_quota_skips_conflicted_quota_path() {
+        let realm_id = RealmId::from_bytes([9; 32]);
+        let quota_a = QuotaConfig {
+            default_group_quota_bytes: Some(1_000),
+            ..QuotaConfig::default()
+        };
+        let quota_b = QuotaConfig {
+            default_group_quota_bytes: Some(2_000),
+            ..QuotaConfig::default()
+        };
+        let state = quota_conflict_state(realm_id, quota_a, quota_b);
+        assert!(state.conflicts.contains_key(REALM_CONFIG_QUOTA_PATH));
+        assert!(state.materialized_realm_config_quota().is_none());
+
+        let original = QuotaConfig {
+            default_group_quota_bytes: Some(42),
+            ..QuotaConfig::default()
+        };
+        let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        document.quota = original.clone();
+        apply_reducer_quota(&mut document, &state);
+        assert_eq!(
+            document.quota, original,
+            "conflicted quota path must not clobber the stored quota"
+        );
+    }
+
+    #[test]
+    fn apply_reducer_quota_sets_materialized_quota_when_not_conflicted() {
+        use aruna_core::admin_documents::{
+            AdminDocumentClock, AdminDocumentEvent, AdminDocumentTarget,
+        };
+
+        let realm_id = RealmId::from_bytes([9; 32]);
+        let quota = QuotaConfig {
+            default_group_quota_bytes: Some(1_000),
+            ..QuotaConfig::default()
+        };
+        let target = AdminDocumentTarget::RealmConfig { realm_id };
+        let mut state = AdminDocumentReducerState::new(target.clone());
+        state
+            .apply(&AdminDocumentEvent {
+                event_id: Ulid::from_bytes([10; 16]),
+                target,
+                origin_node_id: iroh::SecretKey::from_bytes(&[1; 32]).public(),
+                origin_seq: 1,
+                observed: AdminDocumentClock::default(),
+                actor: actor(1, realm_id),
+                op: AdminDocumentOperation::RealmConfigQuotaSet {
+                    quota: quota.clone(),
+                },
+            })
+            .unwrap();
+
+        let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        apply_reducer_quota(&mut document, &state);
+        assert_eq!(document.quota, quota);
     }
 }

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -537,8 +537,10 @@ mod tests {
         let document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
         seed_config(&ctx, &actor, &document).await;
 
-        let mut quota = QuotaConfig::default();
-        quota.max_devices_per_user = Some(4);
+        let quota = QuotaConfig {
+            max_devices_per_user: Some(4),
+            ..Default::default()
+        };
 
         let error = drive(
             SetRealmQuotaOperation::new(SetRealmQuotaConfig { actor, quota }),

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -500,23 +500,30 @@ mod tests {
 
     #[test]
     fn validate_quota_rejects_out_of_range_warn_threshold() {
-        let mut quota = QuotaConfig::default();
-        quota.warn_threshold_percent = 0;
+        let too_low = QuotaConfig {
+            warn_threshold_percent: 0,
+            ..QuotaConfig::default()
+        };
         assert!(matches!(
-            validate_quota(&quota),
+            validate_quota(&too_low),
             Err(SetRealmQuotaError::InvalidQuota { .. })
         ));
-        quota.warn_threshold_percent = 101;
+        let too_high = QuotaConfig {
+            warn_threshold_percent: 101,
+            ..QuotaConfig::default()
+        };
         assert!(matches!(
-            validate_quota(&quota),
+            validate_quota(&too_high),
             Err(SetRealmQuotaError::InvalidQuota { .. })
         ));
     }
 
     #[test]
     fn validate_quota_rejects_low_grace_factor() {
-        let mut quota = QuotaConfig::default();
-        quota.grace_factor_percent = 99;
+        let quota = QuotaConfig {
+            grace_factor_percent: 99,
+            ..QuotaConfig::default()
+        };
         assert!(matches!(
             validate_quota(&quota),
             Err(SetRealmQuotaError::InvalidQuota { .. })

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -1,0 +1,572 @@
+use std::collections::BTreeSet;
+
+use aruna_core::admin_document_reducer::{AdminDocumentReducerError, AdminDocumentReducerState};
+use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
+use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
+use aruna_core::operation::Operation;
+use aruna_core::storage_entries::{
+    admin_document_conflict_write_entries, admin_document_reducer_state_key,
+    admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
+};
+use aruna_core::structs::{Actor, QuotaConfig, RealmConfigDocument};
+use aruna_core::task::TaskEvent;
+use aruna_core::types::{Effects, Key, KeySpace, TxnId, Value};
+use smallvec::smallvec;
+use thiserror::Error;
+use tracing::warn;
+
+use crate::document_sync_outbox::{
+    new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SetRealmQuotaConfig {
+    pub actor: Actor,
+    pub quota: QuotaConfig,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct SetRealmQuotaOperation {
+    config: SetRealmQuotaConfig,
+    txn_id: Option<TxnId>,
+    state: SetRealmQuotaState,
+    output: Option<Result<RealmConfigDocument, SetRealmQuotaError>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum SetRealmQuotaState {
+    Init,
+    StartTransaction,
+    ReadCurrent,
+    WriteDocumentAndAdminState {
+        document: RealmConfigDocument,
+        stale_conflict_deletes: Vec<(KeySpace, Key)>,
+    },
+    DeleteStaleAdminConflicts {
+        document: RealmConfigDocument,
+    },
+    CommitTransaction {
+        document: RealmConfigDocument,
+    },
+    ScheduleDocumentSyncOutboxDrain {
+        document: RealmConfigDocument,
+    },
+    Finish,
+    Error,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum SetRealmQuotaError {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error(transparent)]
+    AdminDocumentReducerError(#[from] AdminDocumentReducerError),
+    #[error("realm config document missing")]
+    RealmConfigNotFound,
+    #[error("invalid quota configuration: {reason}")]
+    InvalidQuota { reason: String },
+    #[error("missing active transaction")]
+    MissingTransaction,
+    #[error("unexpected event in state {state:?}: expected {expected}, got {got}")]
+    UnexpectedEvent {
+        state: String,
+        expected: &'static str,
+        got: String,
+    },
+}
+
+impl SetRealmQuotaOperation {
+    pub fn new(config: SetRealmQuotaConfig) -> Self {
+        Self {
+            config,
+            txn_id: None,
+            state: SetRealmQuotaState::Init,
+            output: None,
+        }
+    }
+
+    fn document_ref(&self) -> DocumentSyncTarget {
+        DocumentSyncTarget::RealmConfig {
+            realm_id: self.config.actor.realm_id,
+        }
+    }
+
+    fn admin_target(&self) -> AdminDocumentTarget {
+        AdminDocumentTarget::RealmConfig {
+            realm_id: self.config.actor.realm_id,
+        }
+    }
+
+    fn emit_read_current(&mut self, txn_id: TxnId) -> Effects {
+        self.txn_id = Some(txn_id);
+        self.state = SetRealmQuotaState::ReadCurrent;
+        let document = self.document_ref();
+        let target = self.admin_target();
+        smallvec![Effect::Storage(StorageEffect::BatchRead {
+            reads: vec![
+                (
+                    document.storage_keyspace().to_string(),
+                    document.storage_key(),
+                ),
+                (
+                    ADMIN_DOCUMENT_STATE_KEYSPACE.to_string(),
+                    admin_document_reducer_state_key(&target),
+                ),
+            ],
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    fn emit_write_document_and_admin_state(
+        &mut self,
+        document_value: Option<Value>,
+        reducer_state_value: Option<Value>,
+    ) -> Result<Effects, SetRealmQuotaError> {
+        let Some(txn_id) = self.txn_id else {
+            return Err(SetRealmQuotaError::MissingTransaction);
+        };
+        validate_quota(&self.config.quota)?;
+
+        let Some(document_value) = document_value else {
+            return Err(SetRealmQuotaError::RealmConfigNotFound);
+        };
+        let mut document = RealmConfigDocument::from_bytes(&document_value)?;
+
+        let target = self.admin_target();
+        let previous_reducer_state = reducer_state_value
+            .as_ref()
+            .map(|value| {
+                postcard::from_bytes::<AdminDocumentReducerState>(value.as_ref())
+                    .map_err(ConversionError::from)
+            })
+            .transpose()?;
+        if previous_reducer_state
+            .as_ref()
+            .is_some_and(|state| state.target != target)
+        {
+            return Err(AdminDocumentReducerError::TargetMismatch.into());
+        }
+
+        let mut reducer_state = previous_reducer_state
+            .clone()
+            .unwrap_or_else(|| AdminDocumentReducerState::new(target));
+        let admin_event = reducer_state.apply_operation(
+            &self.config.actor,
+            AdminDocumentOperation::RealmConfigQuotaSet {
+                quota: self.config.quota.clone(),
+            },
+        )?;
+        document.quota = self.config.quota.clone();
+
+        let stale_conflict_deletes = stale_admin_document_conflict_delete_entries(
+            previous_reducer_state.as_ref(),
+            Some(&reducer_state),
+        );
+        let document_target = self.document_ref();
+        let mut writes = vec![
+            (
+                document_target.storage_keyspace().to_string(),
+                document_target.storage_key(),
+                document.to_bytes(&self.config.actor)?.into(),
+            ),
+            admin_document_reducer_state_write_entry(&reducer_state)?,
+        ];
+        let record = new_outbox_record_with_id(
+            admin_event.event_id,
+            self.config.actor.node_id,
+            document_target,
+            Vec::new(),
+            DocumentSyncOutboxEvent::AdminOperation {
+                event: Box::new(admin_event),
+            },
+        );
+        writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
+        writes.extend(admin_document_conflict_write_entries(&reducer_state)?);
+
+        self.output = Some(Ok(document.clone()));
+        self.state = SetRealmQuotaState::WriteDocumentAndAdminState {
+            document,
+            stale_conflict_deletes,
+        };
+
+        Ok(smallvec![Effect::Storage(StorageEffect::BatchWrite {
+            writes,
+            txn_id: Some(txn_id),
+        })])
+    }
+
+    fn emit_commit_transaction(&mut self, document: RealmConfigDocument) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.fail(SetRealmQuotaError::MissingTransaction);
+        };
+        self.state = SetRealmQuotaState::CommitTransaction { document };
+        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+    }
+
+    fn fail(&mut self, error: SetRealmQuotaError) -> Effects {
+        let cleanup = self.abort();
+        self.state = SetRealmQuotaState::Error;
+        self.output = Some(Err(error));
+        cleanup
+    }
+
+    fn unexpected_event(&mut self, expected: &'static str, got: String) -> Effects {
+        let state = format!("{:?}", self.state);
+        self.fail(SetRealmQuotaError::UnexpectedEvent {
+            state,
+            expected,
+            got,
+        })
+    }
+}
+
+impl Operation for SetRealmQuotaOperation {
+    type Output = RealmConfigDocument;
+    type Error = SetRealmQuotaError;
+
+    fn start(&mut self) -> Effects {
+        self.state = SetRealmQuotaState::StartTransaction;
+        smallvec![Effect::Storage(StorageEffect::StartTransaction {
+            read: false
+        })]
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        match self.state.clone() {
+            SetRealmQuotaState::StartTransaction => match event {
+                Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
+                    self.emit_read_current(txn_id)
+                }
+                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
+                other => self.unexpected_event("transaction start result", format!("{other:?}")),
+            },
+            SetRealmQuotaState::ReadCurrent => match event {
+                Event::Storage(StorageEvent::BatchReadResult { values }) => {
+                    let [(_, document_value), (_, reducer_state_value)] = values.as_slice() else {
+                        return self.unexpected_event(
+                            "storage batch read result with realm config and reducer state",
+                            format!("{values:?}"),
+                        );
+                    };
+                    match self.emit_write_document_and_admin_state(
+                        document_value.clone(),
+                        reducer_state_value.clone(),
+                    ) {
+                        Ok(effects) => effects,
+                        Err(error) => self.fail(error),
+                    }
+                }
+                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
+                other => self.unexpected_event("storage batch read result", format!("{other:?}")),
+            },
+            SetRealmQuotaState::WriteDocumentAndAdminState {
+                document,
+                stale_conflict_deletes,
+            } => match event {
+                Event::Storage(StorageEvent::BatchWriteResult { .. }) => {
+                    let Some(txn_id) = self.txn_id else {
+                        return self.fail(SetRealmQuotaError::MissingTransaction);
+                    };
+                    if !stale_conflict_deletes.is_empty() {
+                        self.state = SetRealmQuotaState::DeleteStaleAdminConflicts { document };
+                        return smallvec![Effect::Storage(StorageEffect::BatchDelete {
+                            deletes: stale_conflict_deletes,
+                            txn_id: Some(txn_id),
+                        })];
+                    }
+                    self.emit_commit_transaction(document)
+                }
+                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
+                other => self.unexpected_event("storage batch write result", format!("{other:?}")),
+            },
+            SetRealmQuotaState::DeleteStaleAdminConflicts { document } => match event {
+                Event::Storage(StorageEvent::BatchDeleteResult { .. }) => {
+                    self.emit_commit_transaction(document)
+                }
+                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
+                other => self.unexpected_event("storage batch delete result", format!("{other:?}")),
+            },
+            SetRealmQuotaState::CommitTransaction { document } => match event {
+                Event::Storage(StorageEvent::TransactionCommitted { .. }) => {
+                    self.txn_id = None;
+                    self.state = SetRealmQuotaState::ScheduleDocumentSyncOutboxDrain { document };
+                    smallvec![schedule_outbox_drain_effect()]
+                }
+                Event::Storage(StorageEvent::Error { error }) => {
+                    self.txn_id = None;
+                    self.fail(error.into())
+                }
+                other => self.unexpected_event("transaction commit result", format!("{other:?}")),
+            },
+            SetRealmQuotaState::ScheduleDocumentSyncOutboxDrain { .. } => match event {
+                Event::Task(TaskEvent::TimerScheduled { .. }) => {
+                    self.state = SetRealmQuotaState::Finish;
+                    smallvec![]
+                }
+                Event::Task(TaskEvent::Error { message, .. }) => {
+                    warn!(error = %message, "Failed to schedule admin document operation outbox drain; durable outbox remains retryable");
+                    self.state = SetRealmQuotaState::Finish;
+                    smallvec![]
+                }
+                other => self.unexpected_event(
+                    "document sync outbox drain timer schedule",
+                    format!("{other:?}"),
+                ),
+            },
+            SetRealmQuotaState::Finish | SetRealmQuotaState::Error | SetRealmQuotaState::Init => {
+                smallvec![]
+            }
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            SetRealmQuotaState::Finish | SetRealmQuotaState::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        self.output
+            .expect("set realm quota operation must set output")
+    }
+
+    fn abort(&mut self) -> Effects {
+        match self.txn_id.take() {
+            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
+            None => smallvec![],
+        }
+    }
+}
+
+fn validate_quota(quota: &QuotaConfig) -> Result<(), SetRealmQuotaError> {
+    if !(1..=100).contains(&quota.warn_threshold_percent) {
+        return Err(SetRealmQuotaError::InvalidQuota {
+            reason: format!(
+                "warn_threshold_percent must be between 1 and 100, got {}",
+                quota.warn_threshold_percent
+            ),
+        });
+    }
+    if quota.grace_factor_percent < 100 {
+        return Err(SetRealmQuotaError::InvalidQuota {
+            reason: format!(
+                "grace_factor_percent must be at least 100, got {}",
+                quota.grace_factor_percent
+            ),
+        });
+    }
+    let mut seen_groups = BTreeSet::new();
+    for over in &quota.group_overrides {
+        if !seen_groups.insert(over.group_id) {
+            return Err(SetRealmQuotaError::InvalidQuota {
+                reason: format!("duplicate group override for group {}", over.group_id),
+            });
+        }
+    }
+    let mut seen_users = BTreeSet::new();
+    for over in &quota.user_group_cap_overrides {
+        if !seen_users.insert(over.user_id) {
+            return Err(SetRealmQuotaError::InvalidQuota {
+                reason: format!("duplicate user cap override for user {}", over.user_id),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::{DriverContext, drive};
+    use crate::get_realm_config::GetRealmConfigOperation;
+    use aruna_core::document::DocumentSyncTarget;
+    use aruna_core::events::StorageEvent;
+    use aruna_core::structs::{
+        GroupQuotaOverride, RealmConfigDocument, RealmId, UserGroupCapOverride,
+    };
+    use aruna_core::types::UserId;
+    use tempfile::tempdir;
+    use ulid::Ulid;
+
+    fn test_ctx(root: &str) -> DriverContext {
+        DriverContext {
+            storage_handle: aruna_storage::FjallStorage::open(root).unwrap(),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        }
+    }
+
+    fn actor(seed: u8, realm_id: RealmId) -> Actor {
+        Actor {
+            node_id: iroh::SecretKey::from_bytes(&[seed; 32]).public(),
+            user_id: UserId::local(Ulid::from_bytes([seed; 16]), realm_id),
+            realm_id,
+        }
+    }
+
+    async fn seed_config(ctx: &DriverContext, actor: &Actor, document: &RealmConfigDocument) {
+        let target = DocumentSyncTarget::RealmConfig {
+            realm_id: actor.realm_id,
+        };
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: target.storage_keyspace().to_string(),
+                key: target.storage_key(),
+                value: document.to_bytes(actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    fn custom_quota() -> QuotaConfig {
+        QuotaConfig {
+            default_group_quota_bytes: Some(1_000_000),
+            grace_factor_percent: 120,
+            warn_threshold_percent: 90,
+            group_overrides: vec![GroupQuotaOverride {
+                group_id: Ulid::from_bytes([7; 16]),
+                quota_bytes: Some(2_000_000),
+                grace_factor_percent: Some(150),
+            }],
+            max_groups_per_user: Some(5),
+            user_group_cap_overrides: vec![UserGroupCapOverride {
+                user_id: UserId::local(Ulid::from_bytes([8; 16]), RealmId::from_bytes([1; 32])),
+                max_groups: Some(10),
+            }],
+            max_devices_per_user: Some(4),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_quota_round_trips_through_config_document() {
+        let dir = tempdir().unwrap();
+        let ctx = test_ctx(dir.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(1, realm_id);
+        let document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        seed_config(&ctx, &actor, &document).await;
+
+        let quota = custom_quota();
+        let stored = drive(
+            SetRealmQuotaOperation::new(SetRealmQuotaConfig {
+                actor: actor.clone(),
+                quota: quota.clone(),
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert_eq!(stored.quota, quota);
+
+        let reread = drive(GetRealmConfigOperation::new(realm_id), &ctx)
+            .await
+            .unwrap();
+        assert_eq!(reread.quota, quota);
+        assert_eq!(reread.quota.max_devices_per_user, Some(4));
+    }
+
+    #[tokio::test]
+    async fn set_quota_fails_when_config_missing() {
+        let dir = tempdir().unwrap();
+        let ctx = test_ctx(dir.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([2; 32]);
+        let actor = actor(2, realm_id);
+
+        let error = drive(
+            SetRealmQuotaOperation::new(SetRealmQuotaConfig {
+                actor,
+                quota: QuotaConfig::default(),
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, SetRealmQuotaError::RealmConfigNotFound);
+    }
+
+    #[test]
+    fn validate_quota_rejects_out_of_range_warn_threshold() {
+        let mut quota = QuotaConfig::default();
+        quota.warn_threshold_percent = 0;
+        assert!(matches!(
+            validate_quota(&quota),
+            Err(SetRealmQuotaError::InvalidQuota { .. })
+        ));
+        quota.warn_threshold_percent = 101;
+        assert!(matches!(
+            validate_quota(&quota),
+            Err(SetRealmQuotaError::InvalidQuota { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_quota_rejects_low_grace_factor() {
+        let mut quota = QuotaConfig::default();
+        quota.grace_factor_percent = 99;
+        assert!(matches!(
+            validate_quota(&quota),
+            Err(SetRealmQuotaError::InvalidQuota { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_quota_rejects_duplicate_group_override() {
+        let mut quota = QuotaConfig::default();
+        let group_id = Ulid::from_bytes([3; 16]);
+        quota.group_overrides = vec![
+            GroupQuotaOverride {
+                group_id,
+                quota_bytes: Some(1),
+                grace_factor_percent: None,
+            },
+            GroupQuotaOverride {
+                group_id,
+                quota_bytes: Some(2),
+                grace_factor_percent: None,
+            },
+        ];
+        assert!(matches!(
+            validate_quota(&quota),
+            Err(SetRealmQuotaError::InvalidQuota { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_quota_rejects_duplicate_user_cap_override() {
+        let mut quota = QuotaConfig::default();
+        let user_id = UserId::local(Ulid::from_bytes([4; 16]), RealmId::from_bytes([1; 32]));
+        quota.user_group_cap_overrides = vec![
+            UserGroupCapOverride {
+                user_id,
+                max_groups: Some(1),
+            },
+            UserGroupCapOverride {
+                user_id,
+                max_groups: Some(2),
+            },
+        ];
+        assert!(matches!(
+            validate_quota(&quota),
+            Err(SetRealmQuotaError::InvalidQuota { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_quota_accepts_default() {
+        assert!(validate_quota(&QuotaConfig::default()).is_ok());
+    }
+}

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -387,6 +387,13 @@ fn validate_quota(quota: &QuotaConfig) -> Result<(), SetRealmQuotaError> {
             ),
         });
     }
+    if quota.max_devices_per_user.is_some() {
+        return Err(SetRealmQuotaError::InvalidQuota {
+            reason:
+                "max_devices_per_user is not supported until device ownership enforcement exists"
+                    .to_string(),
+        });
+    }
     let mut seen_groups = BTreeSet::new();
     for over in &quota.group_overrides {
         if !seen_groups.insert(over.group_id) {
@@ -489,7 +496,7 @@ mod tests {
                 user_id: UserId::local(Ulid::from_bytes([8; 16]), RealmId::from_bytes([1; 32])),
                 max_groups: Some(10),
             }],
-            max_devices_per_user: Some(4),
+            max_devices_per_user: None,
         }
     }
 
@@ -518,7 +525,33 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(reread.quota, quota);
-        assert_eq!(reread.quota.max_devices_per_user, Some(4));
+        assert_eq!(reread.quota.max_devices_per_user, None);
+    }
+
+    #[tokio::test]
+    async fn set_quota_rejects_unsupported_device_cap() {
+        let dir = tempdir().unwrap();
+        let ctx = test_ctx(dir.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(1, realm_id);
+        let document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        seed_config(&ctx, &actor, &document).await;
+
+        let mut quota = QuotaConfig::default();
+        quota.max_devices_per_user = Some(4);
+
+        let error = drive(
+            SetRealmQuotaOperation::new(SetRealmQuotaConfig { actor, quota }),
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            SetRealmQuotaError::InvalidQuota { reason }
+                if reason.contains("max_devices_per_user")
+        ));
     }
 
     #[tokio::test]

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -393,14 +393,22 @@ fn validate_quota(quota: &QuotaConfig) -> Result<(), SetRealmQuotaError> {
                 reason: format!("duplicate group override for group {}", over.group_id),
             });
         }
-        if let Some(grace_factor_percent) = over.grace_factor_percent
-            && grace_factor_percent < 100
-        {
-            return Err(SetRealmQuotaError::InvalidQuota {
-                reason: format!(
-                    "group override grace_factor_percent must be at least 100, got {grace_factor_percent}"
-                ),
-            });
+        if let Some(grace_factor_percent) = over.grace_factor_percent {
+            if grace_factor_percent < 100 {
+                return Err(SetRealmQuotaError::InvalidQuota {
+                    reason: format!(
+                        "group override grace_factor_percent must be at least 100, got {grace_factor_percent}"
+                    ),
+                });
+            }
+            if over.quota_bytes.is_none() {
+                return Err(SetRealmQuotaError::InvalidQuota {
+                    reason: format!(
+                        "group override for group {} sets grace_factor_percent without quota_bytes; grace is incoherent on an unlimited quota",
+                        over.group_id
+                    ),
+                });
+            }
         }
     }
     let mut seen_users = BTreeSet::new();
@@ -632,6 +640,22 @@ mod tests {
             ..QuotaConfig::default()
         };
         assert!(validate_quota(&quota).is_ok());
+    }
+
+    #[test]
+    fn validate_quota_rejects_grace_override_on_unlimited_group_quota() {
+        let quota = QuotaConfig {
+            group_overrides: vec![GroupQuotaOverride {
+                group_id: Ulid::from_bytes([6; 16]),
+                quota_bytes: None,
+                grace_factor_percent: Some(110),
+            }],
+            ..QuotaConfig::default()
+        };
+        assert!(matches!(
+            validate_quota(&quota),
+            Err(SetRealmQuotaError::InvalidQuota { .. })
+        ));
     }
 
     #[test]

--- a/operations/src/staging/reference.rs
+++ b/operations/src/staging/reference.rs
@@ -8,17 +8,25 @@ use crate::staging::descriptor::build_version_source_binding;
 use crate::staging::head_source::{
     HeadStagingSourceError, HeadStagingSourceInput, HeadStagingSourceOperation,
 };
+use crate::task_persistence::persist_task_effect;
+use crate::usage_stats::{
+    QuotaGate, QuotaGateError, UsageCounterUpdate, UsageUpdateError,
+    schedule_usage_snapshot_publish_effect,
+};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{
-    BLOB_HEAD_KEYSPACE, SOURCE_CONNECTOR_INDEX_KEYSPACE, SOURCE_CONNECTOR_SECRET_KEYSPACE,
+    BLOB_HEAD_KEYSPACE, BLOB_VERSIONS_KEYSPACE, SOURCE_CONNECTOR_INDEX_KEYSPACE,
+    SOURCE_CONNECTOR_SECRET_KEYSPACE,
 };
 use aruna_core::structs::{
     BlobHeadKey, BlobVersion, CurrentVersionPointer, RealmId, SourceConnector,
-    SourceConnectorSecret, SourceMetadata, StagingStrategy, VersionKey, VersionSourceBinding,
+    SourceConnectorSecret, SourceMetadata, StagingStrategy, UsageDelta, VersionKey,
+    VersionSourceBinding,
 };
-use aruna_core::types::{GroupId, NodeId, TxnId, UserId};
+use aruna_core::types::{Effects, GroupId, NodeId, TxnId, UserId};
 use std::time::SystemTime;
 use thiserror::Error;
 use ulid::Ulid;
@@ -33,6 +41,7 @@ pub struct MaterializeReferenceInput {
     pub source_path: String,
     pub bucket: String,
     pub key: String,
+    pub quota_ceiling: Option<u64>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -51,6 +60,12 @@ pub enum MaterializeReferenceError {
     Storage(#[from] StorageError),
     #[error(transparent)]
     Conversion(#[from] ConversionError),
+    #[error(transparent)]
+    Usage(#[from] UsageUpdateError),
+    #[error(transparent)]
+    QuotaGate(#[from] QuotaGateError),
+    #[error("group storage quota exceeded: {usage} bytes would exceed limit of {limit} bytes")]
+    QuotaExceeded { limit: u64, usage: u64 },
 }
 
 pub async fn materialize_reference(
@@ -99,6 +114,18 @@ pub async fn materialize_reference(
 
         let existing_pointer =
             read_current_pointer(context, txn_id, &input.bucket, &input.key).await?;
+        let was_live = match existing_pointer.as_ref() {
+            Some(pointer) => read_blob_version(
+                context,
+                txn_id,
+                &input.bucket,
+                &input.key,
+                pointer.version_id,
+            )
+            .await?
+            .is_some_and(|version| !version.is_deleted()),
+            None => false,
+        };
         let next_pointer = CurrentVersionPointer::next_for(existing_pointer.as_ref(), version_id);
 
         for effect in build_head_transition_effects(
@@ -133,6 +160,34 @@ pub async fn materialize_reference(
         )
         .await?;
 
+        let logical_bytes = head_result.metadata.content_length;
+        if let Some(ceiling) = input.quota_ceiling
+            && logical_bytes > 0
+        {
+            enforce_quota(
+                context,
+                txn_id,
+                ceiling,
+                logical_bytes,
+                input.group_id,
+                input.node_id,
+                input.realm_id,
+            )
+            .await?;
+        }
+
+        let mut usage_update = UsageCounterUpdate::for_group(
+            input.group_id,
+            UsageDelta {
+                objects: if was_live { 0 } else { 1 },
+                logical_bytes: i128::from(logical_bytes),
+                ..Default::default()
+            },
+        );
+        if !usage_update.is_noop() {
+            run_usage_update(context, txn_id, &mut usage_update).await?;
+        }
+
         match context
             .storage_handle
             .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
@@ -155,6 +210,7 @@ pub async fn materialize_reference(
     }
 
     result?;
+    schedule_usage_snapshot_publish(context).await;
 
     Ok(MaterializeReferenceResult {
         connector: head_result.connector,
@@ -175,6 +231,17 @@ async fn apply_storage_effect(
     context: &DriverContext,
     effect: Effect,
 ) -> Result<(), MaterializeReferenceError> {
+    match send_storage_effect(context, effect).await? {
+        Event::Storage(StorageEvent::WriteResult { .. })
+        | Event::Storage(StorageEvent::DeleteResult { .. }) => Ok(()),
+        _ => Err(StorageError::WriteError.into()),
+    }
+}
+
+async fn send_storage_effect(
+    context: &DriverContext,
+    effect: Effect,
+) -> Result<Event, MaterializeReferenceError> {
     let Effect::Storage(storage_effect) = effect else {
         return Err(MaterializeReferenceError::Storage(
             StorageError::InvalidEffect,
@@ -186,10 +253,83 @@ async fn apply_storage_effect(
         .send_storage_effect(storage_effect)
         .await
     {
-        Event::Storage(StorageEvent::WriteResult { .. })
-        | Event::Storage(StorageEvent::DeleteResult { .. }) => Ok(()),
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
-        _ => Err(StorageError::WriteError.into()),
+        event => Ok(event),
+    }
+}
+
+async fn send_single_storage_effect(
+    context: &DriverContext,
+    mut effects: Effects,
+) -> Result<Event, MaterializeReferenceError> {
+    if effects.len() != 1 {
+        return Err(StorageError::InvalidEffect.into());
+    }
+    send_storage_effect(
+        context,
+        effects
+            .pop()
+            .expect("effect length was checked before popping"),
+    )
+    .await
+}
+
+async fn enforce_quota(
+    context: &DriverContext,
+    txn_id: TxnId,
+    ceiling: u64,
+    logical_bytes: u64,
+    group_id: GroupId,
+    node_id: NodeId,
+    realm_id: RealmId,
+) -> Result<(), MaterializeReferenceError> {
+    let mut gate = QuotaGate::new_for_realm(ceiling, logical_bytes, group_id, node_id, realm_id);
+    let mut effects = gate.start(txn_id);
+    loop {
+        let event = send_single_storage_effect(context, effects).await?;
+        effects = match gate.step(event, txn_id)? {
+            Some(effects) => effects,
+            None => break,
+        };
+    }
+
+    if gate.is_exceeded() {
+        Err(MaterializeReferenceError::QuotaExceeded {
+            limit: gate.ceiling(),
+            usage: gate.projected_usage(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+async fn run_usage_update(
+    context: &DriverContext,
+    txn_id: TxnId,
+    usage_update: &mut UsageCounterUpdate,
+) -> Result<(), MaterializeReferenceError> {
+    let mut effects = usage_update.start(txn_id);
+    loop {
+        let event = send_single_storage_effect(context, effects).await?;
+        effects = match usage_update.step(event, txn_id)? {
+            Some(effects) => effects,
+            None => return Ok(()),
+        };
+    }
+}
+
+async fn schedule_usage_snapshot_publish(context: &DriverContext) {
+    let Effect::Task(task_effect) = schedule_usage_snapshot_publish_effect() else {
+        return;
+    };
+    if persist_task_effect(&context.storage_handle, &task_effect)
+        .await
+        .is_err()
+    {
+        return;
+    }
+    if let Some(task_handle) = &context.task_handle {
+        let _ = task_handle.send_effect(Effect::Task(task_effect)).await;
     }
 }
 
@@ -211,6 +351,32 @@ async fn read_current_pointer(
         Event::Storage(StorageEvent::ReadResult { value, .. }) => value
             .as_ref()
             .map(|value| CurrentVersionPointer::from_bytes(value.as_ref()))
+            .transpose()
+            .map_err(Into::into),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
+        _ => Err(StorageError::ReadError.into()),
+    }
+}
+
+async fn read_blob_version(
+    context: &DriverContext,
+    txn_id: TxnId,
+    bucket: &str,
+    key: &str,
+    version_id: Ulid,
+) -> Result<Option<BlobVersion>, MaterializeReferenceError> {
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
+            key: VersionKey::new(bucket, key, version_id).to_bytes()?.into(),
+            txn_id: Some(txn_id),
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => value
+            .as_ref()
+            .map(|value| BlobVersion::from_bytes(value.as_ref()))
             .transpose()
             .map_err(Into::into),
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
@@ -279,12 +445,12 @@ mod tests {
     use aruna_core::effects::StorageEffect;
     use aruna_core::keyspaces::{
         BLOB_HEAD_KEYSPACE, BLOB_VERSIONS_KEYSPACE, HASH_PATHS_INDEX_KEYSPACE,
-        SOURCE_CONNECTOR_INDEX_KEYSPACE, SOURCE_CONNECTOR_SECRET_KEYSPACE,
+        SOURCE_CONNECTOR_INDEX_KEYSPACE, SOURCE_CONNECTOR_SECRET_KEYSPACE, USAGE_STATS_KEYSPACE,
     };
     use aruna_core::stream::BackendStream;
     use aruna_core::structs::{
         BlobHeadKey, BlobVersion, CurrentVersionPointer, HashPathIndexKey, SourceConnectorKind,
-        SourceConnectorSecret,
+        SourceConnectorSecret, UsageCounters, usage_global_key_for_group, usage_group_key,
     };
     use aruna_storage::storage;
     use axum::{Router, routing::get};
@@ -433,6 +599,29 @@ mod tests {
         value
     }
 
+    async fn read_usage_counters(context: &DriverContext, key: Vec<u8>) -> UsageCounters {
+        read_value(context, USAGE_STATS_KEYSPACE, key)
+            .await
+            .map(|value| UsageCounters::from_bytes(value.as_ref()).unwrap())
+            .unwrap_or_default()
+    }
+
+    async fn spawn_reference_server(body: &'static str) -> (tokio::task::JoinHandle<()>, String) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let app =
+                Router::new().route(
+                    "/folder/file.txt",
+                    get(move || async move {
+                        ([("etag", "etag-1"), ("content-type", "text/plain")], body)
+                    }),
+                );
+            axum::serve(listener, app).await.unwrap();
+        });
+        (server, format!("http://{addr}"))
+    }
+
     #[tokio::test]
     async fn reference_guard_fails_when_connector_deleted_after_resolve() {
         let (_tempdir, context) = test_context();
@@ -549,22 +738,8 @@ mod tests {
         .unwrap();
         let initial_hash: [u8; 32] = initial.location.get_blake3().unwrap().try_into().unwrap();
 
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let server = tokio::spawn(async move {
-            let app = Router::new().route(
-                "/folder/file.txt",
-                get(|| async {
-                    (
-                        [("etag", "etag-1"), ("content-type", "text/plain")],
-                        "ref-data",
-                    )
-                }),
-            );
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        let connector = create_http_connector(context, group_id, &format!("http://{addr}")).await;
+        let (server, endpoint) = spawn_reference_server("ref-data").await;
+        let connector = create_http_connector(context, group_id, &endpoint).await;
 
         let result = materialize_reference(
             context,
@@ -577,6 +752,7 @@ mod tests {
                 source_path: "folder/file.txt".to_string(),
                 bucket: "bucket-a".to_string(),
                 key: "object.txt".to_string(),
+                quota_ceiling: None,
             },
         )
         .await
@@ -631,5 +807,62 @@ mod tests {
         .await
         .expect("missing historical materialized hash path entry");
         assert!(historical_hash_path.is_empty());
+
+        let group_usage = read_usage_counters(context, usage_group_key(group_id)).await;
+        assert_eq!(group_usage.objects, 1);
+        assert_eq!(group_usage.logical_bytes, 13);
+        let global_usage = read_usage_counters(context, usage_global_key_for_group(group_id)).await;
+        assert_eq!(global_usage.objects, 1);
+        assert_eq!(global_usage.logical_bytes, 13);
+    }
+
+    #[tokio::test]
+    async fn materialize_reference_rejects_over_quota_without_writing_head_or_usage() {
+        let test_context = setup_driver_context().await;
+        let context = &test_context.driver_context;
+        let group_id = Ulid::new();
+        let realm_id = RealmId::from_bytes([8u8; 32]);
+        let node_id = iroh::SecretKey::generate().public();
+        let (server, endpoint) = spawn_reference_server("ref-data").await;
+        let connector = create_http_connector(context, group_id, &endpoint).await;
+
+        let result = materialize_reference(
+            context,
+            MaterializeReferenceInput {
+                group_id,
+                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                realm_id,
+                node_id,
+                connector_id: connector.connector_id,
+                source_path: "folder/file.txt".to_string(),
+                bucket: "bucket-a".to_string(),
+                key: "object.txt".to_string(),
+                quota_ceiling: Some(7),
+            },
+        )
+        .await;
+
+        server.abort();
+        let _ = server.await;
+
+        assert_eq!(
+            result,
+            Err(MaterializeReferenceError::QuotaExceeded { limit: 7, usage: 8 })
+        );
+        assert!(
+            read_value(
+                context,
+                BLOB_HEAD_KEYSPACE,
+                BlobHeadKey::new("bucket-a", "object.txt")
+                    .to_bytes()
+                    .unwrap(),
+            )
+            .await
+            .is_none()
+        );
+        assert_eq!(
+            read_usage_counters(context, usage_group_key(group_id)).await,
+            UsageCounters::default()
+        );
     }
 }

--- a/operations/src/staging/reference.rs
+++ b/operations/src/staging/reference.rs
@@ -539,6 +539,7 @@ mod tests {
                 checksum_type: None,
                 exists: false,
                 version_source: None,
+                quota_ceiling: None,
             }),
             context,
         )

--- a/operations/src/staging/snapshot.rs
+++ b/operations/src/staging/snapshot.rs
@@ -81,6 +81,9 @@ pub async fn materialize_snapshot(
             checksum_type: None,
             exists: false,
             version_source: Some(version_source.clone()),
+            // Staging materialization runs without realm-config access, so no
+            // quota ceiling is resolved here; enforcement lives on the S3 surface.
+            quota_ceiling: None,
         }),
         context,
     )

--- a/operations/src/staging/snapshot.rs
+++ b/operations/src/staging/snapshot.rs
@@ -21,6 +21,7 @@ pub struct MaterializeSnapshotInput {
     pub source_path: String,
     pub bucket: String,
     pub key: String,
+    pub quota_ceiling: Option<u64>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -81,9 +82,7 @@ pub async fn materialize_snapshot(
             checksum_type: None,
             exists: false,
             version_source: Some(version_source.clone()),
-            // Staging materialization runs without realm-config access, so no
-            // quota ceiling is resolved here; enforcement lives on the S3 surface.
-            quota_ceiling: None,
+            quota_ceiling: input.quota_ceiling,
         }),
         context,
     )

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -509,21 +509,14 @@ impl OperationsTaskHandler {
         };
         let node_id = net_handle.node_id();
         let realm_id = *net_handle.realm_id();
-        match crate::usage_stats::publish_usage_snapshots(&self.context, node_id, realm_id, false)
-            .await
+        match crate::usage_stats::publish_and_refresh_usage_snapshots(
+            &self.context,
+            node_id,
+            realm_id,
+            false,
+        )
+        .await
         {
-            Ok(published) if !published.is_empty() => {
-                if let Err(error) = crate::usage_stats::recompute_realm_usage_summary(
-                    &self.context,
-                    node_id,
-                    published.global,
-                    published.groups,
-                )
-                .await
-                {
-                    warn!(error = %error, "Failed to refresh realm usage summary after publishing snapshots");
-                }
-            }
             Ok(_) => {}
             Err(error) => {
                 warn!(error = %error, "Failed to publish usage snapshots");

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -50,6 +50,7 @@ use crate::sync_placement::DOCUMENT_SYNC_RETRY_AFTER;
 use crate::task_persistence::{
     delete_persisted_timer, persist_task_effect, restore_persisted_task_timers,
 };
+use crate::usage_stats::restore_usage_snapshot_publish_timer;
 
 const DRAIN_SUBBATCH_RECORDS: usize = 512;
 const DURABLE_QUEUE_REARM_AFTER: Duration = Duration::from_secs(5);
@@ -491,6 +492,40 @@ impl OperationsTaskHandler {
         Ok(())
     }
 
+    async fn publish_usage_snapshots(&self) {
+        let Some(net_handle) = self.context.net_handle.as_ref() else {
+            warn!("Cannot publish usage snapshots without net handle");
+            return;
+        };
+        let node_id = net_handle.node_id();
+        let realm_id = *net_handle.realm_id();
+        match crate::usage_stats::publish_usage_snapshots(&self.context, node_id, realm_id, false)
+            .await
+        {
+            Ok(published) if !published.is_empty() => {
+                if let Err(error) = crate::usage_stats::recompute_realm_usage_summary(
+                    &self.context,
+                    node_id,
+                    published.global,
+                    published.groups,
+                )
+                .await
+                {
+                    warn!(error = %error, "Failed to refresh realm usage summary after publishing snapshots");
+                }
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(error = %error, "Failed to publish usage snapshots");
+                self.reschedule_timer(
+                    TaskKey::PublishUsageSnapshots,
+                    crate::usage_stats::USAGE_SNAPSHOT_PUBLISH_DEBOUNCE,
+                )
+                .await;
+            }
+        }
+    }
+
     async fn drain_metadata_materialization_queue(&self) {
         match process_metadata_materialization_batch(&self.context).await {
             Ok(result) if result.has_more_due => {
@@ -684,6 +719,7 @@ async fn durable_queue_rearm_loop(context: Weak<DriverContext>, task_handle: Tas
         restore_blob_replication_timer(&context.storage_handle, &task_handle).await;
         restore_reference_metadata_refresh_timer(&context.storage_handle, &task_handle).await;
         restore_document_sync_outbox_timers(&context.storage_handle, &task_handle).await;
+        restore_usage_snapshot_publish_timer(&context.storage_handle, &task_handle).await;
         restore_pending_metadata_projection_timer(&context.storage_handle, &task_handle).await;
         restore_metadata_materialization_timer(&context.storage_handle, &task_handle).await;
         restore_metadata_graph_prune_timer(&context.storage_handle, &task_handle).await;
@@ -699,6 +735,7 @@ pub async fn initialize_task_incoming(context: Arc<DriverContext>, task_handle: 
     spawn_durable_queue_rearm(&context, &task_handle);
     restore_persisted_task_timers(&context.storage_handle, &task_handle).await;
     restore_document_sync_outbox_timers(&context.storage_handle, &task_handle).await;
+    restore_usage_snapshot_publish_timer(&context.storage_handle, &task_handle).await;
     restore_pending_metadata_projection_timer(&context.storage_handle, &task_handle).await;
     restore_metadata_materialization_timer(&context.storage_handle, &task_handle).await;
     restore_metadata_graph_prune_timer(&context.storage_handle, &task_handle).await;
@@ -816,6 +853,9 @@ impl InboundTaskHandler for OperationsTaskHandler {
             }
             TaskKey::DrainDocumentSyncOutbox => {
                 self.drain_document_sync_outbox().await;
+            }
+            TaskKey::PublishUsageSnapshots => {
+                self.publish_usage_snapshots().await;
             }
             TaskKey::DrainMetadataProjectionQueue => {
                 self.drain_metadata_projection_queue().await;

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -387,6 +387,7 @@ impl OperationsTaskHandler {
         let Some(subbatch) = subbatch else {
             return outcome;
         };
+        let requested_targets = subbatch.targets.clone();
         let sync_started = Instant::now();
         let event = net_handle
             .send_effect(Effect::Net(NetEffect::DocumentSync(
@@ -397,14 +398,21 @@ impl OperationsTaskHandler {
             )))
             .await;
         outcome.sync_elapsed = sync_started.elapsed();
-        self.finish_sync_drain_subbatch(retry_key, subbatch.record_keys, event, outcome)
-            .await
+        self.finish_sync_drain_subbatch(
+            retry_key,
+            subbatch.record_keys,
+            requested_targets,
+            event,
+            outcome,
+        )
+        .await
     }
 
     async fn finish_sync_drain_subbatch(
         &self,
         retry_key: &TaskKey,
         record_keys: Vec<Vec<u8>>,
+        requested_targets: Vec<DocumentSyncTarget>,
         event: Event,
         mut outcome: DrainSyncOutcome,
     ) -> DrainSyncOutcome {
@@ -418,10 +426,12 @@ impl OperationsTaskHandler {
                 process_metadata_graph_tombstones(self.context.as_ref(), metadata_graph_tombstones)
                     .await;
                 if let Some(net_handle) = self.context.net_handle.as_ref() {
+                    let mut refresh_targets = targets.clone();
+                    refresh_targets.extend(requested_targets);
                     refresh_realm_usage_summary_for_targets(
                         self.context.as_ref(),
                         net_handle.node_id(),
-                        &targets,
+                        &refresh_targets,
                     )
                     .await;
                 }
@@ -790,6 +800,7 @@ impl InboundTaskHandler for OperationsTaskHandler {
                 target,
                 peers,
             } => {
+                let requested_target = target.clone();
                 let retry_key = TaskKey::SyncDocument {
                     node_id,
                     target: target.clone(),
@@ -820,10 +831,12 @@ impl InboundTaskHandler for OperationsTaskHandler {
                             metadata_graph_tombstones,
                         )
                         .await;
+                        let mut refresh_targets = targets.clone();
+                        refresh_targets.push(requested_target);
                         refresh_realm_usage_summary_for_targets(
                             self.context.as_ref(),
                             net_handle.node_id(),
-                            &targets,
+                            &refresh_targets,
                         )
                         .await;
                         if self
@@ -1142,6 +1155,7 @@ mod tests {
             .finish_sync_drain_subbatch(
                 &TaskKey::DrainDocumentSyncOutbox,
                 vec![key.clone()],
+                Vec::new(),
                 Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
                     target: Some(record.target.clone()),
                     error: "only 1/2 peers synced".to_string(),
@@ -1187,6 +1201,7 @@ mod tests {
             .finish_sync_drain_subbatch(
                 &TaskKey::DrainDocumentSyncOutbox,
                 vec![key.clone()],
+                Vec::new(),
                 Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
                     target: Some(record.target.clone()),
                     error: "sync failed before all peers acknowledged".to_string(),
@@ -1231,6 +1246,7 @@ mod tests {
         let outcome = handler
             .finish_sync_drain_subbatch(
                 &TaskKey::DrainDocumentSyncOutbox,
+                Vec::new(),
                 Vec::new(),
                 Event::Net(NetEvent::DocumentSync(
                     DocumentSyncNetEvent::DocumentsReconciled {
@@ -1343,6 +1359,7 @@ mod tests {
             .finish_sync_drain_subbatch(
                 &TaskKey::DrainDocumentSyncOutbox,
                 Vec::new(),
+                Vec::new(),
                 Event::Net(NetEvent::DocumentSync(
                     DocumentSyncNetEvent::DocumentsReconciled {
                         applied: 1,
@@ -1378,6 +1395,89 @@ mod tests {
                 .logical_bytes,
             15
         );
+
+        net.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn drain_reconcile_clears_realm_usage_summary_for_requested_realm_config() {
+        use aruna_core::keyspaces::USAGE_NODE_STATS_KEYSPACE;
+        use aruna_core::structs::{NODE_USAGE_SUMMARY_GLOBAL_KEY, UsageCounters};
+        use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+
+        let temp_dir = tempdir().expect("temp dir");
+        let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))
+            .expect("storage opens");
+        let realm_id = RealmId::from_bytes([45u8; 32]);
+        let net = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+                realm_id,
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage.clone(),
+        )
+        .await
+        .expect("net handle");
+        match storage
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+                key: NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec().into(),
+                value: UsageCounters {
+                    logical_bytes: 99,
+                    ..Default::default()
+                }
+                .to_bytes()
+                .unwrap()
+                .into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected write event: {other:?}"),
+        }
+
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: Some(net.clone()),
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let handler = OperationsTaskHandler::new(context);
+
+        let outcome = handler
+            .finish_sync_drain_subbatch(
+                &TaskKey::DrainDocumentSyncOutbox,
+                Vec::new(),
+                vec![DocumentSyncTarget::RealmConfig { realm_id }],
+                Event::Net(NetEvent::DocumentSync(
+                    DocumentSyncNetEvent::DocumentsReconciled {
+                        applied: 0,
+                        targets: Vec::new(),
+                        metadata_create_events: Vec::new(),
+                        metadata_graph_tombstones: Vec::new(),
+                    },
+                )),
+                DrainSyncOutcome::default(),
+            )
+            .await;
+
+        assert!(!outcome.retry_needed);
+        match storage
+            .send_effect(Effect::Storage(StorageEffect::Read {
+                key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+                key: NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec().into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {}
+            other => panic!("expected summary cache to be cleared, got {other:?}"),
+        }
 
         net.shutdown().await;
     }

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -50,7 +50,9 @@ use crate::sync_placement::DOCUMENT_SYNC_RETRY_AFTER;
 use crate::task_persistence::{
     delete_persisted_timer, persist_task_effect, restore_persisted_task_timers,
 };
-use crate::usage_stats::restore_usage_snapshot_publish_timer;
+use crate::usage_stats::{
+    refresh_realm_usage_summary_for_targets, restore_usage_snapshot_publish_timer,
+};
 
 const DRAIN_SUBBATCH_RECORDS: usize = 512;
 const DURABLE_QUEUE_REARM_AFTER: Duration = Duration::from_secs(5);
@@ -415,6 +417,14 @@ impl OperationsTaskHandler {
             })) => {
                 process_metadata_graph_tombstones(self.context.as_ref(), metadata_graph_tombstones)
                     .await;
+                if let Some(net_handle) = self.context.net_handle.as_ref() {
+                    refresh_realm_usage_summary_for_targets(
+                        self.context.as_ref(),
+                        net_handle.node_id(),
+                        &targets,
+                    )
+                    .await;
+                }
                 let project_started = Instant::now();
                 let projected = self
                     .project_reconciled_metadata_create_events(
@@ -815,6 +825,12 @@ impl InboundTaskHandler for OperationsTaskHandler {
                         process_metadata_graph_tombstones(
                             self.context.as_ref(),
                             metadata_graph_tombstones,
+                        )
+                        .await;
+                        refresh_realm_usage_summary_for_targets(
+                            self.context.as_ref(),
+                            net_handle.node_id(),
+                            &targets,
                         )
                         .await;
                         if self
@@ -1242,5 +1258,134 @@ mod tests {
         let jobs = read_graph_prune_jobs(&storage).await;
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].graph_iri, tombstone.graph_iri);
+    }
+
+    #[tokio::test]
+    async fn drain_reconcile_refreshes_realm_usage_summary() {
+        use aruna_core::keyspaces::{USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE};
+        use aruna_core::structs::{
+            NODE_USAGE_SUMMARY_GLOBAL_KEY, NodeUsageSnapshot, UsageCounters, node_usage_global_key,
+            usage_global_shard_key,
+        };
+        use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+
+        async fn write_stat(
+            storage: &aruna_storage::StorageHandle,
+            key_space: &str,
+            key: Vec<u8>,
+            value: Vec<u8>,
+        ) {
+            match storage
+                .send_effect(Effect::Storage(StorageEffect::Write {
+                    key_space: key_space.to_string(),
+                    key: key.into(),
+                    value: value.into(),
+                    txn_id: None,
+                }))
+                .await
+            {
+                Event::Storage(StorageEvent::WriteResult { .. }) => {}
+                other => panic!("unexpected write event: {other:?}"),
+            }
+        }
+
+        let temp_dir = tempdir().expect("temp dir");
+        let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))
+            .expect("storage opens");
+        let realm_id = RealmId::from_bytes([44u8; 32]);
+        let net = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+                realm_id,
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage.clone(),
+        )
+        .await
+        .expect("net handle");
+        let remote = node(2);
+
+        // Local global counters (10) plus a remote node's snapshot (5) should sum
+        // to 15 in the refreshed realm summary cache.
+        write_stat(
+            &storage,
+            USAGE_STATS_KEYSPACE,
+            usage_global_shard_key(0),
+            UsageCounters {
+                logical_bytes: 10,
+                ..Default::default()
+            }
+            .to_bytes()
+            .unwrap(),
+        )
+        .await;
+        write_stat(
+            &storage,
+            USAGE_NODE_STATS_KEYSPACE,
+            node_usage_global_key(remote),
+            NodeUsageSnapshot {
+                node_id: remote,
+                counters: UsageCounters {
+                    logical_bytes: 5,
+                    ..Default::default()
+                },
+            }
+            .to_bytes()
+            .unwrap(),
+        )
+        .await;
+
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: Some(net.clone()),
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let handler = OperationsTaskHandler::new(context);
+
+        let outcome = handler
+            .finish_sync_drain_subbatch(
+                &TaskKey::DrainDocumentSyncOutbox,
+                Vec::new(),
+                Event::Net(NetEvent::DocumentSync(
+                    DocumentSyncNetEvent::DocumentsReconciled {
+                        applied: 1,
+                        targets: vec![DocumentSyncTarget::NodeUsage {
+                            realm_id,
+                            node_id: remote,
+                            group_id: None,
+                        }],
+                        metadata_create_events: Vec::new(),
+                        metadata_graph_tombstones: Vec::new(),
+                    },
+                )),
+                DrainSyncOutcome::default(),
+            )
+            .await;
+
+        assert!(!outcome.retry_needed);
+        let summary = match storage
+            .send_effect(Effect::Storage(StorageEffect::Read {
+                key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+                key: NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec().into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::ReadResult { value, .. }) => value,
+            other => panic!("unexpected read event: {other:?}"),
+        };
+        let summary = summary.expect("realm usage summary refreshed by drain reconcile");
+        assert_eq!(
+            UsageCounters::from_bytes(summary.as_ref())
+                .unwrap()
+                .logical_bytes,
+            15
+        );
+
+        net.shutdown().await;
     }
 }

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -1,21 +1,37 @@
+use aruna_core::NodeId;
+use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{
     BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE, S3_BUCKET_KEYSPACE,
-    USAGE_STATS_KEYSPACE,
+    USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE,
 };
 use aruna_core::operation::Operation;
 use aruna_core::structs::{
     BackendLocation, BlobHeadKey, BlobVersion, BlobVersionState, BucketInfo, CurrentVersionPointer,
-    USAGE_GLOBAL_KEY, USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta,
-    VersionKey, usage_global_key_for_group, usage_global_shard_index, usage_global_shard_key,
-    usage_global_shard_keys, usage_group_key,
+    NODE_USAGE_DIRTY_GLOBAL_KEY, NODE_USAGE_DIRTY_PREFIX, NODE_USAGE_GLOBAL_PREFIX,
+    NODE_USAGE_SUMMARY_GLOBAL_KEY, NodeUsageSnapshot, RealmId, USAGE_GLOBAL_KEY,
+    USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta, VersionKey,
+    node_usage_dirty_group_id, node_usage_dirty_group_key, node_usage_global_key,
+    node_usage_group_key, node_usage_group_prefix, node_usage_key_node_id,
+    node_usage_summary_group_key, usage_global_key_for_group, usage_global_shard_index,
+    usage_global_shard_key, usage_global_shard_keys, usage_group_key,
 };
+use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
 use aruna_core::types::{Effects, GroupId, Key, TxnId, Value};
+use aruna_storage::StorageHandle;
+use aruna_tasks::TaskHandle;
+use byteview::ByteView;
 use smallvec::smallvec;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::time::Duration;
 use thiserror::Error;
+use tracing::warn;
+
+use crate::driver::{DriverContext, drive};
+use crate::replicate_documents::{ReplicateDocumentsConfig, ReplicateDocumentsOperation};
 
 #[derive(Debug, Error, PartialEq)]
 pub enum UsageUpdateError {
@@ -41,6 +57,7 @@ enum UsageUpdatePhase {
 #[derive(Clone, Debug, PartialEq)]
 pub struct UsageCounterUpdate {
     entries: Vec<(Vec<u8>, UsageDelta)>,
+    dirty_group: GroupId,
     phase: UsageUpdatePhase,
 }
 
@@ -51,6 +68,7 @@ impl UsageCounterUpdate {
                 (usage_global_key_for_group(group_id), delta),
                 (usage_group_key(group_id), delta),
             ],
+            dirty_group: group_id,
             phase: UsageUpdatePhase::Pending,
         }
     }
@@ -65,8 +83,27 @@ impl UsageCounterUpdate {
                 (usage_global_key_for_group(group_id), global_delta),
                 (usage_group_key(group_id), group_delta),
             ],
+            dirty_group: group_id,
             phase: UsageUpdatePhase::Pending,
         }
+    }
+
+    /// Writes, in the same transaction as the counter update, the dirty markers
+    /// the debounced publisher scans to rebuild and distribute node snapshots.
+    fn dirty_marker_writes(&self) -> Vec<(String, Key, Value)> {
+        let marker = ByteView::from(&[][..]);
+        vec![
+            (
+                USAGE_NODE_STATS_KEYSPACE.to_string(),
+                ByteView::from(NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec()),
+                marker.clone(),
+            ),
+            (
+                USAGE_NODE_STATS_KEYSPACE.to_string(),
+                ByteView::from(node_usage_dirty_group_key(self.dirty_group)),
+                marker,
+            ),
+        ]
     }
 
     pub fn is_noop(&self) -> bool {
@@ -97,7 +134,7 @@ impl UsageCounterUpdate {
                 UsageUpdatePhase::Reading,
                 Event::Storage(StorageEvent::BatchReadResult { values }),
             ) => {
-                let mut writes = Vec::with_capacity(self.entries.len());
+                let mut writes = Vec::with_capacity(self.entries.len() + 2);
                 for ((key, delta), (_, value)) in self.entries.iter().zip(values) {
                     let mut counters = match value {
                         Some(value) => UsageCounters::from_bytes(value.as_ref())?,
@@ -110,6 +147,7 @@ impl UsageCounterUpdate {
                         counters.to_bytes()?.into(),
                     ));
                 }
+                writes.extend(self.dirty_marker_writes());
                 self.phase = UsageUpdatePhase::Writing;
                 Ok(Some(smallvec![Effect::Storage(
                     StorageEffect::BatchWrite {
@@ -695,6 +733,458 @@ impl Operation for RebuildUsageStatsOperation {
     }
 }
 
+/// Debounce window for the coalesced node-usage snapshot publisher. `ShortenTimer`
+/// makes the timer fire this long after the *first* dirty write of a burst and
+/// keeps every later write inside the same window, so bursts collapse into one
+/// publish run with bounded latency.
+pub const USAGE_SNAPSHOT_PUBLISH_DEBOUNCE: Duration = Duration::from_secs(2);
+
+/// Schedules (or shortens toward) the debounced snapshot publish task.
+pub fn schedule_usage_snapshot_publish_effect() -> Effect {
+    Effect::Task(TaskEffect::ShortenTimer {
+        key: TaskKey::PublishUsageSnapshots,
+        after: USAGE_SNAPSHOT_PUBLISH_DEBOUNCE,
+    })
+}
+
+/// Groups/global scope touched by a publish run, so callers can refresh exactly
+/// the affected realm summary cache entries.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PublishedUsage {
+    pub global: bool,
+    pub groups: Vec<GroupId>,
+}
+
+impl PublishedUsage {
+    pub fn is_empty(&self) -> bool {
+        !self.global && self.groups.is_empty()
+    }
+
+    fn targets(&self, realm_id: RealmId, node_id: NodeId) -> Vec<DocumentSyncTarget> {
+        let mut targets = Vec::with_capacity(self.groups.len() + usize::from(self.global));
+        if self.global {
+            targets.push(DocumentSyncTarget::NodeUsage {
+                realm_id,
+                node_id,
+                group_id: None,
+            });
+        }
+        for group_id in &self.groups {
+            targets.push(DocumentSyncTarget::NodeUsage {
+                realm_id,
+                node_id,
+                group_id: Some(*group_id),
+            });
+        }
+        targets
+    }
+}
+
+/// Which realm-wide counter a caller wants to read from the summed cache.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RealmUsageScope {
+    Global,
+    Group(GroupId),
+}
+
+async fn iter_all(
+    storage: &StorageHandle,
+    key_space: &str,
+    prefix: Option<Key>,
+) -> Result<Vec<(Key, Value)>, String> {
+    let mut collected = Vec::new();
+    let mut start = None;
+    loop {
+        match storage
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: key_space.to_string(),
+                prefix: prefix.clone(),
+                start: start.map(IterStart::After),
+                limit: 1_000,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult {
+                values,
+                next_start_after,
+            }) => {
+                collected.extend(values);
+                match next_start_after {
+                    Some(next) => start = Some(next),
+                    None => break,
+                }
+            }
+            Event::Storage(StorageEvent::Error { error }) => return Err(error.to_string()),
+            other => return Err(format!("unexpected iter event: {other:?}")),
+        }
+    }
+    Ok(collected)
+}
+
+async fn read_local_global(storage: &StorageHandle) -> Result<UsageCounters, String> {
+    let reads = usage_global_shard_keys()
+        .into_iter()
+        .map(|key| (USAGE_STATS_KEYSPACE.to_string(), Key::from(key)))
+        .collect();
+    match storage
+        .send_storage_effect(StorageEffect::BatchRead {
+            reads,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchReadResult { values }) => {
+            let mut total = UsageCounters::default();
+            for (_, value) in values {
+                if let Some(bytes) = value {
+                    let counters =
+                        UsageCounters::from_bytes(bytes.as_ref()).map_err(|e| e.to_string())?;
+                    total.add(&counters).map_err(|e| e.to_string())?;
+                }
+            }
+            Ok(total)
+        }
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected global read event: {other:?}")),
+    }
+}
+
+async fn read_local_group(
+    storage: &StorageHandle,
+    group_id: GroupId,
+) -> Result<UsageCounters, String> {
+    match storage
+        .send_storage_effect(StorageEffect::Read {
+            key_space: USAGE_STATS_KEYSPACE.to_string(),
+            key: Key::from(usage_group_key(group_id)),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(bytes), ..
+        }) => UsageCounters::from_bytes(bytes.as_ref()).map_err(|e| e.to_string()),
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
+            Ok(UsageCounters::default())
+        }
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected group read event: {other:?}")),
+    }
+}
+
+/// Sums remote nodes' snapshots under `prefix`, skipping the local node's own
+/// snapshot so it is never double-counted against the live local counters.
+async fn sum_remote_snapshots(
+    storage: &StorageHandle,
+    prefix: Vec<u8>,
+    local_node_id: NodeId,
+) -> Result<UsageCounters, String> {
+    let entries = iter_all(storage, USAGE_NODE_STATS_KEYSPACE, Some(Key::from(prefix))).await?;
+    let mut total = UsageCounters::default();
+    for (key, value) in entries {
+        if node_usage_key_node_id(key.as_ref()) == Some(local_node_id) {
+            continue;
+        }
+        let snapshot = NodeUsageSnapshot::from_bytes(value.as_ref()).map_err(|e| e.to_string())?;
+        total.add(&snapshot.counters).map_err(|e| e.to_string())?;
+    }
+    Ok(total)
+}
+
+/// Rebuilds this node's snapshot documents from live local counters and
+/// distributes them over the sync layer. In dirty mode only groups with a
+/// pending marker are refreshed; in full mode every group plus the global total
+/// is republished (used at startup and after a counter rebuild).
+pub async fn publish_usage_snapshots(
+    ctx: &DriverContext,
+    node_id: NodeId,
+    realm_id: RealmId,
+    full: bool,
+) -> Result<PublishedUsage, String> {
+    let storage = &ctx.storage_handle;
+
+    let dirty = iter_all(
+        storage,
+        USAGE_NODE_STATS_KEYSPACE,
+        Some(Key::from(NODE_USAGE_DIRTY_PREFIX.to_vec())),
+    )
+    .await?;
+    let marker_keys: Vec<Key> = dirty.iter().map(|(key, _)| key.clone()).collect();
+
+    let mut groups: BTreeSet<GroupId> = BTreeSet::new();
+    let mut global = false;
+    for (key, _) in &dirty {
+        if key.as_ref() == NODE_USAGE_DIRTY_GLOBAL_KEY {
+            global = true;
+        } else if let Some(group_id) = node_usage_dirty_group_id(key.as_ref()) {
+            groups.insert(group_id);
+        }
+    }
+
+    if full {
+        global = true;
+        for (key, _) in iter_all(
+            storage,
+            USAGE_STATS_KEYSPACE,
+            Some(Key::from(b"group/".to_vec())),
+        )
+        .await?
+        {
+            if let Some(rest) = key.as_ref().strip_prefix(b"group/")
+                && let Ok(bytes) = <[u8; 16]>::try_from(rest)
+            {
+                groups.insert(GroupId::from_bytes(bytes));
+            }
+        }
+    }
+
+    if !global && groups.is_empty() {
+        return Ok(PublishedUsage::default());
+    }
+
+    let mut writes: Vec<(String, Key, Value)> = Vec::with_capacity(groups.len() + 1);
+    if global {
+        let counters = read_local_global(storage).await?;
+        let snapshot = NodeUsageSnapshot { node_id, counters };
+        writes.push((
+            USAGE_NODE_STATS_KEYSPACE.to_string(),
+            Key::from(node_usage_global_key(node_id)),
+            Value::from(snapshot.to_bytes().map_err(|e| e.to_string())?),
+        ));
+    }
+    let group_list: Vec<GroupId> = groups.into_iter().collect();
+    for group_id in &group_list {
+        let counters = read_local_group(storage, *group_id).await?;
+        let snapshot = NodeUsageSnapshot { node_id, counters };
+        writes.push((
+            USAGE_NODE_STATS_KEYSPACE.to_string(),
+            Key::from(node_usage_group_key(*group_id, node_id)),
+            Value::from(snapshot.to_bytes().map_err(|e| e.to_string())?),
+        ));
+    }
+
+    commit_snapshot_writes(storage, writes, marker_keys).await?;
+
+    let published = PublishedUsage {
+        global,
+        groups: group_list,
+    };
+    let targets = published.targets(realm_id, node_id);
+    if let Err(error) = drive(
+        ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
+            realm_id,
+            local_node_id: node_id,
+            excluded_peers: Vec::new(),
+            documents: targets,
+        }),
+        ctx,
+    )
+    .await
+    {
+        warn!(error = ?error, "Failed to queue node usage snapshot replication");
+    }
+
+    Ok(published)
+}
+
+/// Writes the refreshed snapshot documents and clears the consumed dirty markers
+/// in a single transaction. New markers set concurrently keep their own entries
+/// for the next run.
+async fn commit_snapshot_writes(
+    storage: &StorageHandle,
+    writes: Vec<(String, Key, Value)>,
+    marker_keys: Vec<Key>,
+) -> Result<(), String> {
+    let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = storage
+        .send_storage_effect(StorageEffect::StartTransaction { read: false })
+        .await
+    else {
+        return Err("failed to start snapshot publish transaction".to_string());
+    };
+
+    if !writes.is_empty() {
+        match storage
+            .send_storage_effect(StorageEffect::BatchWrite {
+                writes,
+                txn_id: Some(txn_id),
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::BatchWriteResult { .. }) => {}
+            other => {
+                storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Err(format!("snapshot write failed: {other:?}"));
+            }
+        }
+    }
+    if !marker_keys.is_empty() {
+        let deletes = marker_keys
+            .into_iter()
+            .map(|key| (USAGE_NODE_STATS_KEYSPACE.to_string(), key))
+            .collect();
+        match storage
+            .send_storage_effect(StorageEffect::BatchDelete {
+                deletes,
+                txn_id: Some(txn_id),
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::BatchDeleteResult { .. }) => {}
+            other => {
+                storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Err(format!("dirty marker delete failed: {other:?}"));
+            }
+        }
+    }
+    match storage
+        .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
+        .await
+    {
+        Event::Storage(StorageEvent::TransactionCommitted { .. }) => Ok(()),
+        other => Err(format!("snapshot publish commit failed: {other:?}")),
+    }
+}
+
+/// Recomputes the persisted realm-wide summed cache for the requested scopes:
+/// realm total = live local counters + every remote node's snapshot.
+pub async fn recompute_realm_usage_summary(
+    ctx: &DriverContext,
+    local_node_id: NodeId,
+    include_global: bool,
+    groups: Vec<GroupId>,
+) -> Result<(), String> {
+    let storage = &ctx.storage_handle;
+    let mut writes: Vec<(String, Key, Value)> = Vec::with_capacity(groups.len() + 1);
+
+    if include_global {
+        let total = realm_global_usage(storage, local_node_id).await?;
+        writes.push((
+            USAGE_NODE_STATS_KEYSPACE.to_string(),
+            Key::from(NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec()),
+            Value::from(total.to_bytes().map_err(|e| e.to_string())?),
+        ));
+    }
+    for group_id in groups {
+        let total = realm_group_usage(storage, local_node_id, group_id).await?;
+        writes.push((
+            USAGE_NODE_STATS_KEYSPACE.to_string(),
+            Key::from(node_usage_summary_group_key(group_id)),
+            Value::from(total.to_bytes().map_err(|e| e.to_string())?),
+        ));
+    }
+
+    if writes.is_empty() {
+        return Ok(());
+    }
+    match storage
+        .send_storage_effect(StorageEffect::BatchWrite {
+            writes,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchWriteResult { .. }) => Ok(()),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected summary write event: {other:?}")),
+    }
+}
+
+async fn realm_global_usage(
+    storage: &StorageHandle,
+    local_node_id: NodeId,
+) -> Result<UsageCounters, String> {
+    let mut total = read_local_global(storage).await?;
+    let remote =
+        sum_remote_snapshots(storage, NODE_USAGE_GLOBAL_PREFIX.to_vec(), local_node_id).await?;
+    total.add(&remote).map_err(|e| e.to_string())?;
+    Ok(total)
+}
+
+async fn realm_group_usage(
+    storage: &StorageHandle,
+    local_node_id: NodeId,
+    group_id: GroupId,
+) -> Result<UsageCounters, String> {
+    let mut total = read_local_group(storage, group_id).await?;
+    let remote =
+        sum_remote_snapshots(storage, node_usage_group_prefix(group_id), local_node_id).await?;
+    total.add(&remote).map_err(|e| e.to_string())?;
+    Ok(total)
+}
+
+/// Reads the realm-wide total from the summed cache, falling back to an
+/// on-the-fly recompute when the cache entry has not been materialized yet.
+pub async fn load_realm_usage(
+    ctx: &DriverContext,
+    local_node_id: NodeId,
+    scope: RealmUsageScope,
+) -> Result<UsageCounters, String> {
+    let storage = &ctx.storage_handle;
+    let cache_key = match scope {
+        RealmUsageScope::Global => Key::from(NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec()),
+        RealmUsageScope::Group(group_id) => Key::from(node_usage_summary_group_key(group_id)),
+    };
+    match storage
+        .send_storage_effect(StorageEffect::Read {
+            key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+            key: cache_key,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(bytes), ..
+        }) => UsageCounters::from_bytes(bytes.as_ref()).map_err(|e| e.to_string()),
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => match scope {
+            RealmUsageScope::Global => realm_global_usage(storage, local_node_id).await,
+            RealmUsageScope::Group(group_id) => {
+                realm_group_usage(storage, local_node_id, group_id).await
+            }
+        },
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected realm usage read event: {other:?}")),
+    }
+}
+
+/// Re-arms the debounced publish task when dirty markers survived a restart.
+pub async fn restore_usage_snapshot_publish_timer(
+    storage: &StorageHandle,
+    task_handle: &TaskHandle,
+) {
+    let has_markers = match storage
+        .send_storage_effect(StorageEffect::Iter {
+            key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+            prefix: Some(Key::from(NODE_USAGE_DIRTY_PREFIX.to_vec())),
+            start: None,
+            limit: 1,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::IterResult { values, .. }) => !values.is_empty(),
+        Event::Storage(StorageEvent::Error { error }) => {
+            warn!(error = %error, "Failed to scan node usage dirty markers");
+            return;
+        }
+        other => {
+            warn!(event = ?other, "Unexpected event while scanning node usage dirty markers");
+            return;
+        }
+    };
+    if has_markers
+        && let Event::Task(TaskEvent::Error { message, .. }) = task_handle
+            .send_effect(schedule_usage_snapshot_publish_effect())
+            .await
+    {
+        warn!(message = %message, "Failed to restore node usage publish timer");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1134,6 +1624,270 @@ mod tests {
         );
         assert!(
             read_optional_counters(&ctx, usage_global_shard_key(0))
+                .await
+                .is_some()
+        );
+    }
+
+    fn node(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    async fn read_node_stat(ctx: &DriverContext, key: Vec<u8>) -> Option<Vec<u8>> {
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Read {
+                key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+                key: key.into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::ReadResult { value, .. }) => value.map(|b| b.to_vec()),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    async fn write_node_stat(ctx: &DriverContext, key: Vec<u8>, value: Vec<u8>) {
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+                key: key.into(),
+                value: value.into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn usage_update_writes_dirty_markers_in_transaction() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let group_id = Ulid::new();
+
+        drive(
+            CreateBucketOperation::new(
+                "counted".to_string(),
+                BucketInfo {
+                    group_id,
+                    created_at: SystemTime::now(),
+                    created_by: Default::default(),
+                    cors_configuration: None,
+                },
+            ),
+            &ctx,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_some()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id))
+                .await
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_consumes_markers_and_writes_snapshots() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let node_id = node(1);
+        let realm_id = RealmId::from_bytes([9u8; 32]);
+        let group_id = Ulid::new();
+
+        let counters = UsageCounters {
+            buckets: 1,
+            logical_bytes: 10,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_key_for_group(group_id), counters).await;
+        write_counters(&ctx, usage_group_key(group_id), counters).await;
+        write_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec(), Vec::new()).await;
+        write_node_stat(&ctx, node_usage_dirty_group_key(group_id), Vec::new()).await;
+
+        let published = publish_usage_snapshots(&ctx, node_id, realm_id, false)
+            .await
+            .unwrap();
+        assert!(published.global);
+        assert_eq!(published.groups, vec![group_id]);
+
+        // Markers were consumed.
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_none()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id))
+                .await
+                .is_none()
+        );
+
+        // Snapshot documents were written under this node's keys.
+        let global = NodeUsageSnapshot::from_bytes(
+            &read_node_stat(&ctx, node_usage_global_key(node_id))
+                .await
+                .expect("global snapshot written"),
+        )
+        .unwrap();
+        assert_eq!(global.node_id, node_id);
+        assert_eq!(global.counters.logical_bytes, 10);
+        let group = NodeUsageSnapshot::from_bytes(
+            &read_node_stat(&ctx, node_usage_group_key(group_id, node_id))
+                .await
+                .expect("group snapshot written"),
+        )
+        .unwrap();
+        assert_eq!(group.counters.logical_bytes, 10);
+    }
+
+    #[tokio::test]
+    async fn realm_summary_sums_local_and_remote_excluding_own_snapshot() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let local = node(1);
+        let remote = node(2);
+        let group_id = Ulid::new();
+
+        let local_counters = UsageCounters {
+            logical_bytes: 10,
+            objects: 1,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_key_for_group(group_id), local_counters).await;
+        write_counters(&ctx, usage_group_key(group_id), local_counters).await;
+
+        let remote_snapshot = |counters| NodeUsageSnapshot {
+            node_id: remote,
+            counters,
+        };
+        let remote_counters = UsageCounters {
+            logical_bytes: 5,
+            objects: 1,
+            ..Default::default()
+        };
+        write_node_stat(
+            &ctx,
+            node_usage_global_key(remote),
+            remote_snapshot(remote_counters).to_bytes().unwrap(),
+        )
+        .await;
+        write_node_stat(
+            &ctx,
+            node_usage_group_key(group_id, remote),
+            remote_snapshot(remote_counters).to_bytes().unwrap(),
+        )
+        .await;
+        // This node's own stale snapshot must be ignored in favor of live counters.
+        write_node_stat(
+            &ctx,
+            node_usage_global_key(local),
+            NodeUsageSnapshot {
+                node_id: local,
+                counters: UsageCounters {
+                    logical_bytes: 999,
+                    ..Default::default()
+                },
+            }
+            .to_bytes()
+            .unwrap(),
+        )
+        .await;
+
+        recompute_realm_usage_summary(&ctx, local, true, vec![group_id])
+            .await
+            .unwrap();
+
+        let global = load_realm_usage(&ctx, local, RealmUsageScope::Global)
+            .await
+            .unwrap();
+        assert_eq!(global.logical_bytes, 15);
+        assert_eq!(global.objects, 2);
+        let group = load_realm_usage(&ctx, local, RealmUsageScope::Group(group_id))
+            .await
+            .unwrap();
+        assert_eq!(group.logical_bytes, 15);
+        assert_eq!(group.objects, 2);
+    }
+
+    #[tokio::test]
+    async fn load_realm_usage_falls_back_to_on_the_fly_recompute() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let local = node(1);
+        let remote = node(2);
+
+        write_counters(
+            &ctx,
+            usage_global_shard_key(0),
+            UsageCounters {
+                logical_bytes: 3,
+                ..Default::default()
+            },
+        )
+        .await;
+        write_node_stat(
+            &ctx,
+            node_usage_global_key(remote),
+            NodeUsageSnapshot {
+                node_id: remote,
+                counters: UsageCounters {
+                    logical_bytes: 4,
+                    ..Default::default()
+                },
+            }
+            .to_bytes()
+            .unwrap(),
+        )
+        .await;
+
+        // No summary/global cache entry exists, so the read recomputes on the fly.
+        let global = load_realm_usage(&ctx, local, RealmUsageScope::Global)
+            .await
+            .unwrap();
+        assert_eq!(global.logical_bytes, 7);
+    }
+
+    #[tokio::test]
+    async fn rebuild_leaves_node_usage_keyspace_intact() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let remote = node(2);
+        let snapshot_key = node_usage_global_key(remote);
+        let snapshot = NodeUsageSnapshot {
+            node_id: remote,
+            counters: UsageCounters {
+                logical_bytes: 42,
+                ..Default::default()
+            },
+        };
+        write_node_stat(&ctx, snapshot_key.clone(), snapshot.to_bytes().unwrap()).await;
+        write_node_stat(&ctx, NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec(), Vec::new()).await;
+
+        drive(RebuildUsageStatsOperation::new(), &ctx)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            read_node_stat(&ctx, snapshot_key).await,
+            Some(snapshot.to_bytes().unwrap())
+        );
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec())
                 .await
                 .is_some()
         );

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -886,10 +886,17 @@ async fn sum_remote_snapshots(
     let entries = iter_all(storage, USAGE_NODE_STATS_KEYSPACE, Some(Key::from(prefix))).await?;
     let mut total = UsageCounters::default();
     for (key, value) in entries {
-        if node_usage_key_node_id(key.as_ref()) == Some(local_node_id) {
+        let key_node_id = node_usage_key_node_id(key.as_ref());
+        if key_node_id == Some(local_node_id) {
             continue;
         }
         let snapshot = NodeUsageSnapshot::from_bytes(value.as_ref()).map_err(|e| e.to_string())?;
+        // Defensive: ingest ties a snapshot's node id to its storage key, but
+        // never sum one whose embedded node id disagrees with its key so a
+        // misattributed snapshot can never inflate the realm aggregate.
+        if key_node_id != Some(snapshot.node_id) {
+            continue;
+        }
         total.add(&snapshot.counters).map_err(|e| e.to_string())?;
     }
     Ok(total)

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -5,19 +5,20 @@ use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{
-    BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE, S3_BUCKET_KEYSPACE,
-    USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE,
+    BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE, REALM_CONFIG_KEYSPACE,
+    S3_BUCKET_KEYSPACE, USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE,
 };
 use aruna_core::operation::Operation;
 use aruna_core::structs::{
     BackendLocation, BlobHeadKey, BlobVersion, BlobVersionState, BucketInfo, CurrentVersionPointer,
     NODE_USAGE_DIRTY_GLOBAL_KEY, NODE_USAGE_DIRTY_PREFIX, NODE_USAGE_GLOBAL_PREFIX,
-    NODE_USAGE_GROUP_PREFIX, NODE_USAGE_SUMMARY_GLOBAL_KEY, NodeUsageSnapshot, RealmId,
-    USAGE_GLOBAL_KEY, USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta,
-    VersionKey, node_usage_dirty_group_id, node_usage_dirty_group_key, node_usage_global_key,
-    node_usage_group_key, node_usage_group_key_group_id, node_usage_group_prefix,
-    node_usage_key_node_id, node_usage_summary_group_key, usage_global_key_for_group,
-    usage_global_shard_index, usage_global_shard_key, usage_global_shard_keys, usage_group_key,
+    NODE_USAGE_GROUP_PREFIX, NODE_USAGE_SUMMARY_GLOBAL_KEY, NODE_USAGE_SUMMARY_GROUP_PREFIX,
+    NodeUsageSnapshot, RealmConfigDocument, RealmId, USAGE_GLOBAL_KEY, USAGE_GLOBAL_SHARD_COUNT,
+    UsageCounterError, UsageCounters, UsageDelta, VersionKey, node_usage_dirty_group_id,
+    node_usage_dirty_group_key, node_usage_global_key, node_usage_group_key,
+    node_usage_group_key_group_id, node_usage_group_prefix, node_usage_key_node_id,
+    node_usage_summary_group_key, usage_global_key_for_group, usage_global_shard_index,
+    usage_global_shard_key, usage_global_shard_keys, usage_group_key,
 };
 use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
 use aruna_core::types::{Effects, GroupId, Key, TxnId, Value};
@@ -175,6 +176,7 @@ impl UsageCounterUpdate {
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum QuotaGatePhase {
     Pending,
+    ReadRealmConfig,
     ReadLocal,
     ScanRemote,
     Done,
@@ -204,6 +206,8 @@ pub struct QuotaGate {
     group_key: Vec<u8>,
     remote_prefix: Vec<u8>,
     local_node_id: NodeId,
+    realm_id: Option<RealmId>,
+    active_node_ids: Option<HashSet<NodeId>>,
     usage: u64,
     phase: QuotaGatePhase,
 }
@@ -223,12 +227,39 @@ impl QuotaGate {
             group_key: usage_group_key(group_id),
             remote_prefix: node_usage_group_prefix(group_id),
             local_node_id,
+            realm_id: None,
+            active_node_ids: None,
             usage: 0,
             phase: QuotaGatePhase::Pending,
         }
     }
 
+    pub fn new_for_realm(
+        ceiling: u64,
+        delta_logical_bytes: u64,
+        group_id: GroupId,
+        local_node_id: NodeId,
+        realm_id: RealmId,
+    ) -> Self {
+        Self {
+            realm_id: Some(realm_id),
+            ..Self::new(ceiling, delta_logical_bytes, group_id, local_node_id)
+        }
+    }
+
     pub fn start(&mut self, txn_id: TxnId) -> Effects {
+        if let Some(realm_id) = self.realm_id {
+            self.phase = QuotaGatePhase::ReadRealmConfig;
+            return smallvec![Effect::Storage(StorageEffect::Read {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: DocumentSyncTarget::RealmConfig { realm_id }.storage_key(),
+                txn_id: Some(txn_id),
+            })];
+        }
+        self.read_local_effect(txn_id)
+    }
+
+    fn read_local_effect(&mut self, txn_id: TxnId) -> Effects {
         self.phase = QuotaGatePhase::ReadLocal;
         smallvec![Effect::Storage(StorageEffect::Read {
             key_space: USAGE_STATS_KEYSPACE.to_string(),
@@ -251,6 +282,17 @@ impl QuotaGate {
     /// `Ok(None)` once the group's realm-wide usage has been summed.
     pub fn step(&mut self, event: Event, txn_id: TxnId) -> Result<Option<Effects>, QuotaGateError> {
         match (&self.phase, event) {
+            (
+                QuotaGatePhase::ReadRealmConfig,
+                Event::Storage(StorageEvent::ReadResult { value, .. }),
+            ) => {
+                if let Some(bytes) = value {
+                    let document = RealmConfigDocument::from_bytes(bytes.as_ref())?;
+                    self.active_node_ids =
+                        Some(document.sync_eligible_node_ids()?.into_iter().collect());
+                }
+                Ok(Some(self.read_local_effect(txn_id)))
+            }
             (QuotaGatePhase::ReadLocal, Event::Storage(StorageEvent::ReadResult { value, .. })) => {
                 if let Some(bytes) = value {
                     let counters = UsageCounters::from_bytes(bytes.as_ref())?;
@@ -272,6 +314,12 @@ impl QuotaGate {
                     // whose embedded node id disagrees with its storage key.
                     let key_node_id = node_usage_key_node_id(key.as_ref());
                     if key_node_id == Some(self.local_node_id) {
+                        continue;
+                    }
+                    if let (Some(active_node_ids), Some(node_id)) =
+                        (&self.active_node_ids, key_node_id)
+                        && !active_node_ids.contains(&node_id)
+                    {
                         continue;
                     }
                     let snapshot = NodeUsageSnapshot::from_bytes(value.as_ref())?;
@@ -641,10 +689,15 @@ impl RebuildUsageStatsOperation {
                         }
                     }
 
-                    let BlobVersionState::Materialized { blob_hash, .. } = version.state else {
-                        continue;
-                    };
-                    let Some(size) = self.blob_sizes.get(blob_hash.as_slice()).copied() else {
+                    let Some(size) = (match version.state {
+                        BlobVersionState::Materialized { blob_hash, .. } => {
+                            self.blob_sizes.get(blob_hash.as_slice()).copied()
+                        }
+                        BlobVersionState::Reference {
+                            cached_metadata, ..
+                        } => Some(cached_metadata.content_length),
+                        BlobVersionState::Deleted => None,
+                    }) else {
                         continue;
                     };
                     let delta = UsageCounters {
@@ -1018,12 +1071,18 @@ async fn sum_remote_snapshots(
     storage: &StorageHandle,
     prefix: Vec<u8>,
     local_node_id: NodeId,
+    active_node_ids: Option<&HashSet<NodeId>>,
 ) -> Result<UsageCounters, String> {
     let entries = iter_all(storage, USAGE_NODE_STATS_KEYSPACE, Some(Key::from(prefix))).await?;
     let mut total = UsageCounters::default();
     for (key, value) in entries {
         let key_node_id = node_usage_key_node_id(key.as_ref());
         if key_node_id == Some(local_node_id) {
+            continue;
+        }
+        if let (Some(active_node_ids), Some(node_id)) = (active_node_ids, key_node_id)
+            && !active_node_ids.contains(&node_id)
+        {
             continue;
         }
         let snapshot = NodeUsageSnapshot::from_bytes(value.as_ref()).map_err(|e| e.to_string())?;
@@ -1054,6 +1113,18 @@ pub async fn publish_usage_snapshots(
     realm_id: RealmId,
     full: bool,
 ) -> Result<PublishedUsage, String> {
+    let (published, observed_markers) =
+        publish_usage_snapshots_retaining_markers(ctx, node_id, realm_id, full).await?;
+    clear_consumed_markers(&ctx.storage_handle, observed_markers).await?;
+    Ok(published)
+}
+
+async fn publish_usage_snapshots_retaining_markers(
+    ctx: &DriverContext,
+    node_id: NodeId,
+    realm_id: RealmId,
+    full: bool,
+) -> Result<(PublishedUsage, Vec<(Key, Value)>), String> {
     let storage = &ctx.storage_handle;
 
     let observed_markers = iter_all(
@@ -1108,7 +1179,7 @@ pub async fn publish_usage_snapshots(
     }
 
     if !global && groups.is_empty() {
-        return Ok(PublishedUsage::default());
+        return Ok((PublishedUsage::default(), Vec::new()));
     }
 
     let mut writes: Vec<(String, Key, Value)> = Vec::with_capacity(groups.len() + 1);
@@ -1156,11 +1227,113 @@ pub async fn publish_usage_snapshots(
     .await
     .map_err(|error| format!("node usage snapshot replication failed: {error}"))?;
 
-    // Replication accepted the snapshots; only now consume the markers, and only
-    // those a concurrent write did not re-dirty in the meantime.
-    clear_consumed_markers(storage, observed_markers).await?;
+    Ok((published, observed_markers))
+}
 
+pub async fn publish_and_refresh_usage_snapshots(
+    ctx: &DriverContext,
+    node_id: NodeId,
+    realm_id: RealmId,
+    full: bool,
+) -> Result<PublishedUsage, String> {
+    let (published, observed_markers) =
+        publish_usage_snapshots_retaining_markers(ctx, node_id, realm_id, full).await?;
+    if !published.is_empty() {
+        if let Err(error) =
+            recompute_realm_usage_summary(ctx, node_id, published.global, published.groups.clone())
+                .await
+        {
+            if let Err(retry_error) =
+                signal_usage_snapshot_retry(ctx, &published, &observed_markers).await
+            {
+                return Err(format!(
+                    "{error}; additionally failed to mark usage snapshot retry: {retry_error}"
+                ));
+            }
+            return Err(error);
+        }
+    }
+    // Replication and summary refresh both succeeded; only now consume the
+    // markers, and only those a concurrent write did not re-dirty meanwhile.
+    clear_consumed_markers(&ctx.storage_handle, observed_markers).await?;
     Ok(published)
+}
+
+async fn signal_usage_snapshot_retry(
+    ctx: &DriverContext,
+    published: &PublishedUsage,
+    observed_markers: &[(Key, Value)],
+) -> Result<(), String> {
+    write_usage_snapshot_retry_markers(&ctx.storage_handle, published, observed_markers).await?;
+
+    let Some(task_handle) = ctx.task_handle.as_ref() else {
+        return Ok(());
+    };
+    match task_handle
+        .send_effect(schedule_usage_snapshot_publish_effect())
+        .await
+    {
+        Event::Task(TaskEvent::TimerScheduled { .. }) => Ok(()),
+        Event::Task(TaskEvent::Error { message, .. }) => {
+            warn!(message = %message, "Failed to schedule usage snapshot retry after summary refresh failure");
+            Ok(())
+        }
+        other => {
+            warn!(event = ?other, "Unexpected usage snapshot retry schedule result");
+            Ok(())
+        }
+    }
+}
+
+async fn write_usage_snapshot_retry_markers(
+    storage: &StorageHandle,
+    published: &PublishedUsage,
+    observed_markers: &[(Key, Value)],
+) -> Result<(), String> {
+    if published.is_empty() {
+        return Ok(());
+    }
+
+    let observed_keys: HashSet<Vec<u8>> = observed_markers
+        .iter()
+        .map(|(key, _)| key.as_ref().to_vec())
+        .collect();
+    let generation = Value::from(ulid::Ulid::new().to_bytes().to_vec());
+    let mut writes: Vec<(String, Key, Value)> =
+        Vec::with_capacity(published.groups.len() + usize::from(published.global));
+    if published.global && !observed_keys.contains(NODE_USAGE_DIRTY_GLOBAL_KEY) {
+        writes.push((
+            USAGE_NODE_STATS_KEYSPACE.to_string(),
+            Key::from(NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec()),
+            generation.clone(),
+        ));
+    }
+    for group_id in &published.groups {
+        let marker_key = node_usage_dirty_group_key(*group_id);
+        if observed_keys.contains(&marker_key) {
+            continue;
+        }
+        writes.push((
+            USAGE_NODE_STATS_KEYSPACE.to_string(),
+            Key::from(marker_key),
+            generation.clone(),
+        ));
+    }
+    if writes.is_empty() {
+        return Ok(());
+    }
+
+    match storage
+        .send_storage_effect(StorageEffect::BatchWrite {
+            writes,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchWriteResult { .. }) => Ok(()),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("retry marker write failed: {other:?}")),
+    }
 }
 
 /// Persists the refreshed snapshot documents. Each snapshot key has a single
@@ -1269,6 +1442,68 @@ async fn clear_consumed_markers(
     }
 }
 
+async fn active_usage_node_ids(ctx: &DriverContext) -> Result<Option<HashSet<NodeId>>, String> {
+    let Some(net_handle) = ctx.net_handle.as_ref() else {
+        return Ok(None);
+    };
+    let realm_id = *net_handle.realm_id();
+    let key = DocumentSyncTarget::RealmConfig { realm_id }.storage_key();
+    match ctx
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: REALM_CONFIG_KEYSPACE.to_string(),
+            key,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(bytes), ..
+        }) => {
+            let document = RealmConfigDocument::from_bytes(bytes.as_ref())
+                .map_err(|error| error.to_string())?;
+            Ok(Some(
+                document
+                    .sync_eligible_node_ids()
+                    .map_err(|error| error.to_string())?
+                    .into_iter()
+                    .collect(),
+            ))
+        }
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(None),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected realm config read event: {other:?}")),
+    }
+}
+
+async fn clear_realm_usage_summary_cache(ctx: &DriverContext) -> Result<(), String> {
+    let mut deletes = vec![(
+        USAGE_NODE_STATS_KEYSPACE.to_string(),
+        Key::from(NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec()),
+    )];
+    for (key, _) in iter_all(
+        &ctx.storage_handle,
+        USAGE_NODE_STATS_KEYSPACE,
+        Some(Key::from(NODE_USAGE_SUMMARY_GROUP_PREFIX.to_vec())),
+    )
+    .await?
+    {
+        deletes.push((USAGE_NODE_STATS_KEYSPACE.to_string(), key));
+    }
+    match ctx
+        .storage_handle
+        .send_storage_effect(StorageEffect::BatchDelete {
+            deletes,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchDeleteResult { .. }) => Ok(()),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected summary cache delete event: {other:?}")),
+    }
+}
+
 /// Recomputes the persisted realm-wide summed cache for the requested scopes:
 /// realm total = live local counters + every remote node's snapshot.
 pub async fn recompute_realm_usage_summary(
@@ -1278,10 +1513,11 @@ pub async fn recompute_realm_usage_summary(
     groups: Vec<GroupId>,
 ) -> Result<(), String> {
     let storage = &ctx.storage_handle;
+    let active_node_ids = active_usage_node_ids(ctx).await?;
     let mut writes: Vec<(String, Key, Value)> = Vec::with_capacity(groups.len() + 1);
 
     if include_global {
-        let total = realm_global_usage(storage, local_node_id).await?;
+        let total = realm_global_usage(storage, local_node_id, active_node_ids.as_ref()).await?;
         writes.push((
             USAGE_NODE_STATS_KEYSPACE.to_string(),
             Key::from(NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec()),
@@ -1289,7 +1525,8 @@ pub async fn recompute_realm_usage_summary(
         ));
     }
     for group_id in groups {
-        let total = realm_group_usage(storage, local_node_id, group_id).await?;
+        let total =
+            realm_group_usage(storage, local_node_id, group_id, active_node_ids.as_ref()).await?;
         writes.push((
             USAGE_NODE_STATS_KEYSPACE.to_string(),
             Key::from(node_usage_summary_group_key(group_id)),
@@ -1324,15 +1561,23 @@ pub async fn refresh_realm_usage_summary_for_targets(
 ) {
     let mut include_global = false;
     let mut groups = BTreeSet::new();
+    let mut realm_config_changed = false;
     for target in targets {
-        if let DocumentSyncTarget::NodeUsage { group_id, .. } = target {
-            match group_id {
+        match target {
+            DocumentSyncTarget::NodeUsage { group_id, .. } => match group_id {
                 Some(group_id) => {
                     groups.insert(*group_id);
                 }
                 None => include_global = true,
+            },
+            DocumentSyncTarget::RealmConfig { .. } => {
+                realm_config_changed = true;
             }
+            _ => {}
         }
+    }
+    if realm_config_changed && let Err(error) = clear_realm_usage_summary_cache(ctx).await {
+        warn!(error = %error, "Failed to clear realm usage summary after realm config change");
     }
     if !include_global && groups.is_empty() {
         return;
@@ -1352,10 +1597,16 @@ pub async fn refresh_realm_usage_summary_for_targets(
 async fn realm_global_usage(
     storage: &StorageHandle,
     local_node_id: NodeId,
+    active_node_ids: Option<&HashSet<NodeId>>,
 ) -> Result<UsageCounters, String> {
     let mut total = read_local_global(storage).await?;
-    let remote =
-        sum_remote_snapshots(storage, NODE_USAGE_GLOBAL_PREFIX.to_vec(), local_node_id).await?;
+    let remote = sum_remote_snapshots(
+        storage,
+        NODE_USAGE_GLOBAL_PREFIX.to_vec(),
+        local_node_id,
+        active_node_ids,
+    )
+    .await?;
     total.add(&remote).map_err(|e| e.to_string())?;
     Ok(total)
 }
@@ -1364,10 +1615,16 @@ async fn realm_group_usage(
     storage: &StorageHandle,
     local_node_id: NodeId,
     group_id: GroupId,
+    active_node_ids: Option<&HashSet<NodeId>>,
 ) -> Result<UsageCounters, String> {
     let mut total = read_local_group(storage, group_id).await?;
-    let remote =
-        sum_remote_snapshots(storage, node_usage_group_prefix(group_id), local_node_id).await?;
+    let remote = sum_remote_snapshots(
+        storage,
+        node_usage_group_prefix(group_id),
+        local_node_id,
+        active_node_ids,
+    )
+    .await?;
     total.add(&remote).map_err(|e| e.to_string())?;
     Ok(total)
 }
@@ -1396,9 +1653,13 @@ pub async fn load_realm_usage(
             value: Some(bytes), ..
         }) => UsageCounters::from_bytes(bytes.as_ref()).map_err(|e| e.to_string()),
         Event::Storage(StorageEvent::ReadResult { value: None, .. }) => match scope {
-            RealmUsageScope::Global => realm_global_usage(storage, local_node_id).await,
+            RealmUsageScope::Global => {
+                let active_node_ids = active_usage_node_ids(ctx).await?;
+                realm_global_usage(storage, local_node_id, active_node_ids.as_ref()).await
+            }
             RealmUsageScope::Group(group_id) => {
-                realm_group_usage(storage, local_node_id, group_id).await
+                let active_node_ids = active_usage_node_ids(ctx).await?;
+                realm_group_usage(storage, local_node_id, group_id, active_node_ids.as_ref()).await
             }
         },
         Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
@@ -1446,7 +1707,9 @@ mod tests {
     use crate::driver::{DriverContext, drive};
     use crate::s3::create_bucket::CreateBucketOperation;
     use aruna_core::structs::{
-        BlobHeadKey, BucketInfo, CurrentVersionPointer, usage_global_shard_keys,
+        BlobHeadKey, BucketInfo, CurrentVersionPointer, PortableSourceDescriptor,
+        SourceConnectorKind, SourceMetadata, StagingStrategy, VersionSourceBinding,
+        usage_global_shard_keys,
     };
     use std::time::SystemTime;
     use tempfile::tempdir;
@@ -1733,6 +1996,7 @@ mod tests {
 
         // alpha/live.txt: one materialized version, live.
         // alpha/gone.txt: materialized version superseded by a delete marker.
+        // alpha/ref.txt: one reference version, live.
         // beta/shared.bin: two materialized versions of the shared blob.
         let write_version = async |bucket: &str, key: &str, version: BlobVersion| {
             let version_id = Ulid::new();
@@ -1791,9 +2055,39 @@ mod tests {
             BlobVersion::materialized(hashes[1], now, user, None),
         )
         .await;
+        let alpha_ref_head = write_version(
+            "alpha",
+            "ref.txt",
+            BlobVersion::reference(
+                VersionSourceBinding {
+                    strategy: StagingStrategy::Reference,
+                    descriptor: PortableSourceDescriptor {
+                        kind: SourceConnectorKind::Http,
+                        public_config: Default::default(),
+                        source_path: "ref.txt".to_string(),
+                        version_selector: None,
+                        capabilities: Vec::new(),
+                        origin_node_id: None,
+                    },
+                    connector_id: Some(Ulid::new()),
+                },
+                SourceMetadata {
+                    content_length: 30,
+                    content_type: None,
+                    etag: None,
+                    last_modified: None,
+                    source_version: None,
+                },
+                now,
+                user,
+                now,
+            ),
+        )
+        .await;
 
         write_head("alpha", "live.txt", alpha_live_head).await;
         write_head("alpha", "gone.txt", alpha_gone_head).await;
+        write_head("alpha", "ref.txt", alpha_ref_head).await;
         write_head("beta", "shared.bin", beta_head).await;
 
         ctx.storage_handle
@@ -1806,21 +2100,21 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // live.txt and shared.bin are live; gone.txt ends on a delete marker.
+        // live.txt, ref.txt, and shared.bin are live; gone.txt ends on a delete marker.
         assert_eq!(global.buckets, 2);
-        assert_eq!(global.objects, 2);
+        assert_eq!(global.objects, 3);
         assert_eq!(global.stored_blobs, 2);
         assert_eq!(global.stored_bytes, 140);
-        // 100 + 40 + 40 + 40: every materialized version counts logically.
-        assert_eq!(global.logical_bytes, 220);
+        // 100 + 40 + 30 + 40 + 40: every materialized/reference version counts logically.
+        assert_eq!(global.logical_bytes, 250);
 
         let stored_global = read_global_counters(&ctx).await;
         assert_eq!(stored_global, global);
 
         let alpha = read_counters(&ctx, usage_group_key(group_a)).await;
         assert_eq!(alpha.buckets, 1);
-        assert_eq!(alpha.objects, 1);
-        assert_eq!(alpha.logical_bytes, 140);
+        assert_eq!(alpha.objects, 2);
+        assert_eq!(alpha.logical_bytes, 170);
 
         let beta = read_counters(&ctx, usage_group_key(group_b)).await;
         assert_eq!(beta.buckets, 1);
@@ -2247,6 +2541,119 @@ mod tests {
         );
 
         // Markers survive so the debounced publisher retries the run.
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_some()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id))
+                .await
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn summary_refresh_failure_preserves_dirty_markers() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let node_id = node(1);
+        let remote = node(2);
+        let realm_id = RealmId::from_bytes([9u8; 32]);
+        let group_id = Ulid::new();
+        let generation = Ulid::new().to_bytes().to_vec();
+
+        let counters = UsageCounters {
+            buckets: 1,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_key_for_group(group_id), counters).await;
+        write_counters(&ctx, usage_group_key(group_id), counters).await;
+        write_node_stat(
+            &ctx,
+            NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec(),
+            generation.clone(),
+        )
+        .await;
+        write_node_stat(
+            &ctx,
+            node_usage_dirty_group_key(group_id),
+            generation.clone(),
+        )
+        .await;
+        write_node_stat(&ctx, node_usage_global_key(remote), b"corrupt".to_vec()).await;
+
+        let result = publish_and_refresh_usage_snapshots(&ctx, node_id, realm_id, false).await;
+        assert!(
+            result.is_err(),
+            "summary recompute failure must surface as an error, got {result:?}"
+        );
+
+        // The snapshots were published, but the markers survive so the debounced
+        // publisher retries and refreshes the realm summary cache later.
+        assert!(
+            read_node_stat(&ctx, node_usage_global_key(node_id))
+                .await
+                .is_some()
+        );
+        assert_eq!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec()).await,
+            Some(generation.clone())
+        );
+        assert_eq!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id)).await,
+            Some(generation)
+        );
+    }
+
+    #[tokio::test]
+    async fn full_publish_summary_refresh_failure_marks_published_scopes_dirty() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let node_id = node(1);
+        let remote = node(2);
+        let realm_id = RealmId::from_bytes([9u8; 32]);
+        let group_id = Ulid::new();
+
+        let counters = UsageCounters {
+            buckets: 1,
+            logical_bytes: 10,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_key_for_group(group_id), counters).await;
+        write_counters(&ctx, usage_group_key(group_id), counters).await;
+        write_node_stat(&ctx, node_usage_global_key(remote), b"corrupt".to_vec()).await;
+
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_none()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id))
+                .await
+                .is_none()
+        );
+
+        let result = publish_and_refresh_usage_snapshots(&ctx, node_id, realm_id, true).await;
+        assert!(
+            result.is_err(),
+            "summary recompute failure must surface as an error, got {result:?}"
+        );
+
+        // Full startup publishes can start with no dirty markers. Once snapshots
+        // were published, a summary refresh failure must create retry markers for
+        // every published scope so the debounced publisher can refresh later.
+        assert!(
+            read_node_stat(&ctx, node_usage_global_key(node_id))
+                .await
+                .is_some()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_group_key(group_id, node_id))
+                .await
+                .is_some()
+        );
         assert!(
             read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
                 .await

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -12,12 +12,12 @@ use aruna_core::operation::Operation;
 use aruna_core::structs::{
     BackendLocation, BlobHeadKey, BlobVersion, BlobVersionState, BucketInfo, CurrentVersionPointer,
     NODE_USAGE_DIRTY_GLOBAL_KEY, NODE_USAGE_DIRTY_PREFIX, NODE_USAGE_GLOBAL_PREFIX,
-    NODE_USAGE_SUMMARY_GLOBAL_KEY, NodeUsageSnapshot, RealmId, USAGE_GLOBAL_KEY,
-    USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta, VersionKey,
-    node_usage_dirty_group_id, node_usage_dirty_group_key, node_usage_global_key,
-    node_usage_group_key, node_usage_group_prefix, node_usage_key_node_id,
-    node_usage_summary_group_key, usage_global_key_for_group, usage_global_shard_index,
-    usage_global_shard_key, usage_global_shard_keys, usage_group_key,
+    NODE_USAGE_GROUP_PREFIX, NODE_USAGE_SUMMARY_GLOBAL_KEY, NodeUsageSnapshot, RealmId,
+    USAGE_GLOBAL_KEY, USAGE_GLOBAL_SHARD_COUNT, UsageCounterError, UsageCounters, UsageDelta,
+    VersionKey, node_usage_dirty_group_id, node_usage_dirty_group_key, node_usage_global_key,
+    node_usage_group_key, node_usage_group_key_group_id, node_usage_group_prefix,
+    node_usage_key_node_id, node_usage_summary_group_key, usage_global_key_for_group,
+    usage_global_shard_index, usage_global_shard_key, usage_global_shard_keys, usage_group_key,
 };
 use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
 use aruna_core::types::{Effects, GroupId, Key, TxnId, Value};
@@ -90,18 +90,21 @@ impl UsageCounterUpdate {
 
     /// Writes, in the same transaction as the counter update, the dirty markers
     /// the debounced publisher scans to rebuild and distribute node snapshots.
+    /// The marker value is a fresh generation id: the publisher only clears a
+    /// marker whose stored generation still matches the one it observed, so a
+    /// write that re-dirties a marker mid-publish keeps its retry signal.
     fn dirty_marker_writes(&self) -> Vec<(String, Key, Value)> {
-        let marker = ByteView::from(&[][..]);
+        let generation = ByteView::from(ulid::Ulid::new().to_bytes().to_vec());
         vec![
             (
                 USAGE_NODE_STATS_KEYSPACE.to_string(),
                 ByteView::from(NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec()),
-                marker.clone(),
+                generation.clone(),
             ),
             (
                 USAGE_NODE_STATS_KEYSPACE.to_string(),
                 ByteView::from(node_usage_dirty_group_key(self.dirty_group)),
-                marker,
+                generation,
             ),
         ]
     }
@@ -895,7 +898,13 @@ async fn sum_remote_snapshots(
 /// Rebuilds this node's snapshot documents from live local counters and
 /// distributes them over the sync layer. In dirty mode only groups with a
 /// pending marker are refreshed; in full mode every group plus the global total
-/// is republished (used at startup and after a counter rebuild).
+/// is republished (used at startup and after a counter rebuild), and groups this
+/// node published before but no longer counts are re-published as zero snapshots.
+///
+/// The dirty markers are only cleared after replication has durably accepted the
+/// snapshots, and only for markers whose generation was not bumped by a
+/// concurrent write, so a failed publish or a racing counter update always
+/// leaves a retry signal behind.
 pub async fn publish_usage_snapshots(
     ctx: &DriverContext,
     node_id: NodeId,
@@ -904,17 +913,16 @@ pub async fn publish_usage_snapshots(
 ) -> Result<PublishedUsage, String> {
     let storage = &ctx.storage_handle;
 
-    let dirty = iter_all(
+    let observed_markers = iter_all(
         storage,
         USAGE_NODE_STATS_KEYSPACE,
         Some(Key::from(NODE_USAGE_DIRTY_PREFIX.to_vec())),
     )
     .await?;
-    let marker_keys: Vec<Key> = dirty.iter().map(|(key, _)| key.clone()).collect();
 
     let mut groups: BTreeSet<GroupId> = BTreeSet::new();
     let mut global = false;
-    for (key, _) in &dirty {
+    for (key, _) in &observed_markers {
         if key.as_ref() == NODE_USAGE_DIRTY_GLOBAL_KEY {
             global = true;
         } else if let Some(group_id) = node_usage_dirty_group_id(key.as_ref()) {
@@ -935,6 +943,23 @@ pub async fn publish_usage_snapshots(
                 && let Ok(bytes) = <[u8; 16]>::try_from(rest)
             {
                 groups.insert(GroupId::from_bytes(bytes));
+            }
+        }
+        // Groups this node has a published snapshot for but no live counter (e.g.
+        // their counter key was pruned by a rebuild) are re-published: reading a
+        // missing counter yields zero, so the stale snapshot is overwritten with a
+        // zero total and peers stop summing it.
+        for (key, _) in iter_all(
+            storage,
+            USAGE_NODE_STATS_KEYSPACE,
+            Some(Key::from(NODE_USAGE_GROUP_PREFIX.to_vec())),
+        )
+        .await?
+        {
+            if node_usage_key_node_id(key.as_ref()) == Some(node_id)
+                && let Some(group_id) = node_usage_group_key_group_id(key.as_ref())
+            {
+                groups.insert(group_id);
             }
         }
     }
@@ -964,14 +989,16 @@ pub async fn publish_usage_snapshots(
         ));
     }
 
-    commit_snapshot_writes(storage, writes, marker_keys).await?;
+    // Persist the refreshed snapshots but keep the dirty markers until the
+    // documents have been durably handed to replication.
+    write_snapshot_documents(storage, writes).await?;
 
     let published = PublishedUsage {
         global,
         groups: group_list,
     };
     let targets = published.targets(realm_id, node_id);
-    if let Err(error) = drive(
+    drive(
         ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,
             local_node_id: node_id,
@@ -981,72 +1008,118 @@ pub async fn publish_usage_snapshots(
         ctx,
     )
     .await
-    {
-        warn!(error = ?error, "Failed to queue node usage snapshot replication");
-    }
+    .map_err(|error| format!("node usage snapshot replication failed: {error}"))?;
+
+    // Replication accepted the snapshots; only now consume the markers, and only
+    // those a concurrent write did not re-dirty in the meantime.
+    clear_consumed_markers(storage, observed_markers).await?;
 
     Ok(published)
 }
 
-/// Writes the refreshed snapshot documents and clears the consumed dirty markers
-/// in a single transaction. New markers set concurrently keep their own entries
-/// for the next run.
-async fn commit_snapshot_writes(
+/// Persists the refreshed snapshot documents. Each snapshot key has a single
+/// writer (this node), so a plain batch write is enough.
+async fn write_snapshot_documents(
     storage: &StorageHandle,
     writes: Vec<(String, Key, Value)>,
-    marker_keys: Vec<Key>,
 ) -> Result<(), String> {
+    if writes.is_empty() {
+        return Ok(());
+    }
+    match storage
+        .send_storage_effect(StorageEffect::BatchWrite {
+            writes,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchWriteResult { .. }) => Ok(()),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("snapshot write failed: {other:?}")),
+    }
+}
+
+/// Deletes each observed dirty marker, but only if its stored generation still
+/// matches the one seen when the publish run started. Re-reading the markers
+/// inside the write transaction makes fjall abort the commit if a concurrent
+/// counter update re-dirtied any of them after they were observed, so a racing
+/// write never loses its retry signal.
+async fn clear_consumed_markers(
+    storage: &StorageHandle,
+    observed: Vec<(Key, Value)>,
+) -> Result<(), String> {
+    if observed.is_empty() {
+        return Ok(());
+    }
+
     let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = storage
         .send_storage_effect(StorageEffect::StartTransaction { read: false })
         .await
     else {
-        return Err("failed to start snapshot publish transaction".to_string());
+        return Err("failed to start marker cleanup transaction".to_string());
     };
 
-    if !writes.is_empty() {
-        match storage
-            .send_storage_effect(StorageEffect::BatchWrite {
-                writes,
-                txn_id: Some(txn_id),
-            })
-            .await
-        {
-            Event::Storage(StorageEvent::BatchWriteResult { .. }) => {}
-            other => {
-                storage
-                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
-                    .await;
-                return Err(format!("snapshot write failed: {other:?}"));
-            }
+    let reads = observed
+        .iter()
+        .map(|(key, _)| (USAGE_NODE_STATS_KEYSPACE.to_string(), key.clone()))
+        .collect();
+    let current = match storage
+        .send_storage_effect(StorageEffect::BatchRead {
+            reads,
+            txn_id: Some(txn_id),
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchReadResult { values }) => values,
+        other => {
+            storage
+                .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                .await;
+            return Err(format!("marker re-read failed: {other:?}"));
+        }
+    };
+
+    let mut deletes: Vec<(String, Key)> = Vec::with_capacity(observed.len());
+    for ((key, observed_generation), (_, current_value)) in observed.iter().zip(current) {
+        if current_value.as_ref() == Some(observed_generation) {
+            deletes.push((USAGE_NODE_STATS_KEYSPACE.to_string(), key.clone()));
         }
     }
-    if !marker_keys.is_empty() {
-        let deletes = marker_keys
-            .into_iter()
-            .map(|key| (USAGE_NODE_STATS_KEYSPACE.to_string(), key))
-            .collect();
-        match storage
-            .send_storage_effect(StorageEffect::BatchDelete {
-                deletes,
-                txn_id: Some(txn_id),
-            })
-            .await
-        {
-            Event::Storage(StorageEvent::BatchDeleteResult { .. }) => {}
-            other => {
-                storage
-                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
-                    .await;
-                return Err(format!("dirty marker delete failed: {other:?}"));
-            }
+
+    if deletes.is_empty() {
+        storage
+            .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+            .await;
+        return Ok(());
+    }
+
+    match storage
+        .send_storage_effect(StorageEffect::BatchDelete {
+            deletes,
+            txn_id: Some(txn_id),
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchDeleteResult { .. }) => {}
+        other => {
+            storage
+                .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                .await;
+            return Err(format!("marker delete failed: {other:?}"));
         }
     }
+
     match storage
         .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
         .await
     {
         Event::Storage(StorageEvent::TransactionCommitted { .. }) => Ok(()),
-        other => Err(format!("snapshot publish commit failed: {other:?}")),
+        // A concurrent counter update re-dirtied one of the observed markers; the
+        // conflicting commit aborts and every marker survives for the next run.
+        Event::Storage(StorageEvent::Error {
+            error: StorageError::TransactionConflict,
+        }) => Ok(()),
+        other => Err(format!("marker cleanup commit failed: {other:?}")),
     }
 }
 
@@ -1091,6 +1164,42 @@ pub async fn recompute_realm_usage_summary(
         Event::Storage(StorageEvent::BatchWriteResult { .. }) => Ok(()),
         Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
         other => Err(format!("unexpected summary write event: {other:?}")),
+    }
+}
+
+/// Refreshes the persisted realm usage summed cache for exactly the `NodeUsage`
+/// scopes touched by a document-sync reconcile. Shared by every reconcile
+/// handler (inbound apply, durable outbox drain, and the `SyncDocument` timer) so
+/// remote snapshots that land on any of those paths update the realm aggregate.
+pub async fn refresh_realm_usage_summary_for_targets(
+    ctx: &DriverContext,
+    local_node_id: NodeId,
+    targets: &[DocumentSyncTarget],
+) {
+    let mut include_global = false;
+    let mut groups = BTreeSet::new();
+    for target in targets {
+        if let DocumentSyncTarget::NodeUsage { group_id, .. } = target {
+            match group_id {
+                Some(group_id) => {
+                    groups.insert(*group_id);
+                }
+                None => include_global = true,
+            }
+        }
+    }
+    if !include_global && groups.is_empty() {
+        return;
+    }
+    if let Err(error) = recompute_realm_usage_summary(
+        ctx,
+        local_node_id,
+        include_global,
+        groups.into_iter().collect(),
+    )
+    .await
+    {
+        warn!(error = %error, "Failed to refresh realm usage summary after document sync reconciliation");
     }
 }
 
@@ -1890,6 +1999,252 @@ mod tests {
             read_node_stat(&ctx, NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec())
                 .await
                 .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_consumed_markers_keeps_regenerated_markers() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let generation_one = Ulid::new().to_bytes().to_vec();
+
+        write_node_stat(
+            &ctx,
+            NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec(),
+            generation_one.clone(),
+        )
+        .await;
+        let observed = vec![(
+            Key::from(NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec()),
+            Value::from(generation_one),
+        )];
+
+        // A concurrent counter update re-dirties the marker with a new generation
+        // after it was observed but before it is cleared.
+        let generation_two = Ulid::new().to_bytes().to_vec();
+        write_node_stat(
+            &ctx,
+            NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec(),
+            generation_two.clone(),
+        )
+        .await;
+
+        clear_consumed_markers(&ctx.storage_handle, observed)
+            .await
+            .unwrap();
+
+        // The re-dirtied marker survives, keeping the retry signal for the racing
+        // write's counter change.
+        assert_eq!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec()).await,
+            Some(generation_two.clone())
+        );
+
+        // Observing the current generation lets the marker be consumed.
+        let observed = vec![(
+            Key::from(NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec()),
+            Value::from(generation_two),
+        )];
+        clear_consumed_markers(&ctx.storage_handle, observed)
+            .await
+            .unwrap();
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_failure_preserves_dirty_markers() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let node_id = node(1);
+        let realm_id = RealmId::from_bytes([9u8; 32]);
+        let group_id = Ulid::new();
+        let generation = Ulid::new().to_bytes().to_vec();
+
+        let counters = UsageCounters {
+            buckets: 1,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_key_for_group(group_id), counters).await;
+        write_counters(&ctx, usage_group_key(group_id), counters).await;
+        write_node_stat(
+            &ctx,
+            NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec(),
+            generation.clone(),
+        )
+        .await;
+        write_node_stat(&ctx, node_usage_dirty_group_key(group_id), generation).await;
+
+        // Corrupt the realm config document so replication fails hard.
+        let config_key = DocumentSyncTarget::RealmConfig { realm_id }.storage_key();
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: aruna_core::keyspaces::REALM_CONFIG_KEYSPACE.to_string(),
+                key: config_key,
+                value: Value::from(b"corrupt".to_vec()),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected write event: {other:?}"),
+        }
+
+        let result = publish_usage_snapshots(&ctx, node_id, realm_id, false).await;
+        assert!(
+            result.is_err(),
+            "replication failure must surface as an error, got {result:?}"
+        );
+
+        // Markers survive so the debounced publisher retries the run.
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_some()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id))
+                .await
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn full_publish_zeros_stale_group_snapshots() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let node_id = node(1);
+        let realm_id = RealmId::from_bytes([9u8; 32]);
+        let live_group = Ulid::new();
+        let stale_group = Ulid::new();
+
+        // A live group still has a counter key.
+        let counters = UsageCounters {
+            buckets: 1,
+            logical_bytes: 10,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_group_key(live_group), counters).await;
+
+        // A group this node published before, whose counter key no longer exists
+        // (e.g. pruned by a rebuild), leaves a stale snapshot behind.
+        write_node_stat(
+            &ctx,
+            node_usage_group_key(stale_group, node_id),
+            NodeUsageSnapshot {
+                node_id,
+                counters: UsageCounters {
+                    buckets: 5,
+                    logical_bytes: 500,
+                    ..Default::default()
+                },
+            }
+            .to_bytes()
+            .unwrap(),
+        )
+        .await;
+
+        let published = publish_usage_snapshots(&ctx, node_id, realm_id, true)
+            .await
+            .unwrap();
+        assert!(published.groups.contains(&stale_group));
+        assert!(published.groups.contains(&live_group));
+
+        // The stale snapshot is overwritten with a zero total.
+        let stale = NodeUsageSnapshot::from_bytes(
+            &read_node_stat(&ctx, node_usage_group_key(stale_group, node_id))
+                .await
+                .expect("stale snapshot present"),
+        )
+        .unwrap();
+        assert_eq!(stale.counters, UsageCounters::default());
+
+        // The live group keeps its real total.
+        let live = NodeUsageSnapshot::from_bytes(
+            &read_node_stat(&ctx, node_usage_group_key(live_group, node_id))
+                .await
+                .expect("live snapshot present"),
+        )
+        .unwrap();
+        assert_eq!(live.counters.logical_bytes, 10);
+    }
+
+    #[tokio::test]
+    async fn refresh_summary_from_targets_recomputes_touched_scopes() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let local = node(1);
+        let remote = node(2);
+        let group_id = Ulid::new();
+
+        let local_counters = UsageCounters {
+            logical_bytes: 10,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_key_for_group(group_id), local_counters).await;
+        write_counters(&ctx, usage_group_key(group_id), local_counters).await;
+
+        let remote_counters = UsageCounters {
+            logical_bytes: 5,
+            ..Default::default()
+        };
+        write_node_stat(
+            &ctx,
+            node_usage_global_key(remote),
+            NodeUsageSnapshot {
+                node_id: remote,
+                counters: remote_counters,
+            }
+            .to_bytes()
+            .unwrap(),
+        )
+        .await;
+        write_node_stat(
+            &ctx,
+            node_usage_group_key(group_id, remote),
+            NodeUsageSnapshot {
+                node_id: remote,
+                counters: remote_counters,
+            }
+            .to_bytes()
+            .unwrap(),
+        )
+        .await;
+
+        refresh_realm_usage_summary_for_targets(
+            &ctx,
+            local,
+            &[
+                DocumentSyncTarget::NodeUsage {
+                    realm_id: RealmId::from_bytes([9u8; 32]),
+                    node_id: remote,
+                    group_id: None,
+                },
+                DocumentSyncTarget::NodeUsage {
+                    realm_id: RealmId::from_bytes([9u8; 32]),
+                    node_id: remote,
+                    group_id: Some(group_id),
+                },
+            ],
+        )
+        .await;
+
+        // The summed cache was materialized for both touched scopes.
+        assert_eq!(
+            read_node_stat(&ctx, NODE_USAGE_SUMMARY_GLOBAL_KEY.to_vec())
+                .await
+                .map(|bytes| UsageCounters::from_bytes(&bytes).unwrap().logical_bytes),
+            Some(15)
+        );
+        assert_eq!(
+            read_node_stat(&ctx, node_usage_summary_group_key(group_id))
+                .await
+                .map(|bytes| UsageCounters::from_bytes(&bytes).unwrap().logical_bytes),
+            Some(15)
         );
     }
 }

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -1147,6 +1147,9 @@ pub async fn publish_usage_snapshots(
             local_node_id: node_id,
             excluded_peers: Vec::new(),
             documents: targets,
+            // Steady-state publishers must not mint the shared node-usage
+            // genesis; bootstrap/placement-origin paths do that authoritatively.
+            allow_genesis: false,
         }),
         ctx,
     )

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -173,6 +173,142 @@ impl UsageCounterUpdate {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+enum QuotaGatePhase {
+    Pending,
+    ReadLocal,
+    ScanRemote,
+    Done,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum QuotaGateError {
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
+    #[error("quota gate received unexpected event: {0:?}")]
+    UnexpectedEvent(Event),
+}
+
+/// Embeddable read side of the hard per-group quota gate. Sums the group's
+/// realm-wide `logical_bytes` — the live local group counter plus every remote
+/// node's replicated group snapshot — inside the caller's write transaction right
+/// before it commits the counters, so a concurrent same-group write conflicts on
+/// the group counter key and cannot slip a second write past the ceiling.
+///
+/// `ceiling` already folds in the grace factor; that headroom is deliberately the
+/// budget for remote snapshot staleness, since remote group totals lag the
+/// authoritative counters that produced them.
+#[derive(Clone, Debug, PartialEq)]
+pub struct QuotaGate {
+    ceiling: u64,
+    delta_logical_bytes: u64,
+    group_key: Vec<u8>,
+    remote_prefix: Vec<u8>,
+    local_node_id: NodeId,
+    usage: u64,
+    phase: QuotaGatePhase,
+}
+
+impl QuotaGate {
+    const SCAN_LIMIT: usize = 1_000;
+
+    pub fn new(
+        ceiling: u64,
+        delta_logical_bytes: u64,
+        group_id: GroupId,
+        local_node_id: NodeId,
+    ) -> Self {
+        Self {
+            ceiling,
+            delta_logical_bytes,
+            group_key: usage_group_key(group_id),
+            remote_prefix: node_usage_group_prefix(group_id),
+            local_node_id,
+            usage: 0,
+            phase: QuotaGatePhase::Pending,
+        }
+    }
+
+    pub fn start(&mut self, txn_id: TxnId) -> Effects {
+        self.phase = QuotaGatePhase::ReadLocal;
+        smallvec![Effect::Storage(StorageEffect::Read {
+            key_space: USAGE_STATS_KEYSPACE.to_string(),
+            key: self.group_key.clone().into(),
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    fn scan_effect(&self, start_after: Option<Key>, txn_id: TxnId) -> Effects {
+        smallvec![Effect::Storage(StorageEffect::Iter {
+            key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+            prefix: Some(self.remote_prefix.clone().into()),
+            start: start_after.map(IterStart::After),
+            limit: Self::SCAN_LIMIT,
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    /// Returns `Ok(Some(effects))` while more storage work is needed and
+    /// `Ok(None)` once the group's realm-wide usage has been summed.
+    pub fn step(&mut self, event: Event, txn_id: TxnId) -> Result<Option<Effects>, QuotaGateError> {
+        match (&self.phase, event) {
+            (QuotaGatePhase::ReadLocal, Event::Storage(StorageEvent::ReadResult { value, .. })) => {
+                if let Some(bytes) = value {
+                    let counters = UsageCounters::from_bytes(bytes.as_ref())?;
+                    self.usage = self.usage.saturating_add(counters.logical_bytes);
+                }
+                self.phase = QuotaGatePhase::ScanRemote;
+                Ok(Some(self.scan_effect(None, txn_id)))
+            }
+            (
+                QuotaGatePhase::ScanRemote,
+                Event::Storage(StorageEvent::IterResult {
+                    values,
+                    next_start_after,
+                }),
+            ) => {
+                for (key, value) in values {
+                    // Skip our own snapshot: the live local counter already accounts
+                    // for it. Mirror `sum_remote_snapshots` — never trust a snapshot
+                    // whose embedded node id disagrees with its storage key.
+                    let key_node_id = node_usage_key_node_id(key.as_ref());
+                    if key_node_id == Some(self.local_node_id) {
+                        continue;
+                    }
+                    let snapshot = NodeUsageSnapshot::from_bytes(value.as_ref())?;
+                    if key_node_id != Some(snapshot.node_id) {
+                        continue;
+                    }
+                    self.usage = self.usage.saturating_add(snapshot.counters.logical_bytes);
+                }
+                match next_start_after {
+                    Some(start) => Ok(Some(self.scan_effect(Some(start), txn_id))),
+                    None => {
+                        self.phase = QuotaGatePhase::Done;
+                        Ok(None)
+                    }
+                }
+            }
+            (_, received) => Err(QuotaGateError::UnexpectedEvent(received)),
+        }
+    }
+
+    /// Projected group-wide `logical_bytes` if the pending write commits.
+    pub fn projected_usage(&self) -> u64 {
+        self.usage.saturating_add(self.delta_logical_bytes)
+    }
+
+    /// True when committing the pending write would push the group's realm-wide
+    /// `logical_bytes` past the ceiling. At-ceiling passes; one byte over fails.
+    pub fn is_exceeded(&self) -> bool {
+        self.projected_usage() > self.ceiling
+    }
+
+    pub fn ceiling(&self) -> u64 {
+        self.ceiling
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum LoadUsageCountersState {
     Init,
     ReadCounter,

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -1212,7 +1212,7 @@ async fn publish_usage_snapshots_retaining_markers(
         groups: group_list,
     };
     let targets = published.targets(realm_id, node_id);
-    drive(
+    if let Err(error) = drive(
         ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,
             local_node_id: node_id,
@@ -1225,7 +1225,17 @@ async fn publish_usage_snapshots_retaining_markers(
         ctx,
     )
     .await
-    .map_err(|error| format!("node usage snapshot replication failed: {error}"))?;
+    .map_err(|error| format!("node usage snapshot replication failed: {error}"))
+    {
+        if let Err(retry_error) =
+            signal_usage_snapshot_retry(ctx, &published, &observed_markers).await
+        {
+            return Err(format!(
+                "{error}; additionally failed to mark usage snapshot retry: {retry_error}"
+            ));
+        }
+        return Err(error);
+    }
 
     Ok((published, observed_markers))
 }
@@ -1274,7 +1284,7 @@ async fn signal_usage_snapshot_retry(
     {
         Event::Task(TaskEvent::TimerScheduled { .. }) => Ok(()),
         Event::Task(TaskEvent::Error { message, .. }) => {
-            warn!(message = %message, "Failed to schedule usage snapshot retry after summary refresh failure");
+            warn!(message = %message, "Failed to schedule usage snapshot retry");
             Ok(())
         }
         other => {
@@ -2540,6 +2550,74 @@ mod tests {
         );
 
         // Markers survive so the debounced publisher retries the run.
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_some()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id))
+                .await
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn full_publish_replication_failure_marks_published_scopes_dirty() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let node_id = node(1);
+        let realm_id = RealmId::from_bytes([9u8; 32]);
+        let group_id = Ulid::new();
+
+        let counters = UsageCounters {
+            buckets: 1,
+            ..Default::default()
+        };
+        write_counters(&ctx, usage_global_key_for_group(group_id), counters).await;
+        write_counters(&ctx, usage_group_key(group_id), counters).await;
+        assert!(
+            read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_none()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_dirty_group_key(group_id))
+                .await
+                .is_none()
+        );
+
+        let config_key = DocumentSyncTarget::RealmConfig { realm_id }.storage_key();
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: aruna_core::keyspaces::REALM_CONFIG_KEYSPACE.to_string(),
+                key: config_key,
+                value: Value::from(b"corrupt".to_vec()),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected write event: {other:?}"),
+        }
+
+        let result = publish_and_refresh_usage_snapshots(&ctx, node_id, realm_id, true).await;
+        assert!(
+            result.is_err(),
+            "replication failure must surface as an error, got {result:?}"
+        );
+
+        assert!(
+            read_node_stat(&ctx, node_usage_global_key(node_id))
+                .await
+                .is_some()
+        );
+        assert!(
+            read_node_stat(&ctx, node_usage_group_key(group_id, node_id))
+                .await
+                .is_some()
+        );
         assert!(
             read_node_stat(&ctx, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
                 .await

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -1238,20 +1238,19 @@ pub async fn publish_and_refresh_usage_snapshots(
 ) -> Result<PublishedUsage, String> {
     let (published, observed_markers) =
         publish_usage_snapshots_retaining_markers(ctx, node_id, realm_id, full).await?;
-    if !published.is_empty() {
-        if let Err(error) =
+    if !published.is_empty()
+        && let Err(error) =
             recompute_realm_usage_summary(ctx, node_id, published.global, published.groups.clone())
                 .await
+    {
+        if let Err(retry_error) =
+            signal_usage_snapshot_retry(ctx, &published, &observed_markers).await
         {
-            if let Err(retry_error) =
-                signal_usage_snapshot_retry(ctx, &published, &observed_markers).await
-            {
-                return Err(format!(
-                    "{error}; additionally failed to mark usage snapshot retry: {retry_error}"
-                ));
-            }
-            return Err(error);
+            return Err(format!(
+                "{error}; additionally failed to mark usage snapshot retry: {retry_error}"
+            ));
         }
+        return Err(error);
     }
     // Replication and summary refresh both succeeded; only now consume the
     // markers, and only those a concurrent write did not re-dirty meanwhile.

--- a/operations/tests/multipart.rs
+++ b/operations/tests/multipart.rs
@@ -209,6 +209,7 @@ async fn complete_upload(
             checksum_type,
             object_size,
             created_by,
+            quota_ceiling: None,
         }),
         &context.driver,
     )
@@ -325,6 +326,7 @@ async fn completes_multipart_upload_and_persists_object_part_metadata() {
             checksum_type: MultipartChecksumType::Composite,
             object_size: Some((part1.len() + part2.len()) as u64),
             created_by,
+            quota_ceiling: None,
         }),
         &context.driver,
     )
@@ -594,6 +596,7 @@ async fn completes_multipart_upload_retains_previous_current_hash_path_index() {
             checksum_type: None,
             exists: false,
             version_source: None,
+            quota_ceiling: None,
         }),
         &context.driver,
     )
@@ -688,6 +691,7 @@ async fn completes_multipart_upload_retains_previous_current_hash_path_index() {
             checksum_type: MultipartChecksumType::FullObject,
             object_size: Some((part1.len() + part2.len()) as u64),
             created_by,
+            quota_ceiling: None,
         }),
         &context.driver,
     )
@@ -883,6 +887,7 @@ async fn multipart_completion_deduplicates_against_existing_put_object() {
             checksum_type: None,
             exists: false,
             version_source: None,
+            quota_ceiling: None,
         }),
         &context.driver,
     )
@@ -1303,6 +1308,7 @@ async fn delete_object_removes_completed_multipart_metadata() {
             checksum_type: MultipartChecksumType::FullObject,
             object_size: Some((part1.len() + part2.len()) as u64),
             created_by,
+            quota_ceiling: None,
         }),
         &context.driver,
     )

--- a/operations/tests/usage_deltas.rs
+++ b/operations/tests/usage_deltas.rs
@@ -1,0 +1,309 @@
+use std::collections::{BTreeMap, HashMap};
+
+use aruna_blob::blob::BlobHandler;
+use aruna_core::UserId;
+use aruna_core::effects::StorageEffect;
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
+use aruna_core::stream::{BackendStream, StreamError};
+use aruna_core::structs::{
+    Backend, BackendConfig, BucketInfo, RealmId, UsageCounters, usage_global_shard_keys,
+    usage_group_key,
+};
+use aruna_core::types::NodeId;
+use aruna_net::{NetConfig, NetHandle};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::s3::create_bucket::CreateBucketOperation;
+use aruna_operations::s3::delete_bucket::DeleteBucketOperation;
+use aruna_operations::s3::put_object::{
+    PutObjectConfig, PutObjectInput, PutObjectOperation, PutObjectResult,
+};
+use aruna_operations::usage_stats::RebuildUsageStatsOperation;
+use aruna_storage::storage;
+use tempfile::TempDir;
+use ulid::Ulid;
+
+struct Harness {
+    _temp_dir: TempDir,
+    driver: DriverContext,
+    realm_id: RealmId,
+    node_id: NodeId,
+    created_by: UserId,
+}
+
+async fn setup() -> Harness {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_root = temp_dir.path().to_str().unwrap();
+    let blob_root = format!("{temp_root}/blobstore");
+    std::fs::create_dir_all(&blob_root).unwrap();
+
+    let storage_handle = storage::FjallStorage::open(temp_root).unwrap();
+    let net_handle = NetHandle::new(NetConfig::default(), storage_handle.clone())
+        .await
+        .unwrap();
+    let blob_handle = BlobHandler::new(
+        BackendConfig {
+            backend_type: Backend::FileSystem,
+            root: blob_root,
+            service_config: HashMap::new(),
+            bucket_prefix: Some("aruna_".to_string()),
+            max_bucket_size: Some(100_000),
+            multipart_bucket: Some("uploaded-parts".to_string()),
+            timeouts: Default::default(),
+        },
+        storage_handle.clone(),
+        net_handle.clone(),
+    )
+    .await
+    .unwrap();
+
+    let realm_id = RealmId::from_bytes([7u8; 32]);
+    let node_id = net_handle.node_id();
+    Harness {
+        _temp_dir: temp_dir,
+        driver: DriverContext {
+            storage_handle,
+            net_handle: Some(net_handle),
+            blob_handle: Some(blob_handle),
+            metadata_handle: None,
+            task_handle: None,
+        },
+        realm_id,
+        node_id,
+        created_by: UserId::local(Ulid::new(), realm_id),
+    }
+}
+
+fn stream_from_bytes(bytes: &[u8]) -> BackendStream<Result<bytes::Bytes, StreamError>> {
+    BackendStream::new(tokio_util::io::ReaderStream::new(std::io::Cursor::new(
+        bytes.to_vec(),
+    )))
+}
+
+async fn create_bucket(h: &Harness, bucket: &str, group_id: Ulid) {
+    drive(
+        CreateBucketOperation::new(
+            bucket.to_string(),
+            BucketInfo {
+                group_id,
+                created_at: std::time::SystemTime::now(),
+                created_by: h.created_by,
+                cors_configuration: None,
+            },
+        ),
+        &h.driver,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .unwrap();
+}
+
+async fn put_object(
+    h: &Harness,
+    bucket: &str,
+    key: &str,
+    group_id: Ulid,
+    data: &[u8],
+) -> PutObjectResult {
+    drive(
+        PutObjectOperation::new(PutObjectConfig {
+            user_id: h.created_by,
+            group_id,
+            realm_id: h.realm_id,
+            node_id: h.node_id,
+            request: PutObjectInput {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+                content_length: Some(data.len() as u64),
+                body: Some(stream_from_bytes(data)),
+            },
+            expected_checksums: vec![],
+            checksum_type: None,
+            exists: false,
+            version_source: None,
+        }),
+        &h.driver,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .unwrap()
+}
+
+async fn read_all_usage_stats(ctx: &DriverContext) -> Vec<(Vec<u8>, UsageCounters)> {
+    let Event::Storage(StorageEvent::IterResult { values, .. }) = ctx
+        .storage_handle
+        .send_storage_effect(StorageEffect::Iter {
+            key_space: USAGE_STATS_KEYSPACE.to_string(),
+            prefix: None,
+            start: None,
+            limit: 4096,
+            txn_id: None,
+        })
+        .await
+    else {
+        panic!("unexpected iter event");
+    };
+    values
+        .into_iter()
+        .map(|(key, value)| {
+            (
+                key.to_vec(),
+                UsageCounters::from_bytes(value.as_ref()).unwrap(),
+            )
+        })
+        .collect()
+}
+
+/// Effective, reader-visible counters: the summed global total across all 64
+/// shards, plus every non-zero per-group counter. This is the semantically
+/// meaningful projection both `LoadUsageCountersOperation` and the realm summary
+/// read; per-shard placement of `stored_*` differs between the incremental write
+/// paths (group shard) and a rebuild (shard 0), but the summed total is identical.
+async fn effective_usage(ctx: &DriverContext) -> (UsageCounters, BTreeMap<Vec<u8>, UsageCounters>) {
+    let mut global = UsageCounters::default();
+    let mut groups = BTreeMap::new();
+    for (key, counters) in read_all_usage_stats(ctx).await {
+        if key.starts_with(b"global/") {
+            global.add(&counters).unwrap();
+        } else if key.starts_with(b"group/") && counters != UsageCounters::default() {
+            groups.insert(key, counters);
+        }
+    }
+    (global, groups)
+}
+
+async fn read_group(ctx: &DriverContext, group_id: Ulid) -> UsageCounters {
+    for (key, counters) in read_all_usage_stats(ctx).await {
+        if key == usage_group_key(group_id) {
+            return counters;
+        }
+    }
+    UsageCounters::default()
+}
+
+async fn read_global(ctx: &DriverContext) -> UsageCounters {
+    let shard_keys: std::collections::HashSet<Vec<u8>> =
+        usage_global_shard_keys().into_iter().collect();
+    let mut global = UsageCounters::default();
+    for (key, counters) in read_all_usage_stats(ctx).await {
+        if shard_keys.contains(&key) {
+            global.add(&counters).unwrap();
+        }
+    }
+    global
+}
+
+/// The rebuild-as-oracle assertion: recomputing all counters from a full keyspace
+/// scan must leave the reader-visible counters byte-identical to what the
+/// incremental bookkeeping produced.
+async fn assert_matches_rebuild(ctx: &DriverContext) {
+    let before = effective_usage(ctx).await;
+    drive(RebuildUsageStatsOperation::new(), ctx)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let after = effective_usage(ctx).await;
+    assert_eq!(
+        before, after,
+        "incremental counters diverged from rebuilt truth: before={before:?} after={after:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_and_delete_bucket_delta() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+
+    create_bucket(&h, "counted", group_id).await;
+    assert_eq!(read_global(&h.driver).await.buckets, 1);
+    assert_eq!(read_group(&h.driver, group_id).await.buckets, 1);
+    assert_matches_rebuild(&h.driver).await;
+
+    // delete_bucket refuses non-empty buckets, so only empty deletion is drivable.
+    drive(DeleteBucketOperation::new("counted".to_string()), &h.driver)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(read_global(&h.driver).await.buckets, 0);
+    assert_eq!(read_group(&h.driver, group_id).await.buckets, 0);
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn simple_put_object_delta() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let data = b"hello world";
+    put_object(&h, "bucket", "fresh.txt", group_id, data).await;
+
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.buckets, 1);
+    assert_eq!(global.objects, 1);
+    assert_eq!(global.stored_blobs, 1);
+    assert_eq!(global.stored_bytes, data.len() as u64);
+    assert_eq!(global.logical_bytes, data.len() as u64);
+
+    let group = read_group(&h.driver, group_id).await;
+    assert_eq!(group.buckets, 1);
+    assert_eq!(group.objects, 1);
+    // Per-group counter tracks logical usage only; stored_* live on the global total.
+    assert_eq!(group.stored_blobs, 0);
+    assert_eq!(group.stored_bytes, 0);
+    assert_eq!(group.logical_bytes, data.len() as u64);
+
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn overwrite_put_accumulates_logical_bytes_per_version() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let first = b"first";
+    let second = b"second-longer";
+    put_object(&h, "bucket", "same.txt", group_id, first).await;
+    put_object(&h, "bucket", "same.txt", group_id, second).await;
+
+    // Overwrite semantics are accumulate-per-version, not replace: the object
+    // count stays at 1 (the head moves), but every materialized version's bytes
+    // keep counting logically and each distinct blob is stored.
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.objects, 1);
+    assert_eq!(global.stored_blobs, 2);
+    assert_eq!(global.stored_bytes, (first.len() + second.len()) as u64);
+    assert_eq!(global.logical_bytes, (first.len() + second.len()) as u64);
+
+    let group = read_group(&h.driver, group_id).await;
+    assert_eq!(group.objects, 1);
+    assert_eq!(group.logical_bytes, (first.len() + second.len()) as u64);
+
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn overwrite_put_same_content_double_counts_logical_bytes() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let data = b"identical";
+    put_object(&h, "bucket", "same.txt", group_id, data).await;
+    put_object(&h, "bucket", "same.txt", group_id, data).await;
+
+    // The blob deduplicates physically (one stored blob) but each materialized
+    // version still counts logically, so logical_bytes is charged twice.
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.objects, 1);
+    assert_eq!(global.stored_blobs, 1);
+    assert_eq!(global.stored_bytes, data.len() as u64);
+    assert_eq!(global.logical_bytes, 2 * data.len() as u64);
+
+    assert_matches_rebuild(&h.driver).await;
+}

--- a/operations/tests/usage_deltas.rs
+++ b/operations/tests/usage_deltas.rs
@@ -604,6 +604,7 @@ async fn aborted_multipart_upload_leaves_counters_untouched() {
 // would push a group's realm-wide logical_bytes above the resolved ceiling.
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::result_large_err)]
 async fn try_put_object(
     h: &Harness,
     bucket: &str,
@@ -850,6 +851,7 @@ async fn delete_object_is_never_gated_by_quota() {
     assert_matches_rebuild(&h.driver).await;
 }
 
+#[allow(clippy::result_large_err)]
 async fn try_complete_multipart(
     h: &Harness,
     bucket: &str,

--- a/operations/tests/usage_deltas.rs
+++ b/operations/tests/usage_deltas.rs
@@ -7,13 +7,23 @@ use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
 use aruna_core::stream::{BackendStream, StreamError};
 use aruna_core::structs::{
-    Backend, BackendConfig, BucketInfo, RealmId, UsageCounters, usage_global_shard_keys,
-    usage_group_key,
+    Backend, BackendConfig, BucketInfo, MultipartChecksumType, RealmId, UsageCounters,
+    usage_global_shard_keys, usage_group_key,
 };
 use aruna_core::types::NodeId;
 use aruna_net::{NetConfig, NetHandle};
 use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::s3::abort_multipart_upload::{
+    AbortMultipartUploadInput, AbortMultipartUploadOperation,
+};
+use aruna_operations::s3::complete_multipart_upload::{
+    CompleteMultipartPart, CompleteMultipartUploadInput, CompleteMultipartUploadOperation,
+    CompleteMultipartUploadResult,
+};
 use aruna_operations::s3::create_bucket::CreateBucketOperation;
+use aruna_operations::s3::create_multipart_upload::{
+    CreateMultipartUploadInput, CreateMultipartUploadOperation,
+};
 use aruna_operations::s3::delete_bucket::DeleteBucketOperation;
 use aruna_operations::s3::delete_object::{
     DeleteObjectInput, DeleteObjectOperation, DeleteObjectResult,
@@ -21,6 +31,7 @@ use aruna_operations::s3::delete_object::{
 use aruna_operations::s3::put_object::{
     PutObjectConfig, PutObjectInput, PutObjectOperation, PutObjectResult,
 };
+use aruna_operations::s3::upload_part::{UploadPartInput, UploadPartOperation, UploadPartResult};
 use aruna_operations::usage_stats::RebuildUsageStatsOperation;
 use aruna_storage::storage;
 use tempfile::TempDir;
@@ -150,6 +161,91 @@ async fn delete_object(
             realm_id: h.realm_id,
             node_id: h.node_id,
             deleted_by: h.created_by,
+        }),
+        &h.driver,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .unwrap()
+}
+
+async fn create_upload(h: &Harness, bucket: &str, key: &str, group_id: Ulid) -> Ulid {
+    drive(
+        CreateMultipartUploadOperation::new(CreateMultipartUploadInput {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            group_id,
+            created_by: h.created_by,
+            checksum_hint: None,
+        }),
+        &h.driver,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .unwrap()
+    .record
+    .upload_id
+}
+
+async fn upload_part(
+    h: &Harness,
+    bucket: &str,
+    key: &str,
+    upload_id: Ulid,
+    part_number: u16,
+    bytes: &[u8],
+) -> UploadPartResult {
+    drive(
+        UploadPartOperation::new(UploadPartInput {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            upload_id,
+            part_number,
+            content_length: Some(bytes.len() as u64),
+            body: Some(stream_from_bytes(bytes)),
+            created_by: h.created_by,
+            compressed: false,
+            encrypted: false,
+            expected_checksums: vec![],
+        }),
+        &h.driver,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .unwrap()
+}
+
+async fn complete_upload(
+    h: &Harness,
+    bucket: &str,
+    key: &str,
+    upload_id: Ulid,
+    parts: &[UploadPartResult],
+    object_size: u64,
+) -> CompleteMultipartUploadResult {
+    drive(
+        CompleteMultipartUploadOperation::new(CompleteMultipartUploadInput {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            upload_id,
+            realm_id: h.realm_id,
+            node_id: h.node_id,
+            completed_parts: parts
+                .iter()
+                .enumerate()
+                .map(|(idx, part)| CompleteMultipartPart {
+                    part_number: (idx + 1) as u16,
+                    etag: Some(hex::encode(part.location.hashes.get("md5").unwrap())),
+                    expected_checksums: vec![],
+                })
+                .collect(),
+            expected_checksums: vec![],
+            checksum_type: MultipartChecksumType::FullObject,
+            object_size: Some(object_size),
+            created_by: h.created_by,
         }),
         &h.driver,
     )
@@ -414,6 +510,88 @@ async fn permanent_delete_of_live_version_frees_logical_bytes() {
     let group = read_group(&h.driver, group_id).await;
     assert_eq!(group.objects, 0);
     assert_eq!(group.logical_bytes, 0);
+
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn multipart_staging_counts_nothing_until_completion() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let part1 = b"hello ";
+    let part2 = b"world!!";
+    let upload_id = create_upload(&h, "bucket", "big.bin", group_id).await;
+    upload_part(&h, "bucket", "big.bin", upload_id, 1, part1).await;
+    upload_part(&h, "bucket", "big.bin", upload_id, 2, part2).await;
+
+    // Staged parts live outside the content-addressed blob keyspace: an initiated
+    // but never-completed upload contributes nothing to the counters, and the
+    // rebuild (which scans only completed blobs) agrees.
+    let staged = read_global(&h.driver).await;
+    assert_eq!(staged.objects, 0);
+    assert_eq!(staged.stored_blobs, 0);
+    assert_eq!(staged.stored_bytes, 0);
+    assert_eq!(staged.logical_bytes, 0);
+    assert_matches_rebuild(&h.driver).await;
+
+    // Completion charges the object exactly once, for the assembled blob.
+    let part1_result = upload_part(&h, "bucket", "big.bin", upload_id, 1, part1).await;
+    let part2_result = upload_part(&h, "bucket", "big.bin", upload_id, 2, part2).await;
+    let size = (part1.len() + part2.len()) as u64;
+    complete_upload(
+        &h,
+        "bucket",
+        "big.bin",
+        upload_id,
+        &[part1_result, part2_result],
+        size,
+    )
+    .await;
+
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.objects, 1);
+    assert_eq!(global.stored_blobs, 1);
+    assert_eq!(global.stored_bytes, size);
+    assert_eq!(global.logical_bytes, size);
+
+    let group = read_group(&h.driver, group_id).await;
+    assert_eq!(group.objects, 1);
+    assert_eq!(group.logical_bytes, size);
+
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn aborted_multipart_upload_leaves_counters_untouched() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let upload_id = create_upload(&h, "bucket", "abort.bin", group_id).await;
+    upload_part(&h, "bucket", "abort.bin", upload_id, 1, b"discard me").await;
+
+    drive(
+        AbortMultipartUploadOperation::new(AbortMultipartUploadInput {
+            bucket: "bucket".to_string(),
+            key: "abort.bin".to_string(),
+            upload_id,
+        }),
+        &h.driver,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .unwrap();
+
+    // Abort touches no counters; only the bucket remains accounted for.
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.buckets, 1);
+    assert_eq!(global.objects, 0);
+    assert_eq!(global.stored_blobs, 0);
+    assert_eq!(global.stored_bytes, 0);
+    assert_eq!(global.logical_bytes, 0);
 
     assert_matches_rebuild(&h.driver).await;
 }

--- a/operations/tests/usage_deltas.rs
+++ b/operations/tests/usage_deltas.rs
@@ -4,10 +4,11 @@ use aruna_blob::blob::BlobHandler;
 use aruna_core::UserId;
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
-use aruna_core::keyspaces::USAGE_STATS_KEYSPACE;
+use aruna_core::keyspaces::{USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE};
 use aruna_core::stream::{BackendStream, StreamError};
 use aruna_core::structs::{
-    Backend, BackendConfig, BucketInfo, MultipartChecksumType, RealmId, UsageCounters,
+    Backend, BackendConfig, BucketInfo, GroupQuotaOverride, MultipartChecksumType,
+    NodeUsageSnapshot, QuotaConfig, RealmId, UsageCounters, node_usage_group_key,
     usage_global_shard_keys, usage_group_key,
 };
 use aruna_core::types::NodeId;
@@ -17,8 +18,8 @@ use aruna_operations::s3::abort_multipart_upload::{
     AbortMultipartUploadInput, AbortMultipartUploadOperation,
 };
 use aruna_operations::s3::complete_multipart_upload::{
-    CompleteMultipartPart, CompleteMultipartUploadInput, CompleteMultipartUploadOperation,
-    CompleteMultipartUploadResult,
+    CompleteMultipartPart, CompleteMultipartUploadError, CompleteMultipartUploadInput,
+    CompleteMultipartUploadOperation, CompleteMultipartUploadResult,
 };
 use aruna_operations::s3::create_bucket::CreateBucketOperation;
 use aruna_operations::s3::create_multipart_upload::{
@@ -29,7 +30,7 @@ use aruna_operations::s3::delete_object::{
     DeleteObjectInput, DeleteObjectOperation, DeleteObjectResult,
 };
 use aruna_operations::s3::put_object::{
-    PutObjectConfig, PutObjectInput, PutObjectOperation, PutObjectResult,
+    PutObjectConfig, PutObjectError, PutObjectInput, PutObjectOperation, PutObjectResult,
 };
 use aruna_operations::s3::upload_part::{UploadPartInput, UploadPartOperation, UploadPartResult};
 use aruna_operations::usage_stats::RebuildUsageStatsOperation;
@@ -136,6 +137,7 @@ async fn put_object(
             checksum_type: None,
             exists: false,
             version_source: None,
+            quota_ceiling: None,
         }),
         &h.driver,
     )
@@ -246,6 +248,7 @@ async fn complete_upload(
             checksum_type: MultipartChecksumType::FullObject,
             object_size: Some(object_size),
             created_by: h.created_by,
+            quota_ceiling: None,
         }),
         &h.driver,
     )
@@ -593,5 +596,320 @@ async fn aborted_multipart_upload_leaves_counters_untouched() {
     assert_eq!(global.stored_bytes, 0);
     assert_eq!(global.logical_bytes, 0);
 
+    assert_matches_rebuild(&h.driver).await;
+}
+
+// ---------------------------------------------------------------------------
+// Quota gate (finding 3): hard rejection when a positive logical_bytes delta
+// would push a group's realm-wide logical_bytes above the resolved ceiling.
+// ---------------------------------------------------------------------------
+
+async fn try_put_object(
+    h: &Harness,
+    bucket: &str,
+    key: &str,
+    group_id: Ulid,
+    data: &[u8],
+    quota_ceiling: Option<u64>,
+) -> Result<PutObjectResult, PutObjectError> {
+    drive(
+        PutObjectOperation::new(PutObjectConfig {
+            user_id: h.created_by,
+            group_id,
+            realm_id: h.realm_id,
+            node_id: h.node_id,
+            request: PutObjectInput {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+                content_length: Some(data.len() as u64),
+                body: Some(stream_from_bytes(data)),
+            },
+            expected_checksums: vec![],
+            checksum_type: None,
+            exists: false,
+            version_source: None,
+            quota_ceiling,
+        }),
+        &h.driver,
+    )
+    .await
+    .map(|result| {
+        result
+            .expect("put object output")
+            .expect("put object inner")
+    })
+}
+
+fn remote_node(seed: u8) -> NodeId {
+    iroh::SecretKey::from_bytes(&[seed; 32]).public()
+}
+
+/// Injects a remote node's per-group snapshot so the gate reads a realm-wide
+/// total larger than the live local counters.
+async fn inject_remote_group_snapshot(
+    h: &Harness,
+    group_id: Ulid,
+    node_id: NodeId,
+    logical_bytes: u64,
+) {
+    let snapshot = NodeUsageSnapshot {
+        node_id,
+        counters: UsageCounters {
+            logical_bytes,
+            ..Default::default()
+        },
+    };
+    match h
+        .driver
+        .storage_handle
+        .send_storage_effect(StorageEffect::Write {
+            key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+            key: node_usage_group_key(group_id, node_id).into(),
+            value: snapshot.to_bytes().unwrap().into(),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::WriteResult { .. }) => {}
+        other => panic!("unexpected snapshot write event: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn put_object_gate_allows_under_and_at_ceiling_rejects_over() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+    let ceiling = Some(20);
+
+    // Under the ceiling: 0 + 10 <= 20.
+    try_put_object(&h, "bucket", "a.bin", group_id, &[1u8; 10], ceiling)
+        .await
+        .expect("under ceiling passes");
+    // Exactly at the ceiling: 10 + 10 == 20.
+    try_put_object(&h, "bucket", "b.bin", group_id, &[2u8; 10], ceiling)
+        .await
+        .expect("at ceiling passes");
+    assert_eq!(read_group(&h.driver, group_id).await.logical_bytes, 20);
+
+    // One byte over the ceiling: 20 + 1 > 20.
+    let error = try_put_object(&h, "bucket", "c.bin", group_id, &[3u8; 1], ceiling)
+        .await
+        .expect_err("one byte over ceiling is rejected");
+    assert!(matches!(
+        error,
+        PutObjectError::QuotaExceeded {
+            limit: 20,
+            usage: 21
+        }
+    ));
+
+    // The rejected write left the counters and the blob store untouched.
+    assert_eq!(read_group(&h.driver, group_id).await.logical_bytes, 20);
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn put_object_gate_unlimited_when_ceiling_is_none() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    // None => unlimited, no gate regardless of size.
+    try_put_object(&h, "bucket", "big.bin", group_id, &[7u8; 4096], None)
+        .await
+        .expect("unlimited group is never gated");
+    assert_eq!(read_group(&h.driver, group_id).await.logical_bytes, 4096,);
+}
+
+#[tokio::test]
+async fn put_object_gate_honors_grace_headroom() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    // quota 100 with 110% grace => ceiling 110. Writes above the quota but under
+    // the ceiling are allowed; the grace band is the budget for remote staleness.
+    let quota = QuotaConfig {
+        default_group_quota_bytes: Some(100),
+        grace_factor_percent: 110,
+        ..QuotaConfig::default()
+    };
+    let ceiling = quota.effective_group_ceiling(&group_id);
+    assert_eq!(ceiling, Some(110));
+
+    // 105 bytes: over the 100 quota, still within the 110 ceiling.
+    try_put_object(&h, "bucket", "grace.bin", group_id, &[1u8; 105], ceiling)
+        .await
+        .expect("write inside grace band passes");
+    // 6 more bytes: 105 + 6 = 111 > 110 ceiling.
+    let error = try_put_object(&h, "bucket", "over.bin", group_id, &[2u8; 6], ceiling)
+        .await
+        .expect_err("write past the grace ceiling is rejected");
+    assert!(matches!(
+        error,
+        PutObjectError::QuotaExceeded { limit: 110, .. }
+    ));
+}
+
+#[tokio::test]
+async fn put_object_gate_group_override_takes_precedence_over_default() {
+    let h = setup().await;
+    let overridden = Ulid::new();
+    let plain = Ulid::new();
+    create_bucket(&h, "over-bucket", overridden).await;
+    create_bucket(&h, "plain-bucket", plain).await;
+
+    let quota = QuotaConfig {
+        default_group_quota_bytes: Some(50),
+        grace_factor_percent: 100,
+        group_overrides: vec![GroupQuotaOverride {
+            group_id: overridden,
+            quota_bytes: Some(200),
+            grace_factor_percent: Some(100),
+        }],
+        ..QuotaConfig::default()
+    };
+
+    // Overridden group: 100 bytes fits under its 200 ceiling.
+    let over_ceiling = quota.effective_group_ceiling(&overridden);
+    assert_eq!(over_ceiling, Some(200));
+    try_put_object(
+        &h,
+        "over-bucket",
+        "ok.bin",
+        overridden,
+        &[1u8; 100],
+        over_ceiling,
+    )
+    .await
+    .expect("override quota permits the write");
+
+    // Plain group: the same 100 bytes exceeds the default 50 ceiling.
+    let plain_ceiling = quota.effective_group_ceiling(&plain);
+    assert_eq!(plain_ceiling, Some(50));
+    let error = try_put_object(
+        &h,
+        "plain-bucket",
+        "no.bin",
+        plain,
+        &[1u8; 100],
+        plain_ceiling,
+    )
+    .await
+    .expect_err("default quota rejects the write");
+    assert!(matches!(
+        error,
+        PutObjectError::QuotaExceeded { limit: 50, .. }
+    ));
+}
+
+#[tokio::test]
+async fn put_object_gate_counts_remote_node_snapshots() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+    let ceiling = Some(100);
+
+    // A remote node already reports 80 logical bytes for this group.
+    inject_remote_group_snapshot(&h, group_id, remote_node(9), 80).await;
+
+    // 0 (local) + 80 (remote) + 20 == 100 ceiling: still allowed.
+    try_put_object(&h, "bucket", "ok.bin", group_id, &[1u8; 20], ceiling)
+        .await
+        .expect("realm-wide total at ceiling passes");
+
+    // Now local is 20, remote 80; +1 byte => 101 > 100. The remote snapshot is
+    // what tips the group over, proving the gate sums the realm-wide basis.
+    let error = try_put_object(&h, "bucket", "over.bin", group_id, &[2u8; 1], ceiling)
+        .await
+        .expect_err("remote snapshot pushes the group over the ceiling");
+    assert!(matches!(
+        error,
+        PutObjectError::QuotaExceeded {
+            limit: 100,
+            usage: 101
+        }
+    ));
+}
+
+#[tokio::test]
+async fn delete_object_is_never_gated_by_quota() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    // Fill the group exactly to a tight ceiling.
+    let put = try_put_object(&h, "bucket", "big.bin", group_id, &[1u8; 50], Some(50))
+        .await
+        .expect("at-ceiling write passes");
+
+    // Deletes carry no ceiling and must always proceed, even at/over quota.
+    delete_object(&h, "bucket", "big.bin", group_id, Some(put.version_id)).await;
+    assert_eq!(read_group(&h.driver, group_id).await.logical_bytes, 0);
+    assert_matches_rebuild(&h.driver).await;
+}
+
+async fn try_complete_multipart(
+    h: &Harness,
+    bucket: &str,
+    key: &str,
+    group_id: Ulid,
+    data: &[u8],
+    quota_ceiling: Option<u64>,
+) -> Result<CompleteMultipartUploadResult, CompleteMultipartUploadError> {
+    let upload_id = create_upload(h, bucket, key, group_id).await;
+    let part = upload_part(h, bucket, key, upload_id, 1, data).await;
+    drive(
+        CompleteMultipartUploadOperation::new(CompleteMultipartUploadInput {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            upload_id,
+            realm_id: h.realm_id,
+            node_id: h.node_id,
+            completed_parts: vec![CompleteMultipartPart {
+                part_number: 1,
+                etag: Some(hex::encode(part.location.hashes.get("md5").unwrap())),
+                expected_checksums: vec![],
+            }],
+            expected_checksums: vec![],
+            checksum_type: MultipartChecksumType::FullObject,
+            object_size: Some(data.len() as u64),
+            created_by: h.created_by,
+            quota_ceiling,
+        }),
+        &h.driver,
+    )
+    .await
+    .map(|result| result.expect("complete output").expect("complete inner"))
+}
+
+#[tokio::test]
+async fn multipart_completion_is_gated_like_put() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+    let ceiling = Some(30);
+
+    // 25 bytes under the 30 ceiling: completes.
+    try_complete_multipart(&h, "bucket", "ok.bin", group_id, &[1u8; 25], ceiling)
+        .await
+        .expect("multipart under ceiling completes");
+    assert_eq!(read_group(&h.driver, group_id).await.logical_bytes, 25);
+
+    // 10 more bytes: 25 + 10 = 35 > 30 ceiling: rejected.
+    let error = try_complete_multipart(&h, "bucket", "over.bin", group_id, &[2u8; 10], ceiling)
+        .await
+        .expect_err("multipart over ceiling is rejected");
+    assert!(matches!(
+        error,
+        CompleteMultipartUploadError::QuotaExceeded {
+            limit: 30,
+            usage: 35
+        }
+    ));
+
+    // The rejected completion left the group counter unchanged.
+    assert_eq!(read_group(&h.driver, group_id).await.logical_bytes, 25);
     assert_matches_rebuild(&h.driver).await;
 }

--- a/operations/tests/usage_deltas.rs
+++ b/operations/tests/usage_deltas.rs
@@ -15,6 +15,9 @@ use aruna_net::{NetConfig, NetHandle};
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::s3::create_bucket::CreateBucketOperation;
 use aruna_operations::s3::delete_bucket::DeleteBucketOperation;
+use aruna_operations::s3::delete_object::{
+    DeleteObjectInput, DeleteObjectOperation, DeleteObjectResult,
+};
 use aruna_operations::s3::put_object::{
     PutObjectConfig, PutObjectInput, PutObjectOperation, PutObjectResult,
 };
@@ -122,6 +125,31 @@ async fn put_object(
             checksum_type: None,
             exists: false,
             version_source: None,
+        }),
+        &h.driver,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .unwrap()
+}
+
+async fn delete_object(
+    h: &Harness,
+    bucket: &str,
+    key: &str,
+    group_id: Ulid,
+    version_id: Option<Ulid>,
+) -> DeleteObjectResult {
+    drive(
+        DeleteObjectOperation::new(DeleteObjectInput {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            version_id,
+            group_id,
+            realm_id: h.realm_id,
+            node_id: h.node_id,
+            deleted_by: h.created_by,
         }),
         &h.driver,
     )
@@ -304,6 +332,88 @@ async fn overwrite_put_same_content_double_counts_logical_bytes() {
     assert_eq!(global.stored_blobs, 1);
     assert_eq!(global.stored_bytes, data.len() as u64);
     assert_eq!(global.logical_bytes, 2 * data.len() as u64);
+
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn delete_marker_drops_object_but_keeps_logical_bytes() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let data = b"payload";
+    put_object(&h, "bucket", "obj.txt", group_id, data).await;
+
+    // A versioned delete (version_id: None) writes a delete marker over the live
+    // head: the object stops being live but its materialized version and stored
+    // blob remain, so only the object count drops.
+    let result = delete_object(&h, "bucket", "obj.txt", group_id, None).await;
+    assert!(result.delete_marker);
+
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.objects, 0);
+    assert_eq!(global.stored_blobs, 1);
+    assert_eq!(global.stored_bytes, data.len() as u64);
+    assert_eq!(global.logical_bytes, data.len() as u64);
+
+    let group = read_group(&h.driver, group_id).await;
+    assert_eq!(group.objects, 0);
+    assert_eq!(group.logical_bytes, data.len() as u64);
+
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn put_over_delete_marker_revives_object() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let first = b"first-body";
+    let second = b"second-body-2";
+    put_object(&h, "bucket", "obj.txt", group_id, first).await;
+    delete_object(&h, "bucket", "obj.txt", group_id, None).await;
+    put_object(&h, "bucket", "obj.txt", group_id, second).await;
+
+    // The key is live again. Both materialized versions still count logically and
+    // both distinct blobs are stored; the delete marker contributes nothing.
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.objects, 1);
+    assert_eq!(global.stored_blobs, 2);
+    assert_eq!(global.stored_bytes, (first.len() + second.len()) as u64);
+    assert_eq!(global.logical_bytes, (first.len() + second.len()) as u64);
+
+    let group = read_group(&h.driver, group_id).await;
+    assert_eq!(group.objects, 1);
+    assert_eq!(group.logical_bytes, (first.len() + second.len()) as u64);
+
+    assert_matches_rebuild(&h.driver).await;
+}
+
+#[tokio::test]
+async fn permanent_delete_of_live_version_frees_logical_bytes() {
+    let h = setup().await;
+    let group_id = Ulid::new();
+    create_bucket(&h, "bucket", group_id).await;
+
+    let data = b"payload";
+    let put = put_object(&h, "bucket", "obj.txt", group_id, data).await;
+
+    // A permanent delete by version id removes the only (live) version: the
+    // object and its logical bytes are freed. The content-addressed blob is left
+    // in place, so stored_* are unchanged and the rebuild still counts them.
+    delete_object(&h, "bucket", "obj.txt", group_id, Some(put.version_id)).await;
+
+    let global = read_global(&h.driver).await;
+    assert_eq!(global.objects, 0);
+    assert_eq!(global.logical_bytes, 0);
+    assert_eq!(global.stored_blobs, 1);
+    assert_eq!(global.stored_bytes, data.len() as u64);
+
+    let group = read_group(&h.driver, group_id).await;
+    assert_eq!(group.objects, 0);
+    assert_eq!(group.logical_bytes, 0);
 
     assert_matches_rebuild(&h.driver).await;
 }

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -1,17 +1,24 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
-use aruna_core::keyspaces::{REALM_CONFIG_KEYSPACE, USAGE_STATS_KEYSPACE};
+use aruna_core::keyspaces::{
+    REALM_CONFIG_KEYSPACE, USAGE_NODE_STATS_KEYSPACE, USAGE_STATS_KEYSPACE,
+};
 use aruna_core::structs::{
-    Actor, BucketInfo, NODE_USAGE_DIRTY_GLOBAL_KEY, RealmConfigDocument, RealmId, RealmNodeKind,
-    UsageCounters, node_usage_global_key, usage_global_key_for_group, usage_group_key,
+    Actor, BucketInfo, NODE_USAGE_DIRTY_GLOBAL_KEY, NodeUsageSnapshot, RealmConfigDocument,
+    RealmId, RealmNodeKind, UsageCounters, node_usage_global_key, usage_global_key_for_group,
+    usage_group_key,
 };
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::replicate_documents::{
+    ReplicateDocumentsConfig, ReplicateDocumentsOperation,
+};
 use aruna_operations::s3::create_bucket::CreateBucketOperation;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_operations::usage_stats::{RealmUsageScope, load_realm_usage, publish_usage_snapshots};
@@ -43,6 +50,7 @@ async fn node_usage_snapshot_reaches_peer_realm_aggregate() -> Result<(), Box<dy
     let node_a = &nodes[0];
     let node_b = &nodes[1];
     let group_id = Ulid::new();
+    bootstrap_node_usage_genesis(node_a, node_b, realm_id).await?;
 
     drive(
         CreateBucketOperation::new(
@@ -142,6 +150,7 @@ async fn rich_node_usage_snapshot_ingest_is_counter_neutral()
     let node_a = &nodes[0];
     let node_b = &nodes[1];
     let group_id = Ulid::new();
+    bootstrap_node_usage_genesis(node_a, node_b, realm_id).await?;
 
     // Seed node A's live counters with a full, non-trivial usage total, then let
     // the real publisher distribute it as node-usage snapshot documents.
@@ -296,6 +305,63 @@ async fn write_usage_stat(node: &TestNode, key: Vec<u8>, counters: UsageCounters
     {
         Event::Storage(StorageEvent::WriteResult { .. }) => {}
         other => panic!("unexpected usage stat write event: {other:?}"),
+    }
+}
+
+async fn bootstrap_node_usage_genesis(
+    publisher: &TestNode,
+    subscriber: &TestNode,
+    realm_id: RealmId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let node_id = publisher.net.node_id();
+    let snapshot_key = node_usage_global_key(node_id);
+    let snapshot = NodeUsageSnapshot {
+        node_id,
+        counters: UsageCounters::default(),
+    };
+    match publisher
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Write {
+            key_space: USAGE_NODE_STATS_KEYSPACE.to_string(),
+            key: snapshot_key.clone().into(),
+            value: snapshot.to_bytes()?.into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::WriteResult { .. }) => {}
+        other => return Err(format!("unexpected node usage snapshot write: {other:?}").into()),
+    }
+
+    drive(
+        ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
+            realm_id,
+            local_node_id: node_id,
+            excluded_peers: Vec::new(),
+            documents: vec![DocumentSyncTarget::NodeUsage {
+                realm_id,
+                node_id,
+                group_id: None,
+            }],
+            allow_genesis: true,
+        }),
+        publisher.context.as_ref(),
+    )
+    .await?;
+
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        if read_node_stats(subscriber, snapshot_key.clone())
+            .await
+            .is_some()
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("bootstrap node-usage genesis did not reach peer".into());
+        }
+        sleep(Duration::from_millis(50)).await;
     }
 }
 

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -1,0 +1,267 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::{REALM_CONFIG_KEYSPACE, USAGE_STATS_KEYSPACE};
+use aruna_core::structs::{
+    Actor, BucketInfo, RealmConfigDocument, RealmId, RealmNodeKind, UsageCounters,
+    node_usage_global_key,
+};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::s3::create_bucket::CreateBucketOperation;
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_operations::usage_stats::{RealmUsageScope, load_realm_usage, publish_usage_snapshots};
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use tempfile::TempDir;
+use tokio::time::{Instant, sleep};
+use ulid::Ulid;
+
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+
+struct TestNode {
+    _temp_dir: TempDir,
+    net: NetHandle,
+    context: Arc<DriverContext>,
+}
+
+// Node A's usage counters must become visible in node B's realm-wide aggregate
+// via the real document sync apply path, while B's node-local counter keyspace
+// stays completely untouched by ingest.
+#[tokio::test]
+async fn node_usage_snapshot_reaches_peer_realm_aggregate() -> Result<(), Box<dyn std::error::Error>>
+{
+    let realm_id = RealmId([37u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 2).await?;
+    let node_a = &nodes[0];
+    let node_b = &nodes[1];
+    let group_id = Ulid::new();
+
+    drive(
+        CreateBucketOperation::new(
+            "usage-bucket".to_string(),
+            BucketInfo {
+                group_id,
+                created_at: std::time::SystemTime::now(),
+                created_by: Default::default(),
+                cors_configuration: None,
+            },
+        ),
+        node_a.context.as_ref(),
+    )
+    .await?
+    .unwrap()
+    .unwrap();
+
+    publish_usage_snapshots(
+        node_a.context.as_ref(),
+        node_a.net.node_id(),
+        realm_id,
+        false,
+    )
+    .await?;
+
+    // Node B receives A's snapshots over the sync layer and folds them into the
+    // realm aggregate (global and per-group).
+    let a_snapshot_key = node_usage_global_key(node_a.net.node_id());
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        let received = read_node_stats(node_b, a_snapshot_key.clone())
+            .await
+            .is_some();
+        let global = load_realm_usage(
+            node_b.context.as_ref(),
+            node_b.net.node_id(),
+            RealmUsageScope::Global,
+        )
+        .await
+        .unwrap_or_default();
+        let group = load_realm_usage(
+            node_b.context.as_ref(),
+            node_b.net.node_id(),
+            RealmUsageScope::Group(group_id),
+        )
+        .await
+        .unwrap_or_default();
+        if received && global.buckets == 1 && group.buckets == 1 {
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "node B never observed A's usage snapshot; received={received} global={global:?} group={group:?}"
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    // Realm aggregate on B includes A's bucket even though B created nothing.
+    let realm_global = load_realm_usage(
+        node_b.context.as_ref(),
+        node_b.net.node_id(),
+        RealmUsageScope::Global,
+    )
+    .await?;
+    assert_eq!(realm_global.buckets, 1, "realm global should include A");
+    let realm_group = load_realm_usage(
+        node_b.context.as_ref(),
+        node_b.net.node_id(),
+        RealmUsageScope::Group(group_id),
+    )
+    .await?;
+    assert_eq!(realm_group.buckets, 1, "realm group should include A");
+
+    // Ingest is counter-neutral: B's node-local usage keyspace is untouched.
+    let local_stats = iter_usage_stats(node_b).await;
+    assert!(
+        local_stats.is_empty(),
+        "replication ingest must not write B's node-local usage counters, found {} keys",
+        local_stats.len()
+    );
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+async fn read_node_stats(node: &TestNode, key: Vec<u8>) -> Option<Vec<u8>> {
+    match node
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Read {
+            key_space: aruna_core::keyspaces::USAGE_NODE_STATS_KEYSPACE.to_string(),
+            key: key.into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => value.map(|b| b.to_vec()),
+        other => panic!("unexpected read event: {other:?}"),
+    }
+}
+
+async fn iter_usage_stats(node: &TestNode) -> Vec<UsageCounters> {
+    match node
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Iter {
+            key_space: USAGE_STATS_KEYSPACE.to_string(),
+            prefix: None,
+            start: None,
+            limit: 4096,
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::IterResult { values, .. }) => values
+            .into_iter()
+            .map(|(_, value)| UsageCounters::from_bytes(value.as_ref()).unwrap())
+            .collect(),
+        other => panic!("unexpected iter event: {other:?}"),
+    }
+}
+
+async fn build_realm_nodes(
+    realm_id: &RealmId,
+    count: usize,
+) -> Result<Vec<TestNode>, Box<dyn std::error::Error>> {
+    let mut nodes = Vec::with_capacity(count);
+    for _ in 0..count {
+        nodes.push(spawn_node(*realm_id).await?);
+    }
+
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+
+    install_realm_config(&nodes, realm_id).await?;
+    Ok(nodes)
+}
+
+async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: None,
+        task_handle: Some(task_handle.clone()),
+    });
+
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle).await;
+
+    Ok(TestNode {
+        _temp_dir: temp_dir,
+        net,
+        context,
+    })
+}
+
+async fn install_realm_config(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = RealmConfigDocument::default_for_realm(*realm_id, Vec::new());
+    for node in nodes {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: aruna_core::UserId::nil(*realm_id),
+            realm_id: *realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+
+    Ok(())
+}
+
+async fn shutdown_nodes(nodes: Vec<TestNode>) {
+    for node in nodes {
+        node.net.shutdown().await;
+    }
+}

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -7,7 +7,7 @@ use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{REALM_CONFIG_KEYSPACE, USAGE_STATS_KEYSPACE};
 use aruna_core::structs::{
     Actor, BucketInfo, RealmConfigDocument, RealmId, RealmNodeKind, UsageCounters,
-    node_usage_global_key,
+    node_usage_global_key, usage_global_key_for_group, usage_group_key,
 };
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::driver::{DriverContext, drive};
@@ -125,6 +125,122 @@ async fn node_usage_snapshot_reaches_peer_realm_aggregate() -> Result<(), Box<dy
 
     shutdown_nodes(nodes).await;
     Ok(())
+}
+
+// A snapshot carrying every counter field (objects, blobs, stored/logical bytes)
+// is the real ingest hazard: apply must fold it into node B's realm-wide
+// aggregate (which lives in the node-usage keyspace) while leaving B's live
+// incremental counter keyspace (`USAGE_STATS_KEYSPACE`) completely empty.
+#[tokio::test]
+async fn rich_node_usage_snapshot_ingest_is_counter_neutral()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([41u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 2).await?;
+    let node_a = &nodes[0];
+    let node_b = &nodes[1];
+    let group_id = Ulid::new();
+
+    // Seed node A's live counters with a full, non-trivial usage total, then let
+    // the real publisher distribute it as node-usage snapshot documents.
+    let rich = UsageCounters {
+        buckets: 2,
+        objects: 5,
+        stored_blobs: 3,
+        stored_bytes: 4096,
+        logical_bytes: 8192,
+    };
+    write_usage_stat(node_a, usage_global_key_for_group(group_id), rich).await;
+    write_usage_stat(node_a, usage_group_key(group_id), rich).await;
+
+    publish_usage_snapshots(
+        node_a.context.as_ref(),
+        node_a.net.node_id(),
+        realm_id,
+        true,
+    )
+    .await?;
+
+    let a_snapshot_key = node_usage_global_key(node_a.net.node_id());
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        let received = read_node_stats(node_b, a_snapshot_key.clone())
+            .await
+            .is_some();
+        let global = load_realm_usage(
+            node_b.context.as_ref(),
+            node_b.net.node_id(),
+            RealmUsageScope::Global,
+        )
+        .await
+        .unwrap_or_default();
+        let group = load_realm_usage(
+            node_b.context.as_ref(),
+            node_b.net.node_id(),
+            RealmUsageScope::Group(group_id),
+        )
+        .await
+        .unwrap_or_default();
+        if received && global.objects == rich.objects && group.objects == rich.objects {
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "node B never observed A's rich usage snapshot; received={received} global={global:?} group={group:?}"
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    // Every field of A's snapshot surfaces in B's realm aggregate.
+    let realm_global = load_realm_usage(
+        node_b.context.as_ref(),
+        node_b.net.node_id(),
+        RealmUsageScope::Global,
+    )
+    .await?;
+    assert_eq!(
+        realm_global, rich,
+        "realm global aggregate must equal A's snapshot"
+    );
+    let realm_group = load_realm_usage(
+        node_b.context.as_ref(),
+        node_b.net.node_id(),
+        RealmUsageScope::Group(group_id),
+    )
+    .await?;
+    assert_eq!(
+        realm_group, rich,
+        "realm group aggregate must equal A's snapshot"
+    );
+
+    // Ingest never wrote a single live incremental counter on B.
+    let local_stats = iter_usage_stats(node_b).await;
+    assert!(
+        local_stats.is_empty(),
+        "counter-bearing snapshot ingest must not touch B's live counter keyspace, found {} keys",
+        local_stats.len()
+    );
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+async fn write_usage_stat(node: &TestNode, key: Vec<u8>, counters: UsageCounters) {
+    match node
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Write {
+            key_space: USAGE_STATS_KEYSPACE.to_string(),
+            key: key.into(),
+            value: counters.to_bytes().unwrap().into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::WriteResult { .. }) => {}
+        other => panic!("unexpected usage stat write event: {other:?}"),
+    }
 }
 
 async fn read_node_stats(node: &TestNode, key: Vec<u8>) -> Option<Vec<u8>> {

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -6,8 +6,8 @@ use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{REALM_CONFIG_KEYSPACE, USAGE_STATS_KEYSPACE};
 use aruna_core::structs::{
-    Actor, BucketInfo, RealmConfigDocument, RealmId, RealmNodeKind, UsageCounters,
-    node_usage_global_key, usage_global_key_for_group, usage_group_key,
+    Actor, BucketInfo, NODE_USAGE_DIRTY_GLOBAL_KEY, RealmConfigDocument, RealmId, RealmNodeKind,
+    UsageCounters, node_usage_global_key, usage_global_key_for_group, usage_group_key,
 };
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::driver::{DriverContext, drive};
@@ -22,6 +22,9 @@ use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
 const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+// Comfortably above the durable re-arm interval (5s) plus the publish debounce
+// (2s) so the steady-state publish is observed without flaking.
+const STEADY_STATE_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -221,6 +224,59 @@ async fn rich_node_usage_snapshot_ingest_is_counter_neutral()
         "counter-bearing snapshot ingest must not touch B's live counter keyspace, found {} keys",
         local_stats.len()
     );
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+// A steady-state counter write on a long-running node (no restart) must lead to
+// a published node-usage snapshot within a bounded window. The only thing that
+// turns a durable dirty marker into a publish during steady state is the durable
+// re-arm loop, so this proves that loop closes the gap the marker write leaves.
+#[tokio::test]
+async fn steady_state_write_publishes_snapshot_without_restart()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([53u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 1).await?;
+    let node = &nodes[0];
+    let group_id = Ulid::new();
+
+    // A normal write commit updates counters and stamps dirty markers, but never
+    // schedules a publish itself and never restarts the node.
+    drive(
+        CreateBucketOperation::new(
+            "steady-bucket".to_string(),
+            BucketInfo {
+                group_id,
+                created_at: std::time::SystemTime::now(),
+                created_by: Default::default(),
+                cors_configuration: None,
+            },
+        ),
+        node.context.as_ref(),
+    )
+    .await?
+    .unwrap()
+    .unwrap();
+
+    let snapshot_key = node_usage_global_key(node.net.node_id());
+    let deadline = Instant::now() + STEADY_STATE_TIMEOUT;
+    loop {
+        let published = read_node_stats(node, snapshot_key.clone()).await.is_some();
+        let dirty_cleared = read_node_stats(node, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+            .await
+            .is_none();
+        if published && dirty_cleared {
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "steady-state write never published a snapshot; published={published} dirty_cleared={dirty_cleared}"
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
 
     shutdown_nodes(nodes).await;
     Ok(())


### PR DESCRIPTION
This PR extends the usage accounting feature: quota configuration as realm-replicated admin policy with admin endpoints, distribution of per-node usage counters over the sync layer with realm-wide aggregation, and a hard per-group byte quota gate on the S3 write paths. Includes the delta-test suite required by the issue.

## Changes

- Adds `max_devices_per_user` to `QuotaConfig` as stored configuration for the device cap.
- Adds a `RealmConfigQuotaSet` admin document operation with reducer and overlay materialization so quota changes replicate, and fixes peers resetting quota to defaults when rebuilding realm config from reducer state.
- Adds `SetRealmQuotaOperation` validating the warn threshold (1-100), global and per-override grace factors (>= 100), and duplicate group or user overrides.
- Adds admin-gated `PUT /api/v1/info/realm/quota` (realm admin on a management node, replace semantics) and exposes quota in `GET /api/v1/info/realm`.
- Materializes locally written quota from reducer state so conflicted quota paths behave identically on the local write and replicated overlay paths.
- Adds `NodeUsageSnapshot` documents in a new `usage_node_stats` keyspace, keyed per node for global counters and group-first for per-group counters.
- Adds `DocumentSyncTarget::NodeUsage` replicating snapshots over one shared realm-scoped topic.
- Publishes snapshots through a debounced single-flight task: generation-stamped dirty markers written inside the counter transactions, a 2s debounce with a 5s durable rearm poll, and a full publish at startup after counter rebuild.
- Clears dirty markers only after successful replication using compare-delete so concurrent writes and failed publishes never lose their retry signal.
- Publishes zero snapshots for groups whose counters were pruned so stale remote per-group data converges.
- Validates snapshot ingest cryptographically: only the keyholder of a node id can publish snapshots stored under that node's keys, and forged or malformed events of any kind are skipped without wedging the reconcile cursor.
- Maintains a summed realm usage cache refreshed from all inbound and outbound reconcile handlers.
- Extends `GET /api/v1/info/usage` and `GET /api/v1/groups/{id}/usage` with realm-wide totals; the realm section requires authentication while node-local fields keep their existing behavior.
- Adds an embeddable `QuotaGate` enforcing per-group byte quotas inside the object put and multipart completion write transactions, summing live local counters and remote group snapshots.
- Resolves the effective ceiling at the S3 surface as group override or default quota times the grace factor; no configured quota means no gate, and config load failures fail closed.
- Rejects only writes that would exceed the grace ceiling with S3 403 `QuotaExceeded`; deletes, aborts, and zero-length writes are never gated.
- Cleans up rejected writes: object put aborts the transaction and deletes the orphaned blob, and multipart completion aborts the open finalize transaction before resetting the upload, which also closes a pre-existing transaction leak on finalize errors.
- Adds delta tests for every write path (overwrite, delete markers, put over a delete marker, aborted multipart, content dedup) with a rebuild oracle asserting incremental counters match a full recount after every scenario.
- Adds replication tests for cross-node aggregation, counter-neutral ingest of counter-bearing snapshots, and steady-state publishing without restart.
- Adds NodeUsage targets to the doctor explorer json output.

## GitHub Issues

- Completes #249: quota configuration lives in the realm config as replicated admin policy with API endpoints, per-node and per-group counters distribute over the sync layer with a summed local cache, and the issue's test concept (per-write-path delta tests, explicit replication-ingest neutrality) is implemented.
- Partially addresses #250 by landing the hard enforcement gate that rejects writes above the grace ceiling. This PR does not add warning notifications, hysteresis, usage history snapshots, portal UI, or the periodic recount task.
- Device cap enforcement is intentionally out: no flow creates user-device nodes yet and `RealmNode` carries no ownership, so enforcement is blocked on #271. The config field is stored for it.

## Notes

- Counters on remote nodes are stale by design (roughly 2-7s publish latency); the grace headroom is the documented budget for that staleness.
- Snapshot admission binds the publishing node's identity, not group membership: a node can still misreport its own counters, which now has enforcement consequences. Follow-up for #250/#265.
- Snapshots of departed nodes linger in `usage_node_stats` and keep counting toward realm totals; cleanup belongs to dead-node handling in #265.
- Known follow-ups: the gate's in-transaction remote scan adds a commit-conflict source on hot puts, per-request realm config reads could take a short-TTL cache, and the quota overlay clause exists in two places and should get one canonical helper in core.