### PR TITLE
[fix] Blob layer hardening: framing, streams, finalization, path confinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The system is organized around **realms**. A realm is an organizational trust bo
 ### Data, metadata, and access
 
 Each Aruna node exposes an **S3-compatible API**, so researchers can keep using the tools, scripts, workflow systems, and libraries they already have instead of learning a new storage protocol. Buckets are virtual collections that mix local data, replicated data, and references to remote resources. To a user, this looks like one coherent access point. Underneath, Aruna tracks where data actually lives, which permissions apply, and whether an object should be materialized locally or fetched on demand.
+
+> [!NOTE]
+> Object keys for `PutObject`, `CreateMultipartUpload`, `UploadPart`, and `CompleteMultipartUpload` must be non-empty relative paths; they are rejected if they begin with `/`, contain an exact `..` path segment, or contain control characters.
  
 Metadata is part of the core system, not an external catalog bolted on afterwards. Descriptions are stored as **RO-Crate JSON-LD**, so datasets, files, people, instruments, workflows, software, and process runs can be described in a shared format. These descriptions live in a CRDT-based triple store, which allows concurrent edits on different nodes and merges them without a single authority arbitrating the result. Management resources such as users and groups are synchronized through durable document-sync topics, which lets nodes keep working through network outages and reconcile state once they reconnect.
  

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -9,7 +9,7 @@ use crate::s3::error::IntoS3Error;
 use crate::s3::util::{
     convert_input, multipart_checksum_type_from_s3, parse_completed_part,
     parse_multipart_checksum_hint, parse_multipart_part_number, parse_upload_id, parse_version_id,
-    s3_checksum_type_from_multipart,
+    s3_checksum_type_from_multipart, validate_object_key,
 };
 use aruna_core::NodeId;
 use aruna_core::stream::{BackendStream, StreamError};
@@ -905,6 +905,7 @@ impl S3 for ArunaS3Service {
             error!(error = "Missing user context");
             s3_error!(UnexpectedContent, "Missing user context")
         })?;
+        validate_object_key(&req.input.key)?;
         let bucket_info = req.extensions.get::<BucketInfo>().cloned();
         let checksum_request = parse_upload_checksum_request(&req.headers)?;
         let replication_auth = AuthContext {
@@ -964,6 +965,7 @@ impl S3 for ArunaS3Service {
             error!(error = "Missing user context");
             s3_error!(UnexpectedContent, "Missing user context")
         })?;
+        validate_object_key(&req.input.key)?;
         let bucket_info = req.extensions.get::<BucketInfo>().cloned();
         let checksum_hint = parse_multipart_checksum_hint(&req.input)?;
 
@@ -1007,6 +1009,7 @@ impl S3 for ArunaS3Service {
             error!(error = "Missing user context");
             s3_error!(UnexpectedContent, "Missing user context")
         })?;
+        validate_object_key(&req.input.key)?;
         let checksum_request = parse_upload_checksum_request(&req.headers)?;
         let upload_id = parse_upload_id(&req.input.upload_id)?;
         let body = req
@@ -1068,6 +1071,7 @@ impl S3 for ArunaS3Service {
             error!(error = "Missing user context");
             s3_error!(UnexpectedContent, "Missing user context")
         })?;
+        validate_object_key(&req.input.key)?;
         let bucket_info = req.extensions.get::<BucketInfo>().cloned();
         let group_id = bucket_info
             .as_ref()

--- a/api/src/s3/util.rs
+++ b/api/src/s3/util.rs
@@ -123,6 +123,31 @@ pub(crate) fn is_anonymous_object_read_operation(operation_name: &str) -> bool {
     matches!(operation_name, "GetObject")
 }
 
