### PR TITLE
Fix/admin doc sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+docker/
 .compose-data/
 .idea
 .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,19 +34,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
-dependencies = [
- "cipher 0.5.2",
- "cpubits",
- "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -56,8 +45,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
@@ -1310,7 +1299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
- "zeroize",
 ]
 
 [[package]]
@@ -1360,7 +1348,7 @@ version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d0bd4c2f75335ad98052a37efb54f428b492f64340257143b3429c8a508fa7b"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1432,21 +1420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
-name = "bzip2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
-dependencies = [
- "libbz2-rs-sys",
-]
-
-[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1517,18 +1496,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout 0.1.4",
+ "inout",
  "zeroize",
-]
-
-[[package]]
-name = "cipher"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
-dependencies = [
- "crypto-common 0.2.2",
- "inout 0.2.2",
 ]
 
 [[package]]
@@ -1710,12 +1679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpubits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,8 +1698,8 @@ dependencies = [
 
 [[package]]
 name = "craqle"
-version = "0.1.0"
-source = "git+https://github.com/arunaengine/craqle?branch=feat%2Firokle#7916fa93450e672f324fb917056a9d2b063bfc05"
+version = "0.1.1"
+source = "git+https://github.com/arunaengine/craqle?branch=main#cb38935800ea2df442536230274cdd070acabecd"
 dependencies = [
  "blake3",
  "chrono",
@@ -1930,7 +1893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
  "aead",
- "cipher 0.4.4",
+ "cipher",
  "generic-array",
  "poly1305",
  "salsa20",
@@ -1954,7 +1917,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -2017,18 +1980,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2046,36 +1999,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -2117,7 +2046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2125,12 +2054,6 @@ name = "datasketches"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
-
-[[package]]
-name = "deflate64"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "der"
@@ -2190,7 +2113,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2257,7 +2180,6 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
- "zeroize",
 ]
 
 [[package]]
@@ -3433,7 +3355,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3618,15 +3540,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "inout"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -3861,6 +3774,7 @@ dependencies = [
 [[package]]
 name = "irokle"
 version = "0.1.2"
+source = "git+https://github.com/arunaengine/irokle.git?branch=main#1c014b5b065c0c97aa2f137119c45cf2adb2a476"
 dependencies = [
  "blake3",
  "bytes",
@@ -3880,6 +3794,7 @@ dependencies = [
 [[package]]
 name = "irokle-derive"
 version = "0.1.0"
+source = "git+https://github.com/arunaengine/irokle.git?branch=main#1c014b5b065c0c97aa2f137119c45cf2adb2a476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4123,12 +4038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
-name = "libbz2-rs-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,15 +4179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
-]
-
-[[package]]
-name = "lzma-rust2"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
-dependencies = [
- "sha2 0.11.0",
 ]
 
 [[package]]
@@ -4631,7 +4531,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4674,7 +4574,7 @@ checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5231,7 +5131,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "ryu-js",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5243,9 +5143,9 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.8.6",
+ "rand 0.9.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5258,7 +5158,7 @@ dependencies = [
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5271,7 +5171,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5280,7 +5180,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5293,7 +5193,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5375,16 +5275,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
-dependencies = [
- "digest 0.11.3",
- "hmac 0.13.0",
 ]
 
 [[package]]
@@ -5528,10 +5418,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "cbc",
  "der 0.7.10",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "scrypt",
  "sha2 0.10.9",
  "spki 0.7.3",
@@ -5719,12 +5609,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppmd-rust"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5897,7 +5781,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5935,7 +5819,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6294,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "ro-crate-rs"
 version = "0.5.0"
-source = "git+https://github.com/intbio-ncl/ro-crate-rs.git?branch=main#93536d9e53af1432e67e2b057cc9f9868ab4d23c"
+source = "git+https://github.com/intbio-ncl/ro-crate-rs.git?branch=main#cda69da08d53bb7393c2b7714eae8cde0915ce5b"
 dependencies = [
  "chrono",
  "dirs",
@@ -6595,7 +6479,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -6634,7 +6518,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
 ]
@@ -7005,7 +6889,7 @@ dependencies = [
  "memchr",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7020,7 +6904,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
  "rustc-hash",
  "sha1 0.10.6",
@@ -7028,7 +6912,7 @@ dependencies = [
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7041,8 +6925,8 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.8.6",
- "thiserror 2.0.18",
+ "rand 0.9.4",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7052,7 +6936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
 dependencies = [
  "oxrdf",
- "rand 0.8.6",
+ "rand 0.9.4",
  "spargebra",
 ]
 
@@ -8268,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -8544,7 +8428,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9126,25 +9010,12 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes 0.9.1",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
- "deflate64",
  "flate2",
- "getrandom 0.4.3",
- "hmac 0.13.0",
  "indexmap",
- "lzma-rust2",
  "memchr",
- "pbkdf2 0.13.0",
- "ppmd-rust",
- "sha1 0.11.0",
- "time",
  "typed-path",
- "zeroize",
  "zopfli",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "sha2 0.11.0",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -264,7 +264,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",
@@ -300,7 +300,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -328,7 +328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "ulid",
@@ -367,7 +367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "ulid",
@@ -397,7 +397,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -439,7 +439,7 @@ dependencies = [
  "smallvec",
  "spargebra",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -458,7 +458,7 @@ dependencies = [
  "crossfire",
  "fjall",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "ulid",
@@ -1399,9 +1399,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -1466,6 +1466,12 @@ name = "census"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1586,7 +1592,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1745,7 +1751,7 @@ dependencies = [
  "spareval",
  "spargebra",
  "tantivy",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
@@ -1978,12 +1984,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -2389,11 +2395,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "ed25519 3.0.0",
  "rand_core 0.10.1",
  "serde",
@@ -2607,9 +2613,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fjall"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038acd422d607e0eca09e093f299f9eccf9bd097554343d93746afff81a45113"
+checksum = "9fcdc69609906151dff9b534e30eaf8515082055d36f628e382bd0b5d6a1d362"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -2918,17 +2924,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -3139,10 +3143,10 @@ dependencies = [
  "http 1.4.2",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "rand 0.10.1",
  "rustls 0.23.40",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -3159,12 +3163,12 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -3182,7 +3186,7 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "moka",
  "ndk-context",
  "once_cell",
@@ -3192,7 +3196,7 @@ dependencies = [
  "rustls 0.23.40",
  "smallvec",
  "system-configuration",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tracing",
@@ -3542,12 +3546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
+checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
 dependencies = [
  "backon",
  "blake3",
@@ -3693,9 +3691,9 @@ dependencies = [
  "ctutils",
  "data-encoding",
  "derive_more",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "futures-util",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hickory-resolver",
  "http 1.4.2",
  "ipnet",
@@ -3719,7 +3717,6 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
  "serde",
  "smallvec",
  "strum",
@@ -3730,36 +3727,32 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+checksum = "830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.3",
- "ed25519-dalek 3.0.0-pre.7",
- "getrandom 0.4.2",
+ "ed25519-dalek 3.0.0-rc.0",
+ "getrandom 0.4.3",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+checksum = "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3769,8 +3762,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest",
  "rustls 0.23.40",
  "simple-dns",
  "strum",
@@ -3794,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
@@ -3809,9 +3802,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3821,16 +3814,16 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
+checksum = "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354"
 dependencies = [
  "blake3",
  "bytes",
  "cfg_aliases",
  "data-encoding",
  "derive_more",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hickory-resolver",
  "http 1.4.2",
  "http-body-util",
@@ -3867,20 +3860,19 @@ dependencies = [
 
 [[package]]
 name = "irokle"
-version = "0.1.0"
-source = "git+https://github.com/arunaengine/irokle.git?branch=main#d3e9f1b901caa2774cc1b59912c345eb759ed9c9"
+version = "0.1.2"
 dependencies = [
  "blake3",
  "bytes",
  "ed25519-dalek 2.2.0",
  "fjall",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "iroh",
  "irokle-derive",
  "postcard",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3888,7 +3880,6 @@ dependencies = [
 [[package]]
 name = "irokle-derive"
 version = "0.1.0"
-source = "git+https://github.com/arunaengine/irokle.git?branch=main#d3e9f1b901caa2774cc1b59912c345eb759ed9c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3961,6 +3952,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3968,10 +3975,10 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -3987,6 +3994,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -4099,12 +4115,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "levenshtein_automata"
@@ -4233,9 +4243,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef86c3c797c10eefcc73407c43ae48c19d4df686131a8334b2895a513e91df4"
+checksum = "39ca67401338b98d58447387dd5230552d2241bc388206e491d137b18dfea9d6"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -4419,9 +4429,9 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -4429,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4461,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more",
  "n0-error",
@@ -4478,19 +4488,22 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -4511,21 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
-dependencies = [
- "bitflags",
- "libc",
- "log",
- "netlink-packet-core",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags",
  "libc",
@@ -4544,7 +4545,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4562,14 +4563,15 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
+checksum = "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -4577,7 +4579,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -4617,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+checksum = "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4630,7 +4632,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.40",
  "socket2 0.6.4",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4639,15 +4641,15 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+checksum = "aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3"
 dependencies = [
  "aes-gcm",
  "bytes",
  "derive_more",
  "enum-assoc",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "identity-hash",
  "lru-slab",
  "rand 0.10.1",
@@ -4658,7 +4660,7 @@ dependencies = [
  "rustls-pki-types",
  "slab",
  "sorted-index-buffer",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4666,9 +4668,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5113,7 +5115,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5127,7 +5129,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-types",
@@ -5159,7 +5161,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -5229,7 +5231,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "ryu-js",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5241,9 +5243,9 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.9.4",
+ "rand 0.8.6",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5256,7 +5258,7 @@ dependencies = [
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5269,7 +5271,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5278,7 +5280,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5291,7 +5293,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5639,9 +5641,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
+checksum = "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721"
 dependencies = [
  "base64",
  "bytes",
@@ -5896,7 +5898,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.40",
  "socket2 0.6.4",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5918,7 +5920,7 @@ dependencies = [
  "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5987,7 +5989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -6102,7 +6104,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6303,7 +6305,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "url",
  "uuid",
  "walkdir",
@@ -6477,7 +6479,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls 0.23.40",
@@ -6576,7 +6578,7 @@ dependencies = [
  "std-next",
  "subtle",
  "sync_wrapper",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tower",
@@ -6939,7 +6941,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -7003,7 +7005,7 @@ dependencies = [
  "memchr",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7018,7 +7020,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.9.4",
+ "rand 0.8.6",
  "regex",
  "rustc-hash",
  "sha1 0.10.6",
@@ -7026,7 +7028,7 @@ dependencies = [
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7039,8 +7041,8 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.9.4",
- "thiserror",
+ "rand 0.8.6",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7050,7 +7052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
 dependencies = [
  "oxrdf",
- "rand 0.9.4",
+ "rand 0.8.6",
  "spargebra",
 ]
 
@@ -7141,7 +7143,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7224,7 +7226,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -7261,7 +7263,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -7285,7 +7287,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -7303,7 +7305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04082e93ed1a06debd9148c928234b46d2cf260bc65f44e1d1d3fa594c5beebc"
 dependencies = [
  "simdutf8",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7365,7 +7367,7 @@ dependencies = [
  "log",
  "pin-project",
  "rustls-pki-types",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7494,7 +7496,7 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "typetag",
  "uuid",
@@ -7614,10 +7616,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -7626,7 +7637,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7802,7 +7824,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "http 1.4.2",
  "httparse",
  "rand 0.10.1",
@@ -8250,7 +8272,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -8360,16 +8382,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -8434,28 +8447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8466,18 +8457,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -8688,6 +8667,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8720,6 +8708,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8764,6 +8767,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8776,6 +8785,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8785,6 +8800,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8806,6 +8827,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8815,6 +8842,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8830,6 +8863,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8839,6 +8878,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8863,97 +8908,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wmi"
@@ -8965,7 +8922,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "windows",
  "windows-core",
 ]
@@ -8989,7 +8946,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper",
- "thiserror",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -9098,18 +9055,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9175,7 +9132,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hmac 0.13.0",
  "indexmap",
  "lzma-rust2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,5 +145,13 @@ utoipa = { version = "5.5.0", features = [
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 
+# Pre-release only: point irokle at the remote genesis-tiebreak branch so the
+# additive eviction APIs are available before they land on main. This patch
+# also covers craqle's transitive irokle edge (same git source), keeping one
+# irokle instance across the graph. Drop this section once upstream main has
+# the tie-break APIs.
+[patch."https://github.com/arunaengine/irokle.git"]
+irokle = { git = "https://github.com/arunaengine/irokle", rev = "8d447a81af827eed9a564533a2d0a27a21e6a177" }
+
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ bytes = "1.11.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 console-subscriber = "0.5.0"
-craqle = { git = "https://github.com/arunaengine/craqle", branch = "feat/irokle", features = [
+craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", features = [
     "iroh",
 ] }
 crc-fast = "1.10.0"
@@ -144,14 +144,6 @@ utoipa = { version = "5.5.0", features = [
 ] }
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
-
-# Pre-release only: point irokle at the remote genesis-tiebreak branch so the
-# additive eviction APIs are available before they land on main. This patch
-# also covers craqle's transitive irokle edge (same git source), keeping one
-# irokle instance across the graph. Drop this section once upstream main has
-# the tie-break APIs.
-[patch."https://github.com/arunaengine/irokle.git"]
-irokle = { git = "https://github.com/arunaengine/irokle", rev = "8d447a81af827eed9a564533a2d0a27a21e6a177" }
 
 [profile.release]
 panic = "abort"

--- a/api/tests/document_sync_publish_architecture_guard.rs
+++ b/api/tests/document_sync_publish_architecture_guard.rs
@@ -58,7 +58,7 @@ fn allowed_publish_use(publish_use: &PublishUse) -> bool {
                     publish_use.text.as_str(),
                     "DocumentSyncPublish::Upsert {"
                         | "DocumentSyncPublish::Delete {"
-                        | "DocumentSyncPublish::AdminOperation { target, event } => {"
+                        | "DocumentSyncPublish::AdminOperation { target, event, .. } => {"
                 )
         }
         _ => false,

--- a/aruna/src/bootstrap.rs
+++ b/aruna/src/bootstrap.rs
@@ -53,6 +53,7 @@ pub async fn announce_core_documents(
     driver_ctx: &DriverContext,
     node_id: NodeId,
     realm_id: &aruna_core::structs::RealmId,
+    allow_genesis: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let driver_ctx = driver_ctx.clone();
     let realm_id = *realm_id;
@@ -73,6 +74,10 @@ pub async fn announce_core_documents(
                 local_node_id: node_id,
                 excluded_peers: Vec::new(),
                 documents,
+                // Only the realm-bootstrap node may mint the shared node-usage
+                // genesis; joining/provisioned nodes announce with false and wait
+                // for it to replicate in.
+                allow_genesis,
             }),
             &driver_ctx,
         )

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -129,8 +129,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     match &config.startup_mode {
         StartupMode::InitializeRealm { realm_description } => {
             if realm_bootstrap_exists(driver_ctx.as_ref(), &config.realm_id).await? {
-                announce_core_documents(driver_ctx.as_ref(), config.node_id, &config.realm_id)
-                    .await?;
+                announce_core_documents(
+                    driver_ctx.as_ref(),
+                    config.node_id,
+                    &config.realm_id,
+                    true,
+                )
+                .await?;
             } else {
                 drive(
                     CreateRealmOperation::new(CreateRealmConfig {
@@ -143,6 +148,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                         oidc_providers: config.oidc_providers.clone(),
                     }),
                     driver_ctx.as_ref(),
+                )
+                .await?;
+                // CreateRealm mints the realm-auth/realm-config genesis via its admin
+                // operation outbox records, but not the shared node-usage topic. As
+                // the realm-bootstrap node, announce the core documents here so the
+                // node-usage genesis is minted on the fresh-bootstrap path too.
+                announce_core_documents(
+                    driver_ctx.as_ref(),
+                    config.node_id,
+                    &config.realm_id,
+                    true,
                 )
                 .await?;
             }
@@ -190,7 +206,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     warn!(error = %error, "Failed to refresh realm peers after onboarding document fetch");
                 }
             }
-            announce_core_documents(driver_ctx.as_ref(), config.node_id, &config.realm_id).await?;
+            // A joining node is never the realm-bootstrap node: it announces the
+            // shared node-usage topic with allow_genesis=false and waits for the
+            // bootstrap node's genesis to replicate in.
+            announce_core_documents(driver_ctx.as_ref(), config.node_id, &config.realm_id, false)
+                .await?;
             mark_node_state_complete(&driver_ctx.storage_handle, &config.node_state).await?;
         }
         StartupMode::Provisioned => {
@@ -224,7 +244,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .await?;
             }
 
-            announce_core_documents(driver_ctx.as_ref(), config.node_id, &config.realm_id).await?;
+            // A provisioned node re-announces core documents on restart as a
+            // holder, but the shared node-usage genesis already exists from the
+            // bootstrap node, so it never needs to mint it.
+            announce_core_documents(driver_ctx.as_ref(), config.node_id, &config.realm_id, false)
+                .await?;
         }
     }
 

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -232,6 +232,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         ProcessPlacementsOperation::new(PlacementConfig {
             realm_id: config.realm_id,
             local_node_id: config.node_id,
+            retry_after: aruna_operations::sync_placement::SYNC_PLACEMENT_RETRY_AFTER,
         }),
         driver_ctx.as_ref(),
     )

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -553,7 +553,7 @@ async fn spawn_seed_node_with_mode(mode: NodeServiceMode) -> TestResult<SeedNode
         context.as_ref(),
     )
     .await?;
-    announce_core_documents(context.as_ref(), net.node_id(), &realm_id).await?;
+    announce_core_documents(context.as_ref(), net.node_id(), &realm_id, true).await?;
     drive(
         ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
             actor: Actor {
@@ -644,7 +644,13 @@ async fn spawn_joiner_node_with_mode(
         OnboardingPhase::CoreDocumentsFetched,
     )
     .await?;
-    announce_core_documents(joiner_context.as_ref(), config.node_id, &config.realm_id).await?;
+    announce_core_documents(
+        joiner_context.as_ref(),
+        config.node_id,
+        &config.realm_id,
+        false,
+    )
+    .await?;
     mark_node_state_complete(&joiner_context.storage_handle, &config.node_state).await?;
     announce_realm_presence(joiner_context.as_ref(), &config.realm_id, config.node_id).await?;
 

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -89,6 +89,14 @@ pub enum DocumentSyncOutboxEvent {
     },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DocumentSyncEvictedDocument {
+    pub event_id: Option<Ulid>,
+    pub target: DocumentSyncTarget,
+    pub event: DocumentSyncOutboxEvent,
+    pub allow_genesis: bool,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct DocumentSyncRevision {
     pub generation: u64,

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -223,6 +223,20 @@ pub fn document_sync_apply_decision(
 }
 
 impl DocumentSyncTarget {
+    /// Admin documents (user, group, and realm authorization/config) replicate
+    /// only as `AdminOperation` events over their shared topic; they never take
+    /// placements or sync as whole documents.
+    pub fn is_admin_document(&self) -> bool {
+        matches!(
+            self,
+            Self::Group { .. }
+                | Self::GroupAuthorization { .. }
+                | Self::RealmAuthorization { .. }
+                | Self::RealmConfig { .. }
+                | Self::User { .. }
+        )
+    }
+
     pub fn topic_id(&self) -> TopicId {
         match self {
             Self::Group { group_id } | Self::GroupAuthorization { group_id } => {

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -69,6 +69,10 @@ pub struct DocumentSyncOutboxRecord {
     pub peers: Vec<NodeId>,
     pub event: DocumentSyncOutboxEvent,
     pub updated_at: u64,
+    /// Whether the publisher may mint this document's sync topic genesis when it
+    /// is missing. Only the node that originated the document sets this; every
+    /// other publisher waits (retryable) for the origin's genesis to replicate.
+    pub allow_genesis: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -418,6 +418,11 @@ pub enum DocumentSyncNetEvent {
     DocumentsPublished {
         targets: Vec<DocumentSyncTarget>,
     },
+    DocumentsPartiallyPublished {
+        published_indices: Vec<usize>,
+        retry_indices: Vec<usize>,
+        error: String,
+    },
     DocumentsReconciled {
         applied: usize,
         targets: Vec<DocumentSyncTarget>,

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -134,15 +134,18 @@ pub enum DocumentSyncPublish {
         target: DocumentSyncTarget,
         bytes: Vec<u8>,
         change: DocumentSyncChange,
+        allow_genesis: bool,
     },
     AdminOperation {
         target: DocumentSyncTarget,
         event: Box<AdminDocumentEvent>,
+        allow_genesis: bool,
     },
     Delete {
         event_id: Ulid,
         target: DocumentSyncTarget,
         change: DocumentSyncChange,
+        allow_genesis: bool,
     },
 }
 
@@ -172,6 +175,14 @@ impl DocumentSyncPublish {
         match self {
             Self::Upsert { event_id, .. } | Self::Delete { event_id, .. } => *event_id,
             Self::AdminOperation { event, .. } => event.event_id,
+        }
+    }
+
+    pub fn allow_genesis(&self) -> bool {
+        match self {
+            Self::Upsert { allow_genesis, .. }
+            | Self::Delete { allow_genesis, .. }
+            | Self::AdminOperation { allow_genesis, .. } => *allow_genesis,
         }
     }
 }
@@ -689,6 +700,7 @@ mod tests {
             target: target.clone(),
             bytes: vec![1, 2],
             change,
+            allow_genesis: true,
         };
         let event = DocumentSyncEvent::Upsert {
             event_id,
@@ -700,6 +712,7 @@ mod tests {
         assert_eq!(outbox.kind(), b"upsert");
         assert_eq!(publish.target(), &target);
         assert_eq!(publish.event_id(), event_id);
+        assert!(publish.allow_genesis());
         assert_eq!(event.target(), &target);
         assert_eq!(event.event_id(), event_id);
     }
@@ -716,6 +729,7 @@ mod tests {
             event_id,
             target: target.clone(),
             change,
+            allow_genesis: false,
         };
         let event = DocumentSyncEvent::Delete {
             event_id,
@@ -726,6 +740,7 @@ mod tests {
         assert_eq!(outbox.kind(), b"delete");
         assert_eq!(publish.target(), &target);
         assert_eq!(publish.event_id(), event_id);
+        assert!(!publish.allow_genesis());
         assert_eq!(event.target(), &target);
         assert_eq!(event.event_id(), event_id);
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,7 +28,8 @@ pub mod util;
 
 pub use document::{
     DocumentSyncApplyDecision, DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncEffect,
-    DocumentSyncEvent, DocumentSyncNetEvent, DocumentSyncRevision, DocumentSyncTarget,
+    DocumentSyncEvent, DocumentSyncEvictedDocument, DocumentSyncNetEvent, DocumentSyncRevision,
+    DocumentSyncTarget,
 };
 pub use id::{DhtKeyId, NodeId, NodeIdExt, TopicId};
 pub use keyspaces::*;

--- a/net/src/error.rs
+++ b/net/src/error.rs
@@ -19,6 +19,12 @@ pub enum NetError {
     #[error("Timeout after {0:?}")]
     Timeout(Duration),
 
+    /// The document sync topic has no local genesis yet and this publisher is not
+    /// the document's origin, so it may not mint one. Retryable: the write waits
+    /// for the origin's genesis to replicate in.
+    #[error("Document sync topic {0} not ready")]
+    TopicNotReady(String),
+
     #[error("I/O error: {0}")]
     Io(String),
 

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -90,6 +90,14 @@ struct PendingMetadataCreateApply {
     lifecycle_revision: Option<DocumentSyncChange>,
 }
 
+#[derive(Default)]
+struct PublishEventsOutcome {
+    published: BTreeMap<irokle_crate::TopicId, irokle_crate::ActorClock>,
+    published_indices: Vec<usize>,
+    retry_indices: Vec<usize>,
+    retry_error: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct DocumentSyncService {
     node: irokle_crate::Irokle<irokle_crate::FjallStorage>,
@@ -531,7 +539,25 @@ impl DocumentSyncService {
             .map(|document| document.target().clone())
             .collect::<Vec<_>>();
         match self.publish_events(documents, peers).await {
-            Ok(()) => DocumentSyncNetEvent::DocumentsPublished { targets },
+            Ok(outcome) if outcome.retry_indices.is_empty() => {
+                DocumentSyncNetEvent::DocumentsPublished { targets }
+            }
+            Ok(outcome) if outcome.published_indices.is_empty() => DocumentSyncNetEvent::Error {
+                target: outcome
+                    .retry_indices
+                    .first()
+                    .and_then(|index| targets.get(*index).cloned()),
+                error: outcome
+                    .retry_error
+                    .unwrap_or_else(|| "Document sync topic not ready".to_string()),
+            },
+            Ok(outcome) => DocumentSyncNetEvent::DocumentsPartiallyPublished {
+                published_indices: outcome.published_indices,
+                retry_indices: outcome.retry_indices,
+                error: outcome
+                    .retry_error
+                    .unwrap_or_else(|| "Document sync topic not ready".to_string()),
+            },
             Err(error) => DocumentSyncNetEvent::Error {
                 target: None,
                 error: error.to_string(),
@@ -708,35 +734,36 @@ impl DocumentSyncService {
         &self,
         documents: Vec<DocumentSyncPublish>,
         peers: Vec<NodeId>,
-    ) -> Result<()> {
+    ) -> Result<PublishEventsOutcome> {
         if documents.is_empty() {
-            return Ok(());
+            return Ok(PublishEventsOutcome::default());
         }
         let sync_peers = self.sync_peers(peers);
         self.allow_sync_peers(&sync_peers)?;
         let service = self.clone();
-        let published = tokio::task::spawn_blocking(move || {
+        let mut outcome = tokio::task::spawn_blocking(move || {
             service.publish_events_blocking(documents, &sync_peers)
         })
         .await
         .map_err(|error| NetError::Bootstrap(error.to_string()))??;
+        let published = std::mem::take(&mut outcome.published);
         self.advance_topic_cursors(published).await?;
-        self.flush_database()
+        self.flush_database()?;
+        Ok(outcome)
     }
 
     fn publish_events_blocking(
         &self,
         documents: Vec<DocumentSyncPublish>,
         sync_peers: &BTreeSet<PeerId>,
-    ) -> Result<BTreeMap<irokle_crate::TopicId, irokle_crate::ActorClock>> {
+    ) -> Result<PublishEventsOutcome> {
         let publish_started = Instant::now();
         let document_count = documents.len();
         let mut fast_path = 0usize;
         let mut fallback = 0usize;
         let oplog = Oplog::with_storage(self.node.storage().clone());
-        let mut published: BTreeMap<irokle_crate::TopicId, irokle_crate::ActorClock> =
-            BTreeMap::new();
-        for document in documents {
+        let mut outcome = PublishEventsOutcome::default();
+        for (index, document) in documents.into_iter().enumerate() {
             let allow_genesis = document.allow_genesis();
             let event = match document {
                 DocumentSyncPublish::Upsert {
@@ -770,7 +797,7 @@ impl DocumentSyncService {
             let actor_id = irokle_crate::actor_id_for(topic_id, self.node.peer_id());
             let envelope = EventEnvelope::encode_event(&event)
                 .map_err(|error| NetError::Bootstrap(error.to_string()))?;
-            let op = self.publish_event_op(
+            let op = match self.publish_event_op(
                 &oplog,
                 &target,
                 topic_id,
@@ -780,22 +807,37 @@ impl DocumentSyncService {
                 allow_genesis,
                 &mut fast_path,
                 &mut fallback,
-            )?;
-            published
+            ) {
+                Ok(op) => op,
+                Err(NetError::TopicNotReady(topic)) => {
+                    outcome.retry_indices.push(index);
+                    outcome
+                        .retry_error
+                        .get_or_insert_with(|| NetError::TopicNotReady(topic).to_string());
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            outcome.published_indices.push(index);
+            outcome
+                .published
                 .entry(topic_id)
                 .or_default()
                 .observe(op.signed.body.actor_id, op.signed.body.actor_seq);
         }
+        let published_count = outcome.published_indices.len();
         info!(
             event = "pipeline.publish.summary",
             documents = document_count,
+            published = published_count,
+            retry = outcome.retry_indices.len(),
             fast_path,
             fallback,
-            existing = document_count - fast_path - fallback,
+            existing = published_count.saturating_sub(fast_path + fallback),
             total_ms = duration_ms(publish_started.elapsed()),
             "Document sync publish batch breakdown"
         );
-        Ok(published)
+        Ok(outcome)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -7280,6 +7322,87 @@ mod tests {
         assert!(
             service.has_topic(topic_id).expect("topic lookup"),
             "origin publish must create the topic genesis"
+        );
+    }
+
+    #[tokio::test]
+    async fn topic_not_ready_publish_does_not_block_ready_batch_record() {
+        let (_storage_dir, storage) = test_storage();
+        let doc_dir = tempfile::tempdir().expect("doc dir");
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(62).await,
+            storage,
+            doc_dir.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+        )
+        .expect("document sync service opens");
+
+        let local_node = service.local_node_id().expect("local node id");
+        let blocked_target = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_parts(62, 1),
+        };
+        let ready_target = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_parts(62, 2),
+        };
+        let blocked_topic = blocked_target.sync_topic_id();
+        let ready_topic = ready_target.sync_topic_id();
+        let change = DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id: Ulid::from_parts(62, 3),
+                actor: local_node,
+                updated_at_ms: 1,
+            },
+            kind: DocumentSyncChangeKind::Upsert,
+        };
+
+        let published = service
+            .publish_documents(
+                vec![
+                    DocumentSyncPublish::Upsert {
+                        event_id: Ulid::from_parts(62, 4),
+                        target: blocked_target.clone(),
+                        bytes: b"blocked".to_vec(),
+                        change,
+                        allow_genesis: false,
+                    },
+                    DocumentSyncPublish::Upsert {
+                        event_id: Ulid::from_parts(62, 5),
+                        target: ready_target.clone(),
+                        bytes: b"ready".to_vec(),
+                        change,
+                        allow_genesis: true,
+                    },
+                ],
+                Vec::new(),
+            )
+            .await;
+
+        match published {
+            DocumentSyncNetEvent::DocumentsPartiallyPublished {
+                published_indices,
+                retry_indices,
+                error,
+            } => {
+                assert_eq!(published_indices, vec![1]);
+                assert_eq!(retry_indices, vec![0]);
+                assert!(error.contains(&blocked_topic.to_string()));
+            }
+            other => panic!("expected partial publish, got {other:?}"),
+        }
+        assert!(
+            !service
+                .has_topic(blocked_topic)
+                .expect("blocked topic lookup"),
+            "not-ready record must not mint genesis"
+        );
+        assert!(
+            service.has_topic(ready_topic).expect("ready topic lookup"),
+            "ready record behind not-ready record must publish"
         );
     }
 

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -1419,6 +1419,19 @@ impl DocumentSyncService {
                             applied_targets.push(target);
                         }
                     }
+                    DocumentSyncEvent::Upsert { ref target, .. }
+                    | DocumentSyncEvent::Delete { ref target, .. }
+                        if admin_document_target_for_reduced_document(target).is_some() =>
+                    {
+                        // apply_upsert/apply_delete refuse whole-document admin sync, so
+                        // skip it here to let the cursor advance instead of wedging reconcile.
+                        warn!(
+                            %topic_id,
+                            ?target,
+                            "Skipping unsupported whole-document admin sync event"
+                        );
+                        continue;
+                    }
                     event => {
                         let target = event.target().clone();
                         self.apply_document_event(event).await?;
@@ -7027,5 +7040,131 @@ mod tests {
         assert_eq!(prune_jobs[0].graph_iri, tombstone.graph_iri);
         assert_eq!(prune_jobs[0].attempts, 0);
         assert!(prune_jobs[0].last_error.is_none());
+    }
+
+    // Whole-document admin sync is refused by apply_upsert/apply_delete. If reconcile
+    // `?`-propagated that refusal the applied-ops cursor would never advance, so each
+    // reconcile would re-materialize the whole post-cursor history. The upsert/delete
+    // must be skipped while the admin operation on the same topic still applies.
+    #[tokio::test]
+    async fn reconcile_skips_whole_document_admin_sync_events() {
+        let (_storage_dir, storage) = test_storage();
+        let doc_dir = tempfile::tempdir().expect("doc dir");
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(54).await,
+            storage.clone(),
+            doc_dir.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+        )
+        .expect("document sync service opens");
+
+        let realm_id = RealmId::from_bytes([54u8; 32]);
+        let user_id = UserId::local(Ulid::from_parts(1_400, 1), realm_id);
+        let target = DocumentSyncTarget::User { user_id };
+        let topic_id = target.sync_topic_id();
+
+        let change = |kind| DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id: Ulid::new(),
+                actor: service.local_node_id().expect("local node id"),
+                updated_at_ms: 1,
+            },
+            kind,
+        };
+        let actor = test_actor(8, user_id, realm_id);
+        let admin_event = test_admin_event(
+            Ulid::from_parts(1_401, 1),
+            AdminDocumentTarget::User { user_id },
+            &actor,
+            1,
+            AdminDocumentOperation::UserNameSet {
+                name: "Skip Survivor".to_string(),
+            },
+        );
+
+        // Two hostile whole-document ops (upsert then delete) precede a legitimate
+        // owner-authored admin operation on the same topic.
+        let published = service
+            .publish_documents(
+                vec![
+                    DocumentSyncPublish::Upsert {
+                        event_id: Ulid::new(),
+                        target: target.clone(),
+                        bytes: b"whole-document-admin-upsert".to_vec(),
+                        change: change(DocumentSyncChangeKind::Upsert),
+                    },
+                    DocumentSyncPublish::Delete {
+                        event_id: Ulid::new(),
+                        target: target.clone(),
+                        change: change(DocumentSyncChangeKind::Delete),
+                    },
+                    DocumentSyncPublish::AdminOperation {
+                        target: target.clone(),
+                        event: Box::new(admin_event),
+                    },
+                ],
+                Vec::new(),
+            )
+            .await;
+        assert!(matches!(
+            published,
+            DocumentSyncNetEvent::DocumentsPublished { .. }
+        ));
+
+        // Reset the cursor so reconcile reprocesses every op as a fresh peer would.
+        service
+            .storage_write(
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                topic_cursor_key(topic_id),
+                ByteView::from(
+                    postcard::to_allocvec(&irokle_crate::ActorClock::default())
+                        .expect("clock serializes"),
+                ),
+            )
+            .await
+            .expect("cursor reset");
+
+        // Reconcile completes despite the hostile whole-document ops.
+        let result = service
+            .reconcile_document_topics([topic_id])
+            .await
+            .expect("reconcile skips whole-document admin sync instead of wedging");
+
+        // The admin operation on the same topic still applied.
+        assert!(result.targets.contains(&target));
+        let stored_user = read_storage_value(&storage, USER_KEYSPACE, user_id.to_bytes().into())
+            .await
+            .expect("user materialized by the admin operation");
+        assert_eq!(
+            User::from_bytes(&stored_user).expect("user decodes").name,
+            "Skip Survivor"
+        );
+
+        // The cursor advanced past the hostile ops.
+        let cursor_bytes = read_storage_value(
+            &storage,
+            DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+            topic_cursor_key(topic_id),
+        )
+        .await
+        .expect("cursor persisted");
+        let cursor: irokle_crate::ActorClock =
+            postcard::from_bytes(&cursor_bytes).expect("cursor decodes");
+        let topic_clock = service
+            .node()
+            .storage()
+            .actor_clock(&topic_id)
+            .expect("topic clock");
+        assert!(
+            cursor.dominates(&topic_clock),
+            "cursor must advance past the hostile ops"
+        );
+
+        service.shutdown().await;
     }
 }

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -59,8 +59,10 @@ use irokle_crate::history::HistoryOrder;
 use irokle_crate::net::{decode_sync_message, encode_frame, encode_sync_message};
 use irokle_crate::oplog::Oplog;
 use irokle_crate::sync::{SyncData, SyncMessage, SyncRequest};
-use irokle_crate::{EventEnvelope, PeerId, ReplicationPolicy, TopicGenesis, TopicPayload};
-use parking_lot::RwLock;
+use irokle_crate::{
+    EventEnvelope, PeerId, ReplicationPolicy, TopicEviction, TopicGenesis, TopicPayload,
+};
+use parking_lot::{Mutex, RwLock};
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
@@ -96,6 +98,12 @@ pub struct DocumentSyncService {
     storage: StorageHandle,
     default_peers: Arc<RwLock<BTreeSet<PeerId>>>,
     storage_path: PathBuf,
+    // Genesis tie-break evictions from every admission path (irokle's own
+    // accept/resync loops via the net sink, plus this service's bootstrap and
+    // batch-sync paths) funnel into this sender; the embedder drains the
+    // receiver once via `take_eviction_receiver` and re-emits the payloads.
+    eviction_tx: tokio::sync::mpsc::UnboundedSender<TopicEviction>,
+    eviction_rx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<TopicEviction>>>>,
 }
 
 impl std::fmt::Debug for DocumentSyncService {
@@ -149,12 +157,14 @@ impl DocumentSyncService {
             .map_err(|error| NetError::Bootstrap(error.to_string()))?
             .build()
             .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+        let (eviction_tx, eviction_rx) = tokio::sync::mpsc::unbounded_channel();
         let net = Arc::new(
-            irokle_crate::net::IrohNet::new_with_alpns_and_config(
+            irokle_crate::net::IrohNet::new_with_alpns_config_and_sink(
                 endpoint,
                 node.clone(),
                 alpns,
                 runtime,
+                Some(eviction_tx.clone()),
             )
             .map_err(|error| NetError::Bootstrap(error.to_string()))?,
         );
@@ -169,11 +179,118 @@ impl DocumentSyncService {
             storage,
             default_peers: Arc::new(RwLock::new(default_peers)),
             storage_path,
+            eviction_tx,
+            eviction_rx: Arc::new(Mutex::new(Some(eviction_rx))),
         })
     }
 
     pub fn node(&self) -> irokle_crate::Irokle<irokle_crate::FjallStorage> {
         self.node.clone()
+    }
+
+    /// Takes the genesis tie-break eviction receiver. The embedder calls this
+    /// once to drive the re-emission consumer; later calls return `None`.
+    pub fn take_eviction_receiver(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<TopicEviction>> {
+        self.eviction_rx.lock().take()
+    }
+
+    /// Decodes a genesis tie-break eviction into the document publishes that
+    /// must be re-emitted onto the winning chain. Every publish sets
+    /// `allow_genesis: false` so the loser replays through the normal outbox
+    /// drain instead of minting a rival genesis, and admin events keep their
+    /// embedded event id (appliers dedupe on it). Control ops are skipped,
+    /// whole-document admin poison is dropped with a warning (mirroring the
+    /// reconcile skip arm), and ops not authored by the local node are rejected
+    /// since an eviction is by construction the local node's own chain.
+    pub fn decode_eviction(&self, eviction: TopicEviction) -> Vec<DocumentSyncPublish> {
+        let local_peer = self.node.peer_id();
+        let mut documents = Vec::new();
+        for evicted in eviction.evicted {
+            if evicted.author != local_peer {
+                warn!(
+                    topic_id = %eviction.topic_id,
+                    author = %evicted.author,
+                    "Skipping evicted op not authored by the local node"
+                );
+                continue;
+            }
+            let TopicPayload::Event(envelope) = evicted.payload else {
+                // Non-event control op (e.g. AddPeer/RemovePeer): nothing to re-emit.
+                continue;
+            };
+            let event = match envelope.decode_event::<DocumentSyncEvent>() {
+                Ok(event) => event,
+                Err(error) => {
+                    warn!(
+                        topic_id = %eviction.topic_id,
+                        op_id = %evicted.op_id,
+                        %error,
+                        "Skipping evicted op that is not a document sync event"
+                    );
+                    continue;
+                }
+            };
+            match event {
+                DocumentSyncEvent::AdminOperation { target, event } => {
+                    documents.push(DocumentSyncPublish::AdminOperation {
+                        target,
+                        event,
+                        allow_genesis: false,
+                    });
+                }
+                DocumentSyncEvent::Upsert {
+                    event_id,
+                    target,
+                    bytes,
+                    change,
+                } => {
+                    if admin_document_target_for_reduced_document(&target).is_some() {
+                        warn!(
+                            topic_id = %eviction.topic_id,
+                            ?target,
+                            "Dropping evicted whole-document admin upsert"
+                        );
+                        continue;
+                    }
+                    documents.push(DocumentSyncPublish::Upsert {
+                        event_id,
+                        target,
+                        bytes,
+                        change,
+                        allow_genesis: false,
+                    });
+                }
+                DocumentSyncEvent::Delete {
+                    event_id,
+                    target,
+                    change,
+                } => {
+                    if admin_document_target_for_reduced_document(&target).is_some() {
+                        warn!(
+                            topic_id = %eviction.topic_id,
+                            ?target,
+                            "Dropping evicted whole-document admin delete"
+                        );
+                        continue;
+                    }
+                    documents.push(DocumentSyncPublish::Delete {
+                        event_id,
+                        target,
+                        change,
+                        allow_genesis: false,
+                    });
+                }
+            }
+        }
+        documents
+    }
+
+    /// Forwards evictions produced by this service's own admission paths into
+    /// the shared eviction sink.
+    fn forward_evictions(&self, evictions: Vec<TopicEviction>) {
+        forward_evictions_to(&self.eviction_tx, evictions);
     }
 
     fn local_node_id(&self) -> Result<NodeId> {
@@ -1108,8 +1225,17 @@ impl DocumentSyncService {
         let node = self.node.clone();
         let net = self.net.clone();
         let data_known = known_topics.clone();
+        let eviction_tx = self.eviction_tx.clone();
         let (failed_topics, followup) = tokio::task::spawn_blocking(move || {
-            process_batch_data_responses(&node, &net, peer, &data_known, failed_topics, responses)
+            process_batch_data_responses(
+                &node,
+                &net,
+                peer,
+                &data_known,
+                failed_topics,
+                responses,
+                &eviction_tx,
+            )
         })
         .await
         .map_err(|error| NetError::Bootstrap(error.to_string()))??;
@@ -1236,10 +1362,11 @@ impl DocumentSyncService {
             match response {
                 SyncMessage::Summary(summary) if summary.topic_id == topic_id => {}
                 SyncMessage::Data(data) if data.topic_id == topic_id => {
-                    let ack = self
+                    let (ack, evictions) = self
                         .node
-                        .receive_sync_data_from(peer, data)
+                        .receive_sync_data_from_evicting(peer, data)
                         .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+                    self.forward_evictions(evictions);
                     received_data = true;
                     followup.push(SyncMessage::Ack(ack));
                 }
@@ -3492,6 +3619,17 @@ fn process_batch_summary_responses(
     Ok((responded_topics, failed_topics, sync_messages))
 }
 
+fn forward_evictions_to(
+    sink: &tokio::sync::mpsc::UnboundedSender<TopicEviction>,
+    evictions: Vec<TopicEviction>,
+) {
+    for eviction in evictions {
+        if sink.send(eviction).is_err() {
+            warn!("Document sync eviction consumer closed; dropping re-emitted payloads");
+        }
+    }
+}
+
 fn process_batch_data_responses(
     node: &irokle_crate::Irokle<irokle_crate::FjallStorage>,
     net: &irokle_crate::net::IrohNet<irokle_crate::FjallStorage>,
@@ -3499,6 +3637,7 @@ fn process_batch_data_responses(
     known_topics: &BTreeSet<irokle_crate::TopicId>,
     mut failed_topics: BTreeSet<irokle_crate::TopicId>,
     responses: Vec<SyncMessage>,
+    eviction_tx: &tokio::sync::mpsc::UnboundedSender<TopicEviction>,
 ) -> Result<(BTreeSet<irokle_crate::TopicId>, Vec<SyncMessage>)> {
     let mut followup = Vec::new();
     let mut acks = Vec::new();
@@ -3512,8 +3651,11 @@ fn process_batch_data_responses(
             SyncMessage::Summary(summary) if known_topics.contains(&summary.topic_id) => {}
             SyncMessage::Data(data) if known_topics.contains(&data.topic_id) => {
                 let topic_id = data.topic_id;
-                let ack = match node.receive_sync_data_from(peer, data) {
-                    Ok(ack) => ack,
+                let ack = match node.receive_sync_data_from_evicting(peer, data) {
+                    Ok((ack, evictions)) => {
+                        forward_evictions_to(eviction_tx, evictions);
+                        ack
+                    }
                     Err(error) => {
                         warn!(
                             %peer,

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -7282,6 +7282,221 @@ mod tests {
         );
     }
 
+    // Two services fork one admin topic (each mints its own genesis carrying a
+    // unique admin event). The genesis tie-break resets exactly the losing side,
+    // whose admin event is evicted and decodes back into a re-emittable outbox
+    // publish that preserves the original embedded event id (the applier dedup
+    // key) and refuses to mint a rival genesis.
+    #[tokio::test]
+    async fn forked_admin_topic_eviction_reemits_with_preserved_event_id() {
+        let (_dir_a, storage_a) = test_storage();
+        let (_dir_b, storage_b) = test_storage();
+        let doc_a = tempfile::tempdir().expect("doc a");
+        let doc_b = tempfile::tempdir().expect("doc b");
+        let service_a = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(71).await,
+            storage_a,
+            doc_a.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+        )
+        .expect("service a opens");
+        let service_b = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(72).await,
+            storage_b,
+            doc_b.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+        )
+        .expect("service b opens");
+
+        let node_a = service_a.local_node_id().expect("node a id");
+        let node_b = service_b.local_node_id().expect("node b id");
+
+        let realm_id = RealmId::from_bytes([71; 32]);
+        let user_id = UserId::local(Ulid::from_parts(7, 1), realm_id);
+        let target = DocumentSyncTarget::User { user_id };
+        let admin_target = AdminDocumentTarget::User { user_id };
+        let topic_id = target.sync_topic_id();
+
+        let event_a_id = Ulid::from_parts(0xA1, 1);
+        let event_b_id = Ulid::from_parts(0xB2, 2);
+        let admin_a = test_admin_event(
+            event_a_id,
+            admin_target.clone(),
+            &test_actor(1, user_id, realm_id),
+            1,
+            AdminDocumentOperation::UserNameSet {
+                name: "from-a".into(),
+            },
+        );
+        let admin_b = test_admin_event(
+            event_b_id,
+            admin_target.clone(),
+            &test_actor(2, user_id, realm_id),
+            1,
+            AdminDocumentOperation::UserNameSet {
+                name: "from-b".into(),
+            },
+        );
+
+        // Each side lists the other in its genesis peer set, so the loser is a
+        // member of the winner's topic after the reset.
+        let published_a = service_a
+            .publish_documents(
+                vec![DocumentSyncPublish::AdminOperation {
+                    target: target.clone(),
+                    event: Box::new(admin_a),
+                    allow_genesis: true,
+                }],
+                vec![node_b],
+            )
+            .await;
+        assert!(
+            matches!(published_a, DocumentSyncNetEvent::DocumentsPublished { .. }),
+            "service a publish: {published_a:?}"
+        );
+        let published_b = service_b
+            .publish_documents(
+                vec![DocumentSyncPublish::AdminOperation {
+                    target: target.clone(),
+                    event: Box::new(admin_b),
+                    allow_genesis: true,
+                }],
+                vec![node_a],
+            )
+            .await;
+        assert!(
+            matches!(published_b, DocumentSyncNetEvent::DocumentsPublished { .. }),
+            "service b publish: {published_b:?}"
+        );
+
+        let node_a_handle = service_a.node();
+        let node_b_handle = service_b.node();
+        let genesis_a = node_a_handle
+            .storage()
+            .topic_state(&topic_id)
+            .unwrap()
+            .unwrap()
+            .genesis;
+        let genesis_b = node_b_handle
+            .storage()
+            .topic_state(&topic_id)
+            .unwrap()
+            .unwrap()
+            .genesis;
+        assert_ne!(
+            genesis_a, genesis_b,
+            "the two nodes forked distinct genesis"
+        );
+
+        // The smaller genesis wins; the side holding the larger genesis loses.
+        let (
+            loser,
+            loser_node,
+            winner_node,
+            loser_event_id,
+            winner_genesis,
+            winner_peer,
+            loser_peer,
+        ) = if genesis_a > genesis_b {
+            (
+                &service_a,
+                &node_a_handle,
+                &node_b_handle,
+                event_a_id,
+                genesis_b,
+                node_id_to_peer_id(&node_b),
+                node_id_to_peer_id(&node_a),
+            )
+        } else {
+            (
+                &service_b,
+                &node_b_handle,
+                &node_a_handle,
+                event_b_id,
+                genesis_a,
+                node_id_to_peer_id(&node_a),
+                node_id_to_peer_id(&node_b),
+            )
+        };
+
+        let winner_ops =
+            irokle_crate::oplog::topological(winner_node.storage(), &topic_id).unwrap();
+        let loser_ops = irokle_crate::oplog::topological(loser_node.storage(), &topic_id).unwrap();
+
+        // The winner keeps its genesis and produces no eviction.
+        let (_winner_ack, winner_side) = winner_node
+            .receive_sync_data_from_evicting(
+                loser_peer,
+                SyncData {
+                    topic_id,
+                    ops: loser_ops,
+                },
+            )
+            .unwrap();
+        assert!(
+            winner_side.is_empty(),
+            "winner keeps its genesis; no eviction"
+        );
+
+        // The loser resets and evicts its own admin chain.
+        let (_loser_ack, evictions) = loser_node
+            .receive_sync_data_from_evicting(
+                winner_peer,
+                SyncData {
+                    topic_id,
+                    ops: winner_ops,
+                },
+            )
+            .unwrap();
+        assert_eq!(evictions.len(), 1, "exactly the loser side resets");
+
+        // Both sides now agree on the winning genesis.
+        assert_eq!(
+            loser_node
+                .storage()
+                .topic_state(&topic_id)
+                .unwrap()
+                .unwrap()
+                .genesis,
+            winner_genesis
+        );
+        assert_eq!(
+            winner_node
+                .storage()
+                .topic_state(&topic_id)
+                .unwrap()
+                .unwrap()
+                .genesis,
+            winner_genesis
+        );
+
+        // The evicted admin event re-emits with its original event id preserved
+        // and allow_genesis cleared.
+        let reemitted = loser.decode_eviction(evictions.into_iter().next().unwrap());
+        assert_eq!(reemitted.len(), 1);
+        match &reemitted[0] {
+            DocumentSyncPublish::AdminOperation {
+                target: reemit_target,
+                event,
+                allow_genesis,
+            } => {
+                assert_eq!(reemit_target, &target);
+                assert_eq!(
+                    event.event_id, loser_event_id,
+                    "embedded admin event id must survive for applier dedup"
+                );
+                assert!(!allow_genesis, "re-emission must not mint a rival genesis");
+            }
+            other => panic!("expected an AdminOperation re-emission, got {other:?}"),
+        }
+    }
+
     // Whole-document admin sync is refused by apply_upsert/apply_delete. If reconcile
     // `?`-propagated that refusal the applied-ops cursor would never advance, so each
     // reconcile would re-materialize the whole post-cursor history. The upsert/delete

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -17,8 +17,9 @@ use aruna_core::admin_documents::{
     AdminDocumentEvent, AdminDocumentOperation, AdminDocumentRoleDefinition, AdminDocumentTarget,
 };
 use aruna_core::document::{
-    DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncEvent, DocumentSyncNetEvent,
-    DocumentSyncPublish, DocumentSyncReconcileResult, DocumentSyncTarget,
+    DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncEvent, DocumentSyncEvictedDocument,
+    DocumentSyncNetEvent, DocumentSyncOutboxEvent, DocumentSyncPublish,
+    DocumentSyncReconcileResult, DocumentSyncTarget,
 };
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
@@ -196,15 +197,15 @@ impl DocumentSyncService {
         self.eviction_rx.lock().take()
     }
 
-    /// Decodes a genesis tie-break eviction into the document publishes that
-    /// must be re-emitted onto the winning chain. Every publish sets
+    /// Decodes a genesis tie-break eviction into the document outbox events that
+    /// must be re-emitted onto the winning chain. Every item sets
     /// `allow_genesis: false` so the loser replays through the normal outbox
-    /// drain instead of minting a rival genesis, and admin events keep their
-    /// embedded event id (appliers dedupe on it). Control ops are skipped,
+    /// drain instead of minting a rival genesis, and original ids are preserved
+    /// where the outbox format can carry them. Control ops are skipped,
     /// whole-document admin poison is dropped with a warning (mirroring the
     /// reconcile skip arm), and ops not authored by the local node are rejected
     /// since an eviction is by construction the local node's own chain.
-    pub fn decode_eviction(&self, eviction: TopicEviction) -> Vec<DocumentSyncPublish> {
+    pub fn decode_eviction(&self, eviction: TopicEviction) -> Vec<DocumentSyncEvictedDocument> {
         let local_peer = self.node.peer_id();
         let mut documents = Vec::new();
         for evicted in eviction.evicted {
@@ -234,9 +235,10 @@ impl DocumentSyncService {
             };
             match event {
                 DocumentSyncEvent::AdminOperation { target, event } => {
-                    documents.push(DocumentSyncPublish::AdminOperation {
+                    documents.push(DocumentSyncEvictedDocument {
+                        event_id: None,
                         target,
-                        event,
+                        event: DocumentSyncOutboxEvent::AdminOperation { event },
                         allow_genesis: false,
                     });
                 }
@@ -254,11 +256,10 @@ impl DocumentSyncService {
                         );
                         continue;
                     }
-                    documents.push(DocumentSyncPublish::Upsert {
-                        event_id,
+                    documents.push(DocumentSyncEvictedDocument {
+                        event_id: Some(event_id),
                         target,
-                        bytes,
-                        change,
+                        event: DocumentSyncOutboxEvent::Upsert { bytes, change },
                         allow_genesis: false,
                     });
                 }
@@ -275,10 +276,10 @@ impl DocumentSyncService {
                         );
                         continue;
                     }
-                    documents.push(DocumentSyncPublish::Delete {
-                        event_id,
+                    documents.push(DocumentSyncEvictedDocument {
+                        event_id: Some(event_id),
                         target,
-                        change,
+                        event: DocumentSyncOutboxEvent::Delete { change },
                         allow_genesis: false,
                     });
                 }
@@ -7480,18 +7481,22 @@ mod tests {
         // and allow_genesis cleared.
         let reemitted = loser.decode_eviction(evictions.into_iter().next().unwrap());
         assert_eq!(reemitted.len(), 1);
-        match &reemitted[0] {
-            DocumentSyncPublish::AdminOperation {
-                target: reemit_target,
-                event,
-                allow_genesis,
-            } => {
-                assert_eq!(reemit_target, &target);
+        let reemitted = &reemitted[0];
+        assert_eq!(&reemitted.target, &target);
+        assert!(
+            !reemitted.allow_genesis,
+            "re-emission must not mint a rival genesis"
+        );
+        assert!(
+            reemitted.event_id.is_none(),
+            "admin outbox re-emission uses the embedded admin event id"
+        );
+        match &reemitted.event {
+            DocumentSyncOutboxEvent::AdminOperation { event } => {
                 assert_eq!(
                     event.event_id, loser_event_id,
                     "embedded admin event id must survive for applier dedup"
                 );
-                assert!(!allow_genesis, "re-emission must not mint a rival genesis");
             }
             other => panic!("expected an AdminOperation re-emission, got {other:?}"),
         }

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -337,7 +337,10 @@ impl DocumentSyncService {
         let mut seen_topics = BTreeSet::new();
         for target in targets {
             if seen_topics.insert(target.sync_topic_id()) {
-                self.ensure_topic(target, &sync_peers)?;
+                // Called on the realm node that already holds these documents to
+                // admit an onboarding peer, so it may create any still-missing
+                // topic genesis for documents it originated/holds.
+                self.ensure_topic(target, &sync_peers, true)?;
             }
         }
 
@@ -616,12 +619,14 @@ impl DocumentSyncService {
         let mut published: BTreeMap<irokle_crate::TopicId, irokle_crate::ActorClock> =
             BTreeMap::new();
         for document in documents {
+            let allow_genesis = document.allow_genesis();
             let event = match document {
                 DocumentSyncPublish::Upsert {
                     event_id,
                     target,
                     bytes,
                     change,
+                    ..
                 } => DocumentSyncEvent::Upsert {
                     event_id,
                     target,
@@ -632,12 +637,13 @@ impl DocumentSyncService {
                     event_id,
                     target,
                     change,
+                    ..
                 } => DocumentSyncEvent::Delete {
                     event_id,
                     target,
                     change,
                 },
-                DocumentSyncPublish::AdminOperation { target, event } => {
+                DocumentSyncPublish::AdminOperation { target, event, .. } => {
                     DocumentSyncEvent::AdminOperation { target, event }
                 }
             };
@@ -653,6 +659,7 @@ impl DocumentSyncService {
                 actor_id,
                 envelope,
                 sync_peers,
+                allow_genesis,
                 &mut fast_path,
                 &mut fallback,
             )?;
@@ -682,6 +689,7 @@ impl DocumentSyncService {
         actor_id: irokle_crate::ActorId,
         envelope: EventEnvelope,
         sync_peers: &BTreeSet<PeerId>,
+        allow_genesis: bool,
         fast_path: &mut usize,
         fallback: &mut usize,
     ) -> Result<irokle_crate::Op> {
@@ -695,6 +703,11 @@ impl DocumentSyncService {
             .map_err(|error| NetError::Bootstrap(error.to_string()))?
             .is_none();
         if topic_missing {
+            // Only the document's origin may mint its topic genesis. Any other
+            // publisher waits (retryable) for that genesis to replicate in.
+            if !allow_genesis {
+                return Err(NetError::TopicNotReady(topic_id.to_string()));
+            }
             let genesis = TopicGenesis {
                 event_type_id: DocumentSyncEvent::TYPE_ID.to_string(),
                 initial_peers: sync_peers.clone(),
@@ -718,7 +731,7 @@ impl DocumentSyncService {
                 }
             }
         }
-        let topic_id = self.ensure_topic(target, sync_peers)?;
+        let topic_id = self.ensure_topic(target, sync_peers, allow_genesis)?;
         oplog
             .create_event_op(topic_id, actor_id, envelope, self.node.signer())
             .map_err(|error| NetError::Bootstrap(error.to_string()))
@@ -771,6 +784,7 @@ impl DocumentSyncService {
         &self,
         target: &DocumentSyncTarget,
         peers: &BTreeSet<PeerId>,
+        allow_genesis: bool,
     ) -> Result<irokle_crate::TopicId> {
         let topic_id = target.sync_topic_id();
         let mut genesis_error = None;
@@ -809,6 +823,12 @@ impl DocumentSyncService {
                     self.net.schedule_topic_recheck(topic_id)?;
                 }
                 return Ok(topic_id);
+            }
+
+            // Only the document's origin may mint the genesis; other publishers
+            // wait (retryable) for it to replicate in.
+            if !allow_genesis {
+                return Err(NetError::TopicNotReady(topic_id.to_string()));
             }
 
             let actor_id = irokle_crate::actor_id_for(topic_id, self.node.peer_id());
@@ -6340,6 +6360,7 @@ mod tests {
                         target: target.clone(),
                         bytes: restart_payload(),
                         change: revision_change(),
+                        allow_genesis: true,
                     }],
                     Vec::new(),
                 )
@@ -7042,6 +7063,83 @@ mod tests {
         assert!(prune_jobs[0].last_error.is_none());
     }
 
+    // A publisher that is not the document's origin (allow_genesis=false) must not
+    // mint a missing topic's genesis: it gets a retryable error and no topic is
+    // created. The origin (allow_genesis=true) creates the topic and publishes.
+    #[tokio::test]
+    async fn missing_topic_publish_requires_allow_genesis() {
+        let (_storage_dir, storage) = test_storage();
+        let doc_dir = tempfile::tempdir().expect("doc dir");
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(61).await,
+            storage.clone(),
+            doc_dir.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+        )
+        .expect("document sync service opens");
+
+        let local_node = service.local_node_id().expect("local node id");
+        let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::new(),
+        };
+        let topic_id = target.sync_topic_id();
+        let change = DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id: Ulid::new(),
+                actor: local_node,
+                updated_at_ms: 1,
+            },
+            kind: DocumentSyncChangeKind::Upsert,
+        };
+
+        let blocked = service
+            .publish_documents(
+                vec![DocumentSyncPublish::Upsert {
+                    event_id: Ulid::new(),
+                    target: target.clone(),
+                    bytes: b"blocked".to_vec(),
+                    change,
+                    allow_genesis: false,
+                }],
+                Vec::new(),
+            )
+            .await;
+        assert!(
+            matches!(blocked, DocumentSyncNetEvent::Error { .. }),
+            "non-origin publish must fail retryably: {blocked:?}"
+        );
+        assert!(
+            !service.has_topic(topic_id).expect("topic lookup"),
+            "no genesis may be minted without allow_genesis"
+        );
+
+        let published = service
+            .publish_documents(
+                vec![DocumentSyncPublish::Upsert {
+                    event_id: Ulid::new(),
+                    target: target.clone(),
+                    bytes: b"origin".to_vec(),
+                    change,
+                    allow_genesis: true,
+                }],
+                Vec::new(),
+            )
+            .await;
+        assert!(
+            matches!(published, DocumentSyncNetEvent::DocumentsPublished { .. }),
+            "origin publish must succeed: {published:?}"
+        );
+        assert!(
+            service.has_topic(topic_id).expect("topic lookup"),
+            "origin publish must create the topic genesis"
+        );
+    }
+
     // Whole-document admin sync is refused by apply_upsert/apply_delete. If reconcile
     // `?`-propagated that refusal the applied-ops cursor would never advance, so each
     // reconcile would re-materialize the whole post-cursor history. The upsert/delete
@@ -7097,15 +7195,18 @@ mod tests {
                         target: target.clone(),
                         bytes: b"whole-document-admin-upsert".to_vec(),
                         change: change(DocumentSyncChangeKind::Upsert),
+                        allow_genesis: true,
                     },
                     DocumentSyncPublish::Delete {
                         event_id: Ulid::new(),
                         target: target.clone(),
                         change: change(DocumentSyncChangeKind::Delete),
+                        allow_genesis: true,
                     },
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(admin_event),
+                        allow_genesis: true,
                     },
                 ],
                 Vec::new(),

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod streams;
 mod telemetry;
 
+use std::mem;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -41,7 +42,7 @@ use iroh::address_lookup::{DnsAddressLookup, PkarrPublisher};
 use iroh::endpoint::{QuicTransportConfig, TransportAddrUsage, VarInt, presets};
 use iroh::{Endpoint, EndpointAddr, RelayMap, RelayMode, TransportAddr};
 use parking_lot::RwLock;
-use tokio::sync::{Mutex, Semaphore, mpsc, oneshot};
+use tokio::sync::{Mutex, Notify, Semaphore, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span, debug, warn};
@@ -355,6 +356,24 @@ pub trait InboundEventHandler: Send + Sync {
     async fn handle_evicted_documents(&self, _documents: Vec<DocumentSyncEvictedDocument>) {}
 }
 
+async fn flush_pending_evicted_documents(
+    inbound_handler: &Arc<RwLock<Option<Arc<dyn InboundEventHandler>>>>,
+    pending_documents: &mut Vec<DocumentSyncEvictedDocument>,
+) -> bool {
+    if pending_documents.is_empty() {
+        return true;
+    }
+
+    let handler = inbound_handler.read().clone();
+    let Some(handler) = handler else {
+        return false;
+    };
+
+    let documents = mem::take(pending_documents);
+    handler.handle_evicted_documents(documents).await;
+    true
+}
+
 #[derive(Clone)]
 pub struct NetHandle {
     inner: Arc<NetInner>,
@@ -380,6 +399,8 @@ struct NetInner {
     network_diagnostics: Arc<Mutex<NetworkDiagnosticsState>>,
     peer_connectivity_tx: mpsc::Sender<PeerConnectivityEvent>,
     inbound_handler: Arc<RwLock<Option<Arc<dyn InboundEventHandler>>>>,
+    inbound_handler_registered: Arc<Notify>,
+    eviction_shutdown: CancellationToken,
     shutdown: CancellationToken,
     tasks: Mutex<Vec<JoinHandle<()>>>,
 }
@@ -510,6 +531,7 @@ impl NetHandle {
 
         let inbound_handler: Arc<RwLock<Option<Arc<dyn InboundEventHandler>>>> =
             Arc::new(RwLock::new(None));
+        let inbound_handler_registered = Arc::new(Notify::new());
 
         let connection_pool =
             ConnectionPool::new(endpoint.clone(), ConnectionPoolOptions::default());
@@ -652,31 +674,60 @@ impl NetHandle {
         // Drains genesis tie-break evictions (from irokle's own accept/resync
         // loops and this service's bootstrap/batch-sync paths), decodes them
         // into re-emittable documents, and hands them to the registered inbound
-        // handler for outbox re-enqueue. Reads the handler per batch, so it
-        // works whether or not the handler is registered yet.
+        // handler for outbox re-enqueue. Decoded documents are buffered until
+        // the inbound handler is registered and drained before shutdown exits.
         let eviction_document_sync = document_sync.clone();
         let eviction_inbound_handler = inbound_handler.clone();
-        let eviction_shutdown = shutdown.child_token();
+        let eviction_inbound_handler_registered = inbound_handler_registered.clone();
+        let eviction_shutdown = CancellationToken::new();
+        let eviction_shutdown_for_task = eviction_shutdown.clone();
         let eviction_task = tokio::spawn(async move {
             let Some(mut eviction_rx) = eviction_document_sync.take_eviction_receiver() else {
                 return;
             };
+            let mut pending_documents = Vec::new();
             loop {
                 tokio::select! {
-                    _ = eviction_shutdown.cancelled() => break,
+                    _ = eviction_shutdown_for_task.cancelled() => {
+                        while let Ok(eviction) = eviction_rx.try_recv() {
+                            pending_documents.extend(eviction_document_sync.decode_eviction(eviction));
+                        }
+                        if !flush_pending_evicted_documents(
+                            &eviction_inbound_handler,
+                            &mut pending_documents,
+                        )
+                        .await
+                        {
+                            warn!(
+                                count = pending_documents.len(),
+                                "Dropping re-emitted eviction documents during shutdown without a registered inbound handler"
+                            );
+                        }
+                        break;
+                    },
+                    _ = eviction_inbound_handler_registered.notified(), if !pending_documents.is_empty() => {
+                        let _ = flush_pending_evicted_documents(
+                            &eviction_inbound_handler,
+                            &mut pending_documents,
+                        )
+                        .await;
+                    },
                     maybe_eviction = eviction_rx.recv() => {
                         let Some(eviction) = maybe_eviction else { break };
                         let documents = eviction_document_sync.decode_eviction(eviction);
                         if documents.is_empty() {
                             continue;
                         }
-                        let handler = eviction_inbound_handler.read().clone();
-                        if let Some(handler) = handler {
-                            handler.handle_evicted_documents(documents).await;
-                        } else {
+                        pending_documents.extend(documents);
+                        if !flush_pending_evicted_documents(
+                            &eviction_inbound_handler,
+                            &mut pending_documents,
+                        )
+                        .await
+                        {
                             warn!(
-                                count = documents.len(),
-                                "Dropping re-emitted eviction documents without a registered inbound handler"
+                                count = pending_documents.len(),
+                                "Buffering re-emitted eviction documents until an inbound handler is registered"
                             );
                         }
                     }
@@ -737,6 +788,8 @@ impl NetHandle {
             network_diagnostics,
             peer_connectivity_tx,
             inbound_handler,
+            inbound_handler_registered,
+            eviction_shutdown,
             shutdown,
             tasks: Mutex::new(tasks),
         });
@@ -1092,6 +1145,7 @@ impl NetHandle {
 
     pub fn set_inbound_handler(&self, handler: Arc<dyn InboundEventHandler>) {
         *self.inner.inbound_handler.write() = Some(handler);
+        self.inner.inbound_handler_registered.notify_one();
     }
 
     pub fn clear_inbound_handler(&self) {
@@ -1108,6 +1162,7 @@ impl NetHandle {
             warn!(error = %err, "DHT shutdown returned error");
         }
         self.inner.document_sync.shutdown().await;
+        self.inner.eviction_shutdown.cancel();
         if let Err(err) = self.inner.connection_pool.shutdown().await {
             warn!(error = %err, "Connection pool shutdown returned error");
         }
@@ -2184,6 +2239,71 @@ mod tests {
             sequence,
             signature,
         }
+    }
+
+    fn test_evicted_document(seed: u8) -> DocumentSyncEvictedDocument {
+        let event_id = ulid::Ulid::from_parts(seed as u64, seed as u128);
+        let change = aruna_core::document::DocumentSyncChange {
+            base: None,
+            current: aruna_core::document::DocumentSyncRevision {
+                generation: 1,
+                event_id,
+                actor: make_secret(seed).public(),
+                updated_at_ms: seed as u64,
+            },
+            kind: aruna_core::document::DocumentSyncChangeKind::Delete,
+        };
+
+        DocumentSyncEvictedDocument {
+            event_id: Some(event_id),
+            target: DocumentSyncTarget::RealmConfig {
+                realm_id: RealmId::from_bytes([seed; 32]),
+            },
+            event: aruna_core::document::DocumentSyncOutboxEvent::Delete { change },
+            allow_genesis: false,
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingEvictedHandler {
+        documents: tokio::sync::Mutex<Vec<DocumentSyncEvictedDocument>>,
+    }
+
+    #[async_trait]
+    impl InboundEventHandler for RecordingEvictedHandler {
+        async fn handle_incoming_stream(
+            &self,
+            _alpn: Alpn,
+            _stream: streams::BiStream,
+            _node_id: NodeId,
+        ) {
+        }
+
+        async fn handle_evicted_documents(&self, documents: Vec<DocumentSyncEvictedDocument>) {
+            self.documents.lock().await.extend(documents);
+        }
+    }
+
+    #[tokio::test]
+    async fn evicted_documents_wait_for_registered_inbound_handler() {
+        let inbound_handler: Arc<RwLock<Option<Arc<dyn InboundEventHandler>>>> =
+            Arc::new(RwLock::new(None));
+        let expected = vec![test_evicted_document(11), test_evicted_document(12)];
+        let mut pending_documents = expected.clone();
+
+        assert!(
+            !flush_pending_evicted_documents(&inbound_handler, &mut pending_documents).await,
+            "documents must stay buffered without a handler"
+        );
+        assert_eq!(pending_documents, expected);
+
+        let handler = Arc::new(RecordingEvictedHandler::default());
+        let registered_handler: Arc<dyn InboundEventHandler> = handler.clone();
+        *inbound_handler.write() = Some(registered_handler);
+
+        assert!(flush_pending_evicted_documents(&inbound_handler, &mut pending_documents).await);
+        assert!(pending_documents.is_empty());
+        assert_eq!(*handler.documents.lock().await, expected);
     }
 
     #[test]

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aruna_core::alpn::Alpn;
-use aruna_core::document::{DocumentSyncPublish, DocumentSyncReconcileResult, DocumentSyncTarget};
+use aruna_core::document::{
+    DocumentSyncEvictedDocument, DocumentSyncReconcileResult, DocumentSyncTarget,
+};
 use aruna_core::effects::StorageEffect;
 use aruna_core::effects::{Effect, NetEffect};
 use aruna_core::events::{DhtEntry, Event, NetError as CoreNetError, NetEvent, StorageEvent};
@@ -349,11 +351,8 @@ pub trait InboundEventHandler: Send + Sync {
 
     /// Re-emits the documents recovered from a genesis tie-break eviction: the
     /// loser's own payloads, decoded from the reset chain, to be replayed onto
-    /// the winning genesis (each carries `allow_genesis: false`, and admin
-    /// events keep their original embedded event id so appliers dedupe). The
-    /// default drops them; the operations layer overrides this to enqueue
-    /// outbox records.
-    async fn handle_evicted_documents(&self, _documents: Vec<DocumentSyncPublish>) {}
+    /// the winning genesis via durable operations outbox records.
+    async fn handle_evicted_documents(&self, _documents: Vec<DocumentSyncEvictedDocument>) {}
 }
 
 #[derive(Clone)]

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aruna_core::alpn::Alpn;
-use aruna_core::document::{DocumentSyncReconcileResult, DocumentSyncTarget};
+use aruna_core::document::{DocumentSyncPublish, DocumentSyncReconcileResult, DocumentSyncTarget};
 use aruna_core::effects::StorageEffect;
 use aruna_core::effects::{Effect, NetEffect};
 use aruna_core::events::{DhtEntry, Event, NetError as CoreNetError, NetEvent, StorageEvent};
@@ -346,6 +346,14 @@ enum PeerConnectivityEvent {
 #[async_trait]
 pub trait InboundEventHandler: Send + Sync {
     async fn handle_incoming_stream(&self, alpn: Alpn, stream: streams::BiStream, node_id: NodeId);
+
+    /// Re-emits the documents recovered from a genesis tie-break eviction: the
+    /// loser's own payloads, decoded from the reset chain, to be replayed onto
+    /// the winning genesis (each carries `allow_genesis: false`, and admin
+    /// events keep their original embedded event id so appliers dedupe). The
+    /// default drops them; the operations layer overrides this to enqueue
+    /// outbox records.
+    async fn handle_evicted_documents(&self, _documents: Vec<DocumentSyncPublish>) {}
 }
 
 #[derive(Clone)]
@@ -642,6 +650,41 @@ impl NetHandle {
             .await;
         });
 
+        // Drains genesis tie-break evictions (from irokle's own accept/resync
+        // loops and this service's bootstrap/batch-sync paths), decodes them
+        // into re-emittable documents, and hands them to the registered inbound
+        // handler for outbox re-enqueue. Reads the handler per batch, so it
+        // works whether or not the handler is registered yet.
+        let eviction_document_sync = document_sync.clone();
+        let eviction_inbound_handler = inbound_handler.clone();
+        let eviction_shutdown = shutdown.child_token();
+        let eviction_task = tokio::spawn(async move {
+            let Some(mut eviction_rx) = eviction_document_sync.take_eviction_receiver() else {
+                return;
+            };
+            loop {
+                tokio::select! {
+                    _ = eviction_shutdown.cancelled() => break,
+                    maybe_eviction = eviction_rx.recv() => {
+                        let Some(eviction) = maybe_eviction else { break };
+                        let documents = eviction_document_sync.decode_eviction(eviction);
+                        if documents.is_empty() {
+                            continue;
+                        }
+                        let handler = eviction_inbound_handler.read().clone();
+                        if let Some(handler) = handler {
+                            handler.handle_evicted_documents(documents).await;
+                        } else {
+                            warn!(
+                                count = documents.len(),
+                                "Dropping re-emitted eviction documents without a registered inbound handler"
+                            );
+                        }
+                    }
+                }
+            }
+        });
+
         let peer_connectivity_task = tokio::spawn(run_peer_connectivity_manager(
             dht.clone(),
             address_lookup.clone(),
@@ -672,6 +715,7 @@ impl NetHandle {
             dht_task,
             stream_task,
             accept_task,
+            eviction_task,
             peer_connectivity_task,
         ]);
 

--- a/operations/src/add_group_role.rs
+++ b/operations/src/add_group_role.rs
@@ -332,6 +332,7 @@ impl AddGroupRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/add_realm_role.rs
+++ b/operations/src/add_realm_role.rs
@@ -281,6 +281,7 @@ impl AddRealmRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/add_user_to_group.rs
+++ b/operations/src/add_user_to_group.rs
@@ -304,6 +304,7 @@ impl AddUserToGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/add_user_to_realm_role.rs
+++ b/operations/src/add_user_to_realm_role.rs
@@ -303,6 +303,7 @@ impl AddUserToRealmRolesOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -515,6 +515,44 @@ mod tests {
     }
 
     #[test]
+    fn every_admin_document_target_refuses_whole_document_announce() {
+        let local_node_id = local_node_id();
+        let realm_id = RealmId::from_bytes([2u8; 32]);
+        let group_id = GroupId::new();
+        let (user_id, _) = user_document();
+        let admin_targets = [
+            DocumentSyncTarget::Group { group_id },
+            DocumentSyncTarget::GroupAuthorization { group_id },
+            DocumentSyncTarget::RealmAuthorization { realm_id },
+            DocumentSyncTarget::RealmConfig { realm_id },
+            DocumentSyncTarget::User { user_id },
+        ];
+
+        for target in admin_targets {
+            assert!(target.is_admin_document(), "misclassified {target:?}");
+            let mut operation = AnnounceTopicOperation::new_for_document_with_peers_and_bytes(
+                target.topic_id(),
+                local_node_id,
+                target.clone(),
+                Vec::new(),
+                b"whole admin document".to_vec(),
+            );
+
+            let effects = operation.start();
+            assert!(effects.is_empty(), "unexpected outbox write for {target:?}");
+            assert!(operation.is_complete());
+            assert!(
+                matches!(
+                    operation.finalize(),
+                    Err(AnnounceTopicError::DocumentSync(error))
+                        if error.contains("admin documents must sync as operations")
+                ),
+                "whole-document announce must refuse {target:?}"
+            );
+        }
+    }
+
+    #[test]
     fn user_document_announcement_fails_without_revision() {
         let local_node_id = local_node_id();
         let (_, document) = user_document();

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -48,6 +48,7 @@ pub struct AnnounceTopicOperation {
     local_node_id: NodeId,
     peers: Vec<NodeId>,
     document_bytes: Option<Vec<u8>>,
+    allow_genesis: bool,
     state: AnnounceTopicState,
     pending: VecDeque<PendingDocumentSync>,
     current: Option<DocumentSyncTarget>,
@@ -84,16 +85,17 @@ pub enum AnnounceTopicError {
 }
 
 impl AnnounceTopicOperation {
-    pub fn new(topic: TopicId, _local_node_id: NodeId) -> Self {
-        Self::new_for_document(topic, _local_node_id, None)
+    pub fn new(topic: TopicId, local_node_id: NodeId, allow_genesis: bool) -> Self {
+        Self::new_for_document(topic, local_node_id, None, allow_genesis)
     }
 
     pub fn new_for_document(
         topic: TopicId,
         local_node_id: NodeId,
         document: Option<DocumentSyncTarget>,
+        allow_genesis: bool,
     ) -> Self {
-        Self::new_for_document_with_peers(topic, local_node_id, document, Vec::new())
+        Self::new_for_document_with_peers(topic, local_node_id, document, Vec::new(), allow_genesis)
     }
 
     pub fn new_for_document_with_peers(
@@ -101,6 +103,7 @@ impl AnnounceTopicOperation {
         local_node_id: NodeId,
         document: Option<DocumentSyncTarget>,
         peers: Vec<NodeId>,
+        allow_genesis: bool,
     ) -> Self {
         Self {
             topic,
@@ -108,6 +111,7 @@ impl AnnounceTopicOperation {
             local_node_id,
             peers,
             document_bytes: None,
+            allow_genesis,
             state: AnnounceTopicState::Init,
             pending: VecDeque::new(),
             current: None,
@@ -121,6 +125,7 @@ impl AnnounceTopicOperation {
         document: DocumentSyncTarget,
         peers: Vec<NodeId>,
         bytes: Vec<u8>,
+        allow_genesis: bool,
     ) -> Self {
         Self {
             topic,
@@ -128,6 +133,7 @@ impl AnnounceTopicOperation {
             local_node_id,
             peers,
             document_bytes: Some(bytes),
+            allow_genesis,
             state: AnnounceTopicState::Init,
             pending: VecDeque::new(),
             current: None,
@@ -193,17 +199,12 @@ impl AnnounceTopicOperation {
     ) -> Effects {
         self.current = Some(document.clone());
         self.state = AnnounceTopicState::WriteOutbox;
-        // Whole-document announces (metadata registry/create-event/lifecycle,
-        // graph lifecycle and node-usage snapshots) may originate a topic the
-        // announcing node holds, so they retain the ability to mint genesis.
-        // See fix/admin-doc-sync-309 report: origin-gating this path needs an
-        // origin signal AnnounceTopicOperation does not currently carry.
         let record = new_outbox_record(
             self.local_node_id,
             document,
             self.peers.clone(),
             event,
-            true,
+            self.allow_genesis,
         );
         match write_outbox_effect(&record) {
             Ok(effect) => smallvec![effect],
@@ -490,39 +491,43 @@ mod tests {
 
     #[test]
     fn provided_document_bytes_skip_readback_before_outbox_write() {
-        let local_node_id = local_node_id();
-        let lifecycle = MetadataGraphLifecycleRecord::deleted(
-            "urn:graph:announce".to_string(),
-            RealmId::from_bytes([2u8; 32]),
-            GroupId::new(),
-            Ulid::new(),
-            42,
-        );
-        let document = DocumentSyncTarget::MetadataGraphLifecycle {
-            graph_iri: lifecycle.graph_iri.clone(),
-        };
-        let bytes = postcard::to_allocvec(&lifecycle).expect("lifecycle serializes");
-        let mut operation = AnnounceTopicOperation::new_for_document_with_peers_and_bytes(
-            document.topic_id(),
-            local_node_id,
-            document.clone(),
-            Vec::new(),
-            bytes.clone(),
-        );
+        for allow_genesis in [false, true] {
+            let local_node_id = local_node_id();
+            let lifecycle = MetadataGraphLifecycleRecord::deleted(
+                "urn:graph:announce".to_string(),
+                RealmId::from_bytes([2u8; 32]),
+                GroupId::new(),
+                Ulid::new(),
+                42,
+            );
+            let document = DocumentSyncTarget::MetadataGraphLifecycle {
+                graph_iri: lifecycle.graph_iri.clone(),
+            };
+            let bytes = postcard::to_allocvec(&lifecycle).expect("lifecycle serializes");
+            let mut operation = AnnounceTopicOperation::new_for_document_with_peers_and_bytes(
+                document.topic_id(),
+                local_node_id,
+                document.clone(),
+                Vec::new(),
+                bytes.clone(),
+                allow_genesis,
+            );
 
-        let effects = operation.start();
+            let effects = operation.start();
 
-        let record = written_outbox_record(effects.as_slice());
-        assert_eq!(record.target, document);
-        let DocumentSyncOutboxEvent::Upsert {
-            bytes: actual,
-            change,
-        } = record.event
-        else {
-            panic!("expected revisioned upsert");
-        };
-        assert_eq!(actual, bytes);
-        assert_eq!(change.kind, DocumentSyncChangeKind::Upsert);
+            let record = written_outbox_record(effects.as_slice());
+            assert_eq!(record.target, document);
+            assert_eq!(record.allow_genesis, allow_genesis);
+            let DocumentSyncOutboxEvent::Upsert {
+                bytes: actual,
+                change,
+            } = record.event
+            else {
+                panic!("expected revisioned upsert");
+            };
+            assert_eq!(actual, bytes);
+            assert_eq!(change.kind, DocumentSyncChangeKind::Upsert);
+        }
     }
 
     #[test]
@@ -547,6 +552,7 @@ mod tests {
                 target.clone(),
                 Vec::new(),
                 b"whole admin document".to_vec(),
+                true,
             );
 
             let effects = operation.start();
@@ -573,6 +579,7 @@ mod tests {
             document,
             Vec::new(),
             b"user whole document".to_vec(),
+            true,
         );
 
         let effects = operation.start();
@@ -596,6 +603,7 @@ mod tests {
             document,
             Vec::new(),
             b"realm config whole document".to_vec(),
+            true,
         );
 
         let effects = operation.start();

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -193,7 +193,18 @@ impl AnnounceTopicOperation {
     ) -> Effects {
         self.current = Some(document.clone());
         self.state = AnnounceTopicState::WriteOutbox;
-        let record = new_outbox_record(self.local_node_id, document, self.peers.clone(), event);
+        // Whole-document announces (metadata registry/create-event/lifecycle,
+        // graph lifecycle and node-usage snapshots) may originate a topic the
+        // announcing node holds, so they retain the ability to mint genesis.
+        // See fix/admin-doc-sync-309 report: origin-gating this path needs an
+        // origin signal AnnounceTopicOperation does not currently carry.
+        let record = new_outbox_record(
+            self.local_node_id,
+            document,
+            self.peers.clone(),
+            event,
+            true,
+        );
         match write_outbox_effect(&record) {
             Ok(effect) => smallvec![effect],
             Err(error) => self.fail(AnnounceTopicError::ConversionError(error.into())),

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -188,12 +188,13 @@ async fn process_pending_placements(
         ProcessPlacementsOperation::new(PlacementConfig {
             realm_id: input.realm_id,
             local_node_id: input.local_node_id,
+            retry_after: crate::sync_placement::SYNC_PLACEMENT_RETRY_AFTER,
         }),
         context,
     )
     .await
     {
-        Ok(()) => Ok(()),
+        Ok(_) => Ok(()),
         Err(error) => {
             warn!(error = %error, "Failed to process pending document-sync placements during onboarding");
             Err(error)

--- a/operations/src/claim_initial_realm_admin.rs
+++ b/operations/src/claim_initial_realm_admin.rs
@@ -239,6 +239,7 @@ impl ClaimInitialRealmAdminOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -229,6 +229,7 @@ impl CreateGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event),
                 },
+                true,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }
@@ -712,6 +713,9 @@ mod test {
                     group_id: group.group_id,
                 })
         }));
+        // create_group originates the group authorization document, so every
+        // outbox record it writes is allowed to mint the topic genesis.
+        assert!(outbox_records.iter().all(|record| record.allow_genesis));
         let events = outbox_records
             .iter()
             .map(|record| match &record.event {

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -174,6 +174,7 @@ impl CreateRealmOperation {
             DocumentSyncOutboxEvent::AdminOperation {
                 event: Box::new(realm_role_event),
             },
+            true,
         );
         let mut writes = vec![
             admin_document_reducer_state_write_entry(&realm_state)?,
@@ -189,6 +190,7 @@ impl CreateRealmOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event),
                 },
+                true,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -158,6 +158,11 @@ impl DeleteMetadataDocumentOperation {
             .map_err(|error| DeleteMetadataDocumentError::ConversionError(error.into()))?;
         let change =
             metadata_document_lifecycle_revision_change(lifecycle_record, self.actor.node_id);
+        // Delete tombstones are published by the document's holder onto its own
+        // per-document sync topics; the graph-lifecycle topic in particular is
+        // first written here, so these writes must be able to mint their genesis
+        // or the whole delete batch stalls. Per-document topics are single-origin,
+        // so this does not risk the shared-topic fork this feature guards against.
         Ok(new_outbox_record_with_id(
             lifecycle_record.event_id(),
             self.actor.node_id,
@@ -166,7 +171,7 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
-            false,
+            true,
         ))
     }
 
@@ -211,7 +216,9 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
-            false,
+            // First (and only) write to the per-graph lifecycle topic, so the
+            // deleting holder originates and may mint its genesis.
+            true,
         );
         Ok(smallvec![
             write_outbox_effect_with_txn(&outbox, Some(txn_id))
@@ -245,7 +252,10 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Delete { change },
-            false,
+            // Registry delete rides the document's own topic and shares the delete
+            // publish batch with the tombstones above; keep it consistent so the
+            // batch is not blocked mid-flight.
+            true,
         );
         Ok(smallvec![
             write_outbox_effect_with_txn(&outbox, Some(txn_id))

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -166,6 +166,7 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
+            false,
         ))
     }
 
@@ -210,6 +211,7 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
+            false,
         );
         Ok(smallvec![
             write_outbox_effect_with_txn(&outbox, Some(txn_id))
@@ -243,6 +245,7 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Delete { change },
+            false,
         );
         Ok(smallvec![
             write_outbox_effect_with_txn(&outbox, Some(txn_id))

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -48,8 +48,9 @@ pub fn new_outbox_record(
     target: DocumentSyncTarget,
     peers: Vec<NodeId>,
     event: DocumentSyncOutboxEvent,
+    allow_genesis: bool,
 ) -> DocumentSyncOutboxRecord {
-    new_outbox_record_with_id(Ulid::new(), node_id, target, peers, event)
+    new_outbox_record_with_id(Ulid::new(), node_id, target, peers, event, allow_genesis)
 }
 
 pub fn new_outbox_record_with_id(
@@ -58,6 +59,7 @@ pub fn new_outbox_record_with_id(
     target: DocumentSyncTarget,
     mut peers: Vec<NodeId>,
     event: DocumentSyncOutboxEvent,
+    allow_genesis: bool,
 ) -> DocumentSyncOutboxRecord {
     crate::sync_placement::sort_node_ids(&mut peers);
     DocumentSyncOutboxRecord {
@@ -67,6 +69,7 @@ pub fn new_outbox_record_with_id(
         peers,
         event,
         updated_at: unix_timestamp_secs(),
+        allow_genesis,
     }
 }
 
@@ -345,6 +348,7 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
+            false,
         );
         write_raw_outbox_record(&storage, corrupt_key.clone(), vec![1, 2, 3]).await;
         match storage
@@ -393,6 +397,7 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
+            false,
         );
         let bytes = postcard::to_allocvec(&record).expect("record serializes");
         let decoded: DocumentSyncOutboxRecord =
@@ -412,6 +417,7 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
+            false,
         );
         let bytes = postcard::to_allocvec(&record).expect("record serializes");
         let decoded: DocumentSyncOutboxRecord =
@@ -429,6 +435,7 @@ mod tests {
             DocumentSyncOutboxEvent::Delete {
                 change: delete_change(),
             },
+            false,
         );
         let bytes = postcard::to_allocvec(&record).expect("record serializes");
         let decoded: DocumentSyncOutboxRecord =
@@ -443,8 +450,8 @@ mod tests {
             bytes: vec![1],
             change: change(),
         };
-        let left = new_outbox_record(node(1), target(), vec![node(2)], event.clone());
-        let right = new_outbox_record(node(1), target(), vec![node(2)], event);
+        let left = new_outbox_record(node(1), target(), vec![node(2)], event.clone(), false);
+        let right = new_outbox_record(node(1), target(), vec![node(2)], event, false);
         let prefix = outbox_prefix(&left.event);
 
         assert_ne!(outbox_key(&left), outbox_key(&right));
@@ -458,7 +465,7 @@ mod tests {
             bytes: vec![1],
             change: change(),
         };
-        let mut older = new_outbox_record(node(1), target(), vec![node(2)], event.clone());
+        let mut older = new_outbox_record(node(1), target(), vec![node(2)], event.clone(), false);
         older.outbox_id = Ulid::from_parts(1, 0);
         let mut newer = new_outbox_record(
             node(1),
@@ -467,6 +474,7 @@ mod tests {
             },
             vec![node(2)],
             event,
+            false,
         );
         newer.outbox_id = Ulid::from_parts(2, 0);
 
@@ -482,10 +490,16 @@ mod tests {
             target.clone(),
             Vec::new(),
             user_admin_event(user_id, 1),
+            false,
         );
         earlier.outbox_id = Ulid::from_parts(2, 2);
-        let mut later =
-            new_outbox_record(node(1), target, Vec::new(), user_admin_event(user_id, 2));
+        let mut later = new_outbox_record(
+            node(1),
+            target,
+            Vec::new(),
+            user_admin_event(user_id, 2),
+            false,
+        );
         later.outbox_id = Ulid::from_parts(1, 1);
 
         assert!(outbox_key(&earlier) < outbox_key(&later));

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -417,13 +417,14 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
-            false,
+            true,
         );
         let bytes = postcard::to_allocvec(&record).expect("record serializes");
         let decoded: DocumentSyncOutboxRecord =
             postcard::from_bytes(&bytes).expect("record decodes");
 
         assert_eq!(decoded, record);
+        assert!(decoded.allow_genesis);
     }
 
     #[test]

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -4,9 +4,8 @@ use aruna_core::NodeId;
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncOutboxRecord, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
-use aruna_core::handle::Handle;
 use aruna_core::keyspaces::DOCUMENT_SYNC_OUTBOX_KEYSPACE;
-use aruna_core::task::{TaskEffect, TaskKey};
+use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
 use aruna_core::types::{Key, TxnId};
 use aruna_core::util::unix_timestamp_secs;
 use aruna_storage::StorageHandle;
@@ -225,9 +224,9 @@ pub async fn restore_document_sync_outbox_timers(
 
     if has_records {
         let event = task_handle
-            .send_effect(schedule_outbox_drain_effect())
+            .schedule_timer_if_idle(TaskKey::DrainDocumentSyncOutbox, Duration::ZERO)
             .await;
-        if let Event::Task(aruna_core::task::TaskEvent::Error { message, .. }) = event {
+        if let TaskEvent::Error { message, .. } = event {
             warn!(message = %message, "Failed to restore document sync outbox timer");
         }
     }
@@ -240,6 +239,7 @@ mod tests {
         AdminDocumentClock, AdminDocumentEvent, AdminDocumentOperation, AdminDocumentTarget,
     };
     use aruna_core::document::{DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncRevision};
+    use aruna_core::handle::Handle;
     use aruna_core::structs::{Actor, RealmId};
     use aruna_core::types::UserId;
     use aruna_storage::{FjallStorage, StorageHandle};

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -99,6 +99,42 @@ pub fn write_outbox_effect_with_txn(
     }))
 }
 
+fn decode_outbox_record(bytes: &[u8]) -> Result<DocumentSyncOutboxRecord, postcard::Error> {
+    match postcard::from_bytes::<DocumentSyncOutboxRecord>(bytes) {
+        Ok(record) => Ok(record),
+        Err(_) => postcard::from_bytes::<LegacyDocumentSyncOutboxRecord>(bytes).map(Into::into),
+    }
+}
+
+/// Pre-`allow_genesis` mirror of [`DocumentSyncOutboxRecord`], used only to
+/// decode outbox rows persisted before that field existed. Keep field order
+/// identical to the historical layout.
+#[derive(serde::Deserialize)]
+struct LegacyDocumentSyncOutboxRecord {
+    outbox_id: Ulid,
+    node_id: NodeId,
+    target: DocumentSyncTarget,
+    peers: Vec<NodeId>,
+    event: DocumentSyncOutboxEvent,
+    updated_at: u64,
+}
+
+impl From<LegacyDocumentSyncOutboxRecord> for DocumentSyncOutboxRecord {
+    fn from(legacy: LegacyDocumentSyncOutboxRecord) -> Self {
+        Self {
+            outbox_id: legacy.outbox_id,
+            node_id: legacy.node_id,
+            target: legacy.target,
+            peers: legacy.peers,
+            event: legacy.event,
+            updated_at: legacy.updated_at,
+            // Before `allow_genesis` existed, outbox publishes could mint missing
+            // sync topic genesis. Preserve that behavior for already-queued work.
+            allow_genesis: true,
+        }
+    }
+}
+
 pub fn schedule_outbox_drain_effect() -> Effect {
     Effect::Task(TaskEffect::ResetTimer {
         key: TaskKey::DrainDocumentSyncOutbox,
@@ -119,7 +155,7 @@ pub async fn read_outbox_record(
         .await
     {
         Event::Storage(StorageEvent::ReadResult { value, .. }) => value
-            .map(|bytes| postcard::from_bytes(&bytes).map_err(|error| error.to_string()))
+            .map(|bytes| decode_outbox_record(&bytes).map_err(|error| error.to_string()))
             .transpose(),
         Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
         other => Err(format!("unexpected storage event: {other:?}")),
@@ -151,7 +187,7 @@ pub async fn read_outbox_records(
             let has_more = values.len() > limit;
             let mut records = Vec::with_capacity(values.len().min(limit));
             for (key, value) in values.into_iter().take(limit) {
-                match postcard::from_bytes(&value) {
+                match decode_outbox_record(&value) {
                     Ok(record) => records.push((key.to_vec(), record)),
                     Err(error) => {
                         let key = key.to_vec();
@@ -310,6 +346,69 @@ mod tests {
             Event::Storage(StorageEvent::WriteResult { .. }) => {}
             other => panic!("unexpected outbox write event: {other:?}"),
         }
+    }
+
+    fn legacy_pre_allow_genesis_bytes(record: &DocumentSyncOutboxRecord) -> Vec<u8> {
+        #[derive(serde::Serialize)]
+        struct LegacyRecord {
+            outbox_id: Ulid,
+            node_id: NodeId,
+            target: DocumentSyncTarget,
+            peers: Vec<NodeId>,
+            event: DocumentSyncOutboxEvent,
+            updated_at: u64,
+        }
+
+        postcard::to_allocvec(&LegacyRecord {
+            outbox_id: record.outbox_id,
+            node_id: record.node_id,
+            target: record.target.clone(),
+            peers: record.peers.clone(),
+            event: record.event.clone(),
+            updated_at: record.updated_at,
+        })
+        .expect("legacy record serializes")
+    }
+
+    #[tokio::test]
+    async fn legacy_pre_allow_genesis_outbox_record_is_preserved() {
+        let dir = tempdir().expect("temp dir");
+        let storage =
+            FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
+        let mut legacy = new_outbox_record(
+            node(1),
+            target(),
+            vec![node(2)],
+            DocumentSyncOutboxEvent::Upsert {
+                bytes: vec![4, 5],
+                change: change(),
+            },
+            false,
+        );
+        legacy.outbox_id = Ulid::from_parts(3, 4);
+        legacy.updated_at = 42;
+        let key = outbox_key(&legacy).to_vec();
+        write_raw_outbox_record(
+            &storage,
+            key.clone(),
+            legacy_pre_allow_genesis_bytes(&legacy),
+        )
+        .await;
+
+        let mut expected = legacy;
+        expected.allow_genesis = true;
+        let batch = read_outbox_records(&storage, &[], OUTBOX_DRAIN_BATCH_SIZE)
+            .await
+            .expect("outbox read succeeds");
+
+        assert_eq!(batch.records, vec![(key.clone(), expected.clone())]);
+        assert!(!batch.has_more);
+        assert_eq!(
+            read_outbox_record(&storage, &key)
+                .await
+                .expect("legacy record was preserved"),
+            Some(expected)
+        );
     }
 
     #[tokio::test]

--- a/operations/src/ensure_realm_config.rs
+++ b/operations/src/ensure_realm_config.rs
@@ -227,6 +227,7 @@ impl EnsureRealmConfigOperation {
             DocumentSyncOutboxEvent::AdminOperation {
                 event: Box::new(admin_event),
             },
+            false,
         );
         writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         writes.extend(admin_document_conflict_write_entries(&reducer_state)?);

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -2,6 +2,9 @@ use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use crate::document_sync_outbox::{
+    new_outbox_record, schedule_outbox_drain_effect, write_outbox_effect,
+};
 use crate::driver::{DriverContext, drive};
 use crate::metadata::MetadataHandle;
 use crate::metadata::projector::{
@@ -13,10 +16,14 @@ use crate::process_placements::{PlacementConfig, ProcessPlacementsOperation};
 use crate::replication::incoming_version_replication::IncomingVersionReplicationOperation;
 use crate::replication::protocol::VersionReplicationMessage;
 use aruna_core::alpn::Alpn;
-use aruna_core::document::{DocumentSyncReconcileResult, DocumentSyncTarget};
+use aruna_core::document::{
+    DocumentSyncOutboxEvent, DocumentSyncPublish, DocumentSyncReconcileResult, DocumentSyncTarget,
+};
 use aruna_core::effects::BlobEffect;
-use aruna_core::events::{BlobEvent, Event};
+use aruna_core::events::{BlobEvent, Event, StorageEvent};
+use aruna_core::handle::Handle;
 use aruna_core::id::NodeId;
+use aruna_core::task::TaskEvent;
 use aruna_core::telemetry::{QUEUE_LAG_INTERVAL, duration_ms};
 use aruna_net::InboundEventHandler;
 use aruna_net::streams::BiStream;
@@ -306,6 +313,78 @@ impl InboundEventHandler for OperationsInboundHandler {
         .instrument(span)
         .await;
     }
+
+    async fn handle_evicted_documents(&self, documents: Vec<DocumentSyncPublish>) {
+        reemit_evicted_documents(self.context.as_ref(), documents).await;
+    }
+}
+
+/// Re-enqueues the payloads recovered from a genesis tie-break eviction as
+/// document-sync outbox records so they replay onto the winning chain through
+/// the normal drain. Admin operations keep their original embedded event id,
+/// which is the whole safety story: appliers dedupe on it, so replaying an
+/// event that already landed on the winner chain is a no-op. Every record uses
+/// `allow_genesis: false` (the loser must not mint a rival genesis) and empty
+/// peers (resolved to the realm default set at the net layer, exactly like the
+/// mutation operations that originate admin events).
+async fn reemit_evicted_documents(context: &DriverContext, documents: Vec<DocumentSyncPublish>) {
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        warn!("Cannot re-emit evicted documents without net handle");
+        return;
+    };
+    let node_id = net_handle.node_id();
+    let mut written = 0usize;
+    for publish in documents {
+        let allow_genesis = publish.allow_genesis();
+        let (target, event) = match publish {
+            DocumentSyncPublish::Upsert {
+                target,
+                bytes,
+                change,
+                ..
+            } => (target, DocumentSyncOutboxEvent::Upsert { bytes, change }),
+            DocumentSyncPublish::AdminOperation { target, event, .. } => {
+                (target, DocumentSyncOutboxEvent::AdminOperation { event })
+            }
+            DocumentSyncPublish::Delete { target, change, .. } => {
+                (target, DocumentSyncOutboxEvent::Delete { change })
+            }
+        };
+        let record = new_outbox_record(node_id, target, Vec::new(), event, allow_genesis);
+        let effect = match write_outbox_effect(&record) {
+            Ok(effect) => effect,
+            Err(error) => {
+                warn!(error = %error, "Failed to encode re-emitted eviction outbox record");
+                continue;
+            }
+        };
+        match context.storage_handle.send_effect(effect).await {
+            Event::Storage(StorageEvent::WriteResult { .. }) => written += 1,
+            Event::Storage(StorageEvent::Error { error }) => {
+                warn!(error = %error, "Failed to write re-emitted eviction outbox record");
+            }
+            other => {
+                warn!(event = ?other, "Unexpected event writing re-emitted eviction outbox record");
+            }
+        }
+    }
+    if written == 0 {
+        return;
+    }
+    let Some(task_handle) = context.task_handle.as_ref() else {
+        warn!("Cannot schedule outbox drain for re-emitted evictions without task handle");
+        return;
+    };
+    if let Event::Task(TaskEvent::Error { message, .. }) = task_handle
+        .send_effect(schedule_outbox_drain_effect())
+        .await
+    {
+        warn!(message = %message, "Failed to schedule outbox drain after re-emitting evictions");
+    }
+    info!(
+        count = written,
+        "Re-emitted evicted documents to the sync outbox"
+    );
 }
 
 async fn project_inbound_metadata_create_events(

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use crate::document_sync_outbox::{
-    new_outbox_record, schedule_outbox_drain_effect, write_outbox_effect,
+    new_outbox_record_with_id, schedule_outbox_drain_effect, write_outbox_effect,
 };
 use crate::driver::{DriverContext, drive};
 use crate::metadata::MetadataHandle;
@@ -17,7 +17,7 @@ use crate::replication::incoming_version_replication::IncomingVersionReplication
 use crate::replication::protocol::VersionReplicationMessage;
 use aruna_core::alpn::Alpn;
 use aruna_core::document::{
-    DocumentSyncOutboxEvent, DocumentSyncPublish, DocumentSyncReconcileResult, DocumentSyncTarget,
+    DocumentSyncEvictedDocument, DocumentSyncReconcileResult, DocumentSyncTarget,
 };
 use aruna_core::effects::BlobEffect;
 use aruna_core::events::{BlobEvent, Event, StorageEvent};
@@ -314,7 +314,7 @@ impl InboundEventHandler for OperationsInboundHandler {
         .await;
     }
 
-    async fn handle_evicted_documents(&self, documents: Vec<DocumentSyncPublish>) {
+    async fn handle_evicted_documents(&self, documents: Vec<DocumentSyncEvictedDocument>) {
         reemit_evicted_documents(self.context.as_ref(), documents).await;
     }
 }
@@ -327,30 +327,25 @@ impl InboundEventHandler for OperationsInboundHandler {
 /// `allow_genesis: false` (the loser must not mint a rival genesis) and empty
 /// peers (resolved to the realm default set at the net layer, exactly like the
 /// mutation operations that originate admin events).
-async fn reemit_evicted_documents(context: &DriverContext, documents: Vec<DocumentSyncPublish>) {
+async fn reemit_evicted_documents(
+    context: &DriverContext,
+    documents: Vec<DocumentSyncEvictedDocument>,
+) {
     let Some(net_handle) = context.net_handle.as_ref() else {
         warn!("Cannot re-emit evicted documents without net handle");
         return;
     };
     let node_id = net_handle.node_id();
     let mut written = 0usize;
-    for publish in documents {
-        let allow_genesis = publish.allow_genesis();
-        let (target, event) = match publish {
-            DocumentSyncPublish::Upsert {
-                target,
-                bytes,
-                change,
-                ..
-            } => (target, DocumentSyncOutboxEvent::Upsert { bytes, change }),
-            DocumentSyncPublish::AdminOperation { target, event, .. } => {
-                (target, DocumentSyncOutboxEvent::AdminOperation { event })
-            }
-            DocumentSyncPublish::Delete { target, change, .. } => {
-                (target, DocumentSyncOutboxEvent::Delete { change })
-            }
-        };
-        let record = new_outbox_record(node_id, target, Vec::new(), event, allow_genesis);
+    for document in documents {
+        let record = new_outbox_record_with_id(
+            document.event_id.unwrap_or_else(ulid::Ulid::new),
+            node_id,
+            document.target,
+            Vec::new(),
+            document.event,
+            document.allow_genesis,
+        );
         let effect = match write_outbox_effect(&record) {
             Ok(effect) => effect,
             Err(error) => {

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -163,6 +163,7 @@ async fn reconcile_inbound_document_sync_topics(
         let operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id: *net_handle.realm_id(),
             local_node_id: net_handle.node_id(),
+            retry_after: crate::sync_placement::SYNC_PLACEMENT_RETRY_AFTER,
         });
         if let Err(error) = drive(operation, context.as_ref()).await {
             error!(error = ?error, "Failed to process pending placements after document sync reconciliation");

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -495,7 +495,9 @@ pub async fn project_metadata_create_events(
         let outbox = if local_node_id == Some(event.node_id)
             && (!registry_exists || needs_materialization || holders_changed)
         {
-            Some(create_event_outbox_record(&event))
+            // The local node authored this create event, so it originates the
+            // document's lifecycle sync topic and may mint its genesis.
+            Some(create_event_outbox_record(&event, true))
         } else {
             None
         };
@@ -773,7 +775,10 @@ async fn read_realm_config(
     }
 }
 
-pub fn create_event_outbox_record(event: &MetadataCreateEventRecord) -> DocumentSyncOutboxRecord {
+pub fn create_event_outbox_record(
+    event: &MetadataCreateEventRecord,
+    allow_genesis: bool,
+) -> DocumentSyncOutboxRecord {
     let lifecycle = MetadataDocumentLifecycleRecord::Upsert {
         event: Box::new(event.clone()),
     };
@@ -791,6 +796,7 @@ pub fn create_event_outbox_record(event: &MetadataCreateEventRecord) -> Document
             change,
         },
         updated_at: event.occurred_at_ms / 1_000,
+        allow_genesis,
     }
 }
 
@@ -1247,8 +1253,9 @@ mod tests {
     #[test]
     fn create_event_outbox_record_uses_document_lifecycle_stream() {
         let event = create_event();
-        let outbox = create_event_outbox_record(&event);
+        let outbox = create_event_outbox_record(&event, true);
 
+        assert!(outbox.allow_genesis);
         assert_eq!(outbox.outbox_id, event.event_id);
         assert_eq!(outbox.peers, event.record.holder_node_ids);
         assert_eq!(

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -184,12 +184,16 @@ impl ProcessPlacementsOperation {
         }
 
         self.state = PlacementState::Publish;
+        // Only the placement's authoritative origin may mint the document's topic
+        // genesis; a replica-holder node re-publishing waits for it to replicate in.
+        let allow_genesis = record.authoritative_node_id == self.config.local_node_id;
         smallvec![Effect::SubOperation(boxed_suboperation(
             AnnounceTopicOperation::new_for_document_with_peers(
                 record.target.topic_id(),
                 self.config.local_node_id,
                 Some(record.target),
                 newly_selected,
+                allow_genesis,
             ),
             |result| Event::SubOperation(SubOperationEvent::DocumentSyncResult {
                 result: result.map_err(|error| error.to_string()),
@@ -529,5 +533,72 @@ mod tests {
         assert!(!operation.retry_needed);
         assert_eq!(operation.state, PlacementState::StorePlacement);
         assert!(operation.current.is_none());
+    }
+
+    fn node_usage_target() -> DocumentSyncTarget {
+        DocumentSyncTarget::NodeUsage {
+            realm_id: RealmId::from_bytes([8u8; 32]),
+            node_id: node(1),
+            group_id: None,
+        }
+    }
+
+    fn announce_outbox_allow_genesis(effects: Effects) -> bool {
+        let Some(Effect::SubOperation(mut sub)) = effects.into_iter().next() else {
+            panic!("expected announce sub-operation");
+        };
+        let _read = sub.start();
+        let write_effects = sub.step(Event::Storage(StorageEvent::ReadResult {
+            key: Key::from(vec![0u8]),
+            value: Some(aruna_core::types::Value::from(vec![1u8])),
+        }));
+        let [Effect::Storage(StorageEffect::Write { value, .. })] = write_effects.as_slice() else {
+            panic!("expected announce outbox write, got {write_effects:?}");
+        };
+        let record: aruna_core::document::DocumentSyncOutboxRecord =
+            postcard::from_bytes(value.as_ref()).expect("outbox record decodes");
+        record.allow_genesis
+    }
+
+    #[test]
+    fn announce_allow_genesis_tracks_authoritative_origin() {
+        let realm_id = RealmId::from_bytes([8u8; 32]);
+        let local = node(1);
+
+        let mut origin = ProcessPlacementsOperation::new(PlacementConfig {
+            realm_id,
+            local_node_id: local,
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
+        });
+        origin.realm_nodes = vec![local, node(2), node(3)];
+        origin.records = vec![new_placement(
+            realm_id,
+            node_usage_target(),
+            local,
+            3,
+            Vec::new(),
+        )];
+        assert!(
+            announce_outbox_allow_genesis(origin.emit_next_record()),
+            "origin (authoritative == local) may mint genesis"
+        );
+
+        let mut replica = ProcessPlacementsOperation::new(PlacementConfig {
+            realm_id,
+            local_node_id: node(9),
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
+        });
+        replica.realm_nodes = vec![local, node(2), node(3)];
+        replica.records = vec![new_placement(
+            realm_id,
+            node_usage_target(),
+            local,
+            3,
+            Vec::new(),
+        )];
+        assert!(
+            !announce_outbox_allow_genesis(replica.emit_next_record()),
+            "replica-holder (authoritative != local) must not mint genesis"
+        );
     }
 }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -15,9 +15,10 @@ use crate::announce::AnnounceTopicOperation;
 use crate::document_repository::read_effect;
 use crate::sync_placement::{
     decode_placement, delete_placement_effect, missing_peer_count, new_placement, placement_prefix,
-    placement_satisfied, realm_nodes_from_config_bytes, schedule_placement_retry_effect,
+    placement_satisfied, realm_nodes_from_config_bytes, schedule_placement_retry_after,
     select_sync_peers, sort_node_ids, write_placement_effect,
 };
+use std::time::Duration;
 use tracing::warn;
 
 const PENDING_PLACEMENT_PAGE_SIZE: usize = 256;
@@ -26,6 +27,9 @@ const PENDING_PLACEMENT_PAGE_SIZE: usize = 256;
 pub struct PlacementConfig {
     pub realm_id: RealmId,
     pub local_node_id: NodeId,
+    /// In-memory backoff duration the driver uses for the retry re-arm; not
+    /// persisted anywhere.
+    pub retry_after: Duration,
 }
 
 #[derive(Debug, PartialEq)]
@@ -37,6 +41,7 @@ pub struct ProcessPlacementsOperation {
     next_start_after: Option<Key>,
     current: Option<CurrentPlacement>,
     retry_needed: bool,
+    rearmed: bool,
     output: Option<Result<(), PlacementError>>,
 }
 
@@ -93,6 +98,7 @@ impl ProcessPlacementsOperation {
             next_start_after: None,
             current: None,
             retry_needed: false,
+            rearmed: false,
             output: None,
         }
     }
@@ -226,7 +232,8 @@ impl ProcessPlacementsOperation {
 }
 
 impl Operation for ProcessPlacementsOperation {
-    type Output = ();
+    /// `true` when this tick re-armed the placement retry timer.
+    type Output = bool;
     type Error = PlacementError;
 
     fn start(&mut self) -> Effects {
@@ -298,10 +305,12 @@ impl Operation for ProcessPlacementsOperation {
                 Event::Storage(StorageEvent::WriteResult { .. })
                 | Event::Storage(StorageEvent::DeleteResult { .. }) => {
                     if self.retry_needed {
+                        self.rearmed = true;
                         self.state = PlacementState::ScheduleRetry;
-                        smallvec![schedule_placement_retry_effect(
+                        smallvec![schedule_placement_retry_after(
                             self.config.realm_id,
                             self.config.local_node_id,
+                            self.config.retry_after,
                         )]
                     } else {
                         self.emit_next_record()
@@ -331,7 +340,10 @@ impl Operation for ProcessPlacementsOperation {
     }
 
     fn finalize(self) -> Result<Self::Output, Self::Error> {
-        self.output.unwrap_or(Ok(()))
+        match self.output {
+            Some(Err(error)) => Err(error),
+            _ => Ok(self.rearmed),
+        }
     }
 
     fn abort(&mut self) -> Effects {
@@ -342,6 +354,7 @@ impl Operation for ProcessPlacementsOperation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sync_placement::SYNC_PLACEMENT_RETRY_AFTER;
     use ulid::Ulid;
 
     fn node(seed: u8) -> NodeId {
@@ -366,6 +379,7 @@ mod tests {
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: node(1),
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
         });
         operation.state = PlacementState::ScheduleRetry;
         operation.retry_needed = true;
@@ -377,7 +391,7 @@ mod tests {
 
         assert!(effects.is_empty());
         assert_eq!(operation.state, PlacementState::Finish);
-        assert_eq!(operation.finalize(), Ok(()));
+        assert_eq!(operation.finalize(), Ok(false));
     }
 
     #[test]
@@ -387,6 +401,7 @@ mod tests {
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: node(1),
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
         });
         operation.current = Some(CurrentPlacement {
             target: target.clone(),
@@ -413,6 +428,7 @@ mod tests {
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: node(9),
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
         });
         operation.realm_nodes = vec![authoritative, node(2), node(3), node(4)];
         operation.records = vec![new_placement(
@@ -441,6 +457,7 @@ mod tests {
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: node(9),
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
         });
         operation.current = Some(CurrentPlacement {
             target,
@@ -467,6 +484,7 @@ mod tests {
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: node(9),
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
         });
         operation.realm_nodes = vec![authoritative, node(2)];
         operation.records = vec![new_placement(
@@ -490,6 +508,7 @@ mod tests {
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: node(1),
+            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
         });
         operation.realm_nodes = vec![node(1), node(2), node(3)];
         operation.records = vec![new_placement(

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -535,22 +535,14 @@ mod tests {
         assert!(operation.current.is_none());
     }
 
-    fn node_usage_target() -> DocumentSyncTarget {
-        DocumentSyncTarget::NodeUsage {
-            realm_id: RealmId::from_bytes([8u8; 32]),
-            node_id: node(1),
-            group_id: None,
-        }
-    }
-
-    fn announce_outbox_allow_genesis(effects: Effects) -> bool {
+    fn announce_outbox_allow_genesis(effects: Effects, document_bytes: Vec<u8>) -> bool {
         let Some(Effect::SubOperation(mut sub)) = effects.into_iter().next() else {
             panic!("expected announce sub-operation");
         };
         let _read = sub.start();
         let write_effects = sub.step(Event::Storage(StorageEvent::ReadResult {
             key: Key::from(vec![0u8]),
-            value: Some(aruna_core::types::Value::from(vec![1u8])),
+            value: Some(aruna_core::types::Value::from(document_bytes)),
         }));
         let [Effect::Storage(StorageEffect::Write { value, .. })] = write_effects.as_slice() else {
             panic!("expected announce outbox write, got {write_effects:?}");
@@ -560,44 +552,54 @@ mod tests {
         record.allow_genesis
     }
 
-    #[test]
-    fn announce_allow_genesis_tracks_authoritative_origin() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let local = node(1);
+    fn graph_lifecycle_fixture() -> (DocumentSyncTarget, Vec<u8>) {
+        let record = aruna_core::metadata::MetadataGraphLifecycleRecord::deleted(
+            "urn:graph:placement-test".to_string(),
+            RealmId::from_bytes([8u8; 32]),
+            aruna_core::types::GroupId::new(),
+            Ulid::from_bytes([9u8; 16]),
+            42,
+        );
+        let bytes = postcard::to_allocvec(&record).expect("lifecycle record serializes");
+        let target = DocumentSyncTarget::MetadataGraphLifecycle {
+            graph_iri: record.graph_iri.clone(),
+        };
+        (target, bytes)
+    }
 
-        let mut origin = ProcessPlacementsOperation::new(PlacementConfig {
+    fn placement_announce_allow_genesis(
+        local: NodeId,
+        authoritative: NodeId,
+        target: DocumentSyncTarget,
+        document_bytes: Vec<u8>,
+    ) -> bool {
+        let realm_id = RealmId::from_bytes([8u8; 32]);
+        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: local,
             retry_after: SYNC_PLACEMENT_RETRY_AFTER,
         });
-        origin.realm_nodes = vec![local, node(2), node(3)];
-        origin.records = vec![new_placement(
+        operation.realm_nodes = vec![node(1), node(2), node(3), local];
+        operation.records = vec![new_placement(
             realm_id,
-            node_usage_target(),
-            local,
+            target,
+            authoritative,
             3,
             Vec::new(),
         )];
+        announce_outbox_allow_genesis(operation.emit_next_record(), document_bytes)
+    }
+
+    #[test]
+    fn announce_allow_genesis_tracks_authoritative_origin() {
+        let local = node(1);
+        let (target, bytes) = graph_lifecycle_fixture();
         assert!(
-            announce_outbox_allow_genesis(origin.emit_next_record()),
+            placement_announce_allow_genesis(local, local, target.clone(), bytes.clone()),
             "origin (authoritative == local) may mint genesis"
         );
-
-        let mut replica = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(9),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        replica.realm_nodes = vec![local, node(2), node(3)];
-        replica.records = vec![new_placement(
-            realm_id,
-            node_usage_target(),
-            local,
-            3,
-            Vec::new(),
-        )];
         assert!(
-            !announce_outbox_allow_genesis(replica.emit_next_record()),
+            !placement_announce_allow_genesis(node(9), local, target, bytes),
             "replica-holder (authoritative != local) must not mint genesis"
         );
     }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -139,6 +139,18 @@ impl ProcessPlacementsOperation {
             );
             return self.emit_next_record();
         }
+        if record.target.is_admin_document() {
+            // Admin documents never take placements; drain any stale row instead of
+            // retrying it forever. The satisfied-delete path continues the sweep once
+            // the delete result arrives.
+            self.current = None;
+            self.retry_needed = false;
+            self.state = PlacementState::StorePlacement;
+            return smallvec![delete_placement_effect(
+                self.config.realm_id,
+                &record.target
+            )];
+        }
 
         let missing_peer_count = missing_peer_count(&record);
         let mut selected_peers = record.selected_peers;
@@ -342,6 +354,12 @@ mod tests {
         }
     }
 
+    fn metadata_target(seed: u8) -> DocumentSyncTarget {
+        DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([seed; 16]),
+        }
+    }
+
     #[test]
     fn task_schedule_error_is_non_blocking_after_placement_write() {
         let realm_id = RealmId::from_bytes([8u8; 32]);
@@ -365,7 +383,7 @@ mod tests {
     #[test]
     fn two_remote_peers_complete_existing_default_pending_placement() {
         let realm_id = RealmId::from_bytes([8u8; 32]);
-        let target = group_target(4);
+        let target = metadata_target(4);
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
             local_node_id: node(1),
@@ -399,7 +417,7 @@ mod tests {
         operation.realm_nodes = vec![authoritative, node(2), node(3), node(4)];
         operation.records = vec![new_placement(
             realm_id,
-            group_target(5),
+            metadata_target(5),
             authoritative,
             3,
             vec![node(2)],
@@ -418,7 +436,7 @@ mod tests {
     #[test]
     fn process_placement_does_not_replace_existing_holders() {
         let realm_id = RealmId::from_bytes([8u8; 32]);
-        let target = group_target(6);
+        let target = metadata_target(6);
         let authoritative = node(1);
         let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
             realm_id,
@@ -453,7 +471,7 @@ mod tests {
         operation.realm_nodes = vec![authoritative, node(2)];
         operation.records = vec![new_placement(
             realm_id,
-            group_target(7),
+            metadata_target(7),
             authoritative,
             2,
             Vec::new(),
@@ -464,5 +482,33 @@ mod tests {
         assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
         let current = operation.current.expect("placement is active");
         assert_eq!(current.newly_selected, vec![node(2)]);
+    }
+
+    #[test]
+    fn admin_target_placement_is_drained_not_retried() {
+        let realm_id = RealmId::from_bytes([8u8; 32]);
+        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
+            realm_id,
+            local_node_id: node(1),
+        });
+        operation.realm_nodes = vec![node(1), node(2), node(3)];
+        operation.records = vec![new_placement(
+            realm_id,
+            group_target(4),
+            node(1),
+            3,
+            Vec::new(),
+        )];
+
+        let effects = operation.emit_next_record();
+
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::Delete { key_space, .. })]
+                if key_space == SYNC_PLACEMENT_KEYSPACE
+        ));
+        assert!(!operation.retry_needed);
+        assert_eq!(operation.state, PlacementState::StorePlacement);
+        assert!(operation.current.is_none());
     }
 }

--- a/operations/src/queue_backoff.rs
+++ b/operations/src/queue_backoff.rs
@@ -11,6 +11,25 @@ pub(crate) fn retry_after_ms(attempts: u32, base_ms: u64, max_ms: u64) -> u64 {
     base_ms.saturating_mul(multiplier).min(max_ms)
 }
 
+pub(crate) const TIMER_RETRY_BASE_SECS: u64 = 30;
+pub(crate) const TIMER_RETRY_MAX_SECS: u64 = 300;
+
+/// Timer-scale backoff for the in-memory placement-retry and outbox-drain re-arm
+/// counters: 30s base, doubling, capped at 300s.
+pub(crate) const fn timer_retry_after_secs(attempts: u32) -> u64 {
+    let shift = if attempts < 7 { attempts } else { 7 };
+    let multiplier = match 1u64.checked_shl(shift) {
+        Some(value) => value,
+        None => u64::MAX,
+    };
+    let scaled = TIMER_RETRY_BASE_SECS.saturating_mul(multiplier);
+    if scaled < TIMER_RETRY_MAX_SECS {
+        scaled
+    } else {
+        TIMER_RETRY_MAX_SECS
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -32,6 +51,24 @@ mod tests {
 
         for (attempts, expected_ms) in expected {
             assert_eq!(queue_retry_after_ms(attempts), expected_ms);
+        }
+    }
+
+    #[test]
+    fn timer_backoff_doubles_from_base_to_cap() {
+        let expected = [
+            (0, 30),
+            (1, 60),
+            (2, 120),
+            (3, 240),
+            (4, 300),
+            (5, 300),
+            (7, 300),
+            (u32::MAX, 300),
+        ];
+
+        for (attempts, expected_secs) in expected {
+            assert_eq!(timer_retry_after_secs(attempts), expected_secs);
         }
     }
 }

--- a/operations/src/register_or_get_oidc_user.rs
+++ b/operations/src/register_or_get_oidc_user.rs
@@ -209,6 +209,7 @@ impl RegisterOrGetOidcUserOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                true,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/remove_group_role.rs
+++ b/operations/src/remove_group_role.rs
@@ -341,6 +341,7 @@ impl RemoveGroupRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/remove_user_from_group.rs
+++ b/operations/src/remove_user_from_group.rs
@@ -351,6 +351,7 @@ impl RemoveUserFromGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -180,6 +180,10 @@ impl ReplicateDocumentsOperation {
                 self.config.local_node_id,
                 Some(document),
                 selected_peers,
+                // Replication runs on the node that authored the change and stamps
+                // itself as the placement's authoritative origin, so it may mint the
+                // document's topic genesis.
+                true,
             ),
             |result| Event::SubOperation(SubOperationEvent::DocumentSyncResult {
                 result: result.map_err(|error| error.to_string()),

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -25,6 +25,11 @@ pub struct ReplicateDocumentsConfig {
     pub local_node_id: NodeId,
     pub excluded_peers: Vec<NodeId>,
     pub documents: Vec<DocumentSyncTarget>,
+    /// Whether announces this run may mint a missing topic genesis. True for the
+    /// document's origin; for the shared node-usage topic only the realm-bootstrap
+    /// node passes true, so joining nodes ride the TopicNotReady retry instead of
+    /// forking the genesis.
+    pub allow_genesis: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -86,6 +91,9 @@ pub fn replicate_documents_effect(
             local_node_id,
             excluded_peers: Vec::new(),
             documents,
+            // The node authoring the change originates every document it replicates
+            // here, so it may mint any missing topic genesis.
+            allow_genesis: true,
         }),
         |result| {
             Event::SubOperation(SubOperationEvent::DocumentSyncResult {
@@ -180,10 +188,7 @@ impl ReplicateDocumentsOperation {
                 self.config.local_node_id,
                 Some(document),
                 selected_peers,
-                // Replication runs on the node that authored the change and stamps
-                // itself as the placement's authoritative origin, so it may mint the
-                // document's topic genesis.
-                true,
+                self.config.allow_genesis,
             ),
             |result| Event::SubOperation(SubOperationEvent::DocumentSyncResult {
                 result: result.map_err(|error| error.to_string()),
@@ -361,6 +366,7 @@ mod tests {
             local_node_id: node(1),
             excluded_peers: Vec::new(),
             documents: Vec::new(),
+            allow_genesis: true,
         });
         operation.state = ReplicateDocumentsState::ScheduleRetry;
         operation.retry_needed = true;
@@ -383,6 +389,7 @@ mod tests {
             local_node_id: node(1),
             excluded_peers: Vec::new(),
             documents: vec![target.clone()],
+            allow_genesis: true,
         });
         operation.realm_nodes = vec![node(2), node(3)];
 
@@ -404,6 +411,7 @@ mod tests {
             local_node_id,
             excluded_peers: Vec::new(),
             documents: vec![target],
+            allow_genesis: true,
         });
         operation.realm_nodes = vec![local_node_id, node(2)];
 
@@ -427,6 +435,7 @@ mod tests {
             local_node_id,
             excluded_peers: Vec::new(),
             documents: vec![target.clone()],
+            allow_genesis: true,
         });
         operation.state = ReplicateDocumentsState::Publish;
         operation.placement_action = Some(PlacementAction::Delete(target));
@@ -457,6 +466,7 @@ mod tests {
             local_node_id: node(1),
             excluded_peers: Vec::new(),
             documents: vec![target.clone()],
+            allow_genesis: true,
         });
         first.realm_nodes = realm_nodes.clone();
         let _ = first.emit_next_publish();
@@ -466,6 +476,7 @@ mod tests {
             local_node_id: node(9),
             excluded_peers: Vec::new(),
             documents: vec![target],
+            allow_genesis: true,
         });
         second.realm_nodes = realm_nodes;
         let _ = second.emit_next_publish();
@@ -490,6 +501,7 @@ mod tests {
             local_node_id: node(1),
             excluded_peers: Vec::new(),
             documents: vec![group_target(4)],
+            allow_genesis: true,
         });
         operation.realm_nodes = vec![node(2), node(3)];
 

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -133,6 +133,12 @@ impl ReplicateDocumentsOperation {
             return self.finish_success();
         };
 
+        // Admin documents replicate as operations over their shared topic; they never
+        // take placements, so skip them without a placement write or publish attempt.
+        if document.is_admin_document() {
+            return self.emit_next_publish();
+        }
+
         let desired_count = desired_peer_count(&document);
         if desired_count == 0 {
             return self.emit_next_publish();
@@ -337,6 +343,12 @@ mod tests {
         }
     }
 
+    fn metadata_target(seed: u8) -> DocumentSyncTarget {
+        DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([seed; 16]),
+        }
+    }
+
     #[test]
     fn task_schedule_error_is_non_blocking_after_placement_write() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
@@ -361,7 +373,7 @@ mod tests {
 
     #[test]
     fn two_remote_peers_satisfy_default_document_placement() {
-        let target = group_target(4);
+        let target = metadata_target(4);
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id: RealmId::from_bytes([7u8; 32]),
             local_node_id: node(1),
@@ -381,7 +393,7 @@ mod tests {
     #[test]
     fn pending_placement_records_authoritative_origin() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
-        let target = group_target(5);
+        let target = metadata_target(5);
         let local_node_id = node(1);
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,
@@ -404,7 +416,7 @@ mod tests {
     #[test]
     fn publish_failure_keeps_authoritative_origin() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
-        let target = group_target(6);
+        let target = metadata_target(6);
         let local_node_id = node(1);
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,
@@ -433,7 +445,7 @@ mod tests {
     #[test]
     fn replicate_documents_selection_uses_rendezvous_not_local_salt() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
-        let target = group_target(7);
+        let target = metadata_target(7);
         let realm_nodes = vec![node(2)];
 
         let mut first = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
@@ -465,5 +477,23 @@ mod tests {
             first_record.authoritative_node_id,
             second_record.authoritative_node_id
         );
+    }
+
+    #[test]
+    fn admin_target_creates_no_placement() {
+        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
+            realm_id: RealmId::from_bytes([7u8; 32]),
+            local_node_id: node(1),
+            excluded_peers: Vec::new(),
+            documents: vec![group_target(4)],
+        });
+        operation.realm_nodes = vec![node(2), node(3)];
+
+        let effects = operation.emit_next_publish();
+
+        assert!(effects.is_empty());
+        assert!(operation.placement_action.is_none());
+        assert_eq!(operation.state, ReplicateDocumentsState::Finish);
+        assert_eq!(operation.finalize(), Ok(()));
     }
 }

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -114,6 +114,10 @@ impl RestoreTopicSubscriptionsOperation {
                     document.topic_id(),
                     self.local_node_id,
                     Some(document),
+                    // Startup restore re-announces documents this node already holds
+                    // locally; as the holder of record it may mint any genesis that
+                    // did not survive a restart.
+                    true,
                 ),
                 |result| {
                     Event::SubOperation(SubOperationEvent::DocumentSyncResult {

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -114,10 +114,10 @@ impl RestoreTopicSubscriptionsOperation {
                     document.topic_id(),
                     self.local_node_id,
                     Some(document),
-                    // Startup restore re-announces documents this node already holds
-                    // locally; as the holder of record it may mint any genesis that
-                    // did not survive a restart.
-                    true,
+                    // Placement reconciliation is the only path that knows the
+                    // authoritative origin for metadata documents. Startup restore
+                    // must not let a replica-holder mint a rival genesis.
+                    false,
                 ),
                 |result| {
                     Event::SubOperation(SubOperationEvent::DocumentSyncResult {

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -158,12 +158,20 @@ pub fn delete_placement_effect(realm_id: RealmId, target: &DocumentSyncTarget) -
 }
 
 pub fn schedule_placement_retry_effect(realm_id: RealmId, local_node_id: NodeId) -> Effect {
+    schedule_placement_retry_after(realm_id, local_node_id, SYNC_PLACEMENT_RETRY_AFTER)
+}
+
+pub fn schedule_placement_retry_after(
+    realm_id: RealmId,
+    local_node_id: NodeId,
+    after: Duration,
+) -> Effect {
     Effect::Task(TaskEffect::ResetTimer {
         key: TaskKey::SyncPlacements {
             realm_id,
             node_id: local_node_id,
         },
-        after: SYNC_PLACEMENT_RETRY_AFTER,
+        after,
     })
 }
 

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -930,6 +930,7 @@ mod tests {
                 bytes: b"restore durable work".to_vec(),
                 change: change(),
             },
+            false,
         );
         write_outbox_record(&storage, &record).await;
 
@@ -959,6 +960,7 @@ mod tests {
                 bytes: b"retained work".to_vec(),
                 change: change(),
             },
+            false,
         );
         let key = outbox_key(&record).to_vec();
 
@@ -1004,6 +1006,7 @@ mod tests {
                 bytes: b"retry after restart".to_vec(),
                 change: change(),
             },
+            false,
         );
         let key = outbox_key(&record).to_vec();
         write_outbox_record(&storage, &record).await;

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -81,6 +81,7 @@ fn document_publish_from_outbox(
     event_id: ulid::Ulid,
     target: DocumentSyncTarget,
     event: DocumentSyncOutboxEvent,
+    allow_genesis: bool,
 ) -> DocumentSyncPublish {
     match event {
         DocumentSyncOutboxEvent::Upsert { bytes, change } => DocumentSyncPublish::Upsert {
@@ -88,15 +89,19 @@ fn document_publish_from_outbox(
             target,
             bytes,
             change,
+            allow_genesis,
         },
         DocumentSyncOutboxEvent::Delete { change } => DocumentSyncPublish::Delete {
             event_id,
             target,
             change,
+            allow_genesis,
         },
-        DocumentSyncOutboxEvent::AdminOperation { event } => {
-            DocumentSyncPublish::AdminOperation { target, event }
-        }
+        DocumentSyncOutboxEvent::AdminOperation { event } => DocumentSyncPublish::AdminOperation {
+            target,
+            event,
+            allow_genesis,
+        },
     }
 }
 
@@ -218,8 +223,12 @@ impl OperationsTaskHandler {
         let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
             BTreeMap::new();
         for (record_key, record) in batch.records {
-            let document =
-                document_publish_from_outbox(record.outbox_id, record.target.clone(), record.event);
+            let document = document_publish_from_outbox(
+                record.outbox_id,
+                record.target.clone(),
+                record.event,
+                record.allow_genesis,
+            );
 
             let subbatches = publish_groups.entry(record.peers.clone()).or_default();
             if subbatches
@@ -889,10 +898,12 @@ mod tests {
                 bytes: vec![1, 2, 3],
                 change,
             },
+            true,
         );
 
         assert_eq!(publish.target(), &target);
         assert_eq!(publish.event_id(), event_id);
+        assert!(publish.allow_genesis());
         assert!(matches!(
             publish,
             DocumentSyncPublish::Upsert { bytes, change: actual, .. }

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -951,6 +951,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restore_document_sync_outbox_timers_keeps_existing_backoff_timer() {
+        let temp_dir = tempdir().expect("temp dir");
+        let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))
+            .expect("storage opens");
+        let record = crate::document_sync_outbox::new_outbox_record(
+            node(1),
+            target(),
+            vec![node(2)],
+            DocumentSyncOutboxEvent::Upsert {
+                bytes: b"restore durable work".to_vec(),
+                change: change(),
+            },
+            false,
+        );
+        write_outbox_record(&storage, &record).await;
+
+        let task_handle = TaskHandle::new();
+        let (seen_tx, mut seen_rx) = mpsc::channel(1);
+        task_handle
+            .set_inbound_handler(Arc::new(RecordingTaskHandler { seen: seen_tx }))
+            .await;
+        match task_handle
+            .send_effect(Effect::Task(TaskEffect::ResetTimer {
+                key: TaskKey::DrainDocumentSyncOutbox,
+                after: Duration::from_secs(3600),
+            }))
+            .await
+        {
+            Event::Task(TaskEvent::TimerScheduled { .. }) => {}
+            other => panic!("unexpected timer schedule event: {other:?}"),
+        }
+
+        restore_document_sync_outbox_timers(&storage, &task_handle).await;
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), seen_rx.recv())
+                .await
+                .is_err(),
+            "durable rearm must not replace an active backoff timer"
+        );
+    }
+
+    #[tokio::test]
     async fn outbox_sync_error_retains_record_for_retry() {
         let temp_dir = tempdir().expect("temp dir");
         let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
@@ -38,6 +38,7 @@ use crate::metadata::prune_queue::{
     process_metadata_graph_tombstones, restore_metadata_graph_prune_timer,
 };
 use crate::process_placements::{PlacementConfig, ProcessPlacementsOperation};
+use crate::queue_backoff::timer_retry_after_secs;
 use crate::replication::queue::{
     BLOB_REPLICATION_RETRY_AFTER, process_blob_replication_batch, restore_blob_replication_timer,
 };
@@ -45,7 +46,7 @@ use crate::s3::refresh_reference_metadata::{
     REFERENCE_METADATA_REFRESH_RETRY_AFTER, process_reference_metadata_refresh_batch,
     restore_reference_metadata_refresh_timer,
 };
-use crate::sync_placement::{DOCUMENT_SYNC_RETRY_AFTER, SYNC_PLACEMENT_RETRY_AFTER};
+use crate::sync_placement::DOCUMENT_SYNC_RETRY_AFTER;
 use crate::task_persistence::{
     delete_persisted_timer, persist_task_effect, restore_persisted_task_timers,
 };
@@ -56,6 +57,9 @@ const DURABLE_QUEUE_REARM_AFTER: Duration = Duration::from_secs(5);
 #[derive(Debug)]
 struct OperationsTaskHandler {
     context: Arc<DriverContext>,
+    // In-memory retry-attempt counters keyed by timer. Loss on restart is fine:
+    // a restarted node simply retries from the base interval.
+    retry_backoff: std::sync::Mutex<HashMap<TaskKey, u32>>,
 }
 
 struct DrainSubBatch {
@@ -107,7 +111,46 @@ impl DrainSyncOutcome {
 
 impl OperationsTaskHandler {
     fn new(context: Arc<DriverContext>) -> Self {
-        Self { context }
+        Self {
+            context,
+            retry_backoff: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Backoff interval for the next re-arm of `key`, derived from the in-memory
+    /// attempt count without mutating it.
+    fn backoff_after(&self, key: &TaskKey) -> Duration {
+        let attempts = self
+            .retry_backoff
+            .lock()
+            .expect("retry backoff mutex poisoned")
+            .get(key)
+            .copied()
+            .unwrap_or(0);
+        Duration::from_secs(timer_retry_after_secs(attempts))
+    }
+
+    fn note_retry_backoff(&self, key: &TaskKey) {
+        let mut backoff = self
+            .retry_backoff
+            .lock()
+            .expect("retry backoff mutex poisoned");
+        let attempts = backoff.entry(key.clone()).or_insert(0);
+        *attempts = attempts.saturating_add(1);
+    }
+
+    fn reset_backoff(&self, key: &TaskKey) {
+        self.retry_backoff
+            .lock()
+            .expect("retry backoff mutex poisoned")
+            .remove(key);
+    }
+
+    /// Re-arms `key` at its current backoff interval and records the attempt.
+    async fn reschedule_with_backoff(&self, key: TaskKey) -> bool {
+        let after = self.backoff_after(&key);
+        self.note_retry_backoff(&key);
+        self.reschedule_timer(key, after).await
     }
 
     async fn reschedule_timer(&self, key: TaskKey, after: std::time::Duration) -> bool {
@@ -146,14 +189,15 @@ impl OperationsTaskHandler {
                 Ok(batch) if batch.records.is_empty() => {
                     if batch.has_more {
                         self.reschedule_timer(retry_key, Duration::ZERO).await;
+                    } else {
+                        self.reset_backoff(&retry_key);
                     }
                     return;
                 }
                 Ok(batch) => batch,
                 Err(error) => {
                     warn!(error = %error, "Failed to read document sync outbox record");
-                    self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                        .await;
+                    self.reschedule_with_backoff(retry_key).await;
                     return;
                 }
             };
@@ -167,8 +211,7 @@ impl OperationsTaskHandler {
 
         let Some(net_handle) = self.context.net_handle.as_ref() else {
             warn!(key = ?retry_key, "Cannot drain document sync outbox without net handle");
-            self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                .await;
+            self.reschedule_with_backoff(retry_key).await;
             return;
         };
 
@@ -271,11 +314,12 @@ impl OperationsTaskHandler {
         );
 
         if totals.retry_needed {
-            self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                .await;
+            self.reschedule_with_backoff(retry_key).await;
         } else if batch.has_more {
             self.reschedule_timer(retry_key, std::time::Duration::ZERO)
                 .await;
+        } else {
+            self.reset_backoff(&retry_key);
         }
     }
 
@@ -632,17 +676,22 @@ impl InboundTaskHandler for OperationsTaskHandler {
                 }
             }
             TaskKey::SyncPlacements { realm_id, node_id } => {
+                let retry_key = TaskKey::SyncPlacements { realm_id, node_id };
                 let op = ProcessPlacementsOperation::new(PlacementConfig {
                     realm_id,
                     local_node_id: node_id,
+                    retry_after: self.backoff_after(&retry_key),
                 });
-                if let Err(err) = drive(op, self.context.as_ref()).await {
-                    error!(error = ?err, "Failed to process pending sync placements timer event");
-                    self.reschedule_timer(
-                        TaskKey::SyncPlacements { realm_id, node_id },
-                        SYNC_PLACEMENT_RETRY_AFTER,
-                    )
-                    .await;
+                match drive(op, self.context.as_ref()).await {
+                    // The sweep re-armed itself for still-pending placements: grow the
+                    // backoff so a persistently unsatisfiable placement stops hot-looping.
+                    Ok(true) => self.note_retry_backoff(&retry_key),
+                    // A clean sweep clears the backoff for the next unrelated re-arm.
+                    Ok(false) => self.reset_backoff(&retry_key),
+                    Err(err) => {
+                        error!(error = ?err, "Failed to process pending sync placements timer event");
+                        self.reschedule_with_backoff(retry_key).await;
+                    }
                 }
             }
             TaskKey::SyncDocument {

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -69,6 +69,23 @@ struct DrainSubBatch {
     record_keys: Vec<Vec<u8>>,
 }
 
+impl DrainSubBatch {
+    fn sync_subset(&self, indices: &[usize]) -> Option<Self> {
+        let mut targets = Vec::with_capacity(indices.len());
+        let mut record_keys = Vec::with_capacity(indices.len());
+        for &index in indices {
+            targets.push(self.targets.get(index)?.clone());
+            record_keys.push(self.record_keys.get(index)?.clone());
+        }
+        Some(Self {
+            peers: self.peers.clone(),
+            documents: Vec::new(),
+            targets,
+            record_keys,
+        })
+    }
+}
+
 #[derive(Default)]
 struct DrainSyncOutcome {
     sync_elapsed: Duration,
@@ -280,6 +297,31 @@ impl OperationsTaskHandler {
                     ..
                 })) => {
                     awaiting_sync = Some(subbatch);
+                }
+                Event::Net(NetEvent::DocumentSync(
+                    DocumentSyncNetEvent::DocumentsPartiallyPublished {
+                        published_indices,
+                        retry_indices,
+                        error,
+                    },
+                )) => {
+                    warn!(
+                        key = ?retry_key,
+                        published = published_indices.len(),
+                        retry = retry_indices.len(),
+                        error = %error,
+                        "Partially created local document sync batch"
+                    );
+                    totals.retry_needed = true;
+                    match subbatch.sync_subset(&published_indices) {
+                        Some(published_subbatch) if !published_subbatch.record_keys.is_empty() => {
+                            awaiting_sync = Some(published_subbatch);
+                        }
+                        Some(_) => {}
+                        None => {
+                            warn!(key = ?retry_key, "Invalid partial document publish indices");
+                        }
+                    }
                 }
                 Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
                     error, ..
@@ -909,6 +951,33 @@ mod tests {
             DocumentSyncPublish::Upsert { bytes, change: actual, .. }
                 if bytes == vec![1, 2, 3] && actual == change
         ));
+    }
+
+    #[test]
+    fn partial_publish_indices_select_exact_outbox_records() {
+        let duplicate_target = target();
+        let other_target = DocumentSyncTarget::Group {
+            group_id: Ulid::from_parts(7, 2),
+        };
+        let subbatch = DrainSubBatch {
+            peers: vec![node(2)],
+            documents: Vec::new(),
+            targets: vec![
+                duplicate_target.clone(),
+                other_target,
+                duplicate_target.clone(),
+            ],
+            record_keys: vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()],
+        };
+
+        let selected = subbatch
+            .sync_subset(&[2])
+            .expect("published index selects a record");
+
+        assert_eq!(selected.targets, vec![duplicate_target]);
+        assert_eq!(selected.record_keys, vec![b"third".to_vec()]);
+        assert!(selected.documents.is_empty());
+        assert!(subbatch.sync_subset(&[3]).is_none());
     }
 
     async fn restore_document_sync_outbox_timer_and_receive_key(

--- a/operations/src/update_metadata_document.rs
+++ b/operations/src/update_metadata_document.rs
@@ -212,7 +212,9 @@ impl UpdateMetadataDocumentOperation {
         };
         let now = Self::current_timestamp_ms();
         let audit = self.audit_record(event);
-        let outbox = create_event_outbox_record(event);
+        // Updating an existing document is a mutation, not an origin write, so it
+        // never mints the lifecycle sync topic genesis.
+        let outbox = create_event_outbox_record(event, false);
         let status = new_pending_materialization_status(event, now);
         let job = new_materialization_job(event, now);
         let writes =

--- a/operations/src/update_user.rs
+++ b/operations/src/update_user.rs
@@ -364,6 +364,7 @@ impl UpdateUserOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
         }

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -544,6 +544,7 @@ async fn publish_document_to_peer(
                     target: target.clone(),
                     change: document_change_for_publish(node.net.node_id(), &target, &bytes)?,
                     bytes,
+                    allow_genesis: true,
                 }],
                 peers: vec![peer],
             },

--- a/tasks/src/lib.rs
+++ b/tasks/src/lib.rs
@@ -42,6 +42,11 @@ enum TaskCommand {
         after: Duration,
         response: oneshot::Sender<TaskEvent>,
     },
+    ScheduleTimerIfIdle {
+        key: TaskKey,
+        after: Duration,
+        response: oneshot::Sender<TaskEvent>,
+    },
     CancelTimer {
         key: TaskKey,
         response: oneshot::Sender<TaskEvent>,
@@ -323,6 +328,22 @@ impl SchedulerState {
         TaskEvent::TimerScheduled { key, after }
     }
 
+    fn schedule_timer_if_idle(&mut self, key: TaskKey, after: Duration) -> TaskEvent {
+        let now = Instant::now();
+        if let Some(existing) = self.timers_by_key.get(&key) {
+            return TaskEvent::TimerScheduled {
+                key,
+                after: existing.deadline.saturating_duration_since(now),
+            };
+        }
+
+        if self.in_flight_keys.contains_key(&key) {
+            return TaskEvent::TimerScheduled { key, after };
+        }
+
+        self.reset_timer(key, after)
+    }
+
     fn cancel_timer(&mut self, key: TaskKey) -> TaskEvent {
         self.remove_timer(&key);
         TaskEvent::TimerCancelled { key }
@@ -402,6 +423,13 @@ impl SchedulerState {
                 response,
             } => {
                 let _ = response.send(self.shorten_timer(key, after));
+            }
+            TaskCommand::ScheduleTimerIfIdle {
+                key,
+                after,
+                response,
+            } => {
+                let _ = response.send(self.schedule_timer_if_idle(key, after));
             }
             TaskCommand::CancelTimer { key, response } => {
                 let _ = response.send(self.cancel_timer(key));
@@ -553,6 +581,27 @@ impl TaskHandle {
         if self
             .command_tx
             .send(TaskCommand::ShortenTimer {
+                key,
+                after,
+                response,
+            })
+            .await
+            .is_err()
+        {
+            return scheduler_unavailable(command_key);
+        }
+
+        result
+            .await
+            .unwrap_or_else(|_| scheduler_unavailable(command_key))
+    }
+
+    pub async fn schedule_timer_if_idle(&self, key: TaskKey, after: Duration) -> TaskEvent {
+        let command_key = key.clone();
+        let (response, result) = oneshot::channel();
+        if self
+            .command_tx
+            .send(TaskCommand::ScheduleTimerIfIdle {
                 key,
                 after,
                 response,
@@ -987,5 +1036,61 @@ mod tests {
             panic!("expected timer scheduled event");
         };
         assert!(after <= Duration::from_secs(3600));
+    }
+
+    #[tokio::test]
+    async fn schedule_timer_if_idle_keeps_existing_timer() {
+        let handle = TaskHandle::new();
+        let key = test_key();
+
+        let Event::Task(TaskEvent::TimerScheduled { after, .. }) = handle
+            .send_effect(Effect::Task(TaskEffect::ResetTimer {
+                key: key.clone(),
+                after: Duration::from_secs(3600),
+            }))
+            .await
+        else {
+            panic!("expected timer scheduled event");
+        };
+        assert_eq!(after, Duration::from_secs(3600));
+
+        let TaskEvent::TimerScheduled { after, .. } =
+            handle.schedule_timer_if_idle(key, Duration::ZERO).await
+        else {
+            panic!("expected timer scheduled event");
+        };
+        assert!(after > Duration::from_secs(3000));
+    }
+
+    #[tokio::test]
+    async fn schedule_timer_if_idle_ignores_running_handler() {
+        let handle = TaskHandle::new();
+        let runs = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let gate = Arc::new(tokio::sync::Semaphore::new(0));
+        let key = test_key();
+
+        handle
+            .set_inbound_handler(Arc::new(CountingGatedHandler {
+                runs: runs.clone(),
+                started: started.clone(),
+                gate: gate.clone(),
+            }))
+            .await;
+
+        fire_timer(&handle, key.clone()).await;
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("first handler run should start");
+
+        let TaskEvent::TimerScheduled { .. } =
+            handle.schedule_timer_if_idle(key, Duration::ZERO).await
+        else {
+            panic!("expected timer scheduled event");
+        };
+        gate.add_permits(1);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
This PR fixes the admin document sync hot loop by keeping admin documents out of whole-document sync, making stuck legacy records drain safely, adding retry backoff for durable sync queues, and preventing/fixing document-sync topic genesis forks.

## Changes

- Skips whole-document admin `Upsert`/`Delete` events during reconcile so unsupported admin payloads no longer wedge the applied-ops cursor; `AdminOperation` events on the same topic still apply normally.
- Refuses new whole-document announces for admin document targets, preserving the invariant that users, groups, authorizations, and realm config replicate only as admin operations.
- Stops creating placements for admin documents and drains legacy admin placement rows during the placement sweep instead of retrying them forever.
- Adds `allow_genesis` to document sync publishes and outbox records so only the document origin can mint a missing topic genesis; replica publishers now return retryable `TopicNotReady` instead of forking the topic.
- Restricts shared core-document genesis creation so the realm-bootstrap node can create node-usage genesis while joining nodes wait for it to replicate.
- Handles genesis tie-break evictions from irokle by decoding locally-authored evicted document events and re-enqueuing them through the normal outbox path with `allow_genesis=false`.
- Re-emits evicted admin operations with their original embedded event IDs so admin reducers keep deduping correctly after a fork loser resets onto the winning genesis.
- Adds in-memory exponential backoff for placement retry and document-sync outbox drain timers, capped at five minutes, and preserves active backoff timers during durable timer restoration.
- Updates the craqle dependency back to the `main` branch containing the irokle genesis tie-break support.
- Adds focused tests for admin placement draining, whole-document admin reconcile skips, genesis ownership gating, genesis-fork eviction re-emission, outbox `allow_genesis` persistence, and timer backoff behavior.

## GitHub Issues

- Completes #309: old admin placements are drained, whole-document admin sync records no longer block reconcile cursor progress, durable sync failures back off instead of hot-looping, and document-sync genesis forks are handled by origin-only genesis plus tie-break re-emission.
- Also fixes #310 
