### PR TITLE
Feat/public access: Anonymous read-only access via public roles

### DIFF
--- a/api/src/routes/drs.rs
+++ b/api/src/routes/drs.rs
@@ -263,7 +263,7 @@ pub async fn get_object(
     headers: HeaderMap,
     Path(object_id): Path<String>,
 ) -> Response {
-    let auth = match require_drs_auth(state.as_ref(), auth) {
+    let auth = match drs_auth_or_anonymous(state.as_ref(), auth) {
         Ok(auth) => auth,
         Err(error) => return error.into_response(),
     };
@@ -294,7 +294,7 @@ pub async fn post_objects(
     headers: HeaderMap,
     Json(body): Json<DrsBulkObjectsRequestBody>,
 ) -> Response {
-    let auth = match require_drs_auth(state.as_ref(), auth) {
+    let auth = match drs_auth_or_anonymous(state.as_ref(), auth) {
         Ok(auth) => auth,
         Err(error) => return error.into_response(),
     };
@@ -333,7 +333,7 @@ pub async fn download_object(
     Extension(auth): Extension<Option<AuthContext>>,
     Query(query): Query<DownloadQuery>,
 ) -> Response {
-    let Ok(auth) = require_realm_auth(state.as_ref(), auth) else {
+    let Ok(auth) = drs_auth_or_anonymous(state.as_ref(), auth) else {
         return drs_error(StatusCode::NOT_FOUND, "DRS object not found");
     };
     let resolved = match resolve_object(state.as_ref(), &auth, &query.object_id).await {
@@ -450,6 +450,19 @@ fn require_drs_auth(
     auth: Option<AuthContext>,
 ) -> Result<AuthContext, DrsError> {
     require_realm_auth(state, auth).map_err(|_| DrsError::forbidden("Forbidden"))
+}
+
+/// Requests without a bearer token resolve as the Everyone principal — public
+/// roles are then the only grants that can make an object readable, so private
+/// data keeps returning 403/404 exactly as before.
+fn drs_auth_or_anonymous(
+    state: &ServerState,
+    auth: Option<AuthContext>,
+) -> Result<AuthContext, DrsError> {
+    match auth {
+        Some(_) => require_drs_auth(state, auth),
+        None => Ok(AuthContext::anonymous(state.get_realm_id())),
+    }
 }
 
 async fn resolve_object(

--- a/api/src/routes/drs.rs
+++ b/api/src/routes/drs.rs
@@ -263,6 +263,7 @@ pub async fn get_object(
     headers: HeaderMap,
     Path(object_id): Path<String>,
 ) -> Response {
+    let anonymous = auth.is_none();
     let auth = match drs_auth_or_anonymous(state.as_ref(), auth) {
         Ok(auth) => auth,
         Err(error) => return error.into_response(),
@@ -272,7 +273,7 @@ pub async fn get_object(
         Ok(ResolveOutcome::Found(resolved)) => {
             drs_json_response(StatusCode::OK, build_object_response(&headers, &resolved))
         }
-        Ok(ResolveOutcome::Denied) => DrsError::forbidden("Forbidden").into_response(),
+        Ok(ResolveOutcome::Denied) => drs_denied_error(anonymous).into_response(),
         Ok(ResolveOutcome::NotFound) => DrsError::not_found("DRS object not found").into_response(),
         Err(error) => error.into_response(),
     }
@@ -294,6 +295,7 @@ pub async fn post_objects(
     headers: HeaderMap,
     Json(body): Json<DrsBulkObjectsRequestBody>,
 ) -> Response {
+    let anonymous = auth.is_none();
     let auth = match drs_auth_or_anonymous(state.as_ref(), auth) {
         Ok(auth) => auth,
         Err(error) => return error.into_response(),
@@ -306,7 +308,10 @@ pub async fn post_objects(
                 &headers, &resolved,
             ))
             .unwrap_or_else(|_| json!({ "status_code": 500, "msg": "serialization failed" })),
-            Ok(ResolveOutcome::Denied) => json!({ "status_code": 403, "msg": "Forbidden" }),
+            Ok(ResolveOutcome::Denied) => {
+                let error = drs_denied_error(anonymous);
+                json!({ "status_code": error.status.as_u16(), "msg": error.message })
+            }
             Ok(ResolveOutcome::NotFound) => {
                 json!({ "status_code": 404, "msg": "DRS object not found" })
             }
@@ -333,12 +338,13 @@ pub async fn download_object(
     Extension(auth): Extension<Option<AuthContext>>,
     Query(query): Query<DownloadQuery>,
 ) -> Response {
+    let anonymous = auth.is_none();
     let Ok(auth) = drs_auth_or_anonymous(state.as_ref(), auth) else {
         return drs_error(StatusCode::NOT_FOUND, "DRS object not found");
     };
     let resolved = match resolve_object(state.as_ref(), &auth, &query.object_id).await {
         Ok(ResolveOutcome::Found(resolved)) => resolved,
-        Ok(ResolveOutcome::Denied) => return DrsError::forbidden("Forbidden").into_response(),
+        Ok(ResolveOutcome::Denied) => return drs_denied_error(anonymous).into_response(),
         Ok(ResolveOutcome::NotFound) => {
             return DrsError::not_found("DRS object not found").into_response();
         }
@@ -452,9 +458,9 @@ fn require_drs_auth(
     require_realm_auth(state, auth).map_err(|_| DrsError::forbidden("Forbidden"))
 }
 
-/// Requests without a bearer token resolve as the Everyone principal — public
-/// roles are then the only grants that can make an object readable, so private
-/// data keeps returning 403/404 exactly as before.
+/// Requests without a bearer token resolve as the Everyone principal. Public
+/// roles are then the only grants that can make an object readable; denied
+/// anonymous lookups are mapped to 404 at the route layer.
 fn drs_auth_or_anonymous(
     state: &ServerState,
     auth: Option<AuthContext>,
@@ -462,6 +468,14 @@ fn drs_auth_or_anonymous(
     match auth {
         Some(_) => require_drs_auth(state, auth),
         None => Ok(AuthContext::anonymous(state.get_realm_id())),
+    }
+}
+
+fn drs_denied_error(anonymous: bool) -> DrsError {
+    if anonymous {
+        DrsError::not_found("DRS object not found")
+    } else {
+        DrsError::forbidden("Forbidden")
     }
 }
 
@@ -706,7 +720,7 @@ impl IntoResponse for DrsError {
 mod tests {
     use super::{
         RequestedObjectId, ResolvedObject, W3ID_DATA_PREFIX, build_object_response,
-        encode_component, parse_requested_object_id,
+        drs_denied_error, encode_component, parse_requested_object_id,
     };
     use crate::openapi::ApiDoc;
     use aruna_core::structs::{BackendLocation, RealmId, SourceMetadata};
@@ -754,6 +768,17 @@ mod tests {
     fn test_node_id() -> NodeId {
         NodeId::from_str("ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6")
             .unwrap()
+    }
+
+    #[test]
+    fn anonymous_drs_denied_error_matches_unknown_object() {
+        let anonymous = drs_denied_error(true);
+        assert_eq!(anonymous.status, axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(anonymous.message, "DRS object not found");
+
+        let authenticated = drs_denied_error(false);
+        assert_eq!(authenticated.status, axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(authenticated.message, "Forbidden");
     }
 
     #[test]

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -3,7 +3,8 @@ use crate::server_state::ServerState;
 use aruna_core::UserId;
 use aruna_core::errors::{AuthorizationError, StorageError};
 use aruna_core::structs::{
-    Actor, AuthContext, Group, GroupAuthorizationDocument, Permission, Role, usage_group_key,
+    Actor, AuthContext, Group, GroupAuthorizationDocument, Permission, RealmId, Role,
+    usage_group_key,
 };
 use aruna_core::types::RoleId;
 use aruna_operations::add_group_role::{
@@ -210,14 +211,15 @@ pub struct GroupInfoResponse {
     pub roles: Vec<RoleResponse>,
 }
 
-fn map_roles(auth: GroupAuthorizationDocument) -> Vec<RoleResponse> {
-    map_roles_with_visibility(auth, true)
+fn map_roles(auth: GroupAuthorizationDocument, realm_id: RealmId) -> Vec<RoleResponse> {
+    map_roles_with_visibility(auth, realm_id, true)
 }
 
 /// Member lists are only visible to group members; open endpoints get the
 /// roles without `assigned_users`.
 fn map_roles_with_visibility(
     auth: GroupAuthorizationDocument,
+    realm_id: RealmId,
     include_members: bool,
 ) -> Vec<RoleResponse> {
     auth.roles
@@ -230,12 +232,12 @@ fn map_roles_with_visibility(
                 .iter()
                 .map(|(k, v)| (k.clone(), v.to_string()))
                 .collect(),
-            public: role.is_public(),
+            public: role.is_public(realm_id),
             // The Everyone principal is surfaced via `public`, not as a member.
             assigned_users: include_members.then(|| {
                 role.assigned_users
                     .iter()
-                    .filter(|u| !u.user_ulid.is_nil())
+                    .filter(|u| !u.is_nil())
                     .map(|u| u.to_string())
                     .collect()
             }),
@@ -244,6 +246,10 @@ fn map_roles_with_visibility(
 }
 
 fn is_group_member(auth_doc: &GroupAuthorizationDocument, user_id: UserId) -> bool {
+    if user_id.is_nil() {
+        return false;
+    }
+
     auth_doc
         .roles
         .values()
@@ -260,6 +266,14 @@ fn parse_role_id(role_id: &str) -> ServerResult<RoleId> {
 
 fn parse_user_id(user_id: &str) -> ServerResult<UserId> {
     UserId::from_string(user_id).map_err(|_| ServerError::BadRequest)
+}
+
+fn parse_member_user_id(user_id: &str) -> ServerResult<UserId> {
+    let user_id = parse_user_id(user_id)?;
+    if user_id.is_nil() {
+        return Err(ServerError::BadRequest);
+    }
+    Ok(user_id)
 }
 
 /// Write endpoints mint their permission checks from the caller identity, so
@@ -305,7 +319,7 @@ impl From<(Group, GroupAuthorizationDocument)> for CreateGroupResponse {
             display_name: group.display_name,
             group_id: group.group_id.to_string(),
             realm_id: group.realm_id.to_string(),
-            roles: map_roles(auth),
+            roles: map_roles(auth, group.realm_id),
         }
     }
 }
@@ -316,7 +330,7 @@ impl From<(Group, GroupAuthorizationDocument)> for GroupInfoResponse {
             display_name: group.display_name,
             group_id: group.group_id.to_string(),
             realm_id: group.realm_id.to_string(),
-            roles: map_roles(auth),
+            roles: map_roles(auth, group.realm_id),
         }
     }
 }
@@ -502,7 +516,11 @@ async fn build_api_groups(
             .await
             .map_err(|err| ServerError::InternalError(err.to_string()))?;
             let is_member = is_group_member(&auth_doc, caller);
-            Some(map_roles_with_visibility(auth_doc, is_member))
+            Some(map_roles_with_visibility(
+                auth_doc,
+                group.realm_id,
+                is_member,
+            ))
         } else {
             None
         };
@@ -544,7 +562,7 @@ pub async fn get_group(
             display_name: group.display_name,
             group_id: group.group_id.to_string(),
             realm_id: group.realm_id.to_string(),
-            roles: map_roles_with_visibility(auth_doc, is_member),
+            roles: map_roles_with_visibility(auth_doc, group.realm_id, is_member),
         }),
     ))
 }
@@ -552,6 +570,7 @@ pub async fn get_group(
 fn map_add_member_error(error: AddUserToGroupError) -> ServerError {
     match error {
         AddUserToGroupError::Unauthorized => ServerError::Forbidden,
+        AddUserToGroupError::InvalidUserId => ServerError::BadRequest,
         AddUserToGroupError::RoleNotFound | AddUserToGroupError::AuthDocNotFound => {
             ServerError::NotFound
         }
@@ -562,6 +581,9 @@ fn map_add_member_error(error: AddUserToGroupError) -> ServerError {
 fn map_add_role_error(error: AddGroupRoleError) -> ServerError {
     match error {
         AddGroupRoleError::Unauthorized => ServerError::Forbidden,
+        AddGroupRoleError::InvalidPublicRole | AddGroupRoleError::InvalidAssignedUser => {
+            ServerError::BadRequest
+        }
         AddGroupRoleError::GroupNotFound => ServerError::NotFound,
         AddGroupRoleError::CheckPermissionsError(
             AuthorizationError::GroupNotFound | AuthorizationError::AuthDocNotFound,
@@ -573,6 +595,7 @@ fn map_add_role_error(error: AddGroupRoleError) -> ServerError {
 fn map_remove_member_error(error: RemoveUserFromGroupError) -> ServerError {
     match error {
         RemoveUserFromGroupError::Unauthorized => ServerError::Forbidden,
+        RemoveUserFromGroupError::InvalidUserId => ServerError::BadRequest,
         RemoveUserFromGroupError::RoleNotFound | RemoveUserFromGroupError::AuthDocNotFound => {
             ServerError::NotFound
         }
@@ -664,6 +687,9 @@ pub async fn list_group_members(
     let mut members: HashMap<String, Vec<GroupMemberRoleResponse>> = HashMap::new();
     for (role_id, role) in &auth_doc.roles {
         for user in &role.assigned_users {
+            if user.is_nil() {
+                continue;
+            }
             members
                 .entry(user.to_string())
                 .or_default()
@@ -708,7 +734,7 @@ pub async fn add_group_member(
 ) -> ServerResult<(StatusCode, Json<GroupRolesResponse>)> {
     let auth = require_unrestricted(auth)?;
     let group_id = parse_group_id(&group_id)?;
-    let user_id = parse_user_id(&request.user_id)?;
+    let user_id = parse_member_user_id(&request.user_id)?;
 
     let role_ids: HashSet<Ulid> = match &request.role_ids {
         Some(role_ids) if !role_ids.is_empty() => role_ids
@@ -747,7 +773,7 @@ pub async fn add_group_member(
     Ok((
         StatusCode::CREATED,
         Json(GroupRolesResponse {
-            roles: map_roles(auth_doc),
+            roles: map_roles(auth_doc, state.get_realm_id()),
         }),
     ))
 }
@@ -778,7 +804,7 @@ pub async fn remove_group_member(
 ) -> ServerResult<StatusCode> {
     let auth = require_unrestricted(auth)?;
     let group_id = parse_group_id(&group_id)?;
-    let user_id = parse_user_id(&user_id)?;
+    let user_id = parse_member_user_id(&user_id)?;
     let role_ids = query
         .role_id
         .as_deref()
@@ -881,11 +907,18 @@ pub async fn create_group_role(
         };
         permissions.insert(path.clone(), permission);
     }
+    if request.public
+        && permissions
+            .values()
+            .any(|permission| permission != &Permission::READ)
+    {
+        return Err(ServerError::BadRequest);
+    }
 
     let mut assigned_users = request
         .assigned_users
         .iter()
-        .map(|user_id| parse_user_id(user_id))
+        .map(|user_id| parse_member_user_id(user_id))
         .collect::<ServerResult<HashSet<UserId>>>()?;
     if request.public {
         assigned_users.insert(UserId::nil(realm_id));
@@ -910,7 +943,7 @@ pub async fn create_group_role(
     .await
     .map_err(map_add_role_error)?;
 
-    let role = map_roles(auth_doc)
+    let role = map_roles(auth_doc, realm_id)
         .into_iter()
         .find(|role| role.role_id == role_id.to_string())
         .ok_or_else(|| ServerError::InternalError("created role missing".to_string()))?;

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -93,6 +93,10 @@ pub struct RoleResponse {
     /// Only present when the caller is a member of the group.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assigned_users: Option<Vec<String>>,
+    /// True when the role applies to every principal, including anonymous
+    /// requests (it is assigned to the Everyone principal).
+    #[serde(default)]
+    pub public: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -123,6 +127,10 @@ pub struct CreateGroupRoleRequest {
     pub permissions: HashMap<String, String>,
     #[serde(default)]
     pub assigned_users: Vec<String>,
+    /// Public roles apply to every principal — including anonymous requests —
+    /// by assigning the Everyone principal (the nil user id).
+    #[serde(default)]
+    pub public: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -216,14 +224,21 @@ fn map_roles_with_visibility(
         .into_iter()
         .map(|(role_id, role)| RoleResponse {
             role_id: role_id.to_string(),
-            name: role.name,
+            name: role.name.clone(),
             permissions: role
                 .permissions
                 .iter()
                 .map(|(k, v)| (k.clone(), v.to_string()))
                 .collect(),
-            assigned_users: include_members
-                .then(|| role.assigned_users.iter().map(|u| u.to_string()).collect()),
+            public: role.is_public(),
+            // The Everyone principal is surfaced via `public`, not as a member.
+            assigned_users: include_members.then(|| {
+                role.assigned_users
+                    .iter()
+                    .filter(|u| !u.user_ulid.is_nil())
+                    .map(|u| u.to_string())
+                    .collect()
+            }),
         })
         .collect()
 }
@@ -867,11 +882,14 @@ pub async fn create_group_role(
         permissions.insert(path.clone(), permission);
     }
 
-    let assigned_users = request
+    let mut assigned_users = request
         .assigned_users
         .iter()
         .map(|user_id| parse_user_id(user_id))
         .collect::<ServerResult<HashSet<UserId>>>()?;
+    if request.public {
+        assigned_users.insert(UserId::nil(realm_id));
+    }
 
     let role_id = Ulid::new();
     let (_, auth_doc) = drive(

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -86,17 +86,13 @@ impl S3Access for AuthProvider {
             Action::Write => Permission::WRITE,
         };
 
-        let path = self
+        let (path, auth_context) = self
             .build_authorization_path(cx, &user_access, &action)
             .await?;
 
         let allowed = drive(
             CheckPermissionsOperation::new(CheckPermissionsConfig {
-                auth_context: AuthContext {
-                    user_id: user_access.user_identity,
-                    realm_id: user_access.user_identity.realm_id,
-                    path_restrictions: user_access.path_restrictions.clone(),
-                },
+                auth_context,
                 path,
                 required_permission,
             }),
@@ -212,19 +208,30 @@ impl AuthProvider {
         cx: &mut S3AccessContext<'_>,
         user_access: &UserAccess,
         action: &Action,
-    ) -> S3Result<String> {
+    ) -> S3Result<(String, AuthContext)> {
+        let mut auth_context = AuthContext {
+            user_id: user_access.user_identity,
+            realm_id: user_access.user_identity.realm_id,
+            path_restrictions: user_access.path_restrictions.clone(),
+        };
         let Some(bucket) = cx.s3_path().get_bucket_name().map(str::to_owned) else {
-            return Ok(self.group_data_path(user_access.group_id));
+            return Ok((self.group_data_path(user_access.group_id), auth_context));
         };
         let key = cx.s3_path().get_object_key().map(str::to_owned);
 
         let group_id = match self.find_bucket_info(&bucket).await? {
             Some(bucket_info) => {
-                if bucket_info.group_id != user_access.group_id && !matches!(action, Action::Read) {
-                    return Err(s3_error!(
-                        AccessDenied,
-                        "Bucket belongs to a different group"
-                    ));
+                if bucket_info.group_id != user_access.group_id {
+                    if !matches!(action, Action::Read)
+                        || !is_anonymous_object_read_operation(cx.s3_op().name())
+                        || key.is_none()
+                    {
+                        return Err(s3_error!(
+                            AccessDenied,
+                            "Bucket belongs to a different group"
+                        ));
+                    }
+                    auth_context = AuthContext::anonymous(self.realm_id);
                 }
                 cx.extensions_mut().insert(bucket_info.clone());
                 bucket_info.group_id
@@ -238,12 +245,19 @@ impl AuthProvider {
             }
         };
 
-        Ok(match key {
-            Some(key) => {
-                blob_object_permission_path(self.realm_id, group_id, self.node_id, &bucket, &key)
-            }
-            None => blob_bucket_permission_path(self.realm_id, group_id, self.node_id, &bucket),
-        })
+        Ok((
+            match key {
+                Some(key) => blob_object_permission_path(
+                    self.realm_id,
+                    group_id,
+                    self.node_id,
+                    &bucket,
+                    &key,
+                ),
+                None => blob_bucket_permission_path(self.realm_id, group_id, self.node_id, &bucket),
+            },
+            auth_context,
+        ))
     }
 
     fn group_data_path(&self, group_id: ulid::Ulid) -> String {

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -81,12 +81,14 @@ impl S3Access for AuthProvider {
             return Err(s3_error!(AccessDenied, "Credential has expired"));
         }
 
-        let required_permission = match action {
+        let required_permission = match &action {
             Action::Read => Permission::READ,
             Action::Write => Permission::WRITE,
         };
 
-        let path = self.build_authorization_path(cx, &user_access).await?;
+        let path = self
+            .build_authorization_path(cx, &user_access, &action)
+            .await?;
 
         let allowed = drive(
             CheckPermissionsOperation::new(CheckPermissionsConfig {
@@ -209,6 +211,7 @@ impl AuthProvider {
         &self,
         cx: &mut S3AccessContext<'_>,
         user_access: &UserAccess,
+        action: &Action,
     ) -> S3Result<String> {
         let Some(bucket) = cx.s3_path().get_bucket_name().map(str::to_owned) else {
             return Ok(self.group_data_path(user_access.group_id));
@@ -217,7 +220,7 @@ impl AuthProvider {
 
         let group_id = match self.find_bucket_info(&bucket).await? {
             Some(bucket_info) => {
-                if bucket_info.group_id != user_access.group_id {
+                if bucket_info.group_id != user_access.group_id && !matches!(action, Action::Read) {
                     return Err(s3_error!(
                         AccessDenied,
                         "Bucket belongs to a different group"

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -1,4 +1,4 @@
-use super::util::get_s3_operation_permission;
+use super::util::{get_s3_operation_permission, is_anonymous_object_read_operation};
 use aruna_core::structs::{
     AuthContext, BucketInfo, Permission, RealmId, UserAccess, blob_bucket_permission_path,
     blob_group_permission_path, blob_object_permission_path,
@@ -59,8 +59,8 @@ impl S3Access for AuthProvider {
         let action = get_s3_operation_permission(cx.s3_op().name())
             .ok_or_else(|| s3_error!(InvalidRequest, "Unknown Operation"))?;
 
-        // Unsigned requests are checked as the Everyone principal: read-only,
-        // and only where a public role grants READ.
+        // Unsigned requests are checked as the Everyone principal, but only for
+        // the public object-byte read surface.
         let access_key_id = match cx.credentials() {
             Some(credentials) => credentials.access_key.clone(),
             None => return self.check_anonymous(cx, action).await,
@@ -113,36 +113,36 @@ impl S3Access for AuthProvider {
 }
 
 impl AuthProvider {
-    /// Anonymous access: read-only, addressed to a concrete bucket (never the
-    /// account-level ops like ListBuckets), and allowed only when a public
-    /// role — one assigned to the Everyone principal — grants READ on the
-    /// bucket/object permission path. The bucket's own group scopes that path,
-    /// so the authenticated flow's group-ownership check has no analogue here.
+    /// Anonymous access: object bytes only, addressed to a concrete object, and
+    /// allowed only when a public role — one assigned to the Everyone principal
+    /// — grants READ on the object permission path. The bucket's own group
+    /// scopes that path, so the authenticated flow's group-ownership check has
+    /// no analogue here.
     async fn check_anonymous(&self, cx: &mut S3AccessContext<'_>, action: Action) -> S3Result<()> {
-        if !matches!(action, Action::Read) {
-            return Err(s3_error!(AccessDenied, "Anonymous requests are read-only"));
-        }
-        let Some(bucket) = cx.s3_path().get_bucket_name().map(str::to_owned) else {
+        if !matches!(action, Action::Read) || !is_anonymous_object_read_operation(cx.s3_op().name())
+        {
             return Err(s3_error!(
                 AccessDenied,
-                "Anonymous requests must address a bucket"
+                "Anonymous access is limited to object reads"
+            ));
+        }
+        let Some((bucket, key)) = cx
+            .s3_path()
+            .as_object()
+            .map(|(bucket, key)| (bucket.to_owned(), key.to_owned()))
+        else {
+            return Err(s3_error!(
+                AccessDenied,
+                "Anonymous requests must address an object"
             ));
         };
-        let key = cx.s3_path().get_object_key().map(str::to_owned);
         let Some(bucket_info) = self.find_bucket_info(&bucket).await? else {
-            return Err(s3_error!(
-                NoSuchBucket,
-                "The specified bucket does not exist."
-            ));
+            return Err(s3_error!(AccessDenied, "Permission denied"));
         };
         let group_id = bucket_info.group_id;
 
-        let path = match &key {
-            Some(key) => {
-                blob_object_permission_path(self.realm_id, group_id, self.node_id, &bucket, key)
-            }
-            None => blob_bucket_permission_path(self.realm_id, group_id, self.node_id, &bucket),
-        };
+        let path =
+            blob_object_permission_path(self.realm_id, group_id, self.node_id, &bucket, &key);
 
         let allowed = drive(
             CheckPermissionsOperation::new(CheckPermissionsConfig {

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -1,9 +1,9 @@
 use super::util::get_s3_operation_permission;
-use aruna_core::NodeId;
 use aruna_core::structs::{
     AuthContext, BucketInfo, Permission, RealmId, UserAccess, blob_bucket_permission_path,
     blob_group_permission_path, blob_object_permission_path,
 };
+use aruna_core::{NodeId, UserId};
 use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::s3::get_bucket_info::{GetBucketInfoError, GetBucketInfoOperation};
@@ -59,15 +59,15 @@ impl S3Access for AuthProvider {
         let action = get_s3_operation_permission(cx.s3_op().name())
             .ok_or_else(|| s3_error!(InvalidRequest, "Unknown Operation"))?;
 
+        // Unsigned requests are checked as the Everyone principal: read-only,
+        // and only where a public role grants READ.
+        let access_key_id = match cx.credentials() {
+            Some(credentials) => credentials.access_key.clone(),
+            None => return self.check_anonymous(cx, action).await,
+        };
+
         // Fetch user access -> GetUserAccess state machine
-        let access_key_id = &cx
-            .credentials()
-            .ok_or(s3_error!(
-                AccessDenied,
-                "Credentials missing in access context"
-            ))?
-            .access_key;
-        let user_access = self.query_user_access(access_key_id).await?;
+        let user_access = self.query_user_access(&access_key_id).await?;
 
         if user_access.issued_by != *self.node_id.as_bytes() {
             return Err(s3_error!(InvalidAccessKeyId, "Credential issuer mismatch"));
@@ -113,6 +113,70 @@ impl S3Access for AuthProvider {
 }
 
 impl AuthProvider {
+    /// Anonymous access: read-only, addressed to a concrete bucket (never the
+    /// account-level ops like ListBuckets), and allowed only when a public
+    /// role — one assigned to the Everyone principal — grants READ on the
+    /// bucket/object permission path. The bucket's own group scopes that path,
+    /// so the authenticated flow's group-ownership check has no analogue here.
+    async fn check_anonymous(&self, cx: &mut S3AccessContext<'_>, action: Action) -> S3Result<()> {
+        if !matches!(action, Action::Read) {
+            return Err(s3_error!(AccessDenied, "Anonymous requests are read-only"));
+        }
+        let Some(bucket) = cx.s3_path().get_bucket_name().map(str::to_owned) else {
+            return Err(s3_error!(
+                AccessDenied,
+                "Anonymous requests must address a bucket"
+            ));
+        };
+        let key = cx.s3_path().get_object_key().map(str::to_owned);
+        let Some(bucket_info) = self.find_bucket_info(&bucket).await? else {
+            return Err(s3_error!(
+                NoSuchBucket,
+                "The specified bucket does not exist."
+            ));
+        };
+        let group_id = bucket_info.group_id;
+
+        let path = match &key {
+            Some(key) => {
+                blob_object_permission_path(self.realm_id, group_id, self.node_id, &bucket, key)
+            }
+            None => blob_bucket_permission_path(self.realm_id, group_id, self.node_id, &bucket),
+        };
+
+        let allowed = drive(
+            CheckPermissionsOperation::new(CheckPermissionsConfig {
+                auth_context: AuthContext::anonymous(self.realm_id),
+                path,
+                required_permission: Permission::READ,
+            }),
+            self.driver_ctx.as_ref(),
+        )
+        .await
+        .map_err(|_| s3_error!(InternalError, "Failed to check permissions"))?;
+
+        if !allowed {
+            return Err(s3_error!(AccessDenied, "Permission denied"));
+        }
+
+        // Handlers read UserAccess/BucketInfo from the request extensions;
+        // hand them the Everyone principal scoped to the bucket's group. The
+        // key/secret fields are blank — nothing downstream signs with them —
+        // and expiry is irrelevant because this access was just checked.
+        cx.extensions_mut().insert(bucket_info);
+        cx.extensions_mut().insert(UserAccess {
+            access_key: String::new(),
+            user_identity: UserId::nil(self.realm_id),
+            group_id,
+            secret: String::new(),
+            expiry: SystemTime::now(),
+            path_restrictions: None,
+            issued_by: *self.node_id.as_bytes(),
+            revoked_at: None,
+        });
+        Ok(())
+    }
+
     #[tracing::instrument(level = "trace", skip(self))]
     async fn query_user_access(&self, access_key_id: &str) -> S3Result<UserAccess> {
         let operation = GetUserAccessOperation::new(access_key_id.to_string());

--- a/api/src/s3/util.rs
+++ b/api/src/s3/util.rs
@@ -119,6 +119,10 @@ pub fn get_s3_operation_permission(operation_name: &str) -> Option<Action> {
     }
 }
 
+pub(crate) fn is_anonymous_object_read_operation(operation_name: &str) -> bool {
+    matches!(operation_name, "GetObject")
+}
+
 pub(crate) fn convert_input(mut input: PutObjectInput) -> S3Result<BlobPutObjectInput, S3Error> {
     match input.body.take() {
         None => Err(s3_error!(InvalidRequest, "Missing body")),
@@ -258,8 +262,48 @@ pub(crate) fn checksum_algorithm_from_s3(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_multipart_part_number;
+    use super::{
+        get_s3_operation_permission, is_anonymous_object_read_operation,
+        parse_multipart_part_number,
+    };
+    use crate::s3::auth::Action;
     use s3s::S3ErrorCode;
+
+    #[test]
+    fn anonymous_public_access_only_allows_get_object() {
+        assert!(is_anonymous_object_read_operation("GetObject"));
+
+        for operation in [
+            "HeadObject",
+            "GetObjectAttributes",
+            "GetObjectTagging",
+            "GetBucketCors",
+            "GetBucketVersioning",
+            "ListBuckets",
+            "ListObjectsV2",
+            "ListObjectVersions",
+            "ListMultipartUploads",
+            "ListParts",
+        ] {
+            assert!(
+                !is_anonymous_object_read_operation(operation),
+                "{operation} must not be allowed anonymously"
+            );
+        }
+    }
+
+    #[test]
+    fn authenticated_read_classification_still_includes_metadata_operations() {
+        assert_eq!(get_s3_operation_permission("GetObject"), Some(Action::Read));
+        assert_eq!(
+            get_s3_operation_permission("HeadObject"),
+            Some(Action::Read)
+        );
+        assert_eq!(
+            get_s3_operation_permission("ListObjectsV2"),
+            Some(Action::Read)
+        );
+    }
 
     #[test]
     fn rejects_upload_part_number_zero() {

--- a/api/tests/document_sync_publish_architecture_guard.rs
+++ b/api/tests/document_sync_publish_architecture_guard.rs
@@ -53,11 +53,27 @@ fn allowed_publish_use(publish_use: &PublishUse) -> bool {
             publish_use.function.as_deref() == Some("document_publish_from_outbox")
         }
         "net/src/irokle.rs" => {
-            publish_use.function.as_deref() == Some("publish_events_blocking")
+            matches!(
+                (publish_use.function.as_deref(), publish_use.text.as_str()),
+                (
+                    Some("publish_events_blocking"),
+                    "DocumentSyncPublish::Upsert {"
+                        | "DocumentSyncPublish::Delete {"
+                        | "DocumentSyncPublish::AdminOperation { target, event, .. } => {",
+                ) | (
+                    Some("decode_eviction"),
+                    "documents.push(DocumentSyncPublish::Upsert {"
+                        | "documents.push(DocumentSyncPublish::Delete {"
+                        | "documents.push(DocumentSyncPublish::AdminOperation {",
+                )
+            )
+        }
+        "operations/src/incoming.rs" => {
+            publish_use.function.as_deref() == Some("reemit_evicted_documents")
                 && matches!(
                     publish_use.text.as_str(),
                     "DocumentSyncPublish::Upsert {"
-                        | "DocumentSyncPublish::Delete {"
+                        | "DocumentSyncPublish::Delete { target, change, .. } => {"
                         | "DocumentSyncPublish::AdminOperation { target, event, .. } => {"
                 )
         }

--- a/aruna/tests/groups.rs
+++ b/aruna/tests/groups.rs
@@ -37,6 +37,21 @@ async fn membership_lifecycle_with_invite_and_leave() -> TestResult<()> {
     .await?;
     let group = create_group_via_http(&seed.base_url, &admin_token, "membership-flow").await?;
 
+    let everyone = UserId::nil(seed.realm_id);
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{}/api/v1/groups/{}/members",
+            seed.base_url, group.group_id
+        ))
+        .bearer_auth(&admin_token)
+        .json(&AddGroupMemberRequest {
+            user_id: everyone.to_string(),
+            role_ids: None,
+        })
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
     let member_id = UserId::local(Ulid::new(), seed.realm_id);
     let member_token = create_bearer_token(
         seed.context.as_ref(),
@@ -133,6 +148,40 @@ async fn role_management_rejects_foreign_paths_and_protects_admin() -> TestResul
             name: "escalation".to_string(),
             permissions: HashMap::from([(format!("/{realm_id}/admin/**"), "write".to_string())]),
             assigned_users: Vec::new(),
+            public: false,
+        })
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    for permission in ["write", "deny"] {
+        let response = reqwest::Client::new()
+            .post(format!("{}/api/v1/groups/{group_id}/roles", seed.base_url))
+            .bearer_auth(&admin_token)
+            .json(&CreateGroupRoleRequest {
+                name: format!("public-{permission}"),
+                permissions: HashMap::from([(
+                    format!("/{realm_id}/g/{group_id}/data/**"),
+                    permission.to_string(),
+                )]),
+                assigned_users: Vec::new(),
+                public: true,
+            })
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v1/groups/{group_id}/roles", seed.base_url))
+        .bearer_auth(&admin_token)
+        .json(&CreateGroupRoleRequest {
+            name: "nil-assigned-user".to_string(),
+            permissions: HashMap::from([(
+                format!("/{realm_id}/g/{group_id}/data/**"),
+                "read".to_string(),
+            )]),
+            assigned_users: vec![UserId::nil(realm_id).to_string()],
             public: false,
         })
         .send()

--- a/aruna/tests/groups.rs
+++ b/aruna/tests/groups.rs
@@ -133,6 +133,7 @@ async fn role_management_rejects_foreign_paths_and_protects_admin() -> TestResul
             name: "escalation".to_string(),
             permissions: HashMap::from([(format!("/{realm_id}/admin/**"), "write".to_string())]),
             assigned_users: Vec::new(),
+            public: false,
         })
         .send()
         .await?;
@@ -149,6 +150,7 @@ async fn role_management_rejects_foreign_paths_and_protects_admin() -> TestResul
                 "read".to_string(),
             )]),
             assigned_users: Vec::new(),
+            public: false,
         })
         .send()
         .await?;

--- a/aruna/tests/public_access.rs
+++ b/aruna/tests/public_access.rs
@@ -1,5 +1,7 @@
 mod shared;
 
+use aruna_api::routes::groups::AddGroupMemberRequest;
+use aruna_core::UserId;
 use aruna_core::structs::blob_bucket_permission_path;
 use aws_sdk_s3::primitives::ByteStream;
 use reqwest::StatusCode;
@@ -32,6 +34,31 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
 
         let group =
             create_group_via_http(&seed.base_url, &bearer_token, "public-access-e2e").await?;
+        let credential_group =
+            create_group_via_http(&seed.base_url, &bearer_token, "public-access-credentials")
+                .await?;
+        let member_id = UserId::local(Ulid::new(), seed.realm_id);
+        let member_token = create_bearer_token(
+            seed.context.as_ref(),
+            member_id,
+            seed.realm_id,
+            seed.capabilities.clone(),
+        )
+        .await?;
+        let http = reqwest::Client::new();
+        let add_member = http
+            .post(format!(
+                "{}/api/v1/groups/{}/members",
+                seed.base_url, credential_group.group_id
+            ))
+            .bearer_auth(&bearer_token)
+            .json(&AddGroupMemberRequest {
+                user_id: member_id.to_string(),
+                role_ids: None,
+            })
+            .send()
+            .await?;
+        assert_eq!(add_member.status(), StatusCode::CREATED);
         let s3_endpoint = seed
             .s3
             .as_ref()
@@ -39,6 +66,13 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
         let credentials =
             create_s3_credentials_via_http(&seed.base_url, &bearer_token, &group.group_id).await?;
         let s3 = s3_client(s3_endpoint, &credentials);
+        let cross_group_credentials = create_s3_credentials_via_http(
+            &seed.base_url,
+            &member_token,
+            &credential_group.group_id,
+        )
+        .await?;
+        let cross_group_s3 = s3_client(s3_endpoint, &cross_group_credentials);
 
         let bucket = "public-profiles";
         let key = "profiles/demo/mode.json";
@@ -57,7 +91,6 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
             .send()
             .await?;
 
-        let http = reqwest::Client::new();
         let object_url = format!("{}/{bucket}/{key}", s3_endpoint.endpoint_url);
 
         // Before any public role exists, anonymous reads are denied.
@@ -206,10 +239,15 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
             "absent bucket should match private anonymous denial: {absent_body}"
         );
 
-        // Authenticated requests inherit public grants: signed access is never
-        // weaker than unsigned access (the signing key belongs to the same
-        // group here, but the grant flows through the public role's path).
-        let signed = s3.get_object().bucket(bucket).key(key).send().await?;
+        // Authenticated requests inherit public grants even when the signing
+        // key belongs to another group; signed access is never weaker than
+        // unsigned access.
+        let signed = cross_group_s3
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await?;
         let signed_body = signed.body.collect().await?.into_bytes();
         assert_eq!(signed_body.as_ref(), PUBLIC_BODY);
 

--- a/aruna/tests/public_access.rs
+++ b/aruna/tests/public_access.rs
@@ -1,0 +1,206 @@
+mod shared;
+
+use aruna_core::structs::blob_bucket_permission_path;
+use aws_sdk_s3::primitives::ByteStream;
+use reqwest::StatusCode;
+use serde_json::json;
+use shared::{
+    TestResult, create_bearer_token, create_group_via_http, create_s3_credentials_via_http,
+    s3_client, spawn_full_seed_node,
+};
+use ulid::Ulid;
+
+const PUBLIC_BODY: &[u8] = b"public profile artifact bytes";
+const PRIVATE_BODY: &[u8] = b"private bytes";
+
+/// A public role (assigned to the Everyone principal via `public: true`)
+/// grants anonymous READ on exactly the paths it names — S3 GETs and DRS
+/// lookups/downloads succeed without credentials, while writes and everything
+/// outside the granted path stay denied.
+#[tokio::test]
+async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> {
+    let seed = spawn_full_seed_node().await?;
+
+    let result = async {
+        let bearer_token = create_bearer_token(
+            seed.context.as_ref(),
+            seed.user_id,
+            seed.realm_id,
+            seed.capabilities.clone(),
+        )
+        .await?;
+
+        let group =
+            create_group_via_http(&seed.base_url, &bearer_token, "public-access-e2e").await?;
+        let s3_endpoint = seed
+            .s3
+            .as_ref()
+            .ok_or_else(|| std::io::Error::other("seed node did not start S3 server"))?;
+        let credentials =
+            create_s3_credentials_via_http(&seed.base_url, &bearer_token, &group.group_id).await?;
+        let s3 = s3_client(s3_endpoint, &credentials);
+
+        let bucket = "public-profiles";
+        let key = "profiles/demo/mode.json";
+        s3.create_bucket().bucket(bucket).send().await?;
+        s3.put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(ByteStream::from_static(PUBLIC_BODY))
+            .send()
+            .await?;
+        s3.create_bucket().bucket("private-bucket").send().await?;
+        s3.put_object()
+            .bucket("private-bucket")
+            .key("secret.txt")
+            .body(ByteStream::from_static(PRIVATE_BODY))
+            .send()
+            .await?;
+
+        let http = reqwest::Client::new();
+        let object_url = format!("{}/{bucket}/{key}", s3_endpoint.endpoint_url);
+
+        // Before any public role exists, anonymous reads are denied.
+        let denied = http.get(&object_url).send().await?;
+        assert_eq!(
+            denied.status(),
+            StatusCode::FORBIDDEN,
+            "anonymous GET must be denied before a public role exists"
+        );
+
+        // Anonymous DRS lookups are equally denied (403, not 401 — the object
+        // exists on this node but nothing grants the Everyone principal READ).
+        let public_hash = hex::encode(blake3::hash(PUBLIC_BODY).as_bytes());
+        let drs_object_id = format!(
+            "arn:aruna:{}:{}:ch/{}",
+            seed.realm_id,
+            seed.net.node_id(),
+            public_hash
+        );
+        let drs_object_url = format!(
+            "{}/api/v1/ga4gh/drs/v1/objects/{}",
+            seed.base_url, drs_object_id
+        );
+        let drs_denied = http.get(&drs_object_url).send().await?;
+        assert_eq!(
+            drs_denied.status(),
+            StatusCode::FORBIDDEN,
+            "anonymous DRS lookup must be denied before a public role exists"
+        );
+
+        // Mint a public-read role scoped to the public bucket.
+        let group_ulid = Ulid::from_string(&group.group_id)?;
+        let public_path = format!(
+            "{}/**",
+            blob_bucket_permission_path(seed.realm_id, group_ulid, seed.net.node_id(), bucket)
+        );
+        let permissions = std::collections::HashMap::from([(public_path.clone(), "read")]);
+        let created = http
+            .post(format!(
+                "{}/api/v1/groups/{}/roles",
+                seed.base_url, group.group_id
+            ))
+            .bearer_auth(&bearer_token)
+            .json(&json!({
+                "name": "public-read-profiles",
+                "permissions": permissions,
+                "public": true,
+            }))
+            .send()
+            .await?;
+        let created_status = created.status();
+        let created_body = created.text().await?;
+        assert_eq!(
+            created_status,
+            StatusCode::CREATED,
+            "creating the public role failed: {created_body}"
+        );
+        assert!(
+            created_body.contains("\"public\":true"),
+            "role response should mark the role public: {created_body}"
+        );
+
+        // Anonymous read of the public object now succeeds.
+        let allowed = http.get(&object_url).send().await?;
+        assert_eq!(allowed.status(), StatusCode::OK);
+        assert_eq!(allowed.bytes().await?.as_ref(), PUBLIC_BODY);
+
+        // Anonymous writes stay denied — public roles never grant more than
+        // the anonymous read path allows.
+        let put = http
+            .put(&object_url)
+            .body("overwrite attempt")
+            .send()
+            .await?;
+        assert_eq!(
+            put.status(),
+            StatusCode::FORBIDDEN,
+            "anonymous writes must be denied even on public buckets"
+        );
+
+        // Objects outside the granted path stay private.
+        let private = http
+            .get(format!(
+                "{}/private-bucket/secret.txt",
+                s3_endpoint.endpoint_url
+            ))
+            .send()
+            .await?;
+        assert_eq!(
+            private.status(),
+            StatusCode::FORBIDDEN,
+            "the public role must not leak other buckets"
+        );
+
+        // Authenticated requests inherit public grants: signed access is never
+        // weaker than unsigned access (the signing key belongs to the same
+        // group here, but the grant flows through the public role's path).
+        let signed = s3.get_object().bucket(bucket).key(key).send().await?;
+        let signed_body = signed.body.collect().await?.into_bytes();
+        assert_eq!(signed_body.as_ref(), PUBLIC_BODY);
+
+        // Anonymous DRS lookup and download now resolve through the public role.
+        let drs_allowed = http.get(&drs_object_url).send().await?;
+        let drs_status = drs_allowed.status();
+        let drs_body = drs_allowed.text().await?;
+        assert_eq!(
+            drs_status,
+            StatusCode::OK,
+            "anonymous DRS lookup should succeed via the public role: {drs_body}"
+        );
+
+        let download = http
+            .get(format!(
+                "{}/api/v1/ga4gh/drs/v1/download?object_id={}",
+                seed.base_url, drs_object_id
+            ))
+            .send()
+            .await?;
+        assert_eq!(download.status(), StatusCode::OK);
+        assert_eq!(download.bytes().await?.as_ref(), PUBLIC_BODY);
+
+        // A private object stays unreachable via anonymous DRS.
+        let private_hash = hex::encode(blake3::hash(PRIVATE_BODY).as_bytes());
+        let private_drs = http
+            .get(format!(
+                "{}/api/v1/ga4gh/drs/v1/objects/arn:aruna:{}:{}:ch/{}",
+                seed.base_url,
+                seed.realm_id,
+                seed.net.node_id(),
+                private_hash
+            ))
+            .send()
+            .await?;
+        assert_eq!(
+            private_drs.status(),
+            StatusCode::FORBIDDEN,
+            "anonymous DRS must not resolve private objects"
+        );
+
+        Ok(())
+    }
+    .await;
+
+    seed.shutdown().await;
+    result
+}

--- a/aruna/tests/public_access.rs
+++ b/aruna/tests/public_access.rs
@@ -68,8 +68,7 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
             "anonymous GET must be denied before a public role exists"
         );
 
-        // Anonymous DRS lookups are equally denied (403, not 401 — the object
-        // exists on this node but nothing grants the Everyone principal READ).
+        // Anonymous DRS lookups hide private existence by matching unknown ids.
         let public_hash = hex::encode(blake3::hash(PUBLIC_BODY).as_bytes());
         let drs_object_id = format!(
             "arn:aruna:{}:{}:ch/{}",
@@ -84,8 +83,23 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
         let drs_denied = http.get(&drs_object_url).send().await?;
         assert_eq!(
             drs_denied.status(),
-            StatusCode::FORBIDDEN,
-            "anonymous DRS lookup must be denied before a public role exists"
+            StatusCode::NOT_FOUND,
+            "anonymous DRS lookup must not reveal private existence before a public role exists"
+        );
+        let unknown_drs = http
+            .get(format!(
+                "{}/api/v1/ga4gh/drs/v1/objects/arn:aruna:{}:{}:ch/{}",
+                seed.base_url,
+                seed.realm_id,
+                seed.net.node_id(),
+                "ff".repeat(32)
+            ))
+            .send()
+            .await?;
+        assert_eq!(
+            drs_denied.status(),
+            unknown_drs.status(),
+            "anonymous DRS must not distinguish existing private objects from unknown ids"
         );
 
         // Mint a public-read role scoped to the public bucket.
@@ -125,6 +139,24 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
         assert_eq!(allowed.status(), StatusCode::OK);
         assert_eq!(allowed.bytes().await?.as_ref(), PUBLIC_BODY);
 
+        // Public anonymous S3 access is only object bytes, not object metadata
+        // or bucket listing/configuration surfaces.
+        let head = http.head(&object_url).send().await?;
+        assert_eq!(
+            head.status(),
+            StatusCode::FORBIDDEN,
+            "anonymous HEAD must stay denied even when GET is public"
+        );
+        let list = http
+            .get(format!("{}/{bucket}?list-type=2", s3_endpoint.endpoint_url))
+            .send()
+            .await?;
+        assert_eq!(
+            list.status(),
+            StatusCode::FORBIDDEN,
+            "anonymous bucket listing must stay denied even when object GET is public"
+        );
+
         // Anonymous writes stay denied — public roles never grant more than
         // the anonymous read path allows.
         let put = http
@@ -138,7 +170,8 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
             "anonymous writes must be denied even on public buckets"
         );
 
-        // Objects outside the granted path stay private.
+        // Objects outside the granted path stay private, and anonymous S3 does
+        // not distinguish an existing private bucket from an absent bucket.
         let private = http
             .get(format!(
                 "{}/private-bucket/secret.txt",
@@ -146,10 +179,31 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
             ))
             .send()
             .await?;
+        let private_status = private.status();
+        let private_body = private.text().await?;
         assert_eq!(
-            private.status(),
+            private_status,
             StatusCode::FORBIDDEN,
             "the public role must not leak other buckets"
+        );
+        assert!(
+            private_body.contains("<Code>AccessDenied</Code>"),
+            "private bucket should be hidden as AccessDenied: {private_body}"
+        );
+
+        let absent = http
+            .get(format!(
+                "{}/absent-bucket/secret.txt",
+                s3_endpoint.endpoint_url
+            ))
+            .send()
+            .await?;
+        let absent_status = absent.status();
+        let absent_body = absent.text().await?;
+        assert_eq!(absent_status, private_status);
+        assert!(
+            absent_body.contains("<Code>AccessDenied</Code>"),
+            "absent bucket should match private anonymous denial: {absent_body}"
         );
 
         // Authenticated requests inherit public grants: signed access is never
@@ -193,8 +247,8 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
             .await?;
         assert_eq!(
             private_drs.status(),
-            StatusCode::FORBIDDEN,
-            "anonymous DRS must not resolve private objects"
+            StatusCode::NOT_FOUND,
+            "anonymous DRS must not reveal private object existence"
         );
 
         Ok(())

--- a/core/src/structs/structs.rs
+++ b/core/src/structs/structs.rs
@@ -55,15 +55,11 @@ pub struct Role {
 }
 
 impl Role {
-    /// A role assigned to the Everyone principal (the nil user id) applies to
-    /// every request in the realm — including anonymous, unauthenticated ones
-    /// (see `AuthContext::anonymous`). Encoding publicness as a member instead
-    /// of a struct field keeps stored auth documents (postcard, positional)
-    /// readable without a migration.
-    pub fn is_public(&self) -> bool {
-        self.assigned_users
-            .iter()
-            .any(|user| user.user_ulid.is_nil())
+    /// A role assigned to the realm's Everyone principal applies to every
+    /// request in that realm, including anonymous ones. Encoding publicness as
+    /// a member keeps stored auth documents readable without a migration.
+    pub fn is_public(&self, realm_id: RealmId) -> bool {
+        self.assigned_users.contains(&UserId::nil(realm_id))
     }
 }
 
@@ -179,8 +175,8 @@ pub struct AuthContext {
 
 impl AuthContext {
     /// The Everyone principal: unauthenticated requests are permission-checked
-    /// as the nil user, so exactly the roles that assign `UserId::nil` (public
-    /// roles, `Role::is_public`) grant them access.
+    /// as the nil user, so exactly the roles that assign the realm-scoped
+    /// `UserId::nil` (public roles, `Role::is_public`) grant them access.
     pub fn anonymous(realm_id: RealmId) -> Self {
         Self {
             user_id: UserId::nil(realm_id),
@@ -335,6 +331,27 @@ mod test {
         let hydrated_role: Role = postcard::from_bytes(&bytes).unwrap();
 
         assert_eq!(role, hydrated_role);
+    }
+
+    #[test]
+    pub fn public_role_requires_nil_user_from_same_realm() {
+        let realm_id = RealmId([1u8; 32]);
+        let other_realm_id = RealmId([2u8; 32]);
+        let role = Role {
+            role_id: Ulid::new(),
+            name: "public".to_string(),
+            permissions: HashMap::from([("/test".to_string(), Permission::READ)]),
+            assigned_users: HashSet::from([UserId::nil(realm_id)]),
+        };
+
+        assert!(role.is_public(realm_id));
+        assert!(!role.is_public(other_realm_id));
+
+        let foreign_nil_role = Role {
+            assigned_users: HashSet::from([UserId::nil(other_realm_id)]),
+            ..role
+        };
+        assert!(!foreign_nil_role.is_public(realm_id));
     }
 
     #[test]

--- a/core/src/structs/structs.rs
+++ b/core/src/structs/structs.rs
@@ -54,6 +54,19 @@ pub struct Role {
     pub assigned_users: HashSet<UserId>,
 }
 
+impl Role {
+    /// A role assigned to the Everyone principal (the nil user id) applies to
+    /// every request in the realm — including anonymous, unauthenticated ones
+    /// (see `AuthContext::anonymous`). Encoding publicness as a member instead
+    /// of a struct field keeps stored auth documents (postcard, positional)
+    /// readable without a migration.
+    pub fn is_public(&self) -> bool {
+        self.assigned_users
+            .iter()
+            .any(|user| user.user_ulid.is_nil())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenClaims {
     /// Subject: user identity in format `{user_ulid}@{realm_pubkey_base64}`.
@@ -162,6 +175,19 @@ pub struct AuthContext {
     pub user_id: UserId,
     pub realm_id: RealmId,
     pub path_restrictions: Option<Vec<PathRestriction>>,
+}
+
+impl AuthContext {
+    /// The Everyone principal: unauthenticated requests are permission-checked
+    /// as the nil user, so exactly the roles that assign `UserId::nil` (public
+    /// roles, `Role::is_public`) grant them access.
+    pub fn anonymous(realm_id: RealmId) -> Self {
+        Self {
+            user_id: UserId::nil(realm_id),
+            realm_id,
+            path_restrictions: None,
+        }
+    }
 }
 
 impl TryFrom<TokenClaims> for AuthContext {

--- a/core/src/user_id.rs
+++ b/core/src/user_id.rs
@@ -33,6 +33,16 @@ impl UserId {
     }
 
     #[inline]
+    pub fn is_nil(&self) -> bool {
+        self.user_ulid.is_nil()
+    }
+
+    #[inline]
+    pub fn is_nil_in(&self, realm_id: RealmId) -> bool {
+        self.is_nil() && self.realm_id == realm_id
+    }
+
+    #[inline]
     pub fn to_storage_key(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(48);
         bytes.extend_from_slice(self.realm_id.as_bytes());
@@ -126,5 +136,17 @@ mod tests {
             UserId::from_storage_key(&user_id.to_storage_key()).unwrap(),
             user_id
         );
+    }
+
+    #[test]
+    fn nil_user_id_is_realm_scoped() {
+        let realm_id = RealmId([1u8; 32]);
+        let other_realm_id = RealmId([2u8; 32]);
+        let user_id = UserId::nil(realm_id);
+
+        assert!(user_id.is_nil());
+        assert!(user_id.is_nil_in(realm_id));
+        assert!(!user_id.is_nil_in(other_realm_id));
+        assert!(!UserId::local(Ulid::new(), realm_id).is_nil());
     }
 }

--- a/operations/src/add_group_role.rs
+++ b/operations/src/add_group_role.rs
@@ -117,6 +117,10 @@ pub enum AddGroupRoleError {
     Unauthorized,
     #[error("No group found")]
     GroupNotFound,
+    #[error("Invalid public role")]
+    InvalidPublicRole,
+    #[error("Invalid assigned user")]
+    InvalidAssignedUser,
     #[error(transparent)]
     CheckPermissionsError(#[from] AuthorizationError),
     #[error("Adding role to group did not finish")]
@@ -136,6 +140,31 @@ impl AddGroupRoleOperation {
             state: AddGroupRoleState::Init,
             output: None,
         }
+    }
+
+    fn validate_role(&self) -> Result<(), AddGroupRoleError> {
+        if self
+            .input
+            .role
+            .assigned_users
+            .iter()
+            .any(|user| user.is_nil() && !user.is_nil_in(self.input.realm_id))
+        {
+            return Err(AddGroupRoleError::InvalidAssignedUser);
+        }
+
+        if self.input.role.is_public(self.input.realm_id)
+            && self
+                .input
+                .role
+                .permissions
+                .values()
+                .any(|permission| permission != &Permission::READ)
+        {
+            return Err(AddGroupRoleError::InvalidPublicRole);
+        }
+
+        Ok(())
     }
 
     fn handle_authorization(&mut self, event: Event) -> Effects {
@@ -586,6 +615,10 @@ impl Operation for AddGroupRoleOperation {
     type Error = AddGroupRoleError;
 
     fn start(&mut self) -> Effects {
+        if let Err(error) = self.validate_role() {
+            return self.fail(error);
+        }
+
         self.state = AddGroupRoleState::Auth;
 
         let auth_config = CheckPermissionsConfig {
@@ -762,7 +795,9 @@ fn sorted_user_ids(user_ids: &HashSet<UserId>) -> Vec<UserId> {
 pub mod test {
     use std::collections::{HashMap, HashSet};
 
-    use crate::add_group_role::{AddGroupRoleConfig, AddGroupRoleOperation, AddGroupRoleState};
+    use crate::add_group_role::{
+        AddGroupRoleConfig, AddGroupRoleError, AddGroupRoleOperation, AddGroupRoleState,
+    };
     use aruna_core::UserId;
     use aruna_core::admin_document_reducer::{
         AdminDocumentConflict, AdminDocumentConflictValue, AdminDocumentReducerState,
@@ -788,6 +823,84 @@ pub mod test {
         DOCUMENT_SYNC_OUTBOX_KEYSPACE,
     };
     use ulid::Ulid;
+
+    #[test]
+    fn rejects_public_roles_with_write_or_deny_permissions() {
+        let realm_id = aruna_core::structs::RealmId([1u8; 32]);
+        let user_id = UserId::local(Ulid::from_bytes([2u8; 16]), realm_id);
+        let group_id = Ulid::from_bytes([3u8; 16]);
+        let actor = Actor {
+            node_id: iroh::SecretKey::from_bytes(&[4u8; 32]).public(),
+            user_id,
+            realm_id,
+        };
+
+        for permission in [Permission::WRITE, Permission::DENY] {
+            let mut operation = AddGroupRoleOperation::new(AddGroupRoleConfig {
+                auth_context: aruna_core::structs::AuthContext {
+                    user_id,
+                    realm_id,
+                    path_restrictions: None,
+                },
+                actor: actor.clone(),
+                realm_id,
+                group_id,
+                role: Role {
+                    role_id: Ulid::new(),
+                    name: "public".to_string(),
+                    permissions: HashMap::from([(
+                        format!("/{realm_id}/g/{group_id}/data/**"),
+                        permission,
+                    )]),
+                    assigned_users: HashSet::from([UserId::nil(realm_id)]),
+                },
+            });
+
+            assert!(operation.start().is_empty());
+            assert_eq!(
+                operation.finalize(),
+                Err(AddGroupRoleError::InvalidPublicRole)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_foreign_nil_assigned_users() {
+        let realm_id = aruna_core::structs::RealmId([1u8; 32]);
+        let other_realm_id = aruna_core::structs::RealmId([2u8; 32]);
+        let user_id = UserId::local(Ulid::from_bytes([3u8; 16]), realm_id);
+        let group_id = Ulid::from_bytes([4u8; 16]);
+        let actor = Actor {
+            node_id: iroh::SecretKey::from_bytes(&[5u8; 32]).public(),
+            user_id,
+            realm_id,
+        };
+        let mut operation = AddGroupRoleOperation::new(AddGroupRoleConfig {
+            auth_context: aruna_core::structs::AuthContext {
+                user_id,
+                realm_id,
+                path_restrictions: None,
+            },
+            actor,
+            realm_id,
+            group_id,
+            role: Role {
+                role_id: Ulid::new(),
+                name: "foreign-nil".to_string(),
+                permissions: HashMap::from([(
+                    format!("/{realm_id}/g/{group_id}/data/**"),
+                    Permission::READ,
+                )]),
+                assigned_users: HashSet::from([UserId::nil(other_realm_id)]),
+            },
+        });
+
+        assert!(operation.start().is_empty());
+        assert_eq!(
+            operation.finalize(),
+            Err(AddGroupRoleError::InvalidAssignedUser)
+        );
+    }
 
     #[tokio::test]
     pub async fn test_add_role() {

--- a/operations/src/add_realm_role.rs
+++ b/operations/src/add_realm_role.rs
@@ -102,6 +102,10 @@ pub enum AddRealmRoleError {
     Unauthorized,
     #[error("No realm authorization document found")]
     RealmAuthDocNotFound,
+    #[error("Invalid public role")]
+    InvalidPublicRole,
+    #[error("Invalid assigned user")]
+    InvalidAssignedUser,
     #[error(transparent)]
     CheckPermissionsError(#[from] AuthorizationError),
     #[error("Adding role to realm did not finish")]
@@ -144,6 +148,31 @@ impl AddRealmRoleOperation {
             realm_id: self.input.actor.realm_id,
             path_restrictions: None,
         }
+    }
+
+    fn validate_role(&self) -> Result<(), AddRealmRoleError> {
+        if self
+            .input
+            .role
+            .assigned_users
+            .iter()
+            .any(|user| user.is_nil() && !user.is_nil_in(self.input.realm_id))
+        {
+            return Err(AddRealmRoleError::InvalidAssignedUser);
+        }
+
+        if self.input.role.is_public(self.input.realm_id)
+            && self
+                .input
+                .role
+                .permissions
+                .values()
+                .any(|permission| permission != &Permission::READ)
+        {
+            return Err(AddRealmRoleError::InvalidPublicRole);
+        }
+
+        Ok(())
     }
 
     fn handle_authorization(&mut self, event: Event) -> Effects {
@@ -490,6 +519,10 @@ impl Operation for AddRealmRoleOperation {
     type Error = AddRealmRoleError;
 
     fn start(&mut self) -> Effects {
+        if let Err(error) = self.validate_role() {
+            return self.fail(error);
+        }
+
         self.state = AddRealmRoleState::Auth;
 
         smallvec![Effect::SubOperation(boxed_suboperation(
@@ -650,7 +683,9 @@ fn sorted_user_ids(user_ids: &HashSet<UserId>) -> Vec<UserId> {
 pub mod test {
     use std::collections::{HashMap, HashSet};
 
-    use crate::add_realm_role::{AddRealmRoleConfig, AddRealmRoleOperation, AddRealmRoleState};
+    use crate::add_realm_role::{
+        AddRealmRoleConfig, AddRealmRoleError, AddRealmRoleOperation, AddRealmRoleState,
+    };
     use crate::claim_initial_realm_admin::{
         ClaimInitialRealmAdminInput, ClaimInitialRealmAdminOperation,
     };
@@ -684,6 +719,64 @@ pub mod test {
     use aruna_tasks::TaskHandle;
     use tempfile::tempdir;
     use ulid::Ulid;
+
+    #[test]
+    fn rejects_public_roles_with_write_or_deny_permissions() {
+        let realm_id = aruna_core::structs::RealmId([1u8; 32]);
+        let user_id = UserId::local(Ulid::from_bytes([2u8; 16]), realm_id);
+        let actor = Actor {
+            node_id: iroh::SecretKey::from_bytes(&[3u8; 32]).public(),
+            user_id,
+            realm_id,
+        };
+
+        for permission in [Permission::WRITE, Permission::DENY] {
+            let mut operation = AddRealmRoleOperation::new(AddRealmRoleConfig {
+                actor: actor.clone(),
+                realm_id,
+                role: Role {
+                    role_id: Ulid::new(),
+                    name: "public".to_string(),
+                    permissions: HashMap::from([(format!("/{realm_id}/data/**"), permission)]),
+                    assigned_users: HashSet::from([UserId::nil(realm_id)]),
+                },
+            });
+
+            assert!(operation.start().is_empty());
+            assert_eq!(
+                operation.finalize(),
+                Err(AddRealmRoleError::InvalidPublicRole)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_foreign_nil_assigned_users() {
+        let realm_id = aruna_core::structs::RealmId([1u8; 32]);
+        let other_realm_id = aruna_core::structs::RealmId([2u8; 32]);
+        let user_id = UserId::local(Ulid::from_bytes([3u8; 16]), realm_id);
+        let actor = Actor {
+            node_id: iroh::SecretKey::from_bytes(&[4u8; 32]).public(),
+            user_id,
+            realm_id,
+        };
+        let mut operation = AddRealmRoleOperation::new(AddRealmRoleConfig {
+            actor,
+            realm_id,
+            role: Role {
+                role_id: Ulid::new(),
+                name: "foreign-nil".to_string(),
+                permissions: HashMap::from([(format!("/{realm_id}/data/**"), Permission::READ)]),
+                assigned_users: HashSet::from([UserId::nil(other_realm_id)]),
+            },
+        });
+
+        assert!(operation.start().is_empty());
+        assert_eq!(
+            operation.finalize(),
+            Err(AddRealmRoleError::InvalidAssignedUser)
+        );
+    }
 
     #[test]
     pub fn writes_realm_auth_doc_reducer_state_and_conflicts_in_one_transaction() {

--- a/operations/src/add_user_to_group.rs
+++ b/operations/src/add_user_to_group.rs
@@ -102,6 +102,8 @@ pub enum AddUserToGroupError {
     Unauthorized,
     #[error("Role not found")]
     RoleNotFound,
+    #[error("Invalid user id")]
+    InvalidUserId,
     #[error("Authorization document not found")]
     AuthDocNotFound,
     #[error(transparent)]
@@ -509,6 +511,10 @@ impl Operation for AddUserToGroupOperation {
     type Error = AddUserToGroupError;
 
     fn start(&mut self) -> Effects {
+        if self.input.user_id.is_nil() {
+            return self.fail(AddUserToGroupError::InvalidUserId);
+        }
+
         self.state = AddUserToGroupState::Auth;
 
         smallvec![Effect::SubOperation(boxed_suboperation(
@@ -701,7 +707,9 @@ pub mod test {
     use tempfile::tempdir;
     use ulid::Ulid;
 
-    use crate::add_user_to_group::{AddUserToGroupInput, AddUserToGroupOperation};
+    use crate::add_user_to_group::{
+        AddUserToGroupError, AddUserToGroupInput, AddUserToGroupOperation,
+    };
     use crate::create_group::{CreateGroupConfig, CreateGroupOperation};
     use crate::create_realm::{CreateRealmConfig, CreateRealmOperation};
     use crate::driver::{DriverContext, drive};
@@ -779,6 +787,31 @@ pub mod test {
                 },
             )]),
         }
+    }
+
+    #[test]
+    fn rejects_nil_user_id_as_group_member() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let owner_id = UserId::local(Ulid::from_bytes([2u8; 16]), realm_id);
+        let group_id = Ulid::from_bytes([3u8; 16]);
+        let role_id = Ulid::from_bytes([4u8; 16]);
+        let actor = Actor {
+            node_id: node(5),
+            user_id: owner_id,
+            realm_id,
+        };
+        let mut operation = AddUserToGroupOperation::new(AddUserToGroupInput {
+            actor,
+            group_id,
+            user_id: UserId::nil(realm_id),
+            role_ids: HashSet::from([role_id]),
+        });
+
+        assert!(operation.start().is_empty());
+        assert_eq!(
+            operation.finalize(),
+            Err(AddUserToGroupError::InvalidUserId)
+        );
     }
 
     #[test]

--- a/operations/src/add_user_to_realm_role.rs
+++ b/operations/src/add_user_to_realm_role.rs
@@ -103,6 +103,8 @@ pub enum AddUserToRealmRolesError {
     Unauthorized,
     #[error("Role not found")]
     RoleNotFound,
+    #[error("Invalid user id")]
+    InvalidUserId,
     #[error("Authorization document not found")]
     AuthDocNotFound,
     #[error(transparent)]
@@ -512,6 +514,10 @@ impl Operation for AddUserToRealmRolesOperation {
     type Error = AddUserToRealmRolesError;
 
     fn start(&mut self) -> Effects {
+        if self.input.user_id.is_nil() {
+            return self.fail(AddUserToRealmRolesError::InvalidUserId);
+        }
+
         self.state = AddUserToRealmRolesState::Auth;
 
         smallvec![Effect::SubOperation(boxed_suboperation(
@@ -673,7 +679,9 @@ fn apply_admin_reducer_operation(
 pub mod test {
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-    use crate::add_user_to_realm_role::{AddUserToRealmRolesInput, AddUserToRealmRolesOperation};
+    use crate::add_user_to_realm_role::{
+        AddUserToRealmRolesError, AddUserToRealmRolesInput, AddUserToRealmRolesOperation,
+    };
     use crate::claim_initial_realm_admin::{
         ClaimInitialRealmAdminInput, ClaimInitialRealmAdminOperation,
     };
@@ -782,6 +790,30 @@ pub mod test {
                 },
             )]),
         }
+    }
+
+    #[test]
+    fn rejects_nil_user_id_as_realm_role_assignee() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let owner_id = UserId::local(Ulid::from_bytes([2u8; 16]), realm_id);
+        let role_id = Ulid::from_bytes([3u8; 16]);
+        let actor = Actor {
+            node_id: node(4),
+            user_id: owner_id,
+            realm_id,
+        };
+        let mut operation = AddUserToRealmRolesOperation::new(AddUserToRealmRolesInput {
+            actor,
+            realm_id,
+            user_id: UserId::nil(realm_id),
+            role_ids: HashSet::from([role_id]),
+        });
+
+        assert!(operation.start().is_empty());
+        assert_eq!(
+            operation.finalize(),
+            Err(AddUserToRealmRolesError::InvalidUserId)
+        );
     }
 
     #[test]

--- a/operations/src/check_permissions.rs
+++ b/operations/src/check_permissions.rs
@@ -250,8 +250,15 @@ impl CheckPermissionsOperation {
             roles.extend(group.roles.clone());
         }
         roles.retain(|_id, role| {
-            role.assigned_users
-                .contains(&self.config.auth_context.user_id)
+            // Public roles (assigned to the Everyone principal, UserId::nil)
+            // apply to every request — anonymous ones authenticate as exactly
+            // that nil user (AuthContext::anonymous), and authenticated users
+            // inherit public grants too so signed requests are never weaker
+            // than unsigned ones.
+            role.is_public()
+                || role
+                    .assigned_users
+                    .contains(&self.config.auth_context.user_id)
         });
         Ok(roles)
     }
@@ -475,6 +482,175 @@ mod test {
             permission: Permission::DENY,
         }]);
         assert!(!operation.check_path_restrictions().unwrap());
+    }
+
+    #[tokio::test]
+    pub async fn public_roles_apply_to_everyone_and_deny_wins() {
+        let random_path = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(random_path.path().to_str().unwrap()).unwrap();
+        let net_handle = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().unwrap(),
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage_handle.clone(),
+        )
+        .await
+        .unwrap();
+
+        let context = DriverContext {
+            storage_handle,
+            blob_handle: None,
+            net_handle: Some(net_handle.clone()),
+            metadata_handle: None,
+            task_handle: Some(TaskHandle::new()),
+        };
+
+        let realm_id = RealmId([3u8; 32]);
+        let admin_id = UserId::local(Ulid::new(), realm_id);
+        let node_id = iroh::SecretKey::from_bytes(&[2u8; 32]).public();
+        let actor = Actor {
+            node_id,
+            user_id: admin_id,
+            realm_id,
+        };
+
+        drive(
+            CreateRealmOperation::new(CreateRealmConfig {
+                actor: actor.clone(),
+                realm_description: "Public role test realm".to_string(),
+                oidc_providers: Vec::new(),
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+        drive(
+            ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
+                actor: actor.clone(),
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let (group, _) = drive(
+            CreateGroupOperation::new(CreateGroupConfig {
+                actor: actor.clone(),
+                display_name: "Public group".to_string(),
+                owner_cap: None,
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+        let group_id = group.group_id;
+
+        // A role assigned to the Everyone principal grants READ on the public path.
+        drive(
+            AddGroupRoleOperation::new(AddGroupRoleConfig {
+                auth_context: AuthContext {
+                    user_id: admin_id,
+                    realm_id,
+                    path_restrictions: None,
+                },
+                realm_id,
+                actor: actor.clone(),
+                group_id,
+                role: aruna_core::structs::Role {
+                    role_id: Ulid::new(),
+                    name: "public-read".to_string(),
+                    permissions: HashMap::from([(
+                        format!("/{realm_id}/g/{group_id}/data/**"),
+                        Permission::READ,
+                    )]),
+                    assigned_users: HashSet::from([UserId::nil(realm_id)]),
+                },
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let data_path = format!("/{realm_id}/g/{group_id}/data/node/bucket/key");
+        let check = |auth_context: AuthContext, path: String, permission: Permission| {
+            let context = &context;
+            async move {
+                drive(
+                    CheckPermissionsOperation::new(CheckPermissionsConfig {
+                        auth_context,
+                        path,
+                        required_permission: permission,
+                    }),
+                    context,
+                )
+                .await
+                .unwrap()
+            }
+        };
+
+        // Anonymous requests (the Everyone principal itself) may read…
+        let anonymous = AuthContext::anonymous(realm_id);
+        assert!(check(anonymous.clone(), data_path.clone(), Permission::READ).await);
+        // …but never write, and never outside the granted path.
+        assert!(!check(anonymous.clone(), data_path.clone(), Permission::WRITE).await);
+        assert!(
+            !check(
+                anonymous.clone(),
+                format!("/{realm_id}/g/{group_id}/meta/doc"),
+                Permission::READ
+            )
+            .await
+        );
+
+        // Authenticated strangers inherit public grants — signed access is
+        // never weaker than unsigned access.
+        let stranger = AuthContext {
+            user_id: UserId::local(Ulid::new(), realm_id),
+            realm_id,
+            path_restrictions: None,
+        };
+        assert!(check(stranger.clone(), data_path.clone(), Permission::READ).await);
+
+        // A public DENY role wins over everything, even the admin's own grant.
+        drive(
+            AddGroupRoleOperation::new(AddGroupRoleConfig {
+                auth_context: AuthContext {
+                    user_id: admin_id,
+                    realm_id,
+                    path_restrictions: None,
+                },
+                realm_id,
+                actor: actor.clone(),
+                group_id,
+                role: aruna_core::structs::Role {
+                    role_id: Ulid::new(),
+                    name: "public-deny-quarantine".to_string(),
+                    permissions: HashMap::from([(
+                        format!("/{realm_id}/g/{group_id}/data/node/bucket/quarantined/**"),
+                        Permission::DENY,
+                    )]),
+                    assigned_users: HashSet::from([UserId::nil(realm_id)]),
+                },
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let quarantined = format!("/{realm_id}/g/{group_id}/data/node/bucket/quarantined/key");
+        assert!(!check(anonymous.clone(), quarantined.clone(), Permission::READ).await);
+        let admin_auth = AuthContext {
+            user_id: admin_id,
+            realm_id,
+            path_restrictions: None,
+        };
+        assert!(!check(admin_auth, quarantined, Permission::READ).await);
+
+        net_handle.shutdown().await;
     }
 
     #[tokio::test]

--- a/operations/src/check_permissions.rs
+++ b/operations/src/check_permissions.rs
@@ -9,7 +9,6 @@ use aruna_core::structs::{
 use aruna_core::types::{Effects, GroupId, TxnId};
 use globset::Glob;
 use smallvec::smallvec;
-use std::collections::HashMap;
 use ulid::Ulid;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -28,6 +27,12 @@ pub struct CheckPermissionsOperation {
     group_auth_doc: Option<GroupAuthorizationDocument>,
     output: Option<Result<bool, AuthorizationError>>,
     state: CheckPermissionsState,
+}
+
+struct CollectedRole {
+    role: Role,
+    direct: bool,
+    public: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -239,49 +244,67 @@ impl CheckPermissionsOperation {
         Ok(smallvec![])
     }
 
-    fn collect_roles(&mut self) -> Result<HashMap<Ulid, Role>, AuthorizationError> {
-        let mut roles = self
+    fn collect_roles(&mut self) -> Result<Vec<CollectedRole>, AuthorizationError> {
+        let realm_auth_doc = self
             .realm_auth_doc
             .as_ref()
-            .ok_or_else(|| AuthorizationError::AuthDocNotFound)?
-            .roles
-            .clone();
+            .ok_or_else(|| AuthorizationError::AuthDocNotFound)?;
+        let realm_id = realm_auth_doc.realm_id;
+        let auth_user = self.config.auth_context.user_id;
+        let mut roles = realm_auth_doc.roles.clone();
         if let Some(group) = &self.group_auth_doc {
             roles.extend(group.roles.clone());
         }
-        roles.retain(|_id, role| {
-            // Public roles (assigned to the Everyone principal, UserId::nil)
-            // apply to every request — anonymous ones authenticate as exactly
-            // that nil user (AuthContext::anonymous), and authenticated users
-            // inherit public grants too so signed requests are never weaker
-            // than unsigned ones.
-            role.is_public()
-                || role
-                    .assigned_users
-                    .contains(&self.config.auth_context.user_id)
-        });
-        Ok(roles)
+        Ok(roles
+            .into_values()
+            .filter_map(|role| {
+                // Public roles apply by assigning this realm's exact Everyone
+                // principal. Other nil user ids are not public for this realm.
+                let public = role.is_public(realm_id);
+                let direct = !auth_user.is_nil() && role.assigned_users.contains(&auth_user);
+                (public || direct).then_some(CollectedRole {
+                    role,
+                    direct,
+                    public,
+                })
+            })
+            .collect())
     }
 
-    fn check_permissions(
-        &mut self,
-        roles: HashMap<Ulid, Role>,
-    ) -> Result<bool, AuthorizationError> {
+    fn check_permissions(&mut self, roles: Vec<CollectedRole>) -> Result<bool, AuthorizationError> {
         let mut allowed = false;
-        for (_, role) in roles {
+        for CollectedRole {
+            role,
+            direct,
+            public,
+        } in roles
+        {
             for (path, permission) in role.permissions {
                 let glob = Glob::new(&path)?.compile_matcher();
                 if glob.is_match(&self.config.path) {
-                    match permission {
-                        Permission::DENY => {
-                            return Ok(false);
-                        }
-                        Permission::READ => {
-                            if self.config.required_permission == Permission::READ {
-                                allowed = true;
+                    if public && permission != Permission::READ {
+                        continue;
+                    }
+
+                    if public
+                        && permission == Permission::READ
+                        && self.config.required_permission == Permission::READ
+                    {
+                        allowed = true;
+                    }
+
+                    if direct {
+                        match permission {
+                            Permission::DENY => {
+                                return Ok(false);
                             }
+                            Permission::READ => {
+                                if self.config.required_permission == Permission::READ {
+                                    allowed = true;
+                                }
+                            }
+                            Permission::WRITE => allowed = true,
                         }
-                        Permission::WRITE => allowed = true,
                     }
                 }
             }
@@ -405,7 +428,9 @@ mod test {
     use std::collections::{HashMap, HashSet};
 
     use aruna_core::UserId;
-    use aruna_core::structs::{Actor, AuthContext, PathRestriction, Permission, RealmId};
+    use aruna_core::structs::{
+        Actor, AuthContext, PathRestriction, Permission, RealmAuthorizationDocument, RealmId, Role,
+    };
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
     use aruna_storage::storage;
     use aruna_tasks::TaskHandle;
@@ -413,7 +438,7 @@ mod test {
     use tempfile::tempdir;
     use ulid::Ulid;
 
-    use crate::add_group_role::{AddGroupRoleConfig, AddGroupRoleOperation};
+    use crate::add_group_role::{AddGroupRoleConfig, AddGroupRoleError, AddGroupRoleOperation};
     use crate::add_user_to_group::{AddUserToGroupInput, AddUserToGroupOperation};
     use crate::add_user_to_realm_role::{AddUserToRealmRolesInput, AddUserToRealmRolesOperation};
     use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
@@ -484,8 +509,103 @@ mod test {
         assert!(!operation.check_path_restrictions().unwrap());
     }
 
+    #[test]
+    fn collect_roles_only_treats_same_realm_nil_as_public() {
+        let realm_id = RealmId([1u8; 32]);
+        let other_realm_id = RealmId([2u8; 32]);
+        let group_id = Ulid::new();
+        let role = Role {
+            role_id: Ulid::new(),
+            name: "foreign-nil".to_string(),
+            permissions: HashMap::from([(
+                format!("/{realm_id}/g/{group_id}/data/**"),
+                Permission::READ,
+            )]),
+            assigned_users: HashSet::from([UserId::nil(other_realm_id)]),
+        };
+        let mut operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
+            auth_context: AuthContext::anonymous(realm_id),
+            path: format!("/{realm_id}/g/{group_id}/data/object"),
+            required_permission: Permission::READ,
+        });
+        operation.realm_auth_doc = Some(RealmAuthorizationDocument {
+            realm_id,
+            roles: HashMap::from([(role.role_id, role)]),
+            operation_restrictions: HashMap::new(),
+        });
+
+        assert!(operation.collect_roles().unwrap().is_empty());
+    }
+
+    #[test]
+    fn public_grants_are_read_only_when_evaluating_permissions() {
+        let realm_id = RealmId([2u8; 32]);
+        let group_id = Ulid::new();
+        let user_id = UserId::local(Ulid::new(), realm_id);
+        let path = format!("/{realm_id}/g/{group_id}/data/object");
+
+        let public_write = Role {
+            role_id: Ulid::new(),
+            name: "public-write".to_string(),
+            permissions: HashMap::from([(path.clone(), Permission::WRITE)]),
+            assigned_users: HashSet::from([UserId::nil(realm_id)]),
+        };
+        let mut write_operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
+            auth_context: AuthContext::anonymous(realm_id),
+            path: path.clone(),
+            required_permission: Permission::WRITE,
+        });
+        assert!(
+            !write_operation
+                .check_permissions(vec![super::CollectedRole {
+                    role: public_write,
+                    direct: false,
+                    public: true,
+                }])
+                .unwrap()
+        );
+
+        let public_deny = Role {
+            role_id: Ulid::new(),
+            name: "public-deny".to_string(),
+            permissions: HashMap::from([(path.clone(), Permission::DENY)]),
+            assigned_users: HashSet::from([UserId::nil(realm_id)]),
+        };
+        let direct_read = Role {
+            role_id: Ulid::new(),
+            name: "direct-read".to_string(),
+            permissions: HashMap::from([(path.clone(), Permission::READ)]),
+            assigned_users: HashSet::from([user_id]),
+        };
+        let mut read_operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
+            auth_context: AuthContext {
+                user_id,
+                realm_id,
+                path_restrictions: None,
+            },
+            path,
+            required_permission: Permission::READ,
+        });
+        assert!(
+            read_operation
+                .check_permissions(vec![
+                    super::CollectedRole {
+                        role: public_deny,
+                        direct: false,
+                        public: true,
+                    },
+                    super::CollectedRole {
+                        role: direct_read,
+                        direct: true,
+                        public: false,
+                    },
+                ])
+                .unwrap()
+        );
+    }
+
     #[tokio::test]
-    pub async fn public_roles_apply_to_everyone_and_deny_wins() {
+    pub async fn public_roles_apply_to_everyone_and_are_read_only() {
         let random_path = tempdir().unwrap();
         let storage_handle =
             storage::FjallStorage::open(random_path.path().to_str().unwrap()).unwrap();
@@ -615,40 +735,35 @@ mod test {
         };
         assert!(check(stranger.clone(), data_path.clone(), Permission::READ).await);
 
-        // A public DENY role wins over everything, even the admin's own grant.
-        drive(
-            AddGroupRoleOperation::new(AddGroupRoleConfig {
-                auth_context: AuthContext {
-                    user_id: admin_id,
+        for (name, permission) in [
+            ("public-write", Permission::WRITE),
+            ("public-deny", Permission::DENY),
+        ] {
+            let result = drive(
+                AddGroupRoleOperation::new(AddGroupRoleConfig {
+                    auth_context: AuthContext {
+                        user_id: admin_id,
+                        realm_id,
+                        path_restrictions: None,
+                    },
                     realm_id,
-                    path_restrictions: None,
-                },
-                realm_id,
-                actor: actor.clone(),
-                group_id,
-                role: aruna_core::structs::Role {
-                    role_id: Ulid::new(),
-                    name: "public-deny-quarantine".to_string(),
-                    permissions: HashMap::from([(
-                        format!("/{realm_id}/g/{group_id}/data/node/bucket/quarantined/**"),
-                        Permission::DENY,
-                    )]),
-                    assigned_users: HashSet::from([UserId::nil(realm_id)]),
-                },
-            }),
-            &context,
-        )
-        .await
-        .unwrap();
-
-        let quarantined = format!("/{realm_id}/g/{group_id}/data/node/bucket/quarantined/key");
-        assert!(!check(anonymous.clone(), quarantined.clone(), Permission::READ).await);
-        let admin_auth = AuthContext {
-            user_id: admin_id,
-            realm_id,
-            path_restrictions: None,
-        };
-        assert!(!check(admin_auth, quarantined, Permission::READ).await);
+                    actor: actor.clone(),
+                    group_id,
+                    role: aruna_core::structs::Role {
+                        role_id: Ulid::new(),
+                        name: name.to_string(),
+                        permissions: HashMap::from([(
+                            format!("/{realm_id}/g/{group_id}/data/**"),
+                            permission,
+                        )]),
+                        assigned_users: HashSet::from([UserId::nil(realm_id)]),
+                    },
+                }),
+                &context,
+            )
+            .await;
+            assert!(matches!(result, Err(AddGroupRoleError::InvalidPublicRole)));
+        }
 
         net_handle.shutdown().await;
     }

--- a/operations/src/check_permissions.rs
+++ b/operations/src/check_permissions.rs
@@ -282,10 +282,6 @@ impl CheckPermissionsOperation {
             for (path, permission) in role.permissions {
                 let glob = Glob::new(&path)?.compile_matcher();
                 if glob.is_match(&self.config.path) {
-                    if public && permission != Permission::READ {
-                        continue;
-                    }
-
                     if public
                         && permission == Permission::READ
                         && self.config.required_permission == Permission::READ
@@ -565,6 +561,22 @@ mod test {
                 .unwrap()
         );
 
+        let public_direct_write = Role {
+            role_id: Ulid::new(),
+            name: "public-direct-write".to_string(),
+            permissions: HashMap::from([(path.clone(), Permission::WRITE)]),
+            assigned_users: HashSet::from([UserId::nil(realm_id), user_id]),
+        };
+        assert!(
+            write_operation
+                .check_permissions(vec![super::CollectedRole {
+                    role: public_direct_write,
+                    direct: true,
+                    public: true,
+                }])
+                .unwrap()
+        );
+
         let public_deny = Role {
             role_id: Ulid::new(),
             name: "public-deny".to_string(),
@@ -576,6 +588,12 @@ mod test {
             name: "direct-read".to_string(),
             permissions: HashMap::from([(path.clone(), Permission::READ)]),
             assigned_users: HashSet::from([user_id]),
+        };
+        let public_direct_deny = Role {
+            role_id: Ulid::new(),
+            name: "public-direct-deny".to_string(),
+            permissions: HashMap::from([(path.clone(), Permission::DENY)]),
+            assigned_users: HashSet::from([UserId::nil(realm_id), user_id]),
         };
         let mut read_operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
             auth_context: AuthContext {
@@ -592,6 +610,22 @@ mod test {
                     super::CollectedRole {
                         role: public_deny,
                         direct: false,
+                        public: true,
+                    },
+                    super::CollectedRole {
+                        role: direct_read.clone(),
+                        direct: true,
+                        public: false,
+                    },
+                ])
+                .unwrap()
+        );
+        assert!(
+            !read_operation
+                .check_permissions(vec![
+                    super::CollectedRole {
+                        role: public_direct_deny,
+                        direct: true,
                         public: true,
                     },
                     super::CollectedRole {

--- a/operations/src/remove_user_from_group.rs
+++ b/operations/src/remove_user_from_group.rs
@@ -98,6 +98,8 @@ pub enum RemoveUserFromGroupError {
     Unauthorized,
     #[error("Role not found")]
     RoleNotFound,
+    #[error("Invalid user id")]
+    InvalidUserId,
     #[error("Authorization document not found")]
     AuthDocNotFound,
     #[error("cannot remove the last admin of a group")]
@@ -529,6 +531,10 @@ impl Operation for RemoveUserFromGroupOperation {
     type Error = RemoveUserFromGroupError;
 
     fn start(&mut self) -> Effects {
+        if self.input.user_id.is_nil() {
+            return self.fail(RemoveUserFromGroupError::InvalidUserId);
+        }
+
         // Self-leave needs no admin permission; the last-admin guard still applies.
         if self.input.actor.user_id == self.input.user_id {
             self.state = RemoveUserFromGroupState::StartTransaction;
@@ -676,6 +682,7 @@ pub mod test {
     };
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::keyspaces::AUTH_KEYSPACE;
+    use aruna_core::operation::Operation;
     use aruna_core::structs::{Actor, Group, GroupAuthorizationDocument, RealmId};
     use aruna_core::types::{RoleId, TxnId};
     use aruna_core::{DOCUMENT_SYNC_OUTBOX_KEYSPACE, structs::Permission, structs::Role};
@@ -753,6 +760,31 @@ pub mod test {
             .iter()
             .filter_map(|(k, v)| (v.name == name).then_some(*k))
             .collect()
+    }
+
+    #[test]
+    fn rejects_nil_user_id_as_removal_target() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let owner_id = UserId::local(Ulid::from_bytes([2u8; 16]), realm_id);
+        let group_id = Ulid::from_bytes([3u8; 16]);
+        let role_id = Ulid::from_bytes([4u8; 16]);
+        let actor = Actor {
+            node_id: iroh::SecretKey::from_bytes(&[5u8; 32]).public(),
+            user_id: owner_id,
+            realm_id,
+        };
+        let mut operation = RemoveUserFromGroupOperation::new(RemoveUserFromGroupInput {
+            actor,
+            group_id,
+            user_id: UserId::nil(realm_id),
+            role_ids: Some(HashSet::from([role_id])),
+        });
+
+        assert!(operation.start().is_empty());
+        assert_eq!(
+            operation.finalize(),
+            Err(RemoveUserFromGroupError::InvalidUserId)
+        );
     }
 
     #[test]

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -364,7 +364,6 @@ async fn bootstrap_node_usage_genesis(
         sleep(Duration::from_millis(50)).await;
     }
 }
-
 async fn read_node_stats(node: &TestNode, key: Vec<u8>) -> Option<Vec<u8>> {
     match node
         .context


### PR DESCRIPTION
Adds a public role concept bound to the everyone principal: groups can flag roles as public, permission checks apply public roles to all principals, S3 allows anonymous read-only access through them, and unauthenticated DRS requests resolve as the everyone principal.

Stacked on #305 (feat/quota-config); diff shows only the public-access commits.

## Changes

- Adds a `public` flag to group roles, encoded as an assignment to the everyone principal (`UserId::nil`) with `Role::is_public` helpers.
- Applies public roles to every principal in permission checks, including anonymous requests.
- Exposes the `public` flag on the group role endpoints: settable on role creation and returned in role listings, with the everyone principal surfaced via the flag instead of appearing as a member.
- Allows anonymous read-only S3 access: unsigned requests resolve to the anonymous principal and succeed only where a public role grants read access; write operations remain rejected.
- Resolves unauthenticated DRS requests as the everyone principal so public data is reachable without a token.
- Adds end-to-end anonymous access coverage in `aruna/tests/public_access.rs`.
