### PR TITLE
[fix] Bound issuer key caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "iroh",
  "irokle",
  "jsonwebtoken",
+ "lru 0.18.0",
  "opentelemetry",
  "oxrdf",
  "postcard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ irokle = { git = "https://github.com/arunaengine/irokle.git", branch = "main", f
 iroh-io = "0.6.2"
 iroh-quinn = "0.16.1"
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+lru = "0.18.0"
 md5 = "0.8.0"
 n0-future = "0.3.2"
 opendal = { version = "0.57", features = [

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -516,7 +516,9 @@ mod test {
     use aruna_core::handle::Handle;
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::structs::OidcProviderConfig;
-    use aruna_core::structs::{Actor, NodeCapabilities, RealmAuthorizationDocument, RealmId};
+    use aruna_core::structs::{
+        Actor, NodeCapabilities, RealmAuthorizationDocument, RealmId, TokenClaims,
+    };
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
     use aruna_operations::create_realm::{CreateRealmConfig, CreateRealmOperation};
     use aruna_operations::create_token::{CreateTokenConfig, CreateTokenOperation};
@@ -1722,5 +1724,152 @@ mod test {
             axum::http::HeaderValue::from_str(&format!("Bearer {}", server_token)).unwrap(),
         );
         assert!(extract_auth_context(&state, &headers).await.is_none());
+    }
+
+    fn sign_untrusted_direct_token(issuer_key: &SigningKey, now: u64) -> String {
+        let issuer_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(issuer_key.verifying_key().to_bytes());
+        let claims = TokenClaims {
+            sub: format!("{}@{}", Ulid::new(), issuer_b64),
+            iss: issuer_b64,
+            iat: now,
+            exp: now + 600,
+            jti: Ulid::new().to_string(),
+            restrictions: None,
+            issuer_pubkey: None,
+            delegation_signature: None,
+        };
+        let der = issuer_key
+            .to_pkcs8_pem(ed25519_dalek::pkcs8::spki::der::pem::LineEnding::LF)
+            .unwrap();
+        encode(
+            &Header::new(Algorithm::EdDSA),
+            &claims,
+            &EncodingKey::from_ed_pem(der.as_bytes()).unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn rejected_token_flood_keeps_issuer_cache_bounded() {
+        let mut tempdir = temp_dir();
+        tempdir.push(Ulid::new().to_string());
+        let storage_handle = storage::FjallStorage::open(tempdir.to_str().unwrap()).unwrap();
+        let driver_ctx = Arc::new(DriverContext {
+            storage_handle,
+            net_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+            blob_handle: None,
+        });
+
+        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
+        let realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
+        let node_id = iroh::SecretKey::generate().public();
+
+        drive(
+            CreateRealmOperation::new(CreateRealmConfig {
+                actor: Actor {
+                    node_id,
+                    user_id: UserId::nil(realm_id),
+                    realm_id,
+                },
+                realm_description: "Realm".to_string(),
+                oidc_providers: Vec::new(),
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap();
+
+        let capabilities = NodeCapabilities::management_node(realm_signing_key).unwrap();
+        let state = ServerState::new(
+            driver_ctx.clone(),
+            realm_id,
+            node_id,
+            capabilities,
+            false,
+            None,
+        )
+        .await;
+
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        for _ in 0..2048 {
+            let issuer_key = SigningKey::generate(&mut csprng);
+            let token = sign_untrusted_direct_token(&issuer_key, now);
+            assert!(handle_token(&state, &token).await.is_err());
+        }
+
+        assert_eq!(state.issuer_key_cache_len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn valid_delegated_token_caches_single_issuer_key() {
+        let mut tempdir = temp_dir();
+        tempdir.push(Ulid::new().to_string());
+        let storage_handle = storage::FjallStorage::open(tempdir.to_str().unwrap()).unwrap();
+        let driver_ctx = Arc::new(DriverContext {
+            storage_handle,
+            net_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+            blob_handle: None,
+        });
+
+        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
+        let mut realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
+        let node_id = iroh::SecretKey::generate().public();
+
+        drive(
+            CreateRealmOperation::new(CreateRealmConfig {
+                actor: Actor {
+                    node_id,
+                    user_id: UserId::nil(realm_id),
+                    realm_id,
+                },
+                realm_description: "Realm".to_string(),
+                oidc_providers: Vec::new(),
+            }),
+            &driver_ctx,
+        )
+        .await
+        .unwrap();
+
+        let issuer_key = SigningKey::generate(&mut csprng);
+        let message = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(issuer_key.verifying_key().to_bytes());
+        let delegation_signature = realm_signing_key.sign(message.as_bytes()).to_string();
+        let capabilities =
+            NodeCapabilities::server_node(issuer_key, realm_id, delegation_signature).unwrap();
+        let state = ServerState::new(
+            driver_ctx.clone(),
+            realm_id,
+            node_id,
+            capabilities.clone(),
+            false,
+            None,
+        )
+        .await;
+
+        let token = drive(
+            CreateTokenOperation::new(CreateTokenConfig {
+                time: chrono::Utc::now().timestamp().max(0) as u64,
+                expiry: None,
+                user_id: UserId::local(Ulid::new(), realm_id),
+                realm_id,
+                node_capabilities: capabilities,
+            })
+            .unwrap(),
+            &driver_ctx,
+        )
+        .await
+        .unwrap();
+
+        handle_token(&state, &token).await.unwrap();
+        handle_token(&state, &token).await.unwrap();
+
+        assert_eq!(state.issuer_key_cache_len().await, 1);
     }
 }

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -1750,17 +1750,6 @@ mod test {
         .unwrap()
     }
 
-    fn process_rss_bytes() -> u64 {
-        let status = std::fs::read_to_string("/proc/self/status").unwrap();
-        let rss_kib = status
-            .lines()
-            .find_map(|line| line.strip_prefix("VmRSS:"))
-            .and_then(|value| value.split_whitespace().next())
-            .and_then(|value| value.parse::<u64>().ok())
-            .expect("VmRSS must be available from /proc/self/status");
-        rss_kib * 1024
-    }
-
     #[tokio::test]
     async fn rejected_token_flood_keeps_issuer_cache_bounded() {
         let mut tempdir = temp_dir();
@@ -1809,23 +1798,12 @@ mod test {
         .await;
 
         let now = chrono::Utc::now().timestamp().max(0) as u64;
-        let warmup_key = SigningKey::generate(&mut csprng);
-        let warmup_token = sign_untrusted_direct_token(&warmup_key, now);
-        assert!(handle_token(&state, &warmup_token).await.is_err());
-        let rss_before = process_rss_bytes();
-
         for _ in 0..2048 {
             let issuer_key = SigningKey::generate(&mut csprng);
             let token = sign_untrusted_direct_token(&issuer_key, now);
             assert!(handle_token(&state, &token).await.is_err());
         }
 
-        let rss_growth = process_rss_bytes().saturating_sub(rss_before);
-        // Allow allocator page retention and CI measurement noise without permitting unbounded growth.
-        assert!(
-            rss_growth <= 8 * 1024 * 1024,
-            "rejected-token flood grew process RSS by {rss_growth} bytes"
-        );
         assert_eq!(state.issuer_key_cache_len().await, 0);
     }
 

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -1777,6 +1777,9 @@ mod test {
                 },
                 realm_description: "Realm".to_string(),
                 oidc_providers: Vec::new(),
+                node_location: None,
+                node_weight: None,
+                node_labels: Default::default(),
             }),
             &driver_ctx,
         )
@@ -1831,6 +1834,9 @@ mod test {
                 },
                 realm_description: "Realm".to_string(),
                 oidc_providers: Vec::new(),
+                node_location: None,
+                node_weight: None,
+                node_labels: Default::default(),
             }),
             &driver_ctx,
         )

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -1750,6 +1750,17 @@ mod test {
         .unwrap()
     }
 
+    fn process_rss_bytes() -> u64 {
+        let status = std::fs::read_to_string("/proc/self/status").unwrap();
+        let rss_kib = status
+            .lines()
+            .find_map(|line| line.strip_prefix("VmRSS:"))
+            .and_then(|value| value.split_whitespace().next())
+            .and_then(|value| value.parse::<u64>().ok())
+            .expect("VmRSS must be available from /proc/self/status");
+        rss_kib * 1024
+    }
+
     #[tokio::test]
     async fn rejected_token_flood_keeps_issuer_cache_bounded() {
         let mut tempdir = temp_dir();
@@ -1798,12 +1809,23 @@ mod test {
         .await;
 
         let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let warmup_key = SigningKey::generate(&mut csprng);
+        let warmup_token = sign_untrusted_direct_token(&warmup_key, now);
+        assert!(handle_token(&state, &warmup_token).await.is_err());
+        let rss_before = process_rss_bytes();
+
         for _ in 0..2048 {
             let issuer_key = SigningKey::generate(&mut csprng);
             let token = sign_untrusted_direct_token(&issuer_key, now);
             assert!(handle_token(&state, &token).await.is_err());
         }
 
+        let rss_growth = process_rss_bytes().saturating_sub(rss_before);
+        // Allow allocator page retention and CI measurement noise without permitting unbounded growth.
+        assert!(
+            rss_growth <= 8 * 1024 * 1024,
+            "rejected-token flood grew process RSS by {rss_growth} bytes"
+        );
         assert_eq!(state.issuer_key_cache_len().await, 0);
     }
 

--- a/api/src/server_state.rs
+++ b/api/src/server_state.rs
@@ -11,7 +11,7 @@ use aruna_core::keyspaces::{API_STATE_KEYSPACE, USER_KEYSPACE};
 use aruna_core::onboarding::{OnboardingSecretError, OnboardingSyncTicket};
 use aruna_core::structs::{Actor, AuthContext, NodeCapabilities, OidcProviderConfig, RealmId};
 use aruna_operations::auth::{
-    ArunaBearerTokenError, ArunaBearerTokenValidationState, decoding_key_from_base64_public_key,
+    ArunaBearerTokenError, ArunaBearerTokenValidationState, IssuerKeyCache,
 };
 use aruna_operations::claim_initial_realm_admin::{
     ClaimInitialRealmAdminError, ClaimInitialRealmAdminInput, ClaimInitialRealmAdminOperation,
@@ -31,7 +31,7 @@ use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
 use iroh::EndpointAddr;
 use jsonwebtoken::DecodingKey;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -49,8 +49,8 @@ pub struct ServerState {
     driver_ctx: Arc<DriverContext>,
     // Capabilities defined as in spec: Membership, Server and Local node capabilities
     node_capabilities: NodeCapabilities,
-    // Base64 encoded issuer pubkeys and jsonwebtoken serialized DecodingKeys
-    issuer_keys: Arc<RwLock<HashMap<String, DecodingKey, ahash::RandomState>>>,
+    // Bounded TTL + LRU cache of trusted issuer decoding keys
+    issuer_keys: Arc<IssuerKeyCache>,
     // Contains token id as a string, so also invalid ids get banned
     token_revocation_list: Arc<RwLock<HashSet<String, ahash::RandomState>>>,
     // Contains trusted realms
@@ -159,7 +159,7 @@ impl ServerState {
             node_capabilities,
             token_revocation_list: Arc::new(RwLock::new(token_revocation_list)),
             trusted_realms_list: Arc::new(RwLock::new(trusted_realms)),
-            issuer_keys: Arc::new(RwLock::new(HashMap::default())),
+            issuer_keys: Arc::new(IssuerKeyCache::new()),
             initial_admin_claim,
             interface_state: Arc::new(RwLock::new(InterfaceRuntimeState::default())),
             portal: Arc::new(RwLock::new(PortalRuntimeState::default())),
@@ -338,6 +338,10 @@ impl ServerState {
             .map_err(Into::into)
     }
 
+    pub async fn issuer_key_cache_len(&self) -> usize {
+        self.issuer_keys.len().await
+    }
+
     pub async fn add_token_to_blacklist(&self, token: &str) {
         let hash = bearer_token_hash(token);
         self.token_revocation_list.write().await.insert(hash);
@@ -479,19 +483,7 @@ impl ArunaBearerTokenValidationState for ServerState {
         &self,
         issuer_pubkey: &str,
     ) -> Result<DecodingKey, ArunaBearerTokenError> {
-        let read_lock = self.issuer_keys.read().await;
-        let key = read_lock.get(issuer_pubkey).cloned();
-        drop(read_lock);
-        if let Some(key) = key {
-            return Ok(key);
-        }
-
-        let decoding_key = decoding_key_from_base64_public_key(issuer_pubkey)?;
-        self.issuer_keys
-            .write()
-            .await
-            .insert(issuer_pubkey.to_string(), decoding_key.clone());
-        Ok(decoding_key)
+        self.issuer_keys.get_or_insert(issuer_pubkey).await
     }
 }
 

--- a/api/src/server_state.rs
+++ b/api/src/server_state.rs
@@ -1,5 +1,5 @@
 use crate::auth::{OidcTokenSelector, OidcValidator};
-use crate::error::{OidcError, TokenError};
+use crate::error::OidcError;
 use crate::openapi::ApiDoc;
 use aruna_core::NodeId;
 use aruna_core::auth::{TOKEN_REVOCATION_LIST_KEY, TRUSTED_REALMS_LIST_KEY, bearer_token_hash};
@@ -330,12 +330,6 @@ impl ServerState {
             .map_err(|_| OnboardingSecretError::InvalidSecret),
             _ => Err(OnboardingSecretError::InvalidSecret),
         }
-    }
-
-    pub async fn get_cached_pubkey(&self, pubkey: String) -> Result<DecodingKey, TokenError> {
-        <Self as ArunaBearerTokenValidationState>::decoding_key_for_issuer(self, &pubkey)
-            .await
-            .map_err(Into::into)
     }
 
     pub async fn issuer_key_cache_len(&self) -> usize {

--- a/operations/Cargo.toml
+++ b/operations/Cargo.toml
@@ -26,6 +26,7 @@ futures-util = { workspace = true }
 iroh = { workspace = true }
 irokle = { workspace = true }
 jsonwebtoken = { workspace = true }
+lru = { workspace = true }
 opentelemetry = { workspace = true }
 postcard = { workspace = true }
 rand = { workspace = true }

--- a/operations/src/auth.rs
+++ b/operations/src/auth.rs
@@ -83,11 +83,36 @@ where
         (Some(issuer_pubkey), true) => issuer_pubkey,
         _ => &unvalidated_claims.claims.iss,
     };
-    let decoding_key = state.decoding_key_for_issuer(issuer).await?;
+    // Only trusted realm or delegated issuers may populate the bounded cache;
+    // untrusted issuers are verified with an ephemeral key that is discarded.
+    let decoding_key = if issuer_key_is_trusted(state, &unvalidated_claims.claims).await {
+        state.decoding_key_for_issuer(issuer).await?
+    } else {
+        decoding_key_from_base64_public_key(issuer)?
+    };
     let claims = decode::<TokenClaims>(token, &decoding_key, &Validation::new(Algorithm::EdDSA))?;
 
     validate_aruna_bearer_token_claims(state, &claims.claims).await?;
     Ok(claims.claims)
+}
+
+async fn issuer_key_is_trusted<S>(state: &S, claims: &TokenClaims) -> bool
+where
+    S: ArunaBearerTokenValidationState + ?Sized,
+{
+    let Ok(realm_id) = RealmId::from_base64(&claims.iss) else {
+        return false;
+    };
+    if !state.is_trusted_realm(&realm_id).await {
+        return false;
+    }
+    match (&claims.delegation_signature, &claims.issuer_pubkey) {
+        (Some(delegation_signature), Some(issuer_pubkey)) => {
+            verify_realm_delegation(&claims.iss, issuer_pubkey, delegation_signature).is_ok()
+        }
+        (None, None) => true,
+        (_, _) => false,
+    }
 }
 
 pub async fn validate_aruna_bearer_token_claims<S>(
@@ -110,15 +135,23 @@ where
 
     match (&claims.delegation_signature, &claims.issuer_pubkey) {
         (Some(delegation_signature), Some(issuer_pubkey)) => {
-            let realm_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&claims.iss)?;
-            let realm_verifying_key = VerifyingKey::from_bytes(realm_key.as_slice().try_into()?)?;
-            let signature = Signature::from_str(delegation_signature)?;
-            realm_verifying_key.verify(issuer_pubkey.as_bytes(), &signature)?;
-            Ok(())
+            verify_realm_delegation(&claims.iss, issuer_pubkey, delegation_signature)
         }
         (None, None) => Ok(()),
         (_, _) => Err(ArunaBearerTokenError::InvalidServerToken),
     }
+}
+
+fn verify_realm_delegation(
+    realm_iss: &str,
+    issuer_pubkey: &str,
+    delegation_signature: &str,
+) -> Result<(), ArunaBearerTokenError> {
+    let realm_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(realm_iss)?;
+    let realm_verifying_key = VerifyingKey::from_bytes(realm_key.as_slice().try_into()?)?;
+    let signature = Signature::from_str(delegation_signature)?;
+    realm_verifying_key.verify(issuer_pubkey.as_bytes(), &signature)?;
+    Ok(())
 }
 
 pub fn decoding_key_from_base64_public_key(

--- a/operations/src/auth.rs
+++ b/operations/src/auth.rs
@@ -8,9 +8,13 @@ use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use jsonwebtoken::dangerous::insecure_decode;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use lru::LruCache;
 use std::array::TryFromSliceError;
+use std::num::NonZeroUsize;
 use std::str::FromStr;
+use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 #[async_trait]
 pub trait ArunaBearerTokenValidationState: Sync {
@@ -164,4 +168,118 @@ pub fn decoding_key_from_base64_public_key(
     let public_key = VerifyingKey::from_bytes(&issuer_pubkey)?;
     let public_key_pem = public_key.to_public_key_pem(LineEnding::default())?;
     Ok(DecodingKey::from_ed_pem(public_key_pem.as_bytes())?)
+}
+
+/// Maximum number of issuer decoding keys retained in the process cache.
+pub const ISSUER_KEY_CACHE_CAPACITY: usize = 1024;
+/// Time an issuer decoding key is retained before it is refreshed.
+pub const ISSUER_KEY_CACHE_TTL: Duration = Duration::from_secs(3600);
+
+/// Bounded, TTL + LRU cache of issuer decoding keys keyed by base64 public key.
+pub struct IssuerKeyCache {
+    entries: Mutex<LruCache<String, CachedIssuerKey>>,
+    ttl: Duration,
+}
+
+#[derive(Clone)]
+struct CachedIssuerKey {
+    key: DecodingKey,
+    inserted_at: Instant,
+}
+
+impl std::fmt::Debug for IssuerKeyCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IssuerKeyCache").finish_non_exhaustive()
+    }
+}
+
+impl Default for IssuerKeyCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IssuerKeyCache {
+    pub fn new() -> Self {
+        Self::with_capacity_and_ttl(ISSUER_KEY_CACHE_CAPACITY, ISSUER_KEY_CACHE_TTL)
+    }
+
+    pub fn with_capacity_and_ttl(capacity: usize, ttl: Duration) -> Self {
+        let capacity = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::MIN);
+        Self {
+            entries: Mutex::new(LruCache::new(capacity)),
+            ttl,
+        }
+    }
+
+    pub async fn get_or_insert(
+        &self,
+        issuer_pubkey: &str,
+    ) -> Result<DecodingKey, ArunaBearerTokenError> {
+        let mut entries = self.entries.lock().await;
+        if let Some(entry) = entries.get(issuer_pubkey).cloned() {
+            if entry.inserted_at.elapsed() < self.ttl {
+                return Ok(entry.key);
+            }
+            entries.pop(issuer_pubkey);
+        }
+        let key = decoding_key_from_base64_public_key(issuer_pubkey)?;
+        entries.put(
+            issuer_pubkey.to_string(),
+            CachedIssuerKey {
+                key: key.clone(),
+                inserted_at: Instant::now(),
+            },
+        );
+        Ok(key)
+    }
+
+    pub async fn len(&self) -> usize {
+        self.entries.lock().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.entries.lock().await.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use ed25519_dalek::SigningKey;
+
+    fn pubkey_b64(key: &SigningKey) -> String {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key.verifying_key().to_bytes())
+    }
+
+    #[tokio::test]
+    async fn issuer_key_cache_evicts_beyond_capacity() {
+        let cache = IssuerKeyCache::with_capacity_and_ttl(2, ISSUER_KEY_CACHE_TTL);
+        let mut rng = jsonwebtoken::signature::rand_core::OsRng;
+        for _ in 0..5 {
+            let key = SigningKey::generate(&mut rng);
+            cache.get_or_insert(&pubkey_b64(&key)).await.unwrap();
+        }
+        assert_eq!(cache.len().await, 2);
+    }
+
+    #[tokio::test]
+    async fn issuer_key_cache_refreshes_expired_entries() {
+        let cache = IssuerKeyCache::with_capacity_and_ttl(4, Duration::ZERO);
+        let key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let pubkey = pubkey_b64(&key);
+        cache.get_or_insert(&pubkey).await.unwrap();
+        assert_eq!(cache.len().await, 1);
+        // A zero TTL forces every lookup to expire and refresh instead of accumulating.
+        cache.get_or_insert(&pubkey).await.unwrap();
+        assert_eq!(cache.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn issuer_key_cache_rejects_invalid_pubkey() {
+        let cache = IssuerKeyCache::new();
+        assert!(cache.get_or_insert("not-base64!!").await.is_err());
+        assert!(cache.is_empty().await);
+    }
 }

--- a/operations/src/auth.rs
+++ b/operations/src/auth.rs
@@ -89,7 +89,10 @@ where
     };
     // Only trusted realm or delegated issuers may populate the bounded cache;
     // untrusted issuers are verified with an ephemeral key that is discarded.
-    let decoding_key = if issuer_key_is_trusted(state, &unvalidated_claims.claims).await {
+    let decoding_key = if validate_issuer_trust(state, &unvalidated_claims.claims)
+        .await
+        .is_ok()
+    {
         state.decoding_key_for_issuer(issuer).await?
     } else {
         decoding_key_from_base64_public_key(issuer)?
@@ -100,22 +103,24 @@ where
     Ok(claims.claims)
 }
 
-async fn issuer_key_is_trusted<S>(state: &S, claims: &TokenClaims) -> bool
+async fn validate_issuer_trust<S>(
+    state: &S,
+    claims: &TokenClaims,
+) -> Result<(), ArunaBearerTokenError>
 where
     S: ArunaBearerTokenValidationState + ?Sized,
 {
-    let Ok(realm_id) = RealmId::from_base64(&claims.iss) else {
-        return false;
-    };
+    let realm_id =
+        RealmId::from_base64(&claims.iss).map_err(|_| ArunaBearerTokenError::InvalidIssuerKey)?;
     if !state.is_trusted_realm(&realm_id).await {
-        return false;
+        return Err(ArunaBearerTokenError::RealmNotTrusted);
     }
     match (&claims.delegation_signature, &claims.issuer_pubkey) {
         (Some(delegation_signature), Some(issuer_pubkey)) => {
-            verify_realm_delegation(&claims.iss, issuer_pubkey, delegation_signature).is_ok()
+            verify_realm_delegation(&claims.iss, issuer_pubkey, delegation_signature)
         }
-        (None, None) => true,
-        (_, _) => false,
+        (None, None) => Ok(()),
+        (_, _) => Err(ArunaBearerTokenError::InvalidServerToken),
     }
 }
 
@@ -131,19 +136,7 @@ where
         return Err(ArunaBearerTokenError::Expired);
     }
 
-    let realm_id =
-        RealmId::from_base64(&claims.iss).map_err(|_| ArunaBearerTokenError::InvalidIssuerKey)?;
-    if !state.is_trusted_realm(&realm_id).await {
-        return Err(ArunaBearerTokenError::RealmNotTrusted);
-    }
-
-    match (&claims.delegation_signature, &claims.issuer_pubkey) {
-        (Some(delegation_signature), Some(issuer_pubkey)) => {
-            verify_realm_delegation(&claims.iss, issuer_pubkey, delegation_signature)
-        }
-        (None, None) => Ok(()),
-        (_, _) => Err(ArunaBearerTokenError::InvalidServerToken),
-    }
+    validate_issuer_trust(state, claims).await
 }
 
 fn verify_realm_delegation(

--- a/operations/src/auth.rs
+++ b/operations/src/auth.rs
@@ -264,15 +264,39 @@ mod tests {
         assert_eq!(cache.len().await, 2);
     }
 
+    async fn backdate_entry(cache: &IssuerKeyCache, pubkey: &str, age: Duration) -> Instant {
+        let inserted_at = Instant::now().checked_sub(age).unwrap();
+        cache
+            .entries
+            .lock()
+            .await
+            .peek_mut(pubkey)
+            .unwrap()
+            .inserted_at = inserted_at;
+        inserted_at
+    }
+
+    async fn entry_inserted_at(cache: &IssuerKeyCache, pubkey: &str) -> Instant {
+        cache.entries.lock().await.peek(pubkey).unwrap().inserted_at
+    }
+
     #[tokio::test]
     async fn issuer_key_cache_refreshes_expired_entries() {
-        let cache = IssuerKeyCache::with_capacity_and_ttl(4, Duration::ZERO);
+        let ttl = Duration::from_secs(3600);
+        let cache = IssuerKeyCache::with_capacity_and_ttl(4, ttl);
         let key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
         let pubkey = pubkey_b64(&key);
         cache.get_or_insert(&pubkey).await.unwrap();
-        assert_eq!(cache.len().await, 1);
-        // A zero TTL forces every lookup to expire and refresh instead of accumulating.
+
+        // Just inside the TTL: served from cache, entry untouched.
+        let inside = backdate_entry(&cache, &pubkey, ttl - Duration::from_secs(60)).await;
         cache.get_or_insert(&pubkey).await.unwrap();
+        assert_eq!(entry_inserted_at(&cache, &pubkey).await, inside);
+
+        // Just past the TTL: refreshed in place without accumulating.
+        let expired = backdate_entry(&cache, &pubkey, ttl + Duration::from_secs(1)).await;
+        cache.get_or_insert(&pubkey).await.unwrap();
+        assert!(entry_inserted_at(&cache, &pubkey).await > expired);
         assert_eq!(cache.len().await, 1);
     }
 

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -41,7 +41,6 @@ use jsonwebtoken::DecodingKey;
 use oxrdf::{BlankNode, Literal, NamedNode, Term};
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
-use tokio::sync::RwLock;
 use tokio::time::{sleep, timeout};
 use tracing::{Instrument, Span, debug_span, field, warn};
 use ulid::Ulid;
@@ -49,7 +48,7 @@ use ulid::Ulid;
 use super::protocol::{MetadataAuthToken, MetadataTransportMessage, read_message, write_message};
 use super::repository::{REGISTRY_FILL_PAGE_SIZE, iter_all_registry_effect, parse_registry_iter};
 use crate::auth::{
-    ArunaBearerTokenError, ArunaBearerTokenValidationState, decoding_key_from_base64_public_key,
+    ArunaBearerTokenError, ArunaBearerTokenValidationState, IssuerKeyCache,
     validate_aruna_bearer_token,
 };
 use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
@@ -131,14 +130,14 @@ struct MetadataInner {
 #[derive(Clone)]
 struct MetadataAuthValidationState {
     storage_handle: StorageHandle,
-    issuer_keys: Arc<RwLock<HashMap<String, DecodingKey>>>,
+    issuer_keys: Arc<IssuerKeyCache>,
 }
 
 impl MetadataAuthValidationState {
     fn new(storage_handle: StorageHandle) -> Self {
         Self {
             storage_handle,
-            issuer_keys: Arc::new(RwLock::new(HashMap::new())),
+            issuer_keys: Arc::new(IssuerKeyCache::new()),
         }
     }
 }
@@ -179,19 +178,7 @@ impl ArunaBearerTokenValidationState for MetadataAuthValidationState {
         &self,
         issuer_pubkey: &str,
     ) -> Result<DecodingKey, ArunaBearerTokenError> {
-        let read_lock = self.issuer_keys.read().await;
-        let key = read_lock.get(issuer_pubkey).cloned();
-        drop(read_lock);
-        if let Some(key) = key {
-            return Ok(key);
-        }
-
-        let decoding_key = decoding_key_from_base64_public_key(issuer_pubkey)?;
-        self.issuer_keys
-            .write()
-            .await
-            .insert(issuer_pubkey.to_string(), decoding_key.clone());
-        Ok(decoding_key)
+        self.issuer_keys.get_or_insert(issuer_pubkey).await
     }
 }
 


### PR DESCRIPTION
Closes #345

Unverified JWT claims selected the issuer key, which was parsed and inserted into an unbounded process-lifetime cache before any trust check — an unauthenticated memory-exhaustion vector.

- A trust gate runs before caching: only a trusted realm (with a valid delegation signature over the issuer pubkey) reaches the cached path; untrusted issuers decode with an ephemeral, never-cached key.
- Both caches (API `ServerState` and the metadata validator) are replaced by one bounded `IssuerKeyCache` (LRU 1024 entries + 1h TTL).