+pub(crate) fn validate_object_key(key: &str) -> S3Result<()> {
+    if key.is_empty() {
+        return Err(s3_error!(InvalidArgument, "Object key must not be empty"));
+    }
+    if key.starts_with('/') {
+        return Err(s3_error!(
+            InvalidArgument,
+            "Object key must not be an absolute path"
+        ));
+    }
+    if key.chars().any(|c| c.is_control()) {
+        return Err(s3_error!(
+            InvalidArgument,
+            "Object key must not contain control characters"
+        ));
+    }
+    if key.split('/').any(|segment| segment == "..") {
+        return Err(s3_error!(
+            InvalidArgument,
+            "Object key must not contain `..` path segments"
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) fn convert_input(mut input: PutObjectInput) -> S3Result<BlobPutObjectInput, S3Error> {
     match input.body.take() {
         None => Err(s3_error!(InvalidRequest, "Missing body")),
@@ -264,10 +289,42 @@ pub(crate) fn checksum_algorithm_from_s3(
 mod tests {
     use super::{
         get_s3_operation_permission, is_anonymous_object_read_operation,
-        parse_multipart_part_number,
+        parse_multipart_part_number, validate_object_key,
     };
     use crate::s3::auth::Action;
     use s3s::S3ErrorCode;
+
+    #[test]
+    fn validate_object_key_accepts_ordinary_keys() {
+        for key in ["object.bin", "nested/path/object.bin", "a.b..c/keep..dots"] {
+            assert!(
+                validate_object_key(key).is_ok(),
+                "key {key:?} must be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_object_key_rejects_traversal_and_control_keys() {
+        let cases = [
+            "",
+            "/absolute/key",
+            "../escape",
+            "../../etc/passwd",
+            "nested/../../escape",
+            "trailing/..",
+            "with\u{0000}null",
+            "with\u{007f}delete",
+            "with\nnewline",
+        ];
+        for key in cases {
+            assert_eq!(
+                *validate_object_key(key).unwrap_err().code(),
+                S3ErrorCode::InvalidArgument,
+                "key {key:?} must be rejected"
+            );
+        }
+    }
 
     #[test]
     fn anonymous_public_access_only_allows_get_object() {

--- a/api/src/s3/util.rs
+++ b/api/src/s3/util.rs
@@ -1,7 +1,9 @@
 use crate::s3::auth::Action;
 use aruna_core::stream::BackendStream;
 use aruna_core::structs::checksum::{ChecksumAlgorithm, ExpectedChecksum};
-use aruna_core::structs::{MultipartChecksumType, MultipartUploadChecksumHint};
+use aruna_core::structs::{
+    MultipartChecksumType, MultipartUploadChecksumHint, ensure_confined_relative_path,
+};
 use aruna_operations::s3::complete_multipart_upload::CompleteMultipartPart;
 use aruna_operations::s3::put_object::PutObjectInput as BlobPutObjectInput;
 use base64::prelude::*;
@@ -10,6 +12,7 @@ use s3s::dto::{
     ChecksumType, CompletedPart, CreateMultipartUploadInput, PartNumber, PutObjectInput,
 };
 use s3s::{S3Error, S3ErrorCode, S3Result, s3_error};
+use std::path::Path;
 use ulid::Ulid;
 
 pub fn get_s3_operation_permission(operation_name: &str) -> Option<Action> {
@@ -127,25 +130,9 @@ pub(crate) fn validate_object_key(key: &str) -> S3Result<()> {
     if key.is_empty() {
         return Err(s3_error!(InvalidArgument, "Object key must not be empty"));
     }
-    if key.starts_with('/') {
-        return Err(s3_error!(
-            InvalidArgument,
-            "Object key must not be an absolute path"
-        ));
-    }
-    if key.chars().any(|c| c.is_control()) {
-        return Err(s3_error!(
-            InvalidArgument,
-            "Object key must not contain control characters"
-        ));
-    }
-    if key.split('/').any(|segment| segment == "..") {
-        return Err(s3_error!(
-            InvalidArgument,
-            "Object key must not contain `..` path segments"
-        ));
-    }
-    Ok(())
+
+    ensure_confined_relative_path(Path::new(key))
+        .map_err(|err| s3_error!(InvalidArgument, "{}", err.to_string()))
 }
 
 pub(crate) fn convert_input(mut input: PutObjectInput) -> S3Result<BlobPutObjectInput, S3Error> {

--- a/blob/src/bao_tree.rs
+++ b/blob/src/bao_tree.rs
@@ -151,6 +151,8 @@ impl AsyncStreamReader for RecvStreamWrapper<'_> {
 // ----- FuturesAsyncReader/opendal Writer impls for bao_tree ----------
 pub struct OpenDalWriter {
     writer: opendal::Writer,
+    operator: Operator,
+    storage_path: String,
     pub hasher: Hasher,
     idle_timeout: Duration,
 }
@@ -208,6 +210,8 @@ impl OpenDalWriter {
     ) -> Result<Self, BlobLibError> {
         Ok(Self {
             writer: operator.writer(storage_path).await?,
+            operator: operator.clone(),
+            storage_path: storage_path.to_string(),
             hasher: Hasher::new(),
             idle_timeout,
         })
@@ -227,14 +231,14 @@ impl OpenDalWriter {
         )
         .await;
         if let Err(err) = close_result {
-            abort_partial_writer(&mut self.writer).await;
+            abort_partial_writer(&mut self.writer, &self.operator, &self.storage_path).await;
             return Err(err);
         }
         Ok(())
     }
 
     pub async fn abort(mut self) {
-        abort_partial_writer(&mut self.writer).await;
+        abort_partial_writer(&mut self.writer, &self.operator, &self.storage_path).await;
     }
 }
 

--- a/blob/src/bao_tree.rs
+++ b/blob/src/bao_tree.rs
@@ -1,10 +1,11 @@
 use crate::error::BlobLibError;
 use crate::hash::Hasher;
+use crate::opendal::abort_partial_writer;
 use aruna_net::streams::{RecvStream, SendStream};
 use bytes::Bytes;
-use futures::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use futures::{AsyncReadExt, AsyncSeekExt};
 use iroh_io::{AsyncSliceReader, AsyncSliceWriter, AsyncStreamReader, AsyncStreamWriter};
-use opendal::{FuturesAsyncReader, FuturesAsyncWriter, Operator};
+use opendal::{FuturesAsyncReader, Operator};
 use std::{future::Future, io, time::Duration};
 use tokio::io::AsyncWriteExt as TokioAsyncWriteExt;
 use tokio::time::timeout;
@@ -147,27 +148,25 @@ impl AsyncStreamReader for RecvStreamWrapper<'_> {
     }
 }
 
-// ----- FuturesAsyncReader/FuturesAsyncWriter impls for bao_tree ----------
+// ----- FuturesAsyncReader/opendal Writer impls for bao_tree ----------
 pub struct OpenDalWriter {
-    pub writer: FuturesAsyncWriter,
-    pub len: u64,
+    writer: opendal::Writer,
     pub hasher: Hasher,
-    pub idle_timeout: Duration,
+    idle_timeout: Duration,
 }
 
 impl AsyncSliceWriter for OpenDalWriter {
     async fn write_at(&mut self, offset: u64, data: &[u8]) -> std::io::Result<()> {
         debug!("[OpenDalWriter] Try to write data with offset {}", offset);
         with_transfer_idle_timeout(
-            self.writer.write_all(data),
+            async {
+                self.writer
+                    .write(data.to_vec())
+                    .await
+                    .map_err(io::Error::from)
+            },
             self.idle_timeout,
             "writing replicated chunk to backend storage",
-        )
-        .await?;
-        with_transfer_idle_timeout(
-            self.writer.flush(),
-            self.idle_timeout,
-            "flushing replicated chunk to backend storage",
         )
         .await?;
         self.hasher.update(data);
@@ -177,15 +176,14 @@ impl AsyncSliceWriter for OpenDalWriter {
     async fn write_bytes_at(&mut self, offset: u64, data: Bytes) -> std::io::Result<()> {
         debug!("[OpenDalWriter] Try to write bytes with offset {}", offset);
         with_transfer_idle_timeout(
-            self.writer.write_all(&data),
+            async {
+                self.writer
+                    .write(data.clone())
+                    .await
+                    .map_err(io::Error::from)
+            },
             self.idle_timeout,
             "writing replicated chunk to backend storage",
-        )
-        .await?;
-        with_transfer_idle_timeout(
-            self.writer.flush(),
-            self.idle_timeout,
-            "flushing replicated chunk to backend storage",
         )
         .await?;
         self.hasher.update(&data);
@@ -198,12 +196,6 @@ impl AsyncSliceWriter for OpenDalWriter {
     }
 
     async fn sync(&mut self) -> std::io::Result<()> {
-        with_transfer_idle_timeout(
-            self.writer.flush(),
-            self.idle_timeout,
-            "flushing replicated chunk to backend storage",
-        )
-        .await?;
         Ok(())
     }
 }
@@ -212,18 +204,37 @@ impl OpenDalWriter {
     pub async fn new(
         operator: &Operator,
         storage_path: &str,
-        blob_size: u64,
         idle_timeout: Duration,
     ) -> Result<Self, BlobLibError> {
         Ok(Self {
-            writer: operator
-                .writer(storage_path)
-                .await?
-                .into_futures_async_write(),
-            len: blob_size,
+            writer: operator.writer(storage_path).await?,
             hasher: Hasher::new(),
             idle_timeout,
         })
+    }
+
+    pub async fn finalize(mut self) -> std::io::Result<()> {
+        let close_result = with_transfer_idle_timeout(
+            async {
+                self.writer
+                    .close()
+                    .await
+                    .map(|_| ())
+                    .map_err(io::Error::from)
+            },
+            self.idle_timeout,
+            "finalizing replicated blob in backend storage",
+        )
+        .await;
+        if let Err(err) = close_result {
+            abort_partial_writer(&mut self.writer).await;
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    pub async fn abort(mut self) {
+        abort_partial_writer(&mut self.writer).await;
     }
 }
 

--- a/blob/src/blob/backend.rs
+++ b/blob/src/blob/backend.rs
@@ -7,7 +7,7 @@ use aruna_core::errors::{BlobError, ConversionError};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::BUCKET_STATS_DB;
-use aruna_core::structs::{Backend, BackendBucket, BackendLocation};
+use aruna_core::structs::{Backend, BackendBucket, BackendLocation, ensure_confined_relative_path};
 use opendal::Operator;
 use std::path::PathBuf;
 use ulid::Ulid;
@@ -198,9 +198,9 @@ pub(super) fn build_backend_path(
     key: &str,
     ulid: Ulid,
 ) -> Result<String, ConversionError> {
-    PathBuf::from(bucket)
-        .join(format!("{}_{}", key, ulid))
-        .into_os_string()
+    let path = PathBuf::from(bucket).join(format!("{}_{}", key, ulid));
+    ensure_confined_relative_path(&path)?;
+    path.into_os_string()
         .into_string()
         .map_err(|_| ConversionError::OsStringError)
 }
@@ -227,9 +227,9 @@ pub(super) fn rebuild_backend_path(
         .rsplit_once('_')
         .map_or(file_name, |(base, _)| base);
 
-    parent
-        .join(format!("{}_{}", base_name, ulid))
-        .into_os_string()
+    let path = parent.join(format!("{}_{}", base_name, ulid));
+    ensure_confined_relative_path(&path)?;
+    path.into_os_string()
         .into_string()
         .map_err(|_| ConversionError::OsStringError)
 }

--- a/blob/src/blob/control_plane.rs
+++ b/blob/src/blob/control_plane.rs
@@ -1,15 +1,13 @@
 use super::{BlobEvent, BlobHandler, ControlPlaneTimeoutKind};
+use crate::framing::{MAX_CONTROL_PLANE_FRAME, read_frame, write_frame};
 use crate::messages::{MessageType, ReplicationMessage};
 use aruna_core::errors::BlobError;
 use aruna_core::structs::BackendLocation;
 use aruna_net::streams::{RecvStream, SendStream};
 use std::future::Future;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt as TokioAsyncReadExt, AsyncWriteExt as TokioAsyncWriteExt};
 use tokio::time::timeout;
 use ulid::Ulid;
-
-const MAX_CONTROL_PLANE_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
 pub(super) fn control_plane_timeout_event(
     kind: ControlPlaneTimeoutKind,
@@ -84,19 +82,8 @@ pub(super) async fn send_framed_message_with_timeout(
     timeout_duration: Duration,
     action: &'static str,
 ) -> Result<(), BlobEvent> {
-    if payload.len() > MAX_CONTROL_PLANE_MESSAGE_SIZE {
-        return Err(BlobEvent::Error(BlobError::WriteError(format!(
-            "control-plane message exceeds maximum size: {} bytes",
-            payload.len()
-        ))));
-    }
-
     match with_control_plane_timeout(
-        async {
-            TokioAsyncWriteExt::write_u32(sender, payload.len() as u32).await?;
-            TokioAsyncWriteExt::write_all(sender, payload).await?;
-            TokioAsyncWriteExt::flush(sender).await
-        },
+        write_frame(sender, payload, MAX_CONTROL_PLANE_FRAME),
         timeout_duration,
         ControlPlaneTimeoutKind::Write,
         action,
@@ -115,18 +102,7 @@ pub(super) async fn read_framed_message_with_timeout(
     action: &'static str,
 ) -> Result<Vec<u8>, BlobEvent> {
     match with_control_plane_timeout(
-        async {
-            let msg_len = TokioAsyncReadExt::read_u32(receiver).await?;
-            if msg_len as usize > MAX_CONTROL_PLANE_MESSAGE_SIZE {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("control-plane frame too large: {msg_len} bytes"),
-                ));
-            }
-            let mut buf = vec![0; msg_len as usize];
-            TokioAsyncReadExt::read_exact(receiver, &mut buf).await?;
-            Ok::<Vec<u8>, std::io::Error>(buf)
-        },
+        read_frame(receiver, MAX_CONTROL_PLANE_FRAME),
         timeout_duration,
         ControlPlaneTimeoutKind::Read,
         action,

--- a/blob/src/blob/io.rs
+++ b/blob/src/blob/io.rs
@@ -39,20 +39,20 @@ impl BlobHandler {
             let bytes = match chunk {
                 Ok(bytes) => bytes,
                 Err(err) => {
-                    abort_partial_writer(&mut writer).await;
+                    abort_partial_writer(&mut writer, &operator, &storage_path).await;
                     return BlobEvent::Error(BlobError::WriteError(err.to_string()));
                 }
             };
             hasher.update(&bytes);
             if let Err(err) = writer.write(bytes.to_vec()).await {
-                abort_partial_writer(&mut writer).await;
+                abort_partial_writer(&mut writer, &operator, &storage_path).await;
                 return BlobEvent::Error(BlobError::WriteError(err.to_string()));
             }
             bytes_written += bytes.len() as u64;
         }
 
         if let Err(err) = writer.close().await {
-            abort_partial_writer(&mut writer).await;
+            abort_partial_writer(&mut writer, &operator, &storage_path).await;
             return BlobEvent::Error(BlobError::WriteError(err.to_string()));
         }
         location.blob_size = bytes_written;
@@ -247,7 +247,7 @@ impl BlobHandler {
         let bytes_written = match compose_result {
             Ok(bytes_written) => bytes_written,
             Err(err) => {
-                abort_partial_writer(&mut writer).await;
+                abort_partial_writer(&mut writer, &operator, &storage_path).await;
                 return BlobEvent::Error(err);
             }
         };

--- a/blob/src/blob/io.rs
+++ b/blob/src/blob/io.rs
@@ -1,7 +1,7 @@
 use super::BlobHandler;
 use super::backend::{build_backend_path, build_multipart_part_path};
 use crate::hash::Hasher;
-use crate::opendal::init_backend_operator;
+use crate::opendal::{abort_partial_writer, init_backend_operator};
 use aruna_core::errors::BlobError;
 use aruna_core::events::BlobEvent;
 use aruna_core::stream::BackendStream;
@@ -38,18 +38,21 @@ impl BlobHandler {
         while let Some(chunk) = blob.next().await {
             let bytes = match chunk {
                 Ok(bytes) => bytes,
-                Err(err) => return BlobEvent::Error(BlobError::WriteError(err.to_string())),
+                Err(err) => {
+                    abort_partial_writer(&mut writer).await;
+                    return BlobEvent::Error(BlobError::WriteError(err.to_string()));
+                }
             };
             hasher.update(&bytes);
             if let Err(err) = writer.write(bytes.to_vec()).await {
-                let _ = operator.delete(&storage_path).await;
+                abort_partial_writer(&mut writer).await;
                 return BlobEvent::Error(BlobError::WriteError(err.to_string()));
             }
             bytes_written += bytes.len() as u64;
         }
 
         if let Err(err) = writer.close().await {
-            let _ = operator.delete(&storage_path).await;
+            abort_partial_writer(&mut writer).await;
             return BlobEvent::Error(BlobError::WriteError(err.to_string()));
         }
         location.blob_size = bytes_written;
@@ -173,13 +176,34 @@ impl BlobHandler {
             blob_size: 0,
             hashes: HashMap::new(),
         };
-        let storage_path = match location.get_storage_path() {
-            Ok(storage_path) => storage_path,
-            Err(e) => return BlobEvent::Error(e),
-        };
         let operator = match init_backend_operator(self.backend_config.clone(), backend_bucket) {
             Ok(op) => op,
             Err(err) => return BlobEvent::Error(err),
+        };
+        match self
+            .compose_parts_to_location(location, operator, parts)
+            .await
+        {
+            BlobEvent::WriteFinished { location } => {
+                if let Err(err) = self.increment_bucket_load(&location.storage_bucket).await {
+                    BlobEvent::Error(err)
+                } else {
+                    BlobEvent::WriteFinished { location }
+                }
+            }
+            other => other,
+        }
+    }
+
+    pub(super) async fn compose_parts_to_location(
+        &self,
+        mut location: BackendLocation,
+        operator: Operator,
+        parts: Vec<BackendLocation>,
+    ) -> BlobEvent {
+        let storage_path = match location.get_storage_path() {
+            Ok(storage_path) => storage_path,
+            Err(e) => return BlobEvent::Error(e),
         };
         let Ok(mut writer) = operator.writer(&storage_path).await else {
             return BlobEvent::Error(BlobError::OperatorCreationFailed(
@@ -223,19 +247,14 @@ impl BlobHandler {
         let bytes_written = match compose_result {
             Ok(bytes_written) => bytes_written,
             Err(err) => {
-                let _ = operator.delete(&storage_path).await;
+                abort_partial_writer(&mut writer).await;
                 return BlobEvent::Error(err);
             }
         };
 
-        let mut location = location;
         location.blob_size = bytes_written;
         location.hashes = hasher.to_map();
-        if let Err(err) = self.increment_bucket_load(&location.storage_bucket).await {
-            BlobEvent::Error(err)
-        } else {
-            BlobEvent::WriteFinished { location }
-        }
+        BlobEvent::WriteFinished { location }
     }
 
     pub async fn read_blob(&self, location: BackendLocation) -> BlobEvent {

--- a/blob/src/blob/io.rs
+++ b/blob/src/blob/io.rs
@@ -42,12 +42,16 @@ impl BlobHandler {
             };
             hasher.update(&bytes);
             if let Err(err) = writer.write(bytes.to_vec()).await {
+                let _ = operator.delete(&storage_path).await;
                 return BlobEvent::Error(BlobError::WriteError(err.to_string()));
             }
             bytes_written += bytes.len() as u64;
         }
 
-        _ = writer.close().await;
+        if let Err(err) = writer.close().await {
+            let _ = operator.delete(&storage_path).await;
+            return BlobEvent::Error(BlobError::WriteError(err.to_string()));
+        }
         location.blob_size = bytes_written;
         location.hashes = hasher.to_map();
         BlobEvent::WriteFinished { location }
@@ -184,39 +188,46 @@ impl BlobHandler {
         };
 
         let mut hasher = Hasher::new();
-        let mut bytes_written = 0u64;
-        for part in parts {
-            let part_operator = match self.operator_from_location(&part) {
-                Ok(op) => op,
-                Err(err) => return BlobEvent::Error(err),
-            };
-            let part_storage_path = match part.get_storage_path() {
-                Ok(storage_path) => storage_path,
-                Err(err) => return BlobEvent::Error(err),
-            };
-            let reader = match part_operator.reader(&part_storage_path).await {
-                Ok(reader) => match reader.into_bytes_stream(..).await {
-                    Ok(stream) => stream,
-                    Err(err) => return BlobEvent::Error(BlobError::ReadError(err.to_string())),
-                },
-                Err(err) => return BlobEvent::Error(BlobError::ReadError(err.to_string())),
-            };
+        let compose_result: Result<u64, BlobError> = async {
+            let mut bytes_written = 0u64;
+            for part in parts {
+                let part_operator = self.operator_from_location(&part)?;
+                let part_storage_path = part.get_storage_path()?;
+                let reader = part_operator
+                    .reader(&part_storage_path)
+                    .await
+                    .map_err(|err| BlobError::ReadError(err.to_string()))?
+                    .into_bytes_stream(..)
+                    .await
+                    .map_err(|err| BlobError::ReadError(err.to_string()))?;
 
-            let mut reader = BackendStream::new(reader);
-            while let Some(chunk) = reader.next().await {
-                let bytes = match chunk {
-                    Ok(bytes) => bytes,
-                    Err(err) => return BlobEvent::Error(BlobError::ReadError(err.to_string())),
-                };
-                hasher.update(&bytes);
-                if let Err(err) = writer.write(bytes.to_vec()).await {
-                    return BlobEvent::Error(BlobError::WriteError(err.to_string()));
+                let mut reader = BackendStream::new(reader);
+                while let Some(chunk) = reader.next().await {
+                    let bytes = chunk.map_err(|err| BlobError::ReadError(err.to_string()))?;
+                    hasher.update(&bytes);
+                    writer
+                        .write(bytes.to_vec())
+                        .await
+                        .map_err(|err| BlobError::WriteError(err.to_string()))?;
+                    bytes_written += bytes.len() as u64;
                 }
-                bytes_written += bytes.len() as u64;
             }
+            writer
+                .close()
+                .await
+                .map_err(|err| BlobError::WriteError(err.to_string()))?;
+            Ok(bytes_written)
         }
+        .await;
 
-        _ = writer.close().await;
+        let bytes_written = match compose_result {
+            Ok(bytes_written) => bytes_written,
+            Err(err) => {
+                let _ = operator.delete(&storage_path).await;
+                return BlobEvent::Error(err);
+            }
+        };
+
         let mut location = location;
         location.blob_size = bytes_written;
         location.hashes = hasher.to_map();

--- a/blob/src/blob/mod.rs
+++ b/blob/src/blob/mod.rs
@@ -1,3 +1,4 @@
+use aruna_core::NodeId;
 use aruna_core::effects::BlobEffect;
 use aruna_core::events::BlobEvent;
 use aruna_core::structs::BackendConfig;
@@ -28,6 +29,12 @@ pub type EffectSender = crossfire::MAsyncTx<mpsc::Array<EffectHandle>>;
 pub type EffectReceiver = crossfire::AsyncRx<mpsc::Array<EffectHandle>>;
 type SharedBiStream = Arc<Mutex<BiStream>>;
 
+#[derive(Clone, Debug)]
+struct Connection {
+    peer: NodeId,
+    stream: SharedBiStream,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ControlPlaneTimeoutKind {
     Connection,
@@ -40,7 +47,7 @@ pub struct BlobHandler {
     backend_config: BackendConfig,
     storage: StorageHandle,
     net: NetHandle,
-    connections: Arc<Mutex<HashMap<Ulid, SharedBiStream>>>,
+    connections: Arc<Mutex<HashMap<Ulid, Connection>>>,
     operator_status: Arc<RwLock<aruna_core::structs::Status>>,
 }
 

--- a/blob/src/blob/replication.rs
+++ b/blob/src/blob/replication.rs
@@ -225,7 +225,10 @@ impl BlobHandler {
             return BlobEvent::Error(BlobError::ReplicationFailed(err.to_string()));
         }
         drop(stream);
-        _ = writer.writer.close().await;
+        if let Err(err) = writer.writer.close().await {
+            let _ = operator.delete(&storage_path).await;
+            return BlobEvent::Error(BlobError::ReplicationFailed(err.to_string()));
+        }
         debug!("Decoded all chunks and wrote them into the backend");
 
         let hashes = writer.hasher.to_map();

--- a/blob/src/blob/replication.rs
+++ b/blob/src/blob/replication.rs
@@ -14,7 +14,6 @@ use bao_tree::io::outboard::PreOrderOutboard;
 use bao_tree::io::round_up_to_chunks;
 use bao_tree::{BaoTree, ByteRanges};
 use bytes::BytesMut;
-use futures::AsyncWriteExt;
 use tracing::debug;
 use ulid::Ulid;
 
@@ -202,7 +201,6 @@ impl BlobHandler {
         let mut writer = match OpenDalWriter::new(
             &operator,
             &storage_path,
-            location.blob_size,
             self.transfer_idle_timeout(),
         )
         .await
@@ -221,38 +219,46 @@ impl BlobHandler {
         let chunk_ranges = round_up_to_chunks(&byte_ranges);
 
         debug!("Try to decode chunks received from bidi stream");
-        if let Err(err) = decode_ranges(rx_wrapper, chunk_ranges, &mut writer, &mut ob).await {
-            return BlobEvent::Error(BlobError::ReplicationFailed(err.to_string()));
-        }
+        let decode_result = decode_ranges(rx_wrapper, chunk_ranges, &mut writer, &mut ob).await;
         drop(stream);
-        if let Err(err) = writer.writer.close().await {
-            let _ = operator.delete(&storage_path).await;
-            return BlobEvent::Error(BlobError::ReplicationFailed(err.to_string()));
-        }
-        debug!("Decoded all chunks and wrote them into the backend");
 
-        let hashes = writer.hasher.to_map();
-        let actual_blake3 = writer.hasher.finalize().blake3;
-        if actual_blake3 != root {
-            let _ = operator.delete(&storage_path).await;
-            return BlobEvent::Error(BlobError::IntegrityCheckFailed(
-                "replicated content hash mismatch".to_string(),
-            ));
-        }
-
-        location.hashes = hashes;
-        if let Err(err) = self.increment_bucket_load(&location.storage_bucket).await {
-            BlobEvent::Error(err)
-        } else {
-            if !keep_alive {
-                if let Ok(stream) = self.connection_handle(stream_id).await {
-                    let mut stream = stream.lock().await;
-                    _ = stream.0.finish();
-                    _ = stream.1.stop(0u32.into());
-                }
-                self.connections.lock().await.remove(&stream_id);
+        let event = match decode_result {
+            Err(err) => {
+                writer.abort().await;
+                BlobEvent::Error(BlobError::ReplicationFailed(err.to_string()))
             }
-            BlobEvent::ReplicationFinished { location }
+            Ok(()) => {
+                let hashes = writer.hasher.to_map();
+                let actual_blake3 = writer.hasher.finalize().blake3;
+                match writer.finalize().await {
+                    Err(err) => BlobEvent::Error(BlobError::ReplicationFailed(err.to_string())),
+                    Ok(()) => {
+                        debug!("Decoded all chunks and wrote them into the backend");
+                        if actual_blake3 != root {
+                            if let Err(err) = operator.delete(&storage_path).await {
+                                tracing::warn!(
+                                    error = %err,
+                                    "failed to delete hash-mismatched replicated blob"
+                                );
+                            }
+                            BlobEvent::Error(BlobError::IntegrityCheckFailed(
+                                "replicated content hash mismatch".to_string(),
+                            ))
+                        } else {
+                            location.hashes = hashes;
+                            match self.increment_bucket_load(&location.storage_bucket).await {
+                                Err(err) => BlobEvent::Error(err),
+                                Ok(()) => BlobEvent::ReplicationFinished { location },
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        if !keep_alive {
+            _ = self.close_connection(stream_id).await;
         }
+        event
     }
 }

--- a/blob/src/blob/runtime.rs
+++ b/blob/src/blob/runtime.rs
@@ -87,8 +87,11 @@ impl BlobHandle {
         Event::StagingSource(staging_source_event)
     }
 
-    pub async fn store_connection(&mut self, stream: BiStream) -> Ulid {
-        self.handler.add_connection(None, stream).await
+    pub async fn store_connection(&mut self, peer: NodeId, stream: BiStream) -> Ulid {
+        self.handler
+            .add_connection(None, peer, stream)
+            .await
+            .expect("auto-generated stream id never collides")
     }
 
     pub async fn get_status(&self) -> BlobState {
@@ -221,8 +224,9 @@ impl BlobHandler {
         )
         .await
         {
-            Ok(Ok(stream)) => BlobEvent::ConnectionEstablished {
-                stream_id: self.add_connection(None, stream).await,
+            Ok(Ok(stream)) => match self.add_connection(None, node_id, stream).await {
+                Ok(stream_id) => BlobEvent::ConnectionEstablished { stream_id },
+                Err(err) => BlobEvent::Error(err),
             },
             Ok(Err(err)) => BlobEvent::Error(BlobError::ConnectionFailed(err.to_string())),
             Err(event) => event,
@@ -276,21 +280,52 @@ impl BlobHandler {
         }
     }
 
-    pub async fn add_connection(&mut self, stream_id: Option<Ulid>, stream: BiStream) -> Ulid {
-        let stream_id = stream_id.unwrap_or_default();
-        self.connections
-            .lock()
-            .await
-            .insert(stream_id, Arc::new(Mutex::new(stream)));
-        stream_id
+    pub async fn add_connection(
+        &mut self,
+        stream_id: Option<Ulid>,
+        peer: NodeId,
+        stream: BiStream,
+    ) -> Result<Ulid, BlobError> {
+        let mut connections = self.connections.lock().await;
+        let stream_id = match stream_id {
+            Some(stream_id) => {
+                if stream_id.is_nil() {
+                    return Err(BlobError::ConnectionFailed(
+                        "refusing to register a nil stream id".to_string(),
+                    ));
+                }
+                if connections.contains_key(&stream_id) {
+                    return Err(BlobError::ConnectionFailed(format!(
+                        "stream id already registered: {stream_id}"
+                    )));
+                }
+                stream_id
+            }
+            None => {
+                let mut candidate = Ulid::new();
+                while candidate.is_nil() || connections.contains_key(&candidate) {
+                    candidate = Ulid::new();
+                }
+                candidate
+            }
+        };
+        connections.insert(
+            stream_id,
+            super::Connection {
+                peer,
+                stream: Arc::new(Mutex::new(stream)),
+            },
+        );
+        Ok(stream_id)
     }
 
     pub async fn close_connection(&mut self, stream_id: Ulid) -> BlobEvent {
         let connection = self.connections.lock().await.remove(&stream_id);
-        let Some(stream) = connection else {
+        let Some(connection) = connection else {
             return BlobEvent::ConnectionClosed { stream_id };
         };
-        let mut stream = stream.lock().await;
+        tracing::debug!(stream_id = %stream_id, peer = %connection.peer, "closing blob connection");
+        let mut stream = connection.stream.lock().await;
 
         _ = stream.0.finish();
         _ = stream.1.stop(0u32.into());
@@ -305,7 +340,7 @@ impl BlobHandler {
             .lock()
             .await
             .get(&stream_id)
-            .cloned()
+            .map(|connection| connection.stream.clone())
             .ok_or_else(|| {
                 BlobEvent::Error(BlobError::ReplicationRejected(
                     "Stream not available".to_string(),

--- a/blob/src/blob/runtime.rs
+++ b/blob/src/blob/runtime.rs
@@ -87,11 +87,12 @@ impl BlobHandle {
         Event::StagingSource(staging_source_event)
     }
 
-    pub async fn store_connection(&mut self, peer: NodeId, stream: BiStream) -> Ulid {
-        self.handler
-            .add_connection(None, peer, stream)
-            .await
-            .expect("auto-generated stream id never collides")
+    pub async fn store_connection(
+        &mut self,
+        peer: NodeId,
+        stream: BiStream,
+    ) -> Result<Ulid, BlobError> {
+        self.handler.add_connection(None, peer, stream).await
     }
 
     pub async fn get_status(&self) -> BlobState {

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -30,23 +30,29 @@ mod failing_close {
     use opendal::raw::{Access, AccessorInfo, OpWrite, RpWrite};
     use opendal::{Buffer, Capability, Error, ErrorKind, Metadata, Operator, OperatorBuilder};
     use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
 
     #[derive(Debug)]
     pub(super) struct CloseFailsBackend {
         info: Arc<AccessorInfo>,
+        aborts: Arc<AtomicUsize>,
     }
 
-    impl Default for CloseFailsBackend {
-        fn default() -> Self {
+    impl CloseFailsBackend {
+        fn new(aborts: Arc<AtomicUsize>) -> Self {
             let info = AccessorInfo::default();
             info.set_scheme("close_fails")
                 .set_root("/")
                 .set_native_capability(Capability {
                     write: true,
                     write_can_empty: true,
+                    write_can_multi: true,
                     ..Default::default()
                 });
-            Self { info: info.into() }
+            Self {
+                info: info.into(),
+                aborts,
+            }
         }
     }
 
@@ -66,11 +72,18 @@ mod failing_close {
             _path: &str,
             _args: OpWrite,
         ) -> opendal::Result<(RpWrite, Self::Writer)> {
-            Ok((RpWrite::new(), CloseFailsWriter))
+            Ok((
+                RpWrite::new(),
+                CloseFailsWriter {
+                    aborts: self.aborts.clone(),
+                },
+            ))
         }
     }
 
-    pub(super) struct CloseFailsWriter;
+    pub(super) struct CloseFailsWriter {
+        aborts: Arc<AtomicUsize>,
+    }
 
     impl oio::Write for CloseFailsWriter {
         async fn write(&mut self, _bs: Buffer) -> opendal::Result<()> {
@@ -85,12 +98,16 @@ mod failing_close {
         }
 
         async fn abort(&mut self) -> opendal::Result<()> {
+            self.aborts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(())
         }
     }
 
-    pub(super) fn operator() -> Operator {
-        OperatorBuilder::new(CloseFailsBackend::default()).finish()
+    pub(super) fn operator_with_aborts() -> (Operator, Arc<AtomicUsize>) {
+        let aborts = Arc::new(AtomicUsize::new(0));
+        let operator = OperatorBuilder::new(CloseFailsBackend::new(aborts.clone())).finish();
+        (operator, aborts)
     }
 }
 
@@ -332,7 +349,7 @@ fn parse_replication_init_uses_message_id_when_unknown() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn control_plane_timeout_reports_read_timeout() {
     let event = with_control_plane_timeout(
         tokio::time::sleep(Duration::from_millis(10)),
@@ -633,12 +650,9 @@ async fn write_finalization_failure_emits_no_success_or_load() {
         hashes: HashMap::new(),
     };
 
+    let (operator, aborts) = failing_close::operator_with_aborts();
     let event = handler
-        .write_stream_to_location(
-            location.clone(),
-            failing_close::operator(),
-            stream_from_bytes(b"payload"),
-        )
+        .write_stream_to_location(location.clone(), operator, stream_from_bytes(b"payload"))
         .await;
 
     assert!(
@@ -649,6 +663,72 @@ async fn write_finalization_failure_emits_no_success_or_load() {
         bucket_load(&context.storage_handle, &location.storage_bucket).await,
         0
     );
+    assert_eq!(aborts.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn compose_close_fails() {
+    let context = setup_blob_handle(5).await;
+    let handler = context.blob_handle.handler.clone();
+
+    let Event::Blob(BlobEvent::WriteFinished { location: part }) = context
+        .blob_handle
+        .send_blob_effect(BlobEffect::Write {
+            bucket: "bucket-a".to_string(),
+            key: "part.bin".to_string(),
+            created_by: test_user_id(),
+            blob: stream_from_bytes(b"part-data"),
+        })
+        .await
+    else {
+        panic!("part write failed")
+    };
+
+    let target = BackendLocation {
+        root: "/tmp".to_string(),
+        storage_bucket: "compose-target".to_string(),
+        backend_path: format!("obj/{}", Ulid::new()),
+        ulid: Ulid::new(),
+        compressed: false,
+        encrypted: false,
+        created_by: test_user_id(),
+        created_at: SystemTime::now(),
+        staging: false,
+        partial: false,
+        blob_size: 0,
+        hashes: HashMap::new(),
+    };
+
+    let (operator, aborts) = failing_close::operator_with_aborts();
+    let event = handler
+        .compose_parts_to_location(target.clone(), operator, vec![part])
+        .await;
+
+    assert!(
+        matches!(event, BlobEvent::Error(BlobError::WriteError(_))),
+        "compose close failure must surface as an error, got {event:?}"
+    );
+    assert_eq!(
+        bucket_load(&context.storage_handle, &target.storage_bucket).await,
+        0
+    );
+    assert_eq!(aborts.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn replication_close_fails() {
+    let (operator, aborts) = failing_close::operator_with_aborts();
+    let mut writer =
+        crate::bao_tree::OpenDalWriter::new(&operator, "obj/replica", Duration::from_secs(5))
+            .await
+            .unwrap();
+
+    iroh_io::AsyncSliceWriter::write_bytes_at(&mut writer, 0, bytes::Bytes::from_static(b"data"))
+        .await
+        .unwrap();
+
+    assert!(writer.finalize().await.is_err());
+    assert_eq!(aborts.load(std::sync::atomic::Ordering::SeqCst), 1);
 }
 
 #[test]

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -667,6 +667,50 @@ async fn write_finalization_failure_emits_no_success_or_load() {
 }
 
 #[tokio::test]
+async fn failed_write_cleans() {
+    let context = setup_blob_handle(1).await;
+    let root = tempdir().unwrap();
+    let location = BackendLocation {
+        root: root.path().to_str().unwrap().to_string(),
+        storage_bucket: "bucket".to_string(),
+        backend_path: "partial.bin".to_string(),
+        ulid: Ulid::new(),
+        compressed: false,
+        encrypted: false,
+        created_by: test_user_id(),
+        created_at: SystemTime::now(),
+        staging: false,
+        partial: false,
+        blob_size: 0,
+        hashes: HashMap::new(),
+    };
+    let operator = crate::opendal::init_operator(
+        Backend::FileSystem,
+        HashMap::from([(
+            "root".to_string(),
+            root.path().to_str().unwrap().to_string(),
+        )]),
+    )
+    .unwrap();
+    let blob = BackendStream::new(futures::stream::iter([
+        Ok(bytes::Bytes::from_static(b"partial")),
+        Err(std::io::Error::other("injected stream failure")),
+    ]));
+
+    let event = context
+        .blob_handle
+        .handler
+        .write_stream_to_location(location.clone(), operator, blob)
+        .await;
+
+    assert!(matches!(event, BlobEvent::Error(BlobError::WriteError(_))));
+    assert!(
+        !std::path::Path::new(&location.get_full_path().unwrap()).exists(),
+        "partial filesystem target remains"
+    );
+}
+
+#[tokio::test]
 async fn compose_close_fails() {
     let context = setup_blob_handle(5).await;
     let handler = context.blob_handle.handler.clone();

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -1,3 +1,4 @@
+use super::backend::{build_backend_path, rebuild_backend_path};
 use super::{
     BlobHandle, BlobHandler, ControlPlaneTimeoutKind,
     control_plane::control_plane_timeout_event,
@@ -7,8 +8,9 @@ use super::{
 };
 use crate::messages::{MessageType, ReplicationMessage};
 use aruna_core::UserId;
+use aruna_core::alpn::Alpn;
 use aruna_core::effects::{BlobEffect, StagingSourceEffect, StorageEffect};
-use aruna_core::errors::BlobError;
+use aruna_core::errors::{BlobError, ConversionError};
 use aruna_core::events::{BlobEvent, Event, StagingSourceEvent, StorageEvent};
 use aruna_core::keyspaces::BUCKET_STATS_DB;
 use aruna_core::stream::BackendStream;
@@ -16,12 +18,106 @@ use aruna_core::structs::{
     Backend, BackendConfig, BackendLocation, BlobTimeoutConfig, RealmId, ResolvedSourceAccess,
     SourceConnectorKind,
 };
-use aruna_net::{NetConfig, NetHandle};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_storage::storage;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 use tempfile::tempdir;
 use ulid::Ulid;
+
+mod failing_close {
+    use opendal::raw::oio;
+    use opendal::raw::{Access, AccessorInfo, OpWrite, RpWrite};
+    use opendal::{Buffer, Capability, Error, ErrorKind, Metadata, Operator, OperatorBuilder};
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    pub(super) struct CloseFailsBackend {
+        info: Arc<AccessorInfo>,
+    }
+
+    impl Default for CloseFailsBackend {
+        fn default() -> Self {
+            let info = AccessorInfo::default();
+            info.set_scheme("close_fails")
+                .set_root("/")
+                .set_native_capability(Capability {
+                    write: true,
+                    write_can_empty: true,
+                    ..Default::default()
+                });
+            Self { info: info.into() }
+        }
+    }
+
+    impl Access for CloseFailsBackend {
+        type Reader = ();
+        type Writer = CloseFailsWriter;
+        type Lister = ();
+        type Deleter = ();
+        type Copier = ();
+
+        fn info(&self) -> Arc<AccessorInfo> {
+            self.info.clone()
+        }
+
+        async fn write(
+            &self,
+            _path: &str,
+            _args: OpWrite,
+        ) -> opendal::Result<(RpWrite, Self::Writer)> {
+            Ok((RpWrite::new(), CloseFailsWriter))
+        }
+    }
+
+    pub(super) struct CloseFailsWriter;
+
+    impl oio::Write for CloseFailsWriter {
+        async fn write(&mut self, _bs: Buffer) -> opendal::Result<()> {
+            Ok(())
+        }
+
+        async fn close(&mut self) -> opendal::Result<Metadata> {
+            Err(Error::new(
+                ErrorKind::Unexpected,
+                "injected finalization failure",
+            ))
+        }
+
+        async fn abort(&mut self) -> opendal::Result<()> {
+            Ok(())
+        }
+    }
+
+    pub(super) fn operator() -> Operator {
+        OperatorBuilder::new(CloseFailsBackend::default()).finish()
+    }
+}
+
+async fn loopback_net_handle() -> (NetHandle, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let storage_handle = storage::FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+    let net_handle = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().unwrap(),
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage_handle,
+    )
+    .await
+    .unwrap();
+    (net_handle, dir)
+}
+
+async fn connected_stream_pair() -> (NetHandle, tempfile::TempDir, NetHandle, tempfile::TempDir) {
+    let (net_a, dir_a) = loopback_net_handle().await;
+    let (net_b, dir_b) = loopback_net_handle().await;
+    net_a.add_peer_addr(net_b.endpoint_addr()).await;
+    net_b.add_peer_addr(net_a.endpoint_addr()).await;
+    (net_a, dir_a, net_b, dir_b)
+}
 
 struct TestContext {
     _temp_dir: tempfile::TempDir,
@@ -449,5 +545,152 @@ async fn staging_source_effect_dispatches_via_blob_handle() {
         event,
         Event::StagingSource(StagingSourceEvent::Error { .. })
             | Event::StagingSource(StagingSourceEvent::HeadResult { .. })
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_connections_receive_distinct_non_nil_ids() {
+    let context = setup_blob_handle(1).await;
+    let mut handler = context.blob_handle.handler.clone();
+    let (net_a, _dir_a, net_b, _dir_b) = connected_stream_pair().await;
+    let peer_id = net_b.node_id();
+
+    let stream_a = net_a.open_stream(peer_id, Alpn::Bao).await.unwrap();
+    let stream_b = net_a.open_stream(peer_id, Alpn::Bao).await.unwrap();
+
+    let id_a = handler
+        .add_connection(None, peer_id, stream_a)
+        .await
+        .unwrap();
+    let id_b = handler
+        .add_connection(None, peer_id, stream_b)
+        .await
+        .unwrap();
+
+    assert!(!id_a.is_nil());
+    assert!(!id_b.is_nil());
+    assert_ne!(id_a, id_b);
+
+    handler.close_connection(id_a).await;
+    assert!(handler.connection_handle(id_a).await.is_err());
+    assert!(handler.connection_handle(id_b).await.is_ok());
+
+    net_a.shutdown().await;
+    net_b.shutdown().await;
+}
+
+#[tokio::test]
+async fn add_connection_rejects_nil_and_duplicate_ids() {
+    let context = setup_blob_handle(1).await;
+    let mut handler = context.blob_handle.handler.clone();
+    let (net_a, _dir_a, net_b, _dir_b) = connected_stream_pair().await;
+    let peer_id = net_b.node_id();
+
+    let explicit = Ulid::new();
+    let stream = net_a.open_stream(peer_id, Alpn::Bao).await.unwrap();
+    let id = handler
+        .add_connection(Some(explicit), peer_id, stream)
+        .await
+        .unwrap();
+    assert_eq!(id, explicit);
+
+    let duplicate = net_a.open_stream(peer_id, Alpn::Bao).await.unwrap();
+    assert!(matches!(
+        handler
+            .add_connection(Some(explicit), peer_id, duplicate)
+            .await,
+        Err(BlobError::ConnectionFailed(_))
+    ));
+
+    let nil_stream = net_a.open_stream(peer_id, Alpn::Bao).await.unwrap();
+    assert!(matches!(
+        handler
+            .add_connection(Some(Ulid::nil()), peer_id, nil_stream)
+            .await,
+        Err(BlobError::ConnectionFailed(_))
+    ));
+
+    net_a.shutdown().await;
+    net_b.shutdown().await;
+}
+
+#[tokio::test]
+async fn write_finalization_failure_emits_no_success_or_load() {
+    let context = setup_blob_handle(1).await;
+    let handler = context.blob_handle.handler.clone();
+    let location = BackendLocation {
+        root: "/tmp".to_string(),
+        storage_bucket: "finalization-bucket".to_string(),
+        backend_path: format!("obj/{}", Ulid::new()),
+        ulid: Ulid::new(),
+        compressed: false,
+        encrypted: false,
+        created_by: test_user_id(),
+        created_at: SystemTime::now(),
+        staging: false,
+        partial: false,
+        blob_size: 0,
+        hashes: HashMap::new(),
+    };
+
+    let event = handler
+        .write_stream_to_location(
+            location.clone(),
+            failing_close::operator(),
+            stream_from_bytes(b"payload"),
+        )
+        .await;
+
+    assert!(
+        matches!(event, BlobEvent::Error(BlobError::WriteError(_))),
+        "close failure must surface as an error, got {event:?}"
+    );
+    assert_eq!(
+        bucket_load(&context.storage_handle, &location.storage_bucket).await,
+        0
+    );
+}
+
+#[test]
+fn build_backend_path_rejects_traversal_keys() {
+    let ulid = Ulid::new();
+    assert!(build_backend_path("bucket", "nested/object.bin", ulid).is_ok());
+
+    for key in ["../escape", "../../etc/passwd", "a/../../b", "/abs/path"] {
+        assert!(
+            matches!(
+                build_backend_path("bucket", key, ulid),
+                Err(ConversionError::UnsafePath(_))
+            ),
+            "key {key:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn rebuild_backend_path_rejects_sender_supplied_traversal() {
+    let ulid = Ulid::new();
+    assert!(rebuild_backend_path("bucket/object_0000", ulid).is_ok());
+
+    for path in ["../../etc/cron.d/evil_00", "../escape_00", "/abs/object_00"] {
+        assert!(
+            matches!(
+                rebuild_backend_path(path, ulid),
+                Err(ConversionError::UnsafePath(_))
+            ),
+            "replicated path {path:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn get_storage_path_rejects_replicated_traversal_path() {
+    let mut location = make_test_location();
+    location.storage_bucket = "bucket".to_string();
+    location.backend_path = "../../etc/passwd".to_string();
+
+    assert!(matches!(
+        location.get_storage_path(),
+        Err(BlobError::ConversionError(ConversionError::UnsafePath(_)))
     ));
 }

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -349,7 +349,7 @@ fn parse_replication_init_uses_message_id_when_unknown() {
     );
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn control_plane_timeout_reports_read_timeout() {
     let event = with_control_plane_timeout(
         tokio::time::sleep(Duration::from_millis(10)),

--- a/blob/src/framing.rs
+++ b/blob/src/framing.rs
@@ -1,0 +1,131 @@
+use std::io::{self, ErrorKind};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+pub(crate) const MAX_CONTROL_PLANE_FRAME: usize = 128 * 1024 * 1024;
+
+pub(crate) fn checked_frame_len(len: u32, max_len: usize) -> io::Result<usize> {
+    let len = len as usize;
+    if len == 0 {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "refusing to allocate a zero-length frame",
+        ));
+    }
+    if len > max_len {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            format!("frame length {len} exceeds maximum {max_len}"),
+        ));
+    }
+    Ok(len)
+}
+
+pub(crate) fn checked_send_len(len: usize, max_len: usize) -> io::Result<u32> {
+    if len > max_len {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("frame length {len} exceeds maximum {max_len}"),
+        ));
+    }
+    Ok(len as u32)
+}
+
+pub(crate) async fn write_frame<W>(writer: &mut W, payload: &[u8], max_len: usize) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let len = checked_send_len(payload.len(), max_len)?;
+    writer.write_u32(len).await?;
+    writer.write_all(payload).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+pub(crate) async fn read_frame<R>(reader: &mut R, max_len: usize) -> io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let len = checked_frame_len(reader.read_u32().await?, max_len)?;
+    let mut buf = vec![0; len];
+    reader.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_CONTROL_PLANE_FRAME, checked_frame_len, checked_send_len, read_frame, write_frame,
+    };
+    use std::io::ErrorKind;
+    use tokio::io::AsyncWriteExt;
+
+    const TEST_LIMIT: usize = 64;
+
+    #[tokio::test]
+    async fn round_trips_payload_at_limit() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        let payload = vec![7u8; TEST_LIMIT];
+        write_frame(&mut writer, &payload, TEST_LIMIT)
+            .await
+            .unwrap();
+        let received = read_frame(&mut reader, TEST_LIMIT).await.unwrap();
+        assert_eq!(received, payload);
+    }
+
+    #[tokio::test]
+    async fn rejects_length_one_over_limit_before_allocation() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        writer.write_u32(TEST_LIMIT as u32 + 1).await.unwrap();
+        writer.flush().await.unwrap();
+        let err = read_frame(&mut reader, TEST_LIMIT).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn rejects_u32_max_header_without_allocating() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        writer.write_u32(u32::MAX).await.unwrap();
+        writer.flush().await.unwrap();
+        let err = read_frame(&mut reader, TEST_LIMIT).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_length_header() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        writer.write_u32(0).await.unwrap();
+        writer.flush().await.unwrap();
+        let err = read_frame(&mut reader, TEST_LIMIT).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn refuses_to_send_oversized_payload() {
+        let (mut writer, _reader) = tokio::io::duplex(4096);
+        let payload = vec![0u8; TEST_LIMIT + 1];
+        let err = write_frame(&mut writer, &payload, TEST_LIMIT)
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn checked_frame_len_boundaries() {
+        assert_eq!(
+            checked_frame_len(TEST_LIMIT as u32, TEST_LIMIT).unwrap(),
+            TEST_LIMIT
+        );
+        assert!(checked_frame_len(0, TEST_LIMIT).is_err());
+        assert!(checked_frame_len(TEST_LIMIT as u32 + 1, TEST_LIMIT).is_err());
+        assert!(checked_frame_len(u32::MAX, MAX_CONTROL_PLANE_FRAME).is_err());
+    }
+
+    #[test]
+    fn checked_send_len_rejects_over_limit() {
+        assert_eq!(
+            checked_send_len(TEST_LIMIT, TEST_LIMIT).unwrap(),
+            TEST_LIMIT as u32
+        );
+        assert!(checked_send_len(TEST_LIMIT + 1, TEST_LIMIT).is_err());
+    }
+}

--- a/blob/src/framing.rs
+++ b/blob/src/framing.rs
@@ -21,6 +21,12 @@ pub(crate) fn checked_frame_len(len: u32, max_len: usize) -> io::Result<usize> {
 }
 
 pub(crate) fn checked_send_len(len: usize, max_len: usize) -> io::Result<u32> {
+    if len == 0 {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "refusing to send a zero-length frame",
+        ));
+    }
     if len > max_len {
         return Err(io::Error::new(
             ErrorKind::InvalidInput,
@@ -127,5 +133,12 @@ mod tests {
             TEST_LIMIT as u32
         );
         assert!(checked_send_len(TEST_LIMIT + 1, TEST_LIMIT).is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_send() {
+        let (mut writer, _reader) = tokio::io::duplex(4096);
+        let err = write_frame(&mut writer, &[], TEST_LIMIT).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
     }
 }

--- a/blob/src/lib.rs
+++ b/blob/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod bao_tree;
 pub mod blob;
 pub mod error;
+mod framing;
 pub mod hash;
 mod messages;
 pub mod opendal;

--- a/blob/src/messages.rs
+++ b/blob/src/messages.rs
@@ -1,10 +1,10 @@
 use crate::error::BlobLibError;
+use crate::framing::{MAX_CONTROL_PLANE_FRAME, read_frame, write_frame};
 use aruna_core::errors::BlobError;
 use aruna_core::events::BlobEvent;
 use aruna_core::structs::BackendLocation;
 use aruna_net::streams::{RecvStream, SendStream};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use ulid::Ulid;
 
 #[allow(clippy::large_enum_variant)]
@@ -30,27 +30,15 @@ impl ReplicationMessage {
 
     pub async fn send(self, sender: &mut SendStream) -> Result<(), BlobLibError> {
         let request_buf = postcard::to_allocvec(&self)?;
-        AsyncWriteExt::write_u32(sender, request_buf.len() as u32).await?;
-        AsyncWriteExt::write_all(sender, &request_buf).await?;
-        AsyncWriteExt::flush(sender).await?;
+        write_frame(sender, &request_buf, MAX_CONTROL_PLANE_FRAME).await?;
         Ok(())
     }
 
     pub async fn read(receiver: &mut RecvStream) -> Result<Self, BlobEvent> {
-        let msg_len = match receiver.read_u32().await {
-            Ok(len) => len,
-            Err(err) => return Err(BlobEvent::Error(BlobError::ReadError(err.to_string()))),
-        };
-        let mut buf = vec![0; msg_len as usize];
-        match receiver.read_exact(&mut buf).await {
-            Ok(len) => len,
-            Err(err) => return Err(BlobEvent::Error(BlobError::ReadError(err.to_string()))),
-        };
-
-        let message = match postcard::from_bytes::<ReplicationMessage>(&buf) {
-            Ok(len) => len,
-            Err(err) => return Err(BlobEvent::Error(BlobError::ConversionError(err.into()))),
-        };
-        Ok(message)
+        let buf = read_frame(receiver, MAX_CONTROL_PLANE_FRAME)
+            .await
+            .map_err(|err| BlobEvent::Error(BlobError::ReadError(err.to_string())))?;
+        postcard::from_bytes::<ReplicationMessage>(&buf)
+            .map_err(|err| BlobEvent::Error(BlobError::ConversionError(err.into())))
     }
 }

--- a/blob/src/opendal.rs
+++ b/blob/src/opendal.rs
@@ -8,9 +8,16 @@ use opendal::layers::{LoggingLayer, RetryLayer};
 use opendal::{Builder, Operator, services};
 use std::collections::HashMap;
 
-pub(crate) async fn abort_partial_writer(writer: &mut opendal::Writer) {
+pub(crate) async fn abort_partial_writer(
+    writer: &mut opendal::Writer,
+    operator: &Operator,
+    storage_path: &str,
+) {
     if let Err(err) = writer.abort().await {
-        tracing::warn!(error = %err, "failed to abort partial blob writer");
+        tracing::warn!(error = %err, "failed to abort partial blob writer; deleting output");
+        if let Err(delete_err) = operator.delete(storage_path).await {
+            tracing::warn!(error = %delete_err, "failed to delete partial blob output");
+        }
     }
 }
 

--- a/blob/src/opendal.rs
+++ b/blob/src/opendal.rs
@@ -8,6 +8,12 @@ use opendal::layers::{LoggingLayer, RetryLayer};
 use opendal::{Builder, Operator, services};
 use std::collections::HashMap;
 
+pub(crate) async fn abort_partial_writer(writer: &mut opendal::Writer) {
+    if let Err(err) = writer.abort().await {
+        tracing::warn!(error = %err, "failed to abort partial blob writer");
+    }
+}
+
 pub(crate) fn init_backend_operator(
     mut config: BackendConfig,
     bucket: String,

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -168,6 +168,8 @@ pub enum ConversionError {
     FromStrError(String),
     #[error("Failed to convert OsString to String")]
     OsStringError,
+    #[error("Unsafe path: {0}")]
+    UnsafePath(String),
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
     #[error(transparent)]

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -7,12 +7,39 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use ulid::Ulid;
 
 const ACCESS_KEY_MAX_LEN: usize = 128;
+
+pub fn ensure_confined_relative_path(path: &Path) -> Result<(), ConversionError> {
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let part = part.to_str().ok_or(ConversionError::OsStringError)?;
+                if part.chars().any(|c| c.is_control()) {
+                    return Err(ConversionError::UnsafePath(
+                        "path component contains control characters".to_string(),
+                    ));
+                }
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(ConversionError::UnsafePath(
+                    "path must not contain parent-directory (`..`) components".to_string(),
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(ConversionError::UnsafePath(
+                    "path must be relative to the backend root".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum Backend {
@@ -136,18 +163,23 @@ impl Display for BackendLocation {
 }
 
 impl BackendLocation {
+    fn confined_relative_path(&self) -> Result<PathBuf, ConversionError> {
+        let path = PathBuf::from(&self.storage_bucket).join(&self.backend_path);
+        ensure_confined_relative_path(&path)?;
+        Ok(path)
+    }
+
     pub fn get_full_path(&self) -> Result<String, ConversionError> {
         PathBuf::from(&self.root)
-            .join(&self.storage_bucket)
-            .join(&self.backend_path)
+            .join(self.confined_relative_path()?)
             .into_os_string()
             .into_string()
             .map_err(|_| ConversionError::OsStringError)
     }
 
     pub fn get_storage_path(&self) -> Result<String, BlobError> {
-        Ok(PathBuf::from(&self.storage_bucket)
-            .join(&self.backend_path)
+        Ok(self
+            .confined_relative_path()?
             .into_os_string()
             .into_string()
             .map_err(|_| ConversionError::OsStringError)?)
@@ -769,6 +801,65 @@ mod tests {
         assert!(deleted.blob_hash().is_none());
         assert!(!deleted.is_materialized());
         assert!(deleted.is_deleted());
+    }
+
+    #[test]
+    fn ensure_confined_relative_path_matrix() {
+        use super::ensure_confined_relative_path;
+        use crate::errors::ConversionError;
+        use std::path::Path;
+
+        for ok in [
+            "bucket/object",
+            "bucket/nested/object.bin",
+            "bucket/./object",
+        ] {
+            assert!(ensure_confined_relative_path(Path::new(ok)).is_ok());
+        }
+        for bad in [
+            "../escape",
+            "bucket/../../escape",
+            "/absolute/path",
+            "bucket/../../../etc/passwd",
+        ] {
+            assert!(matches!(
+                ensure_confined_relative_path(Path::new(bad)),
+                Err(ConversionError::UnsafePath(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn get_storage_path_rejects_traversal_in_backend_path() {
+        use crate::errors::{BlobError, ConversionError};
+        use crate::structs::BackendLocation;
+
+        let mut location = BackendLocation {
+            root: "/data".to_string(),
+            storage_bucket: "bucket".to_string(),
+            backend_path: "object.bin".to_string(),
+            ulid: Ulid::new(),
+            compressed: false,
+            encrypted: false,
+            created_by: UserId::default(),
+            created_at: SystemTime::now(),
+            staging: false,
+            partial: false,
+            blob_size: 0,
+            hashes: HashMap::new(),
+        };
+        assert!(location.get_storage_path().is_ok());
+        assert!(location.get_full_path().is_ok());
+
+        location.backend_path = "../../etc/passwd".to_string();
+        assert!(matches!(
+            location.get_storage_path(),
+            Err(BlobError::ConversionError(ConversionError::UnsafePath(_)))
+        ));
+        assert!(matches!(
+            location.get_full_path(),
+            Err(ConversionError::UnsafePath(_))
+        ));
     }
 
     #[test]

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -226,7 +226,7 @@ impl InboundEventHandler for OperationsInboundHandler {
             match alpn {
                 Alpn::Bao => {
                     if let Some(mut blob_handle) = self.context.blob_handle.clone() {
-                        let stream_id = blob_handle.store_connection(stream).await;
+                        let stream_id = blob_handle.store_connection(node_id, stream).await;
                         let Some(net_handle) = self.context.net_handle.as_ref() else {
                             error!(peer = %node_id, "Cannot handle incoming bao stream without net handle");
                             return;

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -235,6 +235,7 @@ impl InboundEventHandler for OperationsInboundHandler {
                         };
                         let Some(net_handle) = self.context.net_handle.as_ref() else {
                             error!(peer = %node_id, "Cannot handle incoming bao stream without net handle");
+                            close_failed_bao(&blob_handle, stream_id).await;
                             return;
                         };
                         let first_event = blob_handle
@@ -270,20 +271,17 @@ impl InboundEventHandler for OperationsInboundHandler {
                                             stream_id = %stream_id,
                                             "Unsupported inbound bao payload"
                                         );
-                                        let close_event = blob_handle
-                                            .send_blob_effect(BlobEffect::CloseConnection { stream_id })
-                                            .await;
-                                        if let Event::Blob(BlobEvent::Error(err)) = close_event {
-                                            error!(error = ?err, "Failed to close unsupported inbound bao stream");
-                                        }
+                                        close_failed_bao(&blob_handle, stream_id).await;
                                     }
                                 }
                             }
                             Event::Blob(BlobEvent::Error(err)) => {
                                 error!(error = ?err, "Failed to read initial inbound bao payload");
+                                close_failed_bao(&blob_handle, stream_id).await;
                             }
                             other => {
                                 error!(event = ?other, "Unexpected first event for inbound bao stream");
+                                close_failed_bao(&blob_handle, stream_id).await;
                             }
                         }
                     } else {
@@ -334,6 +332,15 @@ impl InboundEventHandler for OperationsInboundHandler {
 
     async fn handle_evicted_documents(&self, documents: Vec<DocumentSyncEvictedDocument>) {
         reemit_evicted_documents(self.context.as_ref(), documents).await;
+    }
+}
+
+async fn close_failed_bao(blob_handle: &aruna_blob::blob::BlobHandle, stream_id: ulid::Ulid) {
+    let close_event = blob_handle
+        .send_blob_effect(BlobEffect::CloseConnection { stream_id })
+        .await;
+    if let Event::Blob(BlobEvent::Error(err)) = close_event {
+        error!(error = ?err, "Failed to close rejected inbound bao stream");
     }
 }
 
@@ -498,12 +505,98 @@ async fn run_metadata_document_sync_maintenance(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aruna_blob::blob::BlobHandler;
     use aruna_core::events::StorageEvent;
     use aruna_core::keyspaces::TASK_TIMER_KEYSPACE;
+    use aruna_core::structs::{Backend, BackendConfig};
     use aruna_core::task::{PersistedTaskTimer, TaskKey};
+    use aruna_net::{DiscoveryMethod, NetConfig, RelayMethod};
     use aruna_storage::FjallStorage;
     use aruna_tasks::TaskHandle;
+    use std::collections::HashMap;
     use tempfile::tempdir;
+    use tokio::io::AsyncWriteExt;
+    use tokio::sync::mpsc;
+
+    #[derive(Debug)]
+    struct StreamCapture(mpsc::UnboundedSender<(Alpn, BiStream, NodeId)>);
+
+    #[async_trait]
+    impl InboundEventHandler for StreamCapture {
+        async fn handle_incoming_stream(&self, alpn: Alpn, stream: BiStream, node_id: NodeId) {
+            self.0.send((alpn, stream, node_id)).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_bao_closes() {
+        let dir_a = tempdir().unwrap();
+        let dir_b = tempdir().unwrap();
+        let storage_a = FjallStorage::open(dir_a.path().to_str().unwrap()).unwrap();
+        let storage_b = FjallStorage::open(dir_b.path().to_str().unwrap()).unwrap();
+        let config = || NetConfig {
+            bind_addr: "127.0.0.1:0".parse().unwrap(),
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        };
+        let net_a = aruna_net::NetHandle::new(config(), storage_a)
+            .await
+            .unwrap();
+        let net_b = aruna_net::NetHandle::new(config(), storage_b.clone())
+            .await
+            .unwrap();
+        net_a.add_peer_addr(net_b.endpoint_addr()).await;
+        net_b.add_peer_addr(net_a.endpoint_addr()).await;
+
+        let (stream_tx, mut stream_rx) = mpsc::unbounded_channel();
+        net_b.set_inbound_handler(Arc::new(StreamCapture(stream_tx)));
+        let blob_root = dir_b.path().join("blobs");
+        std::fs::create_dir(&blob_root).unwrap();
+        let blob_handle = BlobHandler::new(
+            BackendConfig {
+                backend_type: Backend::FileSystem,
+                root: blob_root.to_str().unwrap().to_string(),
+                service_config: HashMap::new(),
+                bucket_prefix: None,
+                max_bucket_size: None,
+                multipart_bucket: None,
+                timeouts: Default::default(),
+            },
+            storage_b.clone(),
+            net_b.clone(),
+        )
+        .await
+        .unwrap();
+        let handler = OperationsInboundHandler::new(Arc::new(DriverContext {
+            storage_handle: storage_b,
+            net_handle: Some(net_b.clone()),
+            blob_handle: Some(blob_handle),
+            metadata_handle: None,
+            task_handle: None,
+        }));
+
+        let mut outbound = net_a.open_stream(net_b.node_id(), Alpn::Bao).await.unwrap();
+        outbound.0.write_u32(8).await.unwrap();
+        outbound.0.write_all(b"x").await.unwrap();
+        outbound.0.finish().unwrap();
+        let (alpn, inbound, peer) = tokio::time::timeout(Duration::from_secs(5), stream_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        handler.handle_incoming_stream(alpn, inbound, peer).await;
+
+        let closed =
+            tokio::time::timeout(Duration::from_millis(250), outbound.1.read_to_end(1)).await;
+        assert!(
+            matches!(closed, Ok(Ok(ref bytes)) if bytes.is_empty()),
+            "BR-003_EXPECT_CLOSE: failed initial Bao stream remained open: {closed:?}"
+        );
+
+        net_a.shutdown().await;
+        net_b.shutdown().await;
+    }
 
     #[tokio::test]
     async fn inbound_projection_failure_schedules_durable_projection_retry() {

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -226,7 +226,13 @@ impl InboundEventHandler for OperationsInboundHandler {
             match alpn {
                 Alpn::Bao => {
                     if let Some(mut blob_handle) = self.context.blob_handle.clone() {
-                        let stream_id = blob_handle.store_connection(node_id, stream).await;
+                        let stream_id = match blob_handle.store_connection(node_id, stream).await {
+                            Ok(stream_id) => stream_id,
+                            Err(err) => {
+                                error!(peer = %node_id, error = ?err, "Failed to register inbound bao stream");
+                                return;
+                            }
+                        };
                         let Some(net_handle) = self.context.net_handle.as_ref() else {
                             error!(peer = %node_id, "Cannot handle incoming bao stream without net handle");
                             return;


### PR DESCRIPTION
Closes #334

Fixes four blob-layer defects:

- **Bounded framing** — one shared framing implementation caps control-plane frames at 128 MiB and rejects zero/oversized lengths before allocation (previously a peer-controlled `u32` could drive an allocation near 4 GiB).
- **Unique stream ids** — auto-allocated connections get fresh non-nil ULIDs and carry the authenticated peer id; previously all collided on the nil ULID, cross-wiring concurrent replications.
- **Authoritative finalization** — `writer.close()`/finalize errors propagate on write, compose, and replication paths; a failed finalization aborts the partial upload (via opendal `Writer::abort()`, so multipart uploads on S3-class backends aren't leaked) and emits no success event, metadata, or load update.
- **Path confinement** — object keys are rejected at the API boundary (empty, absolute, `..` segment, control chars) with a canonical root-confinement backstop in the filesystem backend that also covers sender-supplied replicated paths.
