### PR TITLE
[chore] Supply chain and build hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@ target
 .env
 **/.env
 .compose-data
+docker/*
+!docker/portal
+docker/portal/*
+!docker/portal/.gitkeep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,30 +17,33 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install mold linker
         run: sudo apt-get update && sudo apt-get install -y clang mold
 
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: "1.95.0"
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run workspace tests
-        run: cargo test --workspace --all-targets
+        run: cargo test --workspace --all-targets --locked
 
   fmt:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install nightly rustfmt
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: nightly
           components: rustfmt
 
       - name: Check formatting
@@ -51,18 +54,53 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install mold linker
         run: sudo apt-get update && sudo apt-get install -y clang mold
 
       - name: Install nightly clippy
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: nightly
           components: clippy
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run clippy
-        run: cargo +nightly clippy --workspace --all-targets -- -D warnings
+        run: cargo +nightly clippy --workspace --all-targets --locked -- -D warnings
+
+  deny:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check
+
+  shellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run ShellCheck
+        run: shellcheck scripts/*.sh
+
+  compose-config:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Validate compose files
+        run: |
+          docker compose -f scripts/compose.yaml config --quiet
+          docker compose -f scripts/keycloak/docker-compose.yml config --quiet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3425,7 +3425,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -4601,7 +4601,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4644,7 +4644,7 @@ checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5225,7 +5225,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.8.7",
+ "rand 0.9.5",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -5857,7 +5857,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5896,7 +5896,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6989,7 +6989,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.8.7",
+ "rand 0.9.5",
  "regex",
  "rustc-hash",
  "sha1 0.10.7",
@@ -7010,7 +7010,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.8.7",
+ "rand 0.9.5",
  "thiserror 2.0.18",
 ]
 
@@ -7021,7 +7021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
 dependencies = [
  "oxrdf",
- "rand 0.8.7",
+ "rand 0.9.5",
  "spargebra",
 ]
 
@@ -8552,7 +8552,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "ulid",
+ "ulid 2.0.1",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-opentelemetry",
- "ulid",
+ "ulid 2.0.1",
  "url",
  "utoipa",
  "utoipa-swagger-ui",
@@ -293,7 +293,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
+ "ulid 2.0.1",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "ulid",
+ "ulid 2.0.1",
 ]
 
 [[package]]
@@ -359,7 +359,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "ulid",
+ "ulid 2.0.1",
 ]
 
 [[package]]
@@ -392,7 +392,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-opentelemetry",
- "ulid",
+ "ulid 2.0.1",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "ulid",
+ "ulid 2.0.1",
 ]
 
 [[package]]
@@ -453,7 +453,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "ulid",
+ "ulid 2.0.1",
 ]
 
 [[package]]
@@ -8103,7 +8103,16 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.5",
+ "web-time",
+]
+
+[[package]]
+name = "ulid"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39493d572b98fe1d142e132e7a726c50c68121bce84429216a5ec20e1ad7fec5"
+dependencies = [
+ "rand 0.10.2",
  "serde",
  "web-time",
 ]
@@ -8234,7 +8243,7 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.118",
- "ulid",
+ "ulid 1.2.1",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
  "iroh",
  "irokle",
  "jsonwebtoken",
- "lru 0.18.0",
+ "lru 0.18.1",
  "opentelemetry",
  "oxrdf",
  "postcard",
@@ -655,9 +655,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "47712fde1909402600ccfbb26e47d482d2e58bb9e9e603d9f17e67cc435a6319"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -676,7 +676,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.2",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "time",
  "tokio",
  "tracing",
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.5"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.137.0"
+version = "1.138.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874"
+checksum = "7c29be98554a0deea25d4eaca131240a224dcbcaf20357e35cc432e17b721ab5"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -765,6 +765,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
@@ -785,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.102.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
+checksum = "0469f435f645ad2162cfb463b15bde37115966ee3acf2d87fb4871ee309b8401"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -798,6 +799,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -810,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.104.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
+checksum = "085faefb253f770655e162b9304321e62a1e71adf7f019ee1f4454228a377b3a"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -823,6 +825,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -835,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+checksum = "3c72b08911d8128dd360fe1b22a9fec0fa8b552dde8ec828dcf20ef5ec974e9f"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -849,6 +852,7 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
@@ -861,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -888,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -899,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -920,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.21"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -931,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -953,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -983,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -994,18 +998,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "dd22a6ba36e3f113cb8d5b3d1fe0ed31c76ee608ef63322d753bb8d2c9479e77"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -1013,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1039,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1057,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1068,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1079,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1105,18 +1109,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "ea3f68eec3607f02acd24067969ce2abc6ba16aa7d5ce59ca450ed2fb5f78957"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.16"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1336,15 +1343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,7 +1380,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1421,9 +1419,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -1454,19 +1452,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1804,18 +1793,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1823,18 +1812,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1851,20 +1840,20 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossfire"
-version = "3.1.18"
+version = "3.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df981decccf9b846c396ae513b3d2c6a1770d9593c8e47853d8fdb336c7bcb46"
+checksum = "111ce8f7abfbac38b4bc4f32a3a2dda1a8034b873c90c7899f302cc9dbbc05ec"
 dependencies = [
  "crossbeam-utils",
- "embed-collections",
  "futures-core",
  "parking_lot",
+ "pointers",
  "smallvec",
 ]
 
@@ -2014,8 +2003,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -2033,12 +2032,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -2133,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
@@ -2177,7 +2200,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2424,12 +2447,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "embed-collections"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be5eeb1388bef284c44bf61743bc1ec0173c67d2a7d68426bdf758a72c0f13d"
 
 [[package]]
 name = "embedded-io"
@@ -3417,7 +3434,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3600,7 +3617,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -3655,9 +3671,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2e38557969901f8b356d1ebd882253bab98cc81500d53e7bcbf33f56082303"
+checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
 dependencies = [
  "backon",
  "blake3",
@@ -3706,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cdf012298adc13f5c2c821ad87214fecc9ac54c751301d45bf62b229a85da1"
+checksum = "830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d"
 dependencies = [
  "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
@@ -3725,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24b83aae5ed4eced1c3724204c083c28c84c5d225a88e277eceeccce3dc3bd"
+checksum = "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3789,9 +3805,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f16a5505939f9250297ff2f1210b5142d13618f496eab03ce3f964fc47e2e2b"
+checksum = "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354"
 dependencies = [
  "blake3",
  "bytes",
@@ -3807,7 +3823,7 @@ dependencies = [
  "iroh-base",
  "iroh-dns",
  "iroh-metrics",
- "lru 0.18.0",
+ "lru 0.18.1",
  "n0-error",
  "n0-future",
  "noq",
@@ -3886,9 +3902,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -3904,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3915,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -4043,7 +4059,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
@@ -4200,9 +4216,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -4287,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "mea"
@@ -4311,9 +4327,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -4637,7 +4653,7 @@ checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4672,7 +4688,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -4694,11 +4710,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -5123,7 +5138,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5194,7 +5209,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "ryu-js",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5206,9 +5221,9 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5221,7 +5236,7 @@ dependencies = [
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5234,7 +5249,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5243,7 +5258,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5256,7 +5271,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5329,16 +5344,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "peg"
@@ -5476,29 +5481,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der 0.7.10",
- "pbkdf2",
- "scrypt",
- "sha2 0.10.9",
- "spki 0.7.3",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "pkcs5",
- "rand_core 0.6.4",
  "spki 0.7.3",
 ]
 
@@ -5508,7 +5496,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
+ "der 0.8.1",
  "spki 0.8.0",
 ]
 
@@ -5536,6 +5524,12 @@ dependencies = [
  "serde",
  "time",
 ]
+
+[[package]]
+name = "pointers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcdc93847ad24990939cce6e1804361e903efcb5f99daa5abd87943a9d6d7ba"
 
 [[package]]
 name = "polling"
@@ -5770,7 +5764,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -5831,16 +5825,6 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -5918,7 +5902,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5946,9 +5930,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5957,9 +5941,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6121,9 +6105,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6133,9 +6117,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6156,9 +6140,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqsign-aws-v4"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75624bd8a466e37ddc0a7b6c33ac859a85347c153a916e1dd9d0b68338f74a"
+checksum = "4e9e1168fab3883ec6afed1c2e20c25b2a09f366cdb662ac3e0878ae0332d63e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6167,7 +6151,7 @@ dependencies = [
  "http 1.4.2",
  "log",
  "percent-encoding",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "reqsign-core",
  "rust-ini",
  "serde",
@@ -6178,9 +6162,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-core"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fa5cb48808693614d1701fcd3db0b30fa292e0f18e122ae068b6d32eaeed3f"
+checksum = "514a1e0b4aa288652a3fdbda4f0a610f379cdf5374e55a37c9edd03d57ed856b"
 dependencies = [
  "anyhow",
  "base64",
@@ -6193,9 +6177,6 @@ dependencies = [
  "jiff",
  "log",
  "percent-encoding",
- "rsa",
- "serde",
- "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "windows-sys 0.61.2",
@@ -6203,9 +6184,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-file-read-tokio"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4b6f3a3fd29ffcc99a90aec585a65217783badfd73acddf847b63ae683bda9"
+checksum = "2b472a8d1f2e5a4be8ce13bb7bdf4b59e9bee613ce124aca23959ddb42176b39"
 dependencies = [
  "anyhow",
  "reqsign-core",
@@ -6318,7 +6299,6 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -6327,9 +6307,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -6338,10 +6318,11 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
@@ -6351,11 +6332,11 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
@@ -6381,9 +6362,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -6514,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -6538,9 +6519,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "s3s"
@@ -6632,17 +6613,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "sct"
@@ -6818,9 +6788,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -7010,7 +6980,7 @@ dependencies = [
  "memchr",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7025,15 +6995,15 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "rustc-hash",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7046,7 +7016,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
 ]
 
@@ -7057,7 +7027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
 dependencies = [
  "oxrdf",
- "rand 0.9.4",
+ "rand 0.9.5",
  "spargebra",
 ]
 
@@ -7104,7 +7074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -7223,10 +7193,10 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -7261,7 +7231,7 @@ dependencies = [
  "md-5 0.10.6",
  "memchr",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -7669,9 +7639,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -7730,9 +7700,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8139,7 +8109,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "web-time",
 ]
@@ -8579,7 +8549,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9049,18 +9019,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9171,9 +9141,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "craqle"
 version = "0.1.1"
-source = "git+https://github.com/arunaengine/craqle?branch=main#5c31d358b3069595fe663724a92974efb02f73a0"
+source = "git+https://github.com/arunaengine/craqle?rev=5c31d358b3069595fe663724a92974efb02f73a0#5c31d358b3069595fe663724a92974efb02f73a0"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "craqle"
 version = "0.1.1"
-source = "git+https://github.com/arunaengine/craqle?rev=5c31d358b3069595fe663724a92974efb02f73a0#5c31d358b3069595fe663724a92974efb02f73a0"
+source = "git+https://github.com/arunaengine/craqle?rev=cb38935800ea2df442536230274cdd070acabecd#cb38935800ea2df442536230274cdd070acabecd"
 dependencies = [
  "blake3",
  "chrono",
@@ -2094,7 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3425,7 +3425,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4601,7 +4601,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4644,7 +4644,7 @@ checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5225,7 +5225,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.9.5",
+ "rand 0.8.7",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -5857,7 +5857,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5896,7 +5896,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6989,7 +6989,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.9.5",
+ "rand 0.8.7",
  "regex",
  "rustc-hash",
  "sha1 0.10.7",
@@ -7010,7 +7010,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.9.5",
+ "rand 0.8.7",
  "thiserror 2.0.18",
 ]
 
@@ -7021,7 +7021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
 dependencies = [
  "oxrdf",
- "rand 0.9.5",
+ "rand 0.8.7",
  "spargebra",
 ]
 
@@ -8552,7 +8552,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,15 +1768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4894,12 +4885,13 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendal"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
+checksum = "77d02c6564e376d3670aaf66ad886cd34f83c0aca407b6364777c624a63e0e2d"
 dependencies = [
  "ctor",
  "opendal-core",
+ "opendal-http-transport-reqwest",
  "opendal-layer-concurrent-limit",
  "opendal-layer-logging",
  "opendal-layer-retry",
@@ -4914,24 +4906,22 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f8607c90e2c963a91467f50fb49fbc7fb3d573f88cea219ca59ccd3740b309"
+checksum = "f8564bd76b75d2aea59178cb5b6e9f770be1da73b1bca062720ec151cc56215a"
 dependencies = [
  "anyhow",
  "base64",
  "bytes",
  "futures",
  "http 1.4.2",
- "http-body 1.0.1",
  "jiff",
  "log",
  "md-5 0.11.0",
  "mea",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "reqsign-core",
- "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -4941,10 +4931,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-layer-concurrent-limit"
-version = "0.57.0"
+name = "opendal-http-transport-reqwest"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6f81ba6960e3fae1882f253b114b21d7e444e1534f209c7737a79f6243eb6f"
+checksum = "5b7fd001b204df76be5d2b3f7a81c48b5cf25b28e2cfb3b8a819bb89cdc0ea3a"
+dependencies = [
+ "bytes",
+ "futures",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "opendal-core",
+ "reqwest",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "215341e41220815d7945e5b936323ead2248354d2d69573a1cd9d1a30aa09440"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -4954,9 +4958,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ada45c6d81d1aa4c9305d0c7d4bc317c59c85866a0908a2d75a7a978aa5ee2"
+checksum = "ed46bc88c1ea9b961c342a796ec790ee5a0ac5a02bf465aea6791684d72ca291"
 dependencies = [
  "log",
  "opendal-core",
@@ -4964,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2a25a718afb81fad81cb9a0580a1cb989221fa2317f888c6a37f8dad408eb7"
+checksum = "f2df70875ab7fd6f80720d4787c49c70883cef0d81bfae947ecba88b8d1cd62e"
 dependencies = [
  "backon",
  "log",
@@ -4975,9 +4979,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
+checksum = "18f1bb30ab396a617ef884863b27ae91fbe966e312ce69876fa41584ab0fc5c6"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -4985,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e89a665fef0e6bd249cf5ea47fc174b7ba892159bee4b9382528b1ca873a2c"
+checksum = "3f26a923b72b96d1a3dbbe961fcad4d534bf586c3f48c583e9f35649b1b6175f"
 dependencies = [
  "bytes",
  "log",
@@ -4999,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ftp"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9e27d42f3d8c52ff00fa234f0d58115ab13deb9017b0aa1fa71972c7faef5f"
+checksum = "4fd0e582b15c6c4af448c60c877c8fbae3f689f94e66a836972064fee0415529"
 dependencies = [
  "bytes",
  "fastpool",
@@ -5018,9 +5022,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6af628a0bf14075b957179444927e1df40dc7addef382b585a05ef015a077b"
+checksum = "45c7a45ce34d883403eaaa67825a76abc133d6d922b2fe1820b543b71d30e47d"
 dependencies = [
  "http 1.4.2",
  "log",
@@ -5030,9 +5034,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-postgresql"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f3b17c41acaed9644c494ef6f8ea99f1a3be66cd5523018ee4da5caeaf6d96"
+checksum = "73993f9b1864e3104a9c5665b6047b25351c7919fcf5615c16a3ca68430399f5"
 dependencies = [
  "mea",
  "opendal-core",
@@ -5042,18 +5046,18 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313d46c9f5ae70bca26b7c3e3fbb9b639292625f28af73aa016f47e788af9deb"
+checksum = "750d9cc8588c19b27c4c2c5d06d7eb6f2bff62549c48652f1f9a7603cd872377"
 dependencies = [
  "base64",
  "bytes",
- "crc32c",
+ "crc-fast",
  "http 1.4.2",
  "log",
  "md-5 0.11.0",
  "opendal-core",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "reqsign-aws-v4",
  "reqsign-core",
  "reqsign-file-read-tokio",
@@ -5063,9 +5067,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9edadbbf8311e4d382400a5c6021bbfcc850f472a60995897bdc5cbf2d1cabd"
+checksum = "48e7527c793412d4b129f334258af73689e144cb91610cabfbdb47d410248c08"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5073,7 +5077,7 @@ dependencies = [
  "log",
  "mea",
  "opendal-core",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "serde",
 ]
 
@@ -5818,16 +5822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ bytes = "1.12.0"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 console-subscriber = "0.5.0"
-craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", features = [
+craqle = { git = "https://github.com/arunaengine/craqle", rev = "5c31d358b3069595fe663724a92974efb02f73a0", features = [
     "iroh",
 ] }
 crc-fast = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,15 +35,15 @@ aruna-tasks = { path = "tasks" }
 # Third-party crates
 ahash = "0.8.12"
 async-trait = "0.1.89"
-aws-config = "1.8.18"
-aws-sdk-s3 = "1.137.0"
+aws-config = "1.9.0"
+aws-sdk-s3 = "1.138.0"
 axum = "0.8.9"
 axum-extra = { version = "0.12.6", features = ["query"] }
 bao-tree = "0.16.0"
 base64 = "0.22.1"
 blake3 = { version = "1.8.5", features = ["serde"] }
 byteview = "0.10.1"
-bytes = "1.12.0"
+bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 console-subscriber = "0.5.0"
@@ -51,7 +51,7 @@ craqle = { git = "https://github.com/arunaengine/craqle", rev = "5c31d358b306959
     "iroh",
 ] }
 crc-fast = "1.10.0"
-crossfire = "3.1.18"
+crossfire = "3.1.19"
 crypto_box = "0.9.1"
 data-encoding = "2.11.0"
 dotenvy = "0.15.7"
@@ -73,8 +73,8 @@ hyper-util = { version = "0.1.20", features = [
     "tokio",
     "service",
 ] }
-iroh = "1.0.1"
-iroh-base = "1.0.1"
+iroh = "1.0.2"
+iroh-base = "1.0.2"
 irokle = { git = "https://github.com/arunaengine/irokle.git", branch = "main", features = [
     "fjall",
     "iroh",
@@ -82,8 +82,8 @@ irokle = { git = "https://github.com/arunaengine/irokle.git", branch = "main", f
 iroh-io = "0.6.2"
 iroh-quinn = "0.16.1"
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
-lru = "0.18.0"
-md5 = "0.8.0"
+lru = "0.18.1"
+md5 = "0.8.1"
 n0-future = "0.3.2"
 opendal = { version = "0.57", features = [
     "services-postgresql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
 lru = "0.18.1"
 md5 = "0.8.1"
 n0-future = "0.3.2"
-opendal = { version = "0.57", features = [
+opendal = { version = "0.58.0", features = [
     "services-postgresql",
     "services-fs",
     "services-ftp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ tracing-subscriber = { version = "0.3.23", features = [
     "fmt",
     "registry",
 ] }
-ulid = { version = "1.2.1", features = ["serde"] }
+ulid = { version = "2.0.1", features = ["serde"] }
 url = "2.5.8"
 utoipa = { version = "5.5.0", features = [
     "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 console-subscriber = "0.5.0"
-craqle = { git = "https://github.com/arunaengine/craqle", rev = "5c31d358b3069595fe663724a92974efb02f73a0", features = [
+craqle = { git = "https://github.com/arunaengine/craqle", rev = "cb38935800ea2df442536230274cdd070acabecd", features = [
     "iroh",
 ] }
 crc-fast = "1.10.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN cargo install --locked --version 0.101.0 --root target iroh-doctor
 
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 WORKDIR /run
+# .dockerignore strips local files under docker/, so the default build ships an empty portal.
+# To embed portal assets, pass --build-arg PORTAL_EMBED_DIR=<staged dir outside docker/>.
 ARG PORTAL_EMBED_DIR=docker/portal
 ARG PORTAL_MODE=disabled
 RUN apk update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM rust:1-alpine3.24 AS builder
+FROM rust:1-alpine3.24@sha256:ec9c91e77119ce498cd1e87d96d77e0f75b2cee21655a29bc2bf75a51a2b20a4 AS builder
 WORKDIR /build
 RUN apk update
 RUN apk upgrade
@@ -7,11 +7,11 @@ ENV RUSTFLAGS="-C target-feature=-crt-static"
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN apk add llvm cmake gcc ca-certificates libc-dev pkgconfig openssl-dev musl-dev git curl
 COPY . .
-RUN cargo build --release -p aruna
-RUN cargo build --release -p aruna-doctor
-RUN cargo install --locked --root target iroh-doctor
+RUN cargo build --release --locked -p aruna
+RUN cargo build --release --locked -p aruna-doctor
+RUN cargo install --locked --version 0.101.0 --root target iroh-doctor
 
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 WORKDIR /run
 ARG PORTAL_EMBED_DIR=docker/portal
 ARG PORTAL_MODE=disabled

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -792,7 +792,7 @@ mod test {
         let realm_signing_key = SigningKey::generate(&mut csprng);
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::generate().public();
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         drive(
             CreateRealmOperation::new(CreateRealmConfig {
                 actor: Actor {
@@ -1196,7 +1196,7 @@ mod test {
     #[tokio::test]
     pub async fn test_token_capabilities() {
         let mut tempdir = temp_dir();
-        tempdir.push(Ulid::new().to_string());
+        tempdir.push(Ulid::r#gen().to_string());
         let storage_handle = storage::FjallStorage::open(tempdir.to_str().unwrap()).unwrap();
         let driver_ctx = Arc::new(DriverContext {
             storage_handle,
@@ -1235,7 +1235,7 @@ mod test {
 
         let time = chrono::Utc::now().timestamp() as u64;
         let expiry = None;
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
 
         drive(
             RegisterOrGetOidcUserOperation::new(RegisterOrGetOidcUserInput {
@@ -1367,7 +1367,7 @@ mod test {
     #[tokio::test]
     pub async fn test_unknown_token_user_is_rejected() {
         let mut tempdir = temp_dir();
-        tempdir.push(Ulid::new().to_string());
+        tempdir.push(Ulid::r#gen().to_string());
         let storage_handle = storage::FjallStorage::open(tempdir.to_str().unwrap()).unwrap();
         let net_handle = NetHandle::new(
             NetConfig {
@@ -1445,7 +1445,7 @@ mod test {
         .await;
 
         let time = chrono::Utc::now().timestamp() as u64;
-        let unknown_user = UserId::local(Ulid::new(), realm_id);
+        let unknown_user = UserId::local(Ulid::r#gen(), realm_id);
         let token = drive(
             CreateTokenOperation::new(CreateTokenConfig {
                 time,
@@ -1481,7 +1481,7 @@ mod test {
     #[tokio::test]
     pub async fn test_token_validation() {
         let mut tempdir = temp_dir();
-        tempdir.push(Ulid::new().to_string());
+        tempdir.push(Ulid::r#gen().to_string());
         let storage_handle = storage::FjallStorage::open(tempdir.to_str().unwrap()).unwrap();
         let driver_ctx = Arc::new(DriverContext {
             storage_handle,
@@ -1525,7 +1525,7 @@ mod test {
                 .unwrap()
                 .timestamp() as u64,
         );
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
 
         drive(
             RegisterOrGetOidcUserOperation::new(RegisterOrGetOidcUserInput {
@@ -1730,11 +1730,11 @@ mod test {
         let issuer_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(issuer_key.verifying_key().to_bytes());
         let claims = TokenClaims {
-            sub: format!("{}@{}", Ulid::new(), issuer_b64),
+            sub: format!("{}@{}", Ulid::r#gen(), issuer_b64),
             iss: issuer_b64,
             iat: now,
             exp: now + 600,
-            jti: Ulid::new().to_string(),
+            jti: Ulid::r#gen().to_string(),
             restrictions: None,
             issuer_pubkey: None,
             delegation_signature: None,
@@ -1753,7 +1753,7 @@ mod test {
     #[tokio::test]
     async fn rejected_token_flood_keeps_issuer_cache_bounded() {
         let mut tempdir = temp_dir();
-        tempdir.push(Ulid::new().to_string());
+        tempdir.push(Ulid::r#gen().to_string());
         let storage_handle = storage::FjallStorage::open(tempdir.to_str().unwrap()).unwrap();
         let driver_ctx = Arc::new(DriverContext {
             storage_handle,
@@ -1810,7 +1810,7 @@ mod test {
     #[tokio::test]
     async fn valid_delegated_token_caches_single_issuer_key() {
         let mut tempdir = temp_dir();
-        tempdir.push(Ulid::new().to_string());
+        tempdir.push(Ulid::r#gen().to_string());
         let storage_handle = storage::FjallStorage::open(tempdir.to_str().unwrap()).unwrap();
         let driver_ctx = Arc::new(DriverContext {
             storage_handle,
@@ -1863,7 +1863,7 @@ mod test {
             CreateTokenOperation::new(CreateTokenConfig {
                 time: chrono::Utc::now().timestamp().max(0) as u64,
                 expiry: None,
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
                 node_capabilities: capabilities,
             })

--- a/api/src/routes/connectors.rs
+++ b/api/src/routes/connectors.rs
@@ -631,8 +631,8 @@ mod tests {
             storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
         let realm_id = aruna_core::structs::RealmId([3u8; 32]);
         let node_id = iroh::SecretKey::from_bytes(&[11u8; 32]).public();
-        let user_id = UserId::local(Ulid::new(), realm_id);
-        let other_user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
+        let other_user_id = UserId::local(Ulid::r#gen(), realm_id);
         let actor = Actor {
             node_id,
             user_id,
@@ -645,7 +645,7 @@ mod tests {
             metadata_handle: None,
             task_handle: None,
         });
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let group_auth =
             GroupAuthorizationDocument::new_default_group_doc(user_id, realm_id, group_id);
         let group = Group {

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -924,7 +924,7 @@ pub async fn create_group_role(
         assigned_users.insert(UserId::nil(realm_id));
     }
 
-    let role_id = Ulid::new();
+    let role_id = Ulid::r#gen();
     let (_, auth_doc) = drive(
         AddGroupRoleOperation::new(AddGroupRoleConfig {
             auth_context: auth.clone(),

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1639,7 +1639,7 @@ mod tests {
             .send_storage_effect(StorageEffect::Read {
                 key_space: "missing".to_string(),
                 key: b"key".to_vec().into(),
-                txn_id: Some(ulid::Ulid::new()),
+                txn_id: Some(ulid::Ulid::r#gen()),
             })
             .await;
 
@@ -1712,7 +1712,7 @@ mod tests {
 
     fn test_auth_context(state: &Arc<ServerState>) -> AuthContext {
         AuthContext {
-            user_id: UserId::local(Ulid::new(), state.get_realm_id()),
+            user_id: UserId::local(Ulid::r#gen(), state.get_realm_id()),
             realm_id: state.get_realm_id(),
             path_restrictions: None,
         }
@@ -1752,8 +1752,8 @@ mod tests {
 
     #[test]
     fn group_quota_status_reports_warning_and_unlimited() {
-        let group = Ulid::new();
-        let unlimited_group = Ulid::new();
+        let group = Ulid::r#gen();
+        let unlimited_group = Ulid::r#gen();
         let quota = QuotaConfig {
             default_group_quota_bytes: Some(1_000),
             grace_factor_percent: 110,
@@ -1786,7 +1786,7 @@ mod tests {
 
     #[test]
     fn group_quota_status_uses_fractional_warn_threshold_without_flooring() {
-        let group = Ulid::new();
+        let group = Ulid::r#gen();
         let quota = QuotaConfig {
             default_group_quota_bytes: Some(3),
             warn_threshold_percent: 85,
@@ -1840,7 +1840,7 @@ mod tests {
         let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
         let realm_signing_key = SigningKey::generate(&mut csprng);
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::generate().public();
 
         drive(
@@ -1916,7 +1916,7 @@ mod tests {
 
         let (local_state, _tempdir) = setup_state().await;
         let local_auth = AuthContext {
-            user_id: UserId::local(Ulid::new(), local_state.get_realm_id()),
+            user_id: UserId::local(Ulid::r#gen(), local_state.get_realm_id()),
             realm_id: local_state.get_realm_id(),
             path_restrictions: None,
         };
@@ -1934,7 +1934,7 @@ mod tests {
         ));
 
         let stranger = AuthContext {
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
             path_restrictions: None,
         };
@@ -2268,7 +2268,7 @@ mod tests {
     async fn set_realm_quota_rejects_non_admin() {
         let (state, realm_id, _admin, _tempdir) = setup_management_state().await;
         let stranger = AuthContext {
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
             path_restrictions: None,
         };

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -484,7 +484,7 @@ pub async fn create_metadata_document(
                     realm_id: state.get_realm_id(),
                 },
                 group_id,
-                document_id: Ulid::new(),
+                document_id: Ulid::r#gen(),
                 document_path: path,
                 public,
                 payload,
@@ -501,7 +501,7 @@ pub async fn create_metadata_document(
     emit_resource_watch_event(
         ctx.as_ref(),
         WatchEvent {
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             realm_id: state.get_realm_id(),
             kind: WatchEventKind::MetadataCreated,
             path: format!("meta/{}/{}", result.group_id, result.document_path),
@@ -2042,7 +2042,7 @@ mod tests {
         );
         let lifecycle = MetadataDocumentLifecycleRecord::Delete {
             event: MetadataDocumentDeleteRecord {
-                event_id: Ulid::new(),
+                event_id: Ulid::r#gen(),
                 tombstone: tombstone.clone(),
                 deleted_after_event_id: record.last_event_id,
             },
@@ -2160,7 +2160,7 @@ mod tests {
             State(test.state),
             Extension(None),
             Extension(None),
-            Path(Ulid::new().to_string()),
+            Path(Ulid::r#gen().to_string()),
             Json(SparqlQueryRequest {
                 query: "ASK WHERE { ?s ?p ?o }".to_string(),
                 mode: None,
@@ -2251,10 +2251,10 @@ mod tests {
     fn document_replica_query_nodes_use_deduplicated_replicas() {
         let local_node_id = iroh::SecretKey::from_bytes(&[21u8; 32]).public();
         let remote_node_id = iroh::SecretKey::from_bytes(&[22u8; 32]).public();
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let record = MetadataRegistryRecord {
             realm_id: RealmId([3u8; 32]),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             document_id,
             document_path: "datasets/query-targets".to_string(),
             graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
@@ -2306,7 +2306,7 @@ mod tests {
     async fn load_metadata_record_by_document_returns_internal_error_on_storage_failure() {
         let state = setup_state_with_closed_storage().await;
 
-        let result = load_metadata_record_by_document(state.as_ref(), Ulid::new()).await;
+        let result = load_metadata_record_by_document(state.as_ref(), Ulid::r#gen()).await;
 
         assert!(matches!(
             result,
@@ -2317,7 +2317,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_permission_returns_forbidden_for_nonexistent_group() {
         let test = setup_state().await;
-        let missing_group = Ulid::new();
+        let missing_group = Ulid::r#gen();
         let path = format!("/{}/g/{missing_group}/meta/**", test.state.get_realm_id());
 
         let result = ensure_permission(
@@ -2954,8 +2954,8 @@ mod tests {
     async fn setup_distributed_metadata_access_state() -> DistributedMetadataAccessState {
         let realm_signing_key = test_realm_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
-        let user_id = aruna_core::UserId::local(Ulid::new(), realm_id);
-        let group_id = Ulid::new();
+        let user_id = aruna_core::UserId::local(Ulid::r#gen(), realm_id);
+        let group_id = Ulid::r#gen();
         let coordinator = spawn_distributed_metadata_node(realm_id).await;
         let remote = spawn_distributed_metadata_node(realm_id).await;
         let nodes = [&coordinator, &remote];
@@ -3276,7 +3276,7 @@ mod tests {
             iss: realm_id.to_string(),
             iat: now,
             exp: now + 600,
-            jti: Ulid::new().to_string(),
+            jti: Ulid::r#gen().to_string(),
             restrictions: None,
             issuer_pubkey: None,
             delegation_signature: None,
@@ -3300,7 +3300,7 @@ mod tests {
             storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
         let node_id = iroh::SecretKey::from_bytes(&[11u8; 32]).public();
         let realm_id = test_realm_id(3);
-        let user_id = aruna_core::UserId::local(Ulid::new(), realm_id);
+        let user_id = aruna_core::UserId::local(Ulid::r#gen(), realm_id);
         let actor = Actor {
             node_id,
             user_id,
@@ -3323,7 +3323,7 @@ mod tests {
             metadata_handle: Some(metadata_handle),
             task_handle: Some(task_handle),
         });
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let group_auth =
             GroupAuthorizationDocument::new_default_group_doc(user_id, realm_id, group_id);
         let group = Group {

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -990,7 +990,7 @@ mod tests {
     async fn path_restricted_token_rejected() {
         let realm_id = realm_id(5);
         let (_dir, state) = build_state(realm_id, node(5)).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
         let mut auth = auth_for(user_id, realm_id);
         auth.path_restrictions = Some(vec![PathRestriction {
             pattern: "/bucket/**".to_string(),
@@ -1055,7 +1055,7 @@ mod tests {
     async fn mark_read_rejects_bad_ids() {
         let realm_id = realm_id(2);
         let (_dir, state) = build_state(realm_id, node(2)).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
         let error = mark_read(
             State(state),
             Extension(Some(auth_for(user_id, realm_id))),
@@ -1073,13 +1073,13 @@ mod tests {
     async fn mark_read_rejects_too_many_ids() {
         let realm_id = realm_id(6);
         let (_dir, state) = build_state(realm_id, node(6)).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
         let error = mark_read(
             State(state),
             Extension(Some(auth_for(user_id, realm_id))),
             Json(MarkReadApiRequest {
                 ids: (0..=MARK_READ_MAX_IDS)
-                    .map(|_| Ulid::new().to_string())
+                    .map(|_| Ulid::r#gen().to_string())
                     .collect(),
                 up_to_ms: None,
             }),
@@ -1096,7 +1096,7 @@ mod tests {
         let (_dir, state) = build_state(realm_id, holder).await;
         install_local_holder_config(&state, realm_id, holder).await;
 
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
         let records = vec![
             direct_record(user_id, 1),
             direct_record(user_id, 2),
@@ -1155,7 +1155,7 @@ mod tests {
         let realm_id = realm_id(11);
         let (_dir, state, net) = build_state_with_net(realm_id, [11u8; 32]).await;
         install_local_holder_config(&state, realm_id, state.get_node_id()).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
 
         let mut events = Box::pin(unread_count_stream(
             state.get_ctx(),
@@ -1201,7 +1201,7 @@ mod tests {
         let realm_id = realm_id(12);
         let (_dir, state, net) = build_state_with_net(realm_id, [12u8; 32]).await;
         install_local_holder_config(&state, realm_id, state.get_node_id()).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
 
         let mut events = Box::pin(unread_count_stream(
             state.get_ctx(),
@@ -1238,8 +1238,8 @@ mod tests {
     #[tokio::test]
     async fn expired_local_recheck_wins_over_unrelated_wake() {
         let realm_id = realm_id(15);
-        let recipient = UserId::new(Ulid::new(), realm_id);
-        let unrelated = UserId::new(Ulid::new(), realm_id);
+        let recipient = UserId::new(Ulid::r#gen(), realm_id);
+        let unrelated = UserId::new(Ulid::r#gen(), realm_id);
         let (tx, mut rx) = tokio::sync::broadcast::channel(4);
         tx.send(unrelated).expect("receiver is open");
 
@@ -1260,7 +1260,7 @@ mod tests {
         let realm_id = realm_id(13);
         let (_dir, state, _net) = build_state_with_net(realm_id, [13u8; 32]).await;
         install_local_holder_config(&state, realm_id, state.get_node_id()).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
 
         let mut events = Box::pin(unread_count_stream(
             state.get_ctx(),
@@ -1299,7 +1299,7 @@ mod tests {
         let (_dir, state, _net) = build_state_with_net(realm_id, [14u8; 32]).await;
         // The holder is a node that is in no mesh, so every remote poll fails.
         install_local_holder_config(&state, realm_id, node(200)).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
 
         let mut events = Box::pin(unread_count_stream(
             state.get_ctx(),
@@ -1322,10 +1322,10 @@ mod tests {
     #[test]
     fn notification_response_maps_deep_link_ids() {
         let realm_id = RealmId::from_bytes([4u8; 32]);
-        let recipient = UserId::new(Ulid::new(), realm_id);
-        let group_id = Ulid::new();
-        let actor = UserId::new(Ulid::new(), realm_id);
-        let member = UserId::new(Ulid::new(), realm_id);
+        let recipient = UserId::new(Ulid::r#gen(), realm_id);
+        let group_id = Ulid::r#gen();
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
+        let member = UserId::new(Ulid::r#gen(), realm_id);
         let onboarded_node = node(9);
 
         let added = notification_response(&NotificationRecord::new(
@@ -1380,7 +1380,7 @@ mod tests {
         assert_eq!(onboarded.node_id, Some(onboarded_node.to_string()));
         assert_eq!(onboarded.group_id, None);
 
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let metadata_created = notification_response(&NotificationRecord::new(
             recipient,
             NotificationClass::Transient,
@@ -1441,8 +1441,8 @@ mod tests {
         let holder = node(6);
         let (_dir, state) = build_state(realm_id, holder).await;
         install_local_holder_config(&state, realm_id, holder).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
-        let group_id = Ulid::new();
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
+        let group_id = Ulid::r#gen();
         install_group_authorization(&state, realm_id, group_id, user_id, &[]).await;
         let path_prefix = data_watch_resource_path(group_id, node(60), "bucket", "prefix");
 
@@ -1490,9 +1490,9 @@ mod tests {
         let holder = node(15);
         let (_dir, state) = build_state(realm_id, holder).await;
         install_local_holder_config(&state, realm_id, holder).await;
-        let authorized = UserId::new(Ulid::new(), realm_id);
-        let unauthorized = UserId::new(Ulid::new(), realm_id);
-        let group_id = Ulid::new();
+        let authorized = UserId::new(Ulid::r#gen(), realm_id);
+        let unauthorized = UserId::new(Ulid::r#gen(), realm_id);
+        let group_id = Ulid::r#gen();
         install_group_authorization(&state, realm_id, group_id, authorized, &[]).await;
         let path_prefix = format!("meta/{group_id}/datasets/proteomics");
 
@@ -1528,9 +1528,9 @@ mod tests {
         let holder = node(16);
         let (_dir, state) = build_state(realm_id, holder).await;
         install_local_holder_config(&state, realm_id, holder).await;
-        let authorized = UserId::new(Ulid::new(), realm_id);
-        let unauthorized = UserId::new(Ulid::new(), realm_id);
-        let bucket_group_id = Ulid::new();
+        let authorized = UserId::new(Ulid::r#gen(), realm_id);
+        let unauthorized = UserId::new(Ulid::r#gen(), realm_id);
+        let bucket_group_id = Ulid::r#gen();
         install_group_authorization(&state, realm_id, bucket_group_id, authorized, &[]).await;
         let remote_bucket_node = node(99);
         let path_prefix =
@@ -1567,8 +1567,8 @@ mod tests {
         let realm_id = realm_id(17);
         let holder = node(17);
         let (_dir, state) = build_state(realm_id, holder).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
-        let metadata_group_id = Ulid::new();
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
+        let metadata_group_id = Ulid::r#gen();
         let path_prefix = format!("meta/{metadata_group_id}/datasets/shared");
         let events = vec!["metadata_created".to_string(), "data_uploaded".to_string()];
 
@@ -1589,7 +1589,7 @@ mod tests {
     async fn create_watch_validates_input() {
         let realm_id = realm_id(7);
         let (_dir, state) = build_state(realm_id, node(7)).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
 
         let empty_prefix = create_watch(
             State(state.clone()),
@@ -1651,7 +1651,7 @@ mod tests {
         .expect_err("a prefix without a bucket boundary is ambiguous");
         assert!(matches!(unscoped_data, ServerError::BadRequest));
 
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let unscoped_metadata = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
@@ -1681,7 +1681,7 @@ mod tests {
     async fn delete_watch_rejects_bad_id() {
         let realm_id = realm_id(8);
         let (_dir, state) = build_state(realm_id, node(8)).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
         let error = delete_watch(
             State(state),
             Extension(Some(auth_for(user_id, realm_id))),
@@ -1696,7 +1696,7 @@ mod tests {
     async fn watch_endpoints_reject_path_restricted_token() {
         let realm_id = realm_id(9);
         let (_dir, state) = build_state(realm_id, node(9)).await;
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
         let mut auth = auth_for(user_id, realm_id);
         auth.path_restrictions = Some(vec![PathRestriction {
             pattern: "/bucket/**".to_string(),
@@ -1723,7 +1723,7 @@ mod tests {
         let delete_err = delete_watch(
             State(state),
             Extension(Some(auth)),
-            Path(Ulid::new().to_string()),
+            Path(Ulid::r#gen().to_string()),
         )
         .await
         .expect_err("delegated token must be rejected");

--- a/api/src/routes/onboarding.rs
+++ b/api/src/routes/onboarding.rs
@@ -218,7 +218,7 @@ pub async fn create_onboarding_secret(
 
     let onboarding_secret = OnboardingSecret {
         seed_url: request.seed_url,
-        enrollment_id: ulid::Ulid::new(),
+        enrollment_id: ulid::Ulid::r#gen(),
         secret: secret_bytes,
         mode: request.mode,
     };
@@ -665,7 +665,7 @@ mod tests {
         let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
         let realm_signing_key = SigningKey::generate(&mut csprng);
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = net_handle.node_id();
 
         drive(
@@ -900,7 +900,7 @@ mod tests {
             path_restrictions: None,
         };
 
-        let finalizing_id = Ulid::new();
+        let finalizing_id = Ulid::r#gen();
         drive(
             CreateOnboardingSecretOperation::new(CreateOnboardingSecretInput {
                 record: OnboardingSecretRecord {
@@ -929,7 +929,7 @@ mod tests {
         .await
         .unwrap();
 
-        let stale_id = Ulid::new();
+        let stale_id = Ulid::r#gen();
         drive(
             CreateOnboardingSecretOperation::new(CreateOnboardingSecretInput {
                 record: OnboardingSecretRecord {

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -498,7 +498,7 @@ mod tests {
     #[tokio::test]
     async fn staging_queue_failure_after_snapshot_commit_leaves_obligation_repairable() {
         let test = setup_state().await;
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         write_doc(
             &test.state.get_ctx(),
             S3_BUCKET_REPLICATION_KEYSPACE,
@@ -583,8 +583,8 @@ mod tests {
         let realm_id =
             aruna_core::structs::RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::from_bytes(&[13u8; 32]).public();
-        let user_with_source_read = UserId::local(Ulid::new(), realm_id);
-        let user_without_source_read = UserId::local(Ulid::new(), realm_id);
+        let user_with_source_read = UserId::local(Ulid::r#gen(), realm_id);
+        let user_without_source_read = UserId::local(Ulid::r#gen(), realm_id);
         let actor = Actor {
             node_id,
             user_id: user_with_source_read,
@@ -598,8 +598,8 @@ mod tests {
             task_handle: None,
         });
 
-        let bucket_group_id = Ulid::new();
-        let source_group_id = Ulid::new();
+        let bucket_group_id = Ulid::r#gen();
+        let source_group_id = Ulid::r#gen();
         let mut bucket_auth = GroupAuthorizationDocument::new_default_group_doc(
             user_with_source_read,
             realm_id,
@@ -680,7 +680,7 @@ mod tests {
 
         let bucket = "stage-bucket".to_string();
         let key = "test.txt".to_string();
-        let connector_id = Ulid::new();
+        let connector_id = Ulid::r#gen();
         let source_path = "folder/file.txt".to_string();
         let bucket_info = BucketInfo {
             group_id: bucket_group_id,

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -514,7 +514,7 @@ async fn register_user(
     let token = bearer_token(&headers).ok_or(ServerError::Unauthorized)?;
     let oidc_identity = validate_oidc_token(&state, token).await?;
 
-    let user_id = UserId::local(Ulid::new(), state.get_realm_id());
+    let user_id = UserId::local(Ulid::r#gen(), state.get_realm_id());
     let name = oidc_identity
         .display_name
         .clone()
@@ -1100,7 +1100,7 @@ mod tests {
             iss: node.realm_id.to_string(),
             iat: now,
             exp: now + 600,
-            jti: Ulid::new().to_string(),
+            jti: Ulid::r#gen().to_string(),
             restrictions,
             issuer_pubkey: None,
             delegation_signature: None,
@@ -1168,7 +1168,7 @@ mod tests {
             SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = net_handle.node_id();
-        let realm_admin_id = UserId::local(Ulid::new(), realm_id);
+        let realm_admin_id = UserId::local(Ulid::r#gen(), realm_id);
 
         drive(
             CreateRealmOperation::new(CreateRealmConfig {
@@ -1317,7 +1317,7 @@ mod tests {
     async fn create_local_onboarding_secret(node: &TestNode) -> String {
         let onboarding_secret = OnboardingSecret {
             seed_url: node.base_url.clone(),
-            enrollment_id: Ulid::new(),
+            enrollment_id: Ulid::r#gen(),
             secret: [7u8; 32],
             mode: OnboardingMode::Local,
         };
@@ -1469,7 +1469,7 @@ mod tests {
         )
         .await;
 
-        let missing_user_id = UserId::local(Ulid::new(), node.realm_id);
+        let missing_user_id = UserId::local(Ulid::r#gen(), node.realm_id);
         let response = reqwest::Client::new()
             .get(format!(
                 "{}/api/v1/users/{}",
@@ -1495,7 +1495,7 @@ mod tests {
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
-        let missing_user_id = UserId::local(Ulid::new(), node.realm_id);
+        let missing_user_id = UserId::local(Ulid::r#gen(), node.realm_id);
         let response = reqwest::Client::new()
             .get(format!(
                 "{}/api/v1/users/{}",
@@ -1525,7 +1525,7 @@ mod tests {
         let foreign_realm_id =
             RealmId::from_bytes(foreign_realm_signing_key.verifying_key().to_bytes());
         node.state.add_trusted_realm(foreign_realm_id).await;
-        let foreign_user_id = UserId::local(Ulid::new(), foreign_realm_id);
+        let foreign_user_id = UserId::local(Ulid::r#gen(), foreign_realm_id);
         match node
             .context
             .storage_handle

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -335,7 +335,7 @@ impl ArunaS3Service {
     ) {
         let path = data_watch_resource_path(group_id, self.node_id, &bucket, &key);
         let event = WatchEvent {
-            event_id: ulid::Ulid::new(),
+            event_id: ulid::Ulid::r#gen(),
             realm_id: self.realm_id,
             kind: WatchEventKind::DataUploaded,
             path,
@@ -1507,8 +1507,8 @@ mod tests {
         let service = ArunaS3Service::new(context, realm_id, node_id).await;
         let bucket = "bucket".to_string();
         let key = "object".to_string();
-        let version_id = Ulid::new();
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let version_id = Ulid::r#gen();
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let auth = AuthContext {
             user_id,
             realm_id,
@@ -1548,7 +1548,7 @@ mod tests {
             .put_object_response(
                 &checksum_request,
                 auth,
-                Ulid::new(),
+                Ulid::r#gen(),
                 bucket.clone(),
                 key,
                 PutObjectResult {
@@ -1691,9 +1691,9 @@ mod tests {
         let holder = net.node_id();
 
         let service = ArunaS3Service::new(context.clone(), realm_id, net.node_id()).await;
-        let user_id = UserId::local(Ulid::new(), realm_id);
-        let watcher = UserId::local(Ulid::new(), realm_id);
-        let group_id = Ulid::new();
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
+        let watcher = UserId::local(Ulid::r#gen(), realm_id);
+        let group_id = Ulid::r#gen();
         let watch_prefix = data_watch_resource_path(group_id, net.node_id(), "bucket", "");
         net.replace_watch_interest(data_uploaded_interest(
             realm_id,
@@ -1730,7 +1730,7 @@ mod tests {
                 "object".to_string(),
                 PutObjectResult {
                     location: response_location(user_id),
-                    version_id: Ulid::new(),
+                    version_id: Ulid::r#gen(),
                 },
             )
             .await
@@ -1777,12 +1777,12 @@ mod tests {
         net.replace_watch_interest(data_uploaded_interest(
             realm_id,
             holder,
-            data_watch_resource_path(Ulid::new(), net.node_id(), "bucket", ""),
+            data_watch_resource_path(Ulid::r#gen(), net.node_id(), "bucket", ""),
         ));
 
         let service = ArunaS3Service::new(context.clone(), realm_id, net.node_id()).await;
         let anonymous = UserId::nil(realm_id);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let auth = AuthContext {
             user_id: anonymous,
             realm_id,
@@ -1803,7 +1803,7 @@ mod tests {
                 "object".to_string(),
                 PutObjectResult {
                     location: response_location(anonymous),
-                    version_id: Ulid::new(),
+                    version_id: Ulid::r#gen(),
                 },
             )
             .await
@@ -1832,7 +1832,7 @@ mod tests {
         let refresh = ReferenceMetadataRefresh {
             bucket: "bucket".to_string(),
             key: "reference".to_string(),
-            version_id: Ulid::new(),
+            version_id: Ulid::r#gen(),
             metadata: source_metadata(2, "etag"),
             refreshed_at: UNIX_EPOCH.checked_sub(Duration::from_secs(1)).unwrap(),
         };
@@ -1933,8 +1933,8 @@ mod tests {
             context,
             bucket: "bucket".to_string(),
             key: "key".to_string(),
-            version_id: Ulid::new(),
-            created_by: UserId::local(Ulid::new(), realm_id),
+            version_id: Ulid::r#gen(),
+            created_by: UserId::local(Ulid::r#gen(), realm_id),
         }
     }
 
@@ -1946,7 +1946,7 @@ mod tests {
             root: "/tmp".to_string(),
             storage_bucket: "objects".to_string(),
             backend_path: "bucket/object".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by,
@@ -2154,7 +2154,7 @@ mod tests {
             root: "/tmp".to_string(),
             storage_bucket: "objects".to_string(),
             backend_path: format!("path/{key}"),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by,
@@ -2220,7 +2220,7 @@ mod tests {
     fn test_user_access(group_id: Ulid, realm_id: RealmId) -> UserAccess {
         UserAccess {
             access_key: "test-key".to_string(),
-            user_identity: UserId::local(Ulid::new(), realm_id),
+            user_identity: UserId::local(Ulid::r#gen(), realm_id),
             group_id,
             secret: "secret".to_string(),
             expiry: SystemTime::now() + Duration::from_secs(3600),
@@ -2247,7 +2247,7 @@ mod tests {
         created_at: SystemTime,
     ) {
         for key in keys {
-            let version_id = Ulid::new();
+            let version_id = Ulid::r#gen();
             let hash = [key.len() as u8; 32];
             write_head(storage_handle, bucket, key, version_id).await;
             write_materialized_version(
@@ -2294,8 +2294,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([2u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
         let created_at = UNIX_EPOCH;
 
         let service = ArunaS3Service::new(
@@ -2372,8 +2372,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([3u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
         let created_at = UNIX_EPOCH;
 
         let service = ArunaS3Service::new(
@@ -2458,8 +2458,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([33u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
 
         let service =
             ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
@@ -2524,8 +2524,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([34u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
 
         let service = ArunaS3Service::new(
             context.clone(),
@@ -2645,8 +2645,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([4u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
         let created_at = UNIX_EPOCH + Duration::from_secs(1);
 
         let service = ArunaS3Service::new(
@@ -2661,7 +2661,7 @@ mod tests {
         // through it.
         for i in 0..305 {
             let key = format!("dir/key_{:04}", i);
-            let version_id = Ulid::new();
+            let version_id = Ulid::r#gen();
             let hash = [i as u8; 32];
             write_head(&storage_handle, "bucket", &key, version_id).await;
             write_materialized_version(
@@ -2730,8 +2730,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([5u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
         let created_at = UNIX_EPOCH + Duration::from_secs(5);
         let last_refresh = UNIX_EPOCH + Duration::from_secs(20);
 
@@ -2750,7 +2750,7 @@ mod tests {
             source_version: None,
         };
 
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         write_reference_version_with_metadata(
             &storage_handle,
             "bucket",
@@ -2827,8 +2827,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([6u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
         let created_at = UNIX_EPOCH + Duration::from_secs(5);
 
         let service = ArunaS3Service::new(
@@ -2892,8 +2892,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([7u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
         let created_at = UNIX_EPOCH;
 
         let service = ArunaS3Service::new(
@@ -3004,8 +3004,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([35u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
 
         let service =
             ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
@@ -3065,8 +3065,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([36u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
 
         let service =
             ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;
@@ -3140,8 +3140,8 @@ mod tests {
             task_handle: None,
         });
         let realm_id = RealmId([37u8; 32]);
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
 
         let service =
             ArunaS3Service::new(context, realm_id, NodeId::from_bytes(&[0u8; 32]).unwrap()).await;

--- a/api/src/telemetry.rs
+++ b/api/src/telemetry.rs
@@ -107,7 +107,7 @@ pub fn make_request_span(
     method: &Method,
     path: &str,
 ) -> Span {
-    let request_id = Ulid::new().to_string();
+    let request_id = Ulid::r#gen().to_string();
     let span = info_span!(
         "request",
         "otel.kind" = "server",

--- a/aruna-doctor/src/explorer.rs
+++ b/aruna-doctor/src/explorer.rs
@@ -1660,11 +1660,11 @@ mod tests {
     #[test]
     fn decodes_typed_group_entries() {
         let temp = tempdir().unwrap();
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId::from_bytes([7_u8; 32]);
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[9_u8; 32]).public(),
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         };
         let group = Group {
@@ -1672,7 +1672,7 @@ mod tests {
             group_id,
             realm_id,
             roles: Default::default(),
-            owner: aruna_core::UserId::local(Ulid::new(), realm_id),
+            owner: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
         };
 
         {
@@ -1737,7 +1737,7 @@ mod tests {
         let realm_id = RealmId::from_bytes([1_u8; 32]);
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[3_u8; 32]).public(),
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         };
         let mut realm_config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
@@ -1768,7 +1768,7 @@ mod tests {
     #[test]
     fn decodes_onboarding_secret_record_value() {
         let record = OnboardingSecretRecord {
-            enrollment_id: Ulid::new(),
+            enrollment_id: Ulid::r#gen(),
             secret_hash: "hash123".to_string(),
             mode: OnboardingMode::Server,
             expires_at: 1234,
@@ -1911,7 +1911,7 @@ mod tests {
     #[test]
     fn decodes_multipart_upload_entry() {
         let realm_id = RealmId::from_bytes([3_u8; 32]);
-        let created_by = aruna_core::UserId::local(Ulid::new(), realm_id);
+        let created_by = aruna_core::UserId::local(Ulid::r#gen(), realm_id);
         let upload = MultipartUpload {
             upload_id: Ulid::from_bytes([7_u8; 16]),
             bucket: "bucket-a".to_string(),
@@ -1943,7 +1943,7 @@ mod tests {
     #[test]
     fn decodes_multipart_upload_part_entry() {
         let realm_id = RealmId::from_bytes([9_u8; 32]);
-        let created_by = aruna_core::UserId::local(Ulid::new(), realm_id);
+        let created_by = aruna_core::UserId::local(Ulid::r#gen(), realm_id);
         let key = MultipartUploadPartKey::new(Ulid::from_bytes([2_u8; 16]), 5);
         let part = MultipartUploadPart {
             part_number: 5,
@@ -2234,7 +2234,7 @@ mod tests {
         let realm_id = RealmId::from_bytes([1_u8; 32]);
         let group_id = Ulid::from_bytes([2_u8; 16]);
         let node_id = iroh::SecretKey::from_bytes(&[3_u8; 32]).public();
-        let created_by = aruna_core::UserId::local(Ulid::new(), realm_id);
+        let created_by = aruna_core::UserId::local(Ulid::r#gen(), realm_id);
         let head_key = BlobHeadKey::new("bucket", "path/file.txt");
         let head_value = aruna_core::structs::CurrentVersionPointer::new_with_generation(
             Ulid::from_bytes([4_u8; 16]),

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -332,7 +332,7 @@ mod tests {
             SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let capabilities = NodeCapabilities::management_node(realm_signing_key).unwrap();
-        let bootstrap_user = aruna_core::UserId::local(Ulid::new(), realm_id);
+        let bootstrap_user = aruna_core::UserId::local(Ulid::r#gen(), realm_id);
         drive(
             CreateRealmOperation::new(CreateRealmConfig {
                 actor: aruna_core::structs::Actor {

--- a/aruna-doctor/src/storage.rs
+++ b/aruna-doctor/src/storage.rs
@@ -648,7 +648,7 @@ mod tests {
             )
             .await;
 
-            let realm_admin = aruna_core::UserId::local(Ulid::new(), config.realm_id);
+            let realm_admin = aruna_core::UserId::local(Ulid::r#gen(), config.realm_id);
             drive(
                 CreateRealmOperation::new(CreateRealmConfig {
                     actor: Actor {

--- a/aruna-doctor/src/tokens.rs
+++ b/aruna-doctor/src/tokens.rs
@@ -106,7 +106,7 @@ async fn create_direct_local_bootstrap_token(bootstrap_secret: String) -> Result
 
     let onboarding_secret = OnboardingSecret::decode(&bootstrap_secret)?;
     let now = chrono::Utc::now().timestamp().max(0) as u64;
-    let user_id = UserId::local(Ulid::new(), config.realm_id);
+    let user_id = UserId::local(Ulid::r#gen(), config.realm_id);
     let inspected = drive(
         InspectOnboardingSecretOperation::new(InspectOnboardingSecretInput {
             enrollment_id: onboarding_secret.enrollment_id,
@@ -733,7 +733,7 @@ mod tests {
         let realm_id =
             aruna_core::structs::RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let capabilities = NodeCapabilities::management_node(realm_signing_key).unwrap();
-        let bootstrap_user = UserId::local(Ulid::new(), realm_id);
+        let bootstrap_user = UserId::local(Ulid::r#gen(), realm_id);
         drive(
             CreateRealmOperation::new(CreateRealmConfig {
                 actor: Actor {
@@ -872,7 +872,7 @@ mod tests {
     fn aruna_token_fixture() -> (SigningKey, RealmId, UserId) {
         let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
         let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         (signing_key, realm_id, user_id)
     }
 
@@ -883,7 +883,7 @@ mod tests {
             iss: realm_id.to_string(),
             iat: now,
             exp: now + 600,
-            jti: Ulid::new().to_string(),
+            jti: Ulid::r#gen().to_string(),
             restrictions: None,
             issuer_pubkey: None,
             delegation_signature: None,

--- a/aruna/src/bootstrap.rs
+++ b/aruna/src/bootstrap.rs
@@ -262,7 +262,7 @@ pub async fn ensure_initial_local_onboarding_secret(
     rand::rng().fill_bytes(&mut secret_bytes);
     let onboarding_secret = OnboardingSecret {
         seed_url,
-        enrollment_id: ulid::Ulid::new(),
+        enrollment_id: ulid::Ulid::r#gen(),
         secret: secret_bytes,
         mode: OnboardingMode::Local,
     };

--- a/aruna/tests/groups.rs
+++ b/aruna/tests/groups.rs
@@ -52,7 +52,7 @@ async fn membership_lifecycle_with_invite_and_leave() -> TestResult<()> {
         .await?;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    let member_id = UserId::local(Ulid::new(), seed.realm_id);
+    let member_id = UserId::local(Ulid::r#gen(), seed.realm_id);
     let member_token = create_bearer_token(
         seed.context.as_ref(),
         member_id,
@@ -247,7 +247,7 @@ async fn open_group_endpoints_hide_member_lists_from_non_members() -> TestResult
 
     let outsider_token = create_bearer_token(
         seed.context.as_ref(),
-        UserId::local(Ulid::new(), seed.realm_id),
+        UserId::local(Ulid::r#gen(), seed.realm_id),
         seed.realm_id,
         seed.capabilities.clone(),
     )

--- a/aruna/tests/oidc_registration.rs
+++ b/aruna/tests/oidc_registration.rs
@@ -204,7 +204,7 @@ async fn spawn_test_node(provider: OidcProviderConfig) -> TestNode {
     let realm_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
     let realm_id =
         aruna_core::structs::RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
-    let bootstrap_user = UserId::local(Ulid::new(), realm_id);
+    let bootstrap_user = UserId::local(Ulid::r#gen(), realm_id);
     drive(
         CreateRealmOperation::new(CreateRealmConfig {
             actor: Actor {

--- a/aruna/tests/public_access.rs
+++ b/aruna/tests/public_access.rs
@@ -37,7 +37,7 @@ async fn public_role_grants_anonymous_read_and_nothing_else() -> TestResult<()> 
         let credential_group =
             create_group_via_http(&seed.base_url, &bearer_token, "public-access-credentials")
                 .await?;
-        let member_id = UserId::local(Ulid::new(), seed.realm_id);
+        let member_id = UserId::local(Ulid::r#gen(), seed.realm_id);
         let member_token = create_bearer_token(
             seed.context.as_ref(),
             member_id,

--- a/aruna/tests/self_service_groups.rs
+++ b/aruna/tests/self_service_groups.rs
@@ -22,7 +22,7 @@ async fn fresh_user_creates_groups_up_to_the_cap() -> TestResult<()> {
     let seed = spawn_seed_node().await?;
     let member_token = create_bearer_token(
         seed.context.as_ref(),
-        UserId::local(Ulid::new(), seed.realm_id),
+        UserId::local(Ulid::r#gen(), seed.realm_id),
         seed.realm_id,
         seed.capabilities.clone(),
     )
@@ -58,7 +58,7 @@ async fn concurrent_creates_cannot_slip_past_the_cap() -> TestResult<()> {
     let seed = spawn_seed_node().await?;
     let member_token = create_bearer_token(
         seed.context.as_ref(),
-        UserId::local(Ulid::new(), seed.realm_id),
+        UserId::local(Ulid::r#gen(), seed.realm_id),
         seed.realm_id,
         seed.capabilities.clone(),
     )

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -283,7 +283,7 @@ pub(crate) fn sign_scoped_bearer_token(
         iss: seed.realm_id.to_string(),
         iat: now,
         exp: now + 600,
-        jti: Ulid::new().to_string(),
+        jti: Ulid::r#gen().to_string(),
         restrictions: Some(path_restrictions),
         issuer_pubkey: None,
         delegation_signature: None,
@@ -526,7 +526,7 @@ async fn spawn_seed_node_with_mode(mode: NodeServiceMode) -> TestResult<SeedNode
     let storage = FjallStorage::open(storage_path)?;
     let realm_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
     let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
-    let user_id = UserId::new(Ulid::new(), realm_id);
+    let user_id = UserId::new(Ulid::r#gen(), realm_id);
     let net = NetHandle::new(
         NetConfig {
             bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),

--- a/blob/src/blob/backend.rs
+++ b/blob/src/blob/backend.rs
@@ -190,7 +190,7 @@ impl BlobHandler {
 
 pub(super) fn generate_bucket_name(prefix: Option<&str>) -> String {
     let prefix = prefix.unwrap_or("aruna-");
-    format!("{}{}", prefix, Ulid::new().to_string().to_lowercase())
+    format!("{}{}", prefix, Ulid::r#gen().to_string().to_lowercase())
 }
 
 pub(super) fn build_backend_path(

--- a/blob/src/blob/io.rs
+++ b/blob/src/blob/io.rs
@@ -71,7 +71,7 @@ impl BlobHandler {
             Ok(bucket) => bucket,
             Err(err) => return BlobEvent::Error(err),
         };
-        let ulid = Ulid::new();
+        let ulid = Ulid::r#gen();
         let backend_path = match build_backend_path(request_bucket, request_key, ulid) {
             Ok(path) => path,
             Err(err) => return BlobEvent::Error(BlobError::ConversionError(err)),
@@ -123,7 +123,7 @@ impl BlobHandler {
             Ok(bucket) => bucket.to_string(),
             Err(err) => return BlobEvent::Error(err),
         };
-        let ulid = Ulid::new();
+        let ulid = Ulid::r#gen();
         let location = BackendLocation {
             root: self.backend_config.root.clone(),
             storage_bucket: multipart_bucket.clone(),
@@ -157,7 +157,7 @@ impl BlobHandler {
             Ok(bucket) => bucket,
             Err(err) => return BlobEvent::Error(err),
         };
-        let ulid = Ulid::new();
+        let ulid = Ulid::r#gen();
         let backend_path = match build_backend_path(request_bucket, request_key, ulid) {
             Ok(path) => path,
             Err(err) => return BlobEvent::Error(BlobError::ConversionError(err)),

--- a/blob/src/blob/replication.rs
+++ b/blob/src/blob/replication.rs
@@ -171,7 +171,7 @@ impl BlobHandler {
             Ok(bucket) => bucket,
             Err(err) => return BlobEvent::Error(err),
         };
-        let ulid = Ulid::new();
+        let ulid = Ulid::r#gen();
         location.root = self.backend_config.root.clone();
         location.storage_bucket = backend_bucket.clone();
         location.backend_path = match rebuild_backend_path(&location.backend_path, ulid) {

--- a/blob/src/blob/runtime.rs
+++ b/blob/src/blob/runtime.rs
@@ -303,9 +303,9 @@ impl BlobHandler {
                 stream_id
             }
             None => {
-                let mut candidate = Ulid::new();
+                let mut candidate = Ulid::r#gen();
                 while candidate.is_nil() || connections.contains_key(&candidate) {
-                    candidate = Ulid::new();
+                    candidate = Ulid::r#gen();
                 }
                 candidate
             }

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -27,57 +27,142 @@ use ulid::Ulid;
 
 mod failing_close {
     use opendal::raw::oio;
-    use opendal::raw::{Access, AccessorInfo, OpWrite, RpWrite};
-    use opendal::{Buffer, Capability, Error, ErrorKind, Metadata, Operator, OperatorBuilder};
+    use opendal::raw::{
+        OpCopier, OpCopy, OpCreateDir, OpList, OpPresign, OpRead, OpRename, OpStat, OpWrite,
+        RpCreateDir, RpPresign, RpRename, RpStat, Service, ServiceInfo,
+    };
+    use opendal::{
+        Buffer, Builder, Capability, Error, ErrorKind, Metadata, OperationContext, Operator,
+    };
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
 
-    #[derive(Debug)]
-    pub(super) struct CloseFailsBackend {
-        info: Arc<AccessorInfo>,
+    fn unsupported<T>() -> opendal::Result<T> {
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "operation is not supported",
+        ))
+    }
+
+    #[derive(Debug, Default)]
+    pub(super) struct CloseFailsBuilder {
         aborts: Arc<AtomicUsize>,
     }
 
-    impl CloseFailsBackend {
-        fn new(aborts: Arc<AtomicUsize>) -> Self {
-            let info = AccessorInfo::default();
-            info.set_scheme("close_fails")
-                .set_root("/")
-                .set_native_capability(Capability {
-                    write: true,
-                    write_can_empty: true,
-                    write_can_multi: true,
-                    ..Default::default()
-                });
-            Self {
-                info: info.into(),
-                aborts,
-            }
+    impl Builder for CloseFailsBuilder {
+        type Config = ();
+
+        fn build(self) -> opendal::Result<impl Service> {
+            Ok(CloseFailsBackend {
+                aborts: self.aborts,
+            })
         }
     }
 
-    impl Access for CloseFailsBackend {
+    #[derive(Debug)]
+    pub(super) struct CloseFailsBackend {
+        aborts: Arc<AtomicUsize>,
+    }
+
+    impl Service for CloseFailsBackend {
         type Reader = ();
         type Writer = CloseFailsWriter;
         type Lister = ();
         type Deleter = ();
         type Copier = ();
 
-        fn info(&self) -> Arc<AccessorInfo> {
-            self.info.clone()
+        fn info(&self) -> ServiceInfo {
+            ServiceInfo::new("close_fails", "/", "")
         }
 
-        async fn write(
+        fn capability(&self) -> Capability {
+            Capability {
+                write: true,
+                write_can_empty: true,
+                write_can_multi: true,
+                ..Default::default()
+            }
+        }
+
+        fn write(
             &self,
+            _ctx: &OperationContext,
             _path: &str,
             _args: OpWrite,
-        ) -> opendal::Result<(RpWrite, Self::Writer)> {
-            Ok((
-                RpWrite::new(),
-                CloseFailsWriter {
-                    aborts: self.aborts.clone(),
-                },
-            ))
+        ) -> opendal::Result<Self::Writer> {
+            Ok(CloseFailsWriter {
+                aborts: self.aborts.clone(),
+            })
+        }
+
+        async fn create_dir(
+            &self,
+            _ctx: &OperationContext,
+            _path: &str,
+            _args: OpCreateDir,
+        ) -> opendal::Result<RpCreateDir> {
+            unsupported()
+        }
+
+        async fn stat(
+            &self,
+            _ctx: &OperationContext,
+            _path: &str,
+            _args: OpStat,
+        ) -> opendal::Result<RpStat> {
+            unsupported()
+        }
+
+        fn read(
+            &self,
+            _ctx: &OperationContext,
+            _path: &str,
+            _args: OpRead,
+        ) -> opendal::Result<Self::Reader> {
+            unsupported()
+        }
+
+        fn delete(&self, _ctx: &OperationContext) -> opendal::Result<Self::Deleter> {
+            unsupported()
+        }
+
+        fn list(
+            &self,
+            _ctx: &OperationContext,
+            _path: &str,
+            _args: OpList,
+        ) -> opendal::Result<Self::Lister> {
+            unsupported()
+        }
+
+        fn copy(
+            &self,
+            _ctx: &OperationContext,
+            _from: &str,
+            _to: &str,
+            _args: OpCopy,
+            _opts: OpCopier,
+        ) -> opendal::Result<Self::Copier> {
+            unsupported()
+        }
+
+        async fn rename(
+            &self,
+            _ctx: &OperationContext,
+            _from: &str,
+            _to: &str,
+            _args: OpRename,
+        ) -> opendal::Result<RpRename> {
+            unsupported()
+        }
+
+        async fn presign(
+            &self,
+            _ctx: &OperationContext,
+            _path: &str,
+            _args: OpPresign,
+        ) -> opendal::Result<RpPresign> {
+            unsupported()
         }
     }
 
@@ -106,7 +191,10 @@ mod failing_close {
 
     pub(super) fn operator_with_aborts() -> (Operator, Arc<AtomicUsize>) {
         let aborts = Arc::new(AtomicUsize::new(0));
-        let operator = OperatorBuilder::new(CloseFailsBackend::new(aborts.clone())).finish();
+        let operator = Operator::new(CloseFailsBuilder {
+            aborts: aborts.clone(),
+        })
+        .unwrap();
         (operator, aborts)
     }
 }

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -295,8 +295,8 @@ fn make_test_location() -> BackendLocation {
     BackendLocation {
         root: "/tmp".to_string(),
         storage_bucket: "bucket".to_string(),
-        backend_path: format!("blob/{}", Ulid::new()),
-        ulid: Ulid::new(),
+        backend_path: format!("blob/{}", Ulid::r#gen()),
+        ulid: Ulid::r#gen(),
         compressed: false,
         encrypted: false,
         created_by: test_user_id(),
@@ -340,7 +340,7 @@ fn backend_config_exposes_custom_timeout_values() {
 
 #[test]
 fn replication_init_ack_accepts_matching_ack() {
-    let replication_id = Ulid::new();
+    let replication_id = Ulid::r#gen();
     let ack = ReplicationMessage::new(replication_id, MessageType::BaoTreeInfoReceived);
 
     assert_eq!(validate_replication_init_ack(ack, replication_id), Ok(()));
@@ -348,7 +348,7 @@ fn replication_init_ack_accepts_matching_ack() {
 
 #[test]
 fn replication_init_ack_rejects_unexpected_message_type() {
-    let replication_id = Ulid::new();
+    let replication_id = Ulid::r#gen();
     let message = ReplicationMessage::new(
         replication_id,
         MessageType::BaoTreeInfo {
@@ -367,8 +367,8 @@ fn replication_init_ack_rejects_unexpected_message_type() {
 
 #[test]
 fn replication_init_ack_rejects_wrong_replication_id() {
-    let replication_id = Ulid::new();
-    let wrong_id = Ulid::new();
+    let replication_id = Ulid::r#gen();
+    let wrong_id = Ulid::r#gen();
     let ack = ReplicationMessage::new(wrong_id, MessageType::BaoTreeInfoReceived);
 
     assert_eq!(
@@ -381,7 +381,7 @@ fn replication_init_ack_rejects_wrong_replication_id() {
 
 #[test]
 fn parse_replication_init_accepts_matching_bao_tree_info() {
-    let replication_id = Ulid::new();
+    let replication_id = Ulid::r#gen();
     let location = make_test_location();
     let root = blake3::hash(b"hello world");
     let message = ReplicationMessage::new(
@@ -400,8 +400,8 @@ fn parse_replication_init_accepts_matching_bao_tree_info() {
 
 #[test]
 fn parse_replication_init_rejects_wrong_replication_id() {
-    let replication_id = Ulid::new();
-    let wrong_id = Ulid::new();
+    let replication_id = Ulid::r#gen();
+    let wrong_id = Ulid::r#gen();
     let message = ReplicationMessage::new(
         wrong_id,
         MessageType::BaoTreeInfo {
@@ -420,7 +420,7 @@ fn parse_replication_init_rejects_wrong_replication_id() {
 
 #[test]
 fn parse_replication_init_uses_message_id_when_unknown() {
-    let replication_id = Ulid::new();
+    let replication_id = Ulid::r#gen();
     let location = make_test_location();
     let root = blake3::hash(b"hello world");
     let message = ReplicationMessage::new(
@@ -608,7 +608,7 @@ async fn multipart_part_bucket_is_excluded_from_bucket_stats() {
     let Event::Blob(BlobEvent::WriteFinished { location }) = context
         .blob_handle
         .send_blob_effect(BlobEffect::WritePart {
-            upload_id: Ulid::new(),
+            upload_id: Ulid::r#gen(),
             part_number: 1,
             created_by: test_user_id(),
             compressed: false,
@@ -691,7 +691,7 @@ async fn add_connection_rejects_nil_and_duplicate_ids() {
     let (net_a, _dir_a, net_b, _dir_b) = connected_stream_pair().await;
     let peer_id = net_b.node_id();
 
-    let explicit = Ulid::new();
+    let explicit = Ulid::r#gen();
     let stream = net_a.open_stream(peer_id, Alpn::Bao).await.unwrap();
     let id = handler
         .add_connection(Some(explicit), peer_id, stream)
@@ -726,8 +726,8 @@ async fn write_finalization_failure_emits_no_success_or_load() {
     let location = BackendLocation {
         root: "/tmp".to_string(),
         storage_bucket: "finalization-bucket".to_string(),
-        backend_path: format!("obj/{}", Ulid::new()),
-        ulid: Ulid::new(),
+        backend_path: format!("obj/{}", Ulid::r#gen()),
+        ulid: Ulid::r#gen(),
         compressed: false,
         encrypted: false,
         created_by: test_user_id(),
@@ -762,7 +762,7 @@ async fn failed_write_cleans() {
         root: root.path().to_str().unwrap().to_string(),
         storage_bucket: "bucket".to_string(),
         backend_path: "partial.bin".to_string(),
-        ulid: Ulid::new(),
+        ulid: Ulid::r#gen(),
         compressed: false,
         encrypted: false,
         created_by: test_user_id(),
@@ -819,8 +819,8 @@ async fn compose_close_fails() {
     let target = BackendLocation {
         root: "/tmp".to_string(),
         storage_bucket: "compose-target".to_string(),
-        backend_path: format!("obj/{}", Ulid::new()),
-        ulid: Ulid::new(),
+        backend_path: format!("obj/{}", Ulid::r#gen()),
+        ulid: Ulid::r#gen(),
         compressed: false,
         encrypted: false,
         created_by: test_user_id(),
@@ -865,7 +865,7 @@ async fn replication_close_fails() {
 
 #[test]
 fn build_backend_path_rejects_traversal_keys() {
-    let ulid = Ulid::new();
+    let ulid = Ulid::r#gen();
     assert!(build_backend_path("bucket", "nested/object.bin", ulid).is_ok());
 
     for key in ["../escape", "../../etc/passwd", "a/../../b", "/abs/path"] {
@@ -881,7 +881,7 @@ fn build_backend_path_rejects_traversal_keys() {
 
 #[test]
 fn rebuild_backend_path_rejects_sender_supplied_traversal() {
-    let ulid = Ulid::new();
+    let ulid = Ulid::r#gen();
     assert!(rebuild_backend_path("bucket/object_0000", ulid).is_ok());
 
     for path in ["../../etc/cron.d/evil_00", "../escape_00", "/abs/object_00"] {

--- a/blob/src/opendal.rs
+++ b/blob/src/opendal.rs
@@ -147,8 +147,7 @@ where
     Ok(Operator::from_iter::<B>(config)
         .map_err(|error| error.to_string())?
         .layer(LoggingLayer::default())
-        .layer(RetryLayer::new())
-        .finish())
+        .layer(RetryLayer::new()))
 }
 
 fn blob_operator_creation_error(error: String) -> BlobError {

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -257,7 +257,7 @@ impl AdminDocumentReducerState {
     ) -> Result<AdminDocumentEvent, AdminDocumentReducerError> {
         let observed = self.clock.clone();
         let event = AdminDocumentEvent {
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             target: self.target.clone(),
             origin_node_id: actor.node_id,
             origin_seq: observed.sequence_for(&actor.node_id) + 1,

--- a/core/src/id.rs
+++ b/core/src/id.rs
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_topic_id_group() {
-        let topic = TopicId::group(GroupId::new());
+        let topic = TopicId::group(GroupId::r#gen());
         let bytes = topic.to_bytes();
         assert_eq!(bytes[0], PREFIX_GROUP);
         let parsed = TopicId::from_bytes(&bytes).unwrap();

--- a/core/src/metadata.rs
+++ b/core/src/metadata.rs
@@ -597,7 +597,7 @@ mod tests {
 
     fn create_event(document_id: Ulid, event_id: Ulid) -> MetadataCreateEventRecord {
         let realm_id = RealmId::from_bytes([8u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let document_path = "datasets/lifecycle";
         let record = MetadataRegistryRecord {
             realm_id,
@@ -620,7 +620,7 @@ mod tests {
         MetadataCreateEventRecord {
             event_id,
             record,
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             node_id: node(1),
             payload: MetadataCreateEventPayload::Scaffold {
                 name: "Lifecycle".to_string(),
@@ -634,8 +634,8 @@ mod tests {
 
     #[test]
     fn metadata_document_lifecycle_upsert_wraps_create_event() {
-        let document_id = Ulid::new();
-        let event_id = Ulid::new();
+        let document_id = Ulid::r#gen();
+        let event_id = Ulid::r#gen();
         let create = create_event(document_id, event_id);
 
         let lifecycle = MetadataDocumentLifecycleRecord::Upsert {
@@ -655,11 +655,11 @@ mod tests {
 
     #[test]
     fn metadata_document_lifecycle_delete_carries_tombstone_and_fence() {
-        let document_id = Ulid::new();
-        let event_id = Ulid::new();
-        let deleted_after_event_id = Ulid::new();
+        let document_id = Ulid::r#gen();
+        let event_id = Ulid::r#gen();
+        let deleted_after_event_id = Ulid::r#gen();
         let realm_id = RealmId::from_bytes([9u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
         let tombstone = MetadataGraphLifecycleRecord::deleted(
             graph_iri.clone(),

--- a/core/src/onboarding.rs
+++ b/core/src/onboarding.rs
@@ -251,7 +251,7 @@ mod tests {
     fn onboarding_secret_roundtrip() {
         let secret = OnboardingSecret {
             seed_url: "http://127.0.0.1:3000".to_string(),
-            enrollment_id: Ulid::new(),
+            enrollment_id: Ulid::r#gen(),
             secret: [7u8; 32],
             mode: OnboardingMode::Server,
         };
@@ -265,7 +265,7 @@ mod tests {
     fn onboarding_secret_hash_matches_existing_blake3_hex() {
         let secret = OnboardingSecret {
             seed_url: "http://127.0.0.1:3000".to_string(),
-            enrollment_id: Ulid::new(),
+            enrollment_id: Ulid::r#gen(),
             secret: [7u8; 32],
             mode: OnboardingMode::Server,
         };

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -838,7 +838,7 @@ mod tests {
             root: "/data".to_string(),
             storage_bucket: "bucket".to_string(),
             backend_path: "object.bin".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by: UserId::default(),

--- a/core/src/structs/group.rs
+++ b/core/src/structs/group.rs
@@ -46,7 +46,7 @@ pub struct GroupAuthorizationDocument {
 impl GroupAuthorizationDocument {
     pub fn new_default_group_doc(user_id: UserId, realm_id: RealmId, group_id: GroupId) -> Self {
         let mut roles = HashMap::new();
-        let admin = Ulid::new();
+        let admin = Ulid::r#gen();
         roles.insert(
             admin,
             Role {
@@ -60,7 +60,7 @@ impl GroupAuthorizationDocument {
             },
         );
 
-        let user = Ulid::new();
+        let user = Ulid::r#gen();
         roles.insert(
             user,
             Role {
@@ -84,7 +84,7 @@ impl GroupAuthorizationDocument {
             },
         );
 
-        let viewer = Ulid::new();
+        let viewer = Ulid::r#gen();
         roles.insert(
             viewer,
             Role {
@@ -126,14 +126,14 @@ mod test {
     pub fn test_group_conversion() {
         let group = Group {
             display_name: "A group".to_string(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             realm_id: RealmId([0u8; 32]),
-            roles: HashSet::from([Ulid::new(), Ulid::new()]),
-            owner: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+            roles: HashSet::from([Ulid::r#gen(), Ulid::r#gen()]),
+            owner: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
         };
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
-            user_id: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+            user_id: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
             realm_id: RealmId([0u8; 32]),
         };
         let bytes = group.to_bytes(&actor).unwrap();
@@ -145,13 +145,13 @@ mod test {
     #[test]
     pub fn test_group_auth_doc_conversion() {
         let auth_doc = GroupAuthorizationDocument::new_default_group_doc(
-            UserId::local(Ulid::new(), RealmId([0u8; 32])),
+            UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
             RealmId([0u8; 32]),
-            Ulid::new(),
+            Ulid::r#gen(),
         );
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
-            user_id: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+            user_id: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
             realm_id: RealmId([0u8; 32]),
         };
         let bytes = auth_doc.to_bytes(&actor).unwrap();

--- a/core/src/structs/notification.rs
+++ b/core/src/structs/notification.rs
@@ -108,7 +108,7 @@ impl NotificationRecord {
         created_at_ms: u64,
     ) -> Self {
         Self {
-            notification_id: Ulid::new(),
+            notification_id: Ulid::r#gen(),
             recipient,
             class,
             kind,
@@ -242,7 +242,7 @@ mod tests {
 
     fn added(actor: u8) -> NotificationKind {
         NotificationKind::AddedToGroup {
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             actor_user_id: user(1, actor),
         }
     }
@@ -250,20 +250,20 @@ mod tests {
     #[test]
     fn notification_record_roundtrips_through_postcard() {
         let recipient = user(1, 2);
-        let metadata_group_id = Ulid::new();
-        let data_group_id = Ulid::new();
+        let metadata_group_id = Ulid::r#gen();
+        let data_group_id = Ulid::r#gen();
         let data_node_id = make_node_id(8);
         for kind in [
             NotificationKind::AddedToGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: user(1, 3),
             },
             NotificationKind::RemovedFromGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: user(1, 3),
             },
             NotificationKind::GroupMemberAdded {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 member_user_id: user(1, 4),
                 actor_user_id: user(1, 3),
             },
@@ -274,7 +274,7 @@ mod tests {
             NotificationKind::MetadataCreated {
                 path: format!("meta/{metadata_group_id}/datasets/project/run-42"),
                 group_id: metadata_group_id,
-                document_id: Ulid::new(),
+                document_id: Ulid::r#gen(),
                 actor_user_id: user(1, 5),
             },
             NotificationKind::DataUploaded {
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn inbox_keys_order_newest_first_within_recipient() {
         let r = user(1, 2);
-        let id = Ulid::new();
+        let id = Ulid::r#gen();
         assert!(notification_inbox_key(r, 2000, id) < notification_inbox_key(r, 1000, id));
 
         let id_a = Ulid::from_bytes([0u8; 16]);
@@ -316,7 +316,7 @@ mod tests {
     fn inbox_key_is_recipient_prefixed() {
         let a = user(1, 2);
         let b = user(1, 3);
-        let id = Ulid::new();
+        let id = Ulid::r#gen();
         let ka = notification_inbox_key(a, 1000, id);
         let kb = notification_inbox_key(b, 1000, id);
         assert_ne!(&ka[..48], &kb[..48]);
@@ -328,7 +328,7 @@ mod tests {
     fn inbox_key_roundtrips_through_parser() {
         let r = user(5, 9);
         let ts = 1_700_000_000_000u64;
-        let id = Ulid::new();
+        let id = Ulid::r#gen();
         let key = notification_inbox_key(r, ts, id);
         assert_eq!(parse_notification_inbox_key(&key).unwrap(), (r, ts, id));
         assert!(matches!(
@@ -370,7 +370,7 @@ mod tests {
     fn cursor_is_key_suffix() {
         let r = user(1, 2);
         let ts = 42u64;
-        let id = Ulid::new();
+        let id = Ulid::r#gen();
         let cursor = notification_inbox_cursor(ts, id);
         assert_eq!(cursor.len(), 24);
         assert_eq!(
@@ -430,15 +430,15 @@ mod tests {
     #[test]
     fn kind_categories_are_stable() {
         let added = NotificationKind::AddedToGroup {
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             actor_user_id: user(1, 3),
         };
         let removed = NotificationKind::RemovedFromGroup {
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             actor_user_id: user(1, 3),
         };
         let member = NotificationKind::GroupMemberAdded {
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             member_user_id: user(1, 4),
             actor_user_id: user(1, 3),
         };
@@ -446,14 +446,14 @@ mod tests {
             realm_id: RealmId([1; 32]),
             node_id: make_node_id(1),
         };
-        let metadata_group_id = Ulid::new();
+        let metadata_group_id = Ulid::r#gen();
         let metadata_created = NotificationKind::MetadataCreated {
             path: format!("meta/{metadata_group_id}/datasets/project/run-42"),
             group_id: metadata_group_id,
-            document_id: Ulid::new(),
+            document_id: Ulid::r#gen(),
             actor_user_id: user(1, 5),
         };
-        let data_group_id = Ulid::new();
+        let data_group_id = Ulid::r#gen();
         let data_node_id = make_node_id(2);
         let data_uploaded = NotificationKind::DataUploaded {
             path: crate::structs::data_watch_resource_path(

--- a/core/src/structs/notification_watch.rs
+++ b/core/src/structs/notification_watch.rs
@@ -249,7 +249,7 @@ impl WatchSubscription {
         created_at_ms: u64,
     ) -> Self {
         Self {
-            watch_id: Ulid::new(),
+            watch_id: Ulid::r#gen(),
             owner,
             path_prefix,
             event_mask,
@@ -527,7 +527,7 @@ mod tests {
     fn keys_are_owner_isolated() {
         let a = user(1, 2);
         let b = user(1, 3);
-        let watch_id = Ulid::new();
+        let watch_id = Ulid::r#gen();
         let ka = watch_subscription_key(a, watch_id);
         let kb = watch_subscription_key(b, watch_id);
         assert_ne!(&ka[..48], &kb[..48]);
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn key_roundtrips_through_parser() {
         let owner = user(5, 9);
-        let watch_id = Ulid::new();
+        let watch_id = Ulid::r#gen();
         let key = watch_subscription_key(owner, watch_id);
         assert_eq!(
             parse_watch_subscription_key(&key).unwrap(),
@@ -657,7 +657,7 @@ mod tests {
         let group_id = Ulid::from_bytes([5u8; 16]);
         let node_id = node(6);
         let uploaded = WatchEvent {
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             realm_id: RealmId([1u8; 32]),
             kind: WatchEventKind::DataUploaded,
             path: data_watch_resource_path(group_id, node_id, "bucket", "object"),

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -116,7 +116,7 @@ impl std::fmt::Display for RealmLevelOperation {
 impl RealmAuthorizationDocument {
     pub fn new_default_realm_doc(realm_id: RealmId) -> Self {
         let mut roles = HashMap::new();
-        let admin = Ulid::new();
+        let admin = Ulid::r#gen();
         roles.insert(
             admin,
             Role {
@@ -378,14 +378,14 @@ impl RealmConfigDocument {
     /// strategy configuration.
     pub fn seed_default_placement(&mut self) {
         let default_strategy = PlacementStrategy {
-            strategy_id: Ulid::new(),
+            strategy_id: Ulid::r#gen(),
             name: "default".to_string(),
             replica_count: Some(self.metadata_replication.default_replication_factor),
             distinct_locations: false,
             affinity: Vec::new(),
         };
         let everywhere_strategy = PlacementStrategy {
-            strategy_id: Ulid::new(),
+            strategy_id: Ulid::r#gen(),
             name: "everywhere".to_string(),
             replica_count: None,
             distinct_locations: false,
@@ -576,7 +576,7 @@ mod test {
         let auth_doc = RealmAuthorizationDocument::new_default_realm_doc(RealmId([0u8; 32]));
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
-            user_id: crate::UserId::new(Ulid::new(), RealmId([0u8; 32])),
+            user_id: crate::UserId::new(Ulid::r#gen(), RealmId([0u8; 32])),
             realm_id: RealmId([0u8; 32]),
         };
         let bytes = auth_doc.to_bytes(&actor).unwrap();
@@ -592,7 +592,7 @@ mod test {
 
     #[test]
     pub fn test_realm_config_doc_roundtrip() {
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let document = RealmConfigDocument {
             realm_id: RealmId([4u8; 32]),
             metadata_replication: super::MetadataReplicationConfig {
@@ -626,7 +626,7 @@ mod test {
         };
         let actor = Actor {
             node_id: iroh::SecretKey::from_bytes(&[14u8; 32]).public(),
-            user_id: crate::UserId::new(Ulid::new(), RealmId([4u8; 32])),
+            user_id: crate::UserId::new(Ulid::r#gen(), RealmId([4u8; 32])),
             realm_id: RealmId([4u8; 32]),
         };
 
@@ -698,8 +698,8 @@ mod test {
 
     #[test]
     pub fn test_realm_config_replication_resolution() {
-        let group_id = Ulid::new();
-        let other_group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
+        let other_group_id = Ulid::r#gen();
         let document = RealmConfigDocument {
             realm_id: RealmId([5u8; 32]),
             metadata_replication: super::MetadataReplicationConfig {

--- a/core/src/structs/structs.rs
+++ b/core/src/structs/structs.rs
@@ -318,13 +318,13 @@ mod test {
     #[test]
     pub fn test_role_conversion() {
         let role = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "admin".to_string(),
             permissions: HashMap::from([(
-                format!("/{}/g/{}/**", RealmId([0u8; 32]), Ulid::new().to_string()),
+                format!("/{}/g/{}/**", RealmId([0u8; 32]), Ulid::r#gen().to_string()),
                 Permission::WRITE,
             )]),
-            assigned_users: HashSet::from([UserId::new(Ulid::new(), RealmId([1u8; 32]))]),
+            assigned_users: HashSet::from([UserId::new(Ulid::r#gen(), RealmId([1u8; 32]))]),
         };
 
         let bytes = postcard::to_allocvec(&role).unwrap();
@@ -338,7 +338,7 @@ mod test {
         let realm_id = RealmId([1u8; 32]);
         let other_realm_id = RealmId([2u8; 32]);
         let role = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "public".to_string(),
             permissions: HashMap::from([("/test".to_string(), Permission::READ)]),
             assigned_users: HashSet::from([UserId::nil(realm_id)]),
@@ -357,7 +357,7 @@ mod test {
     #[test]
     pub fn test_user_attributes_roundtrip() {
         let realm_id = RealmId([2u8; 32]);
-        let user_id = UserId::new(Ulid::new(), realm_id);
+        let user_id = UserId::new(Ulid::r#gen(), realm_id);
         let user = User {
             user_id,
             name: "alice".to_string(),

--- a/core/src/user_id.rs
+++ b/core/src/user_id.rs
@@ -125,13 +125,13 @@ mod tests {
 
     #[test]
     fn user_id_roundtrips_through_string() {
-        let user_id = UserId::new(Ulid::new(), RealmId([7u8; 32]));
+        let user_id = UserId::new(Ulid::r#gen(), RealmId([7u8; 32]));
         assert_eq!(UserId::from_str(&user_id.to_string()).unwrap(), user_id);
     }
 
     #[test]
     fn user_id_roundtrips_through_storage_key() {
-        let user_id = UserId::new(Ulid::new(), RealmId([9u8; 32]));
+        let user_id = UserId::new(Ulid::r#gen(), RealmId([9u8; 32]));
         assert_eq!(
             UserId::from_storage_key(&user_id.to_storage_key()).unwrap(),
             user_id
@@ -147,6 +147,6 @@ mod tests {
         assert!(user_id.is_nil());
         assert!(user_id.is_nil_in(realm_id));
         assert!(!user_id.is_nil_in(other_realm_id));
-        assert!(!UserId::local(Ulid::new(), realm_id).is_nil());
+        assert!(!UserId::local(Ulid::r#gen(), realm_id).is_nil());
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,55 @@
+[graph]
+all-features = true
+
+[advisories]
+yanked = "deny"
+# Pre-existing transitive advisories acknowledged for deliberate follow-up
+# updates; new advisories beyond this set still fail the gate.
+ignore = [
+    "RUSTSEC-2023-0071", # rsa Marvin timing sidechannel, no fixed release
+    "RUSTSEC-2023-0089", # atomic-polyfill unmaintained (transitive)
+    "RUSTSEC-2024-0370", # proc-macro-error unmaintained (transitive)
+    "RUSTSEC-2024-0436", # paste unmaintained (transitive)
+    "RUSTSEC-2025-0052", # async-std discontinued (transitive)
+    "RUSTSEC-2026-0098", # rustls-webpki name-constraints (transitive)
+    "RUSTSEC-2026-0099", # rustls-webpki name-constraints (transitive)
+    "RUSTSEC-2026-0104", # rustls-webpki CRL parsing panic (transitive)
+    "RUSTSEC-2026-0194", # quick-xml quadratic parse via RDF stack (upstream craqle)
+    "RUSTSEC-2026-0195", # quick-xml namespace allocation via RDF stack (upstream craqle)
+    "RUSTSEC-2026-0204", # crossbeam-utils fmt::Pointer deref (transitive)
+]
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "zlib-acknowledgement",
+]
+
+[bans]
+multiple-versions = "allow"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = [
+    "https://github.com/arunaengine/craqle",
+    "https://github.com/arunaengine/irokle.git",
+    "https://github.com/intbio-ncl/ro-crate-rs.git",
+]

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -4033,7 +4033,7 @@ async fn apply_watch_subscription_change_to_storage(
             (
                 NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
                 ByteView::from(watch_interest_dirty_key(realm_id)),
-                ByteView::from(Ulid::new().to_bytes().to_vec()),
+                ByteView::from(Ulid::r#gen().to_bytes().to_vec()),
             ),
         ];
         let deletes = if let Some(bytes) = bytes.as_ref() {
@@ -7784,7 +7784,7 @@ mod tests {
         ];
         let additions = actors.each_ref().map(|actor| {
             test_admin_event(
-                Ulid::new(),
+                Ulid::r#gen(),
                 AdminDocumentTarget::User {
                     user_id: actor.user_id,
                 },
@@ -7834,7 +7834,7 @@ mod tests {
         }
 
         let mut removal = test_admin_event(
-            Ulid::new(),
+            Ulid::r#gen(),
             AdminDocumentTarget::User {
                 user_id: user_ids[0],
             },
@@ -9444,14 +9444,14 @@ mod tests {
 
         let local_node = service.local_node_id().expect("local node id");
         let target = DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: Ulid::new(),
+            document_id: Ulid::r#gen(),
         };
         let topic_id = target.sync_topic_id();
         let change = DocumentSyncChange {
             base: None,
             current: DocumentSyncRevision {
                 generation: 1,
-                event_id: Ulid::new(),
+                event_id: Ulid::r#gen(),
                 actor: local_node,
                 updated_at_ms: 1,
             },
@@ -9462,7 +9462,7 @@ mod tests {
         let blocked = service
             .publish_documents(
                 vec![DocumentSyncPublish::Upsert {
-                    event_id: Ulid::new(),
+                    event_id: Ulid::r#gen(),
                     target: target.clone(),
                     bytes: b"blocked".to_vec(),
                     change,
@@ -9483,7 +9483,7 @@ mod tests {
         let published = service
             .publish_documents(
                 vec![DocumentSyncPublish::Upsert {
-                    event_id: Ulid::new(),
+                    event_id: Ulid::r#gen(),
                     target: target.clone(),
                     bytes: b"origin".to_vec(),
                     change,
@@ -9831,7 +9831,7 @@ mod tests {
             base: None,
             current: DocumentSyncRevision {
                 generation: 1,
-                event_id: Ulid::new(),
+                event_id: Ulid::r#gen(),
                 actor: service.local_node_id().expect("local node id"),
                 updated_at_ms: 1,
             },
@@ -9870,14 +9870,14 @@ mod tests {
             .publish_documents(
                 vec![
                     DocumentSyncPublish::Upsert {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: target.clone(),
                         bytes: b"whole-document-admin-upsert".to_vec(),
                         change: change(DocumentSyncChangeKind::Upsert),
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::Delete {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: target.clone(),
                         change: change(DocumentSyncChangeKind::Delete),
                         allow_genesis: true,
@@ -10132,7 +10132,7 @@ mod tests {
             AdminEventValidation::Accepted
         );
 
-        let server_actor = test_actor(66, UserId::local(Ulid::new(), realm_id), realm_id);
+        let server_actor = test_actor(66, UserId::local(Ulid::r#gen(), realm_id), realm_id);
         let mut server_config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
         server_config.ensure_node(server_actor.node_id, RealmNodeKind::Server);
         storage_batch_write_to(
@@ -10168,7 +10168,7 @@ mod tests {
                     &server_actor,
                     1,
                     AdminDocumentOperation::RealmRoleAdded {
-                        role_id: Ulid::new(),
+                        role_id: Ulid::r#gen(),
                     },
                 ),
             ),
@@ -10195,9 +10195,9 @@ mod tests {
     async fn inbound_admin_validation_rejects_target_and_malformed_events() {
         let (_dir, storage) = test_storage();
         let realm_id = RealmId::from_bytes([67; 32]);
-        let actor = test_actor(67, UserId::local(Ulid::new(), realm_id), realm_id);
+        let actor = test_actor(67, UserId::local(Ulid::r#gen(), realm_id), realm_id);
         let user_id = actor.user_id;
-        let other_user = UserId::local(Ulid::new(), realm_id);
+        let other_user = UserId::local(Ulid::r#gen(), realm_id);
         let mut config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
         config.ensure_node(actor.node_id, RealmNodeKind::Server);
         storage_batch_write_to(
@@ -10899,7 +10899,7 @@ mod tests {
             base: None,
             current: DocumentSyncRevision {
                 generation: 1,
-                event_id: Ulid::new(),
+                event_id: Ulid::r#gen(),
                 actor: local_node,
                 updated_at_ms: 1,
             },
@@ -10929,14 +10929,14 @@ mod tests {
             .publish_documents(
                 vec![
                     DocumentSyncPublish::Upsert {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: forged_target.clone(),
                         bytes: forged_digest.to_bytes().expect("digest serializes"),
                         change: change(),
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::Upsert {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: target.clone(),
                         bytes: owned_bytes.clone(),
                         change: change(),
@@ -11045,7 +11045,7 @@ mod tests {
             base: None,
             current: DocumentSyncRevision {
                 generation: 1,
-                event_id: Ulid::new(),
+                event_id: Ulid::r#gen(),
                 actor: local_node,
                 updated_at_ms: 1,
             },
@@ -11082,7 +11082,7 @@ mod tests {
             .publish_documents(
                 vec![
                     DocumentSyncPublish::Delete {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: forged_target.clone(),
                         change: change(DocumentSyncChangeKind::Delete),
                         allow_genesis: true,
@@ -11093,7 +11093,7 @@ mod tests {
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::Upsert {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: target.clone(),
                         bytes: digest_bytes.clone(),
                         change: change(DocumentSyncChangeKind::Upsert),
@@ -11199,7 +11199,7 @@ mod tests {
             base: None,
             current: DocumentSyncRevision {
                 generation: 1,
-                event_id: Ulid::new(),
+                event_id: Ulid::r#gen(),
                 actor: local_node,
                 updated_at_ms: 1,
             },
@@ -11222,13 +11222,13 @@ mod tests {
             .publish_documents(
                 vec![
                     DocumentSyncPublish::Delete {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: target.clone(),
                         change: change(DocumentSyncChangeKind::Delete),
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::Upsert {
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         target: target.clone(),
                         bytes: snapshot_bytes.clone(),
                         change: change(DocumentSyncChangeKind::Upsert),

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -565,7 +565,7 @@ impl NetHandle {
             .document_sync_storage_path
             .clone()
             .unwrap_or_else(|| {
-                std::env::temp_dir().join(format!("aruna-document-sync-{}", ulid::Ulid::new()))
+                std::env::temp_dir().join(format!("aruna-document-sync-{}", ulid::Ulid::r#gen()))
             });
         let document_sync = Arc::new(DocumentSyncService::open_with_persist_policy(
             endpoint.clone(),

--- a/net/tests/integration.rs
+++ b/net/tests/integration.rs
@@ -414,10 +414,10 @@ fn test_topic_id_creation() {
     let topic2 = TopicId::from_bytes(&bytes).expect("topic roundtrip");
     assert_eq!(topic1, topic2);
 
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let topic3 = TopicId::group(group_id);
     let topic4 = TopicId::group(group_id);
-    let topic5 = TopicId::group(Ulid::new());
+    let topic5 = TopicId::group(Ulid::r#gen());
 
     assert_eq!(topic3, topic4);
     assert_ne!(topic3, topic5);

--- a/operations/src/add_group_role.rs
+++ b/operations/src/add_group_role.rs
@@ -987,7 +987,7 @@ pub mod test {
         let realm_id = RealmId([0u8; 32]);
         let actor = Actor {
             node_id: node(1),
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         };
         drive(
@@ -1078,7 +1078,7 @@ pub mod test {
                 realm_id,
                 group_id,
                 role: Role {
-                    role_id: Ulid::new(),
+                    role_id: Ulid::r#gen(),
                     name: name.to_string(),
                     permissions: HashMap::from([(
                         format!("/{realm_id}/g/{group_id}/data/**"),
@@ -1118,7 +1118,7 @@ pub mod test {
                 realm_id,
                 group_id,
                 role: Role {
-                    role_id: Ulid::new(),
+                    role_id: Ulid::r#gen(),
                     name: "public".to_string(),
                     permissions: HashMap::from([(
                         format!("/{realm_id}/g/{group_id}/data/**"),
@@ -1157,7 +1157,7 @@ pub mod test {
             realm_id,
             group_id,
             role: Role {
-                role_id: Ulid::new(),
+                role_id: Ulid::r#gen(),
                 name: "foreign-nil".to_string(),
                 permissions: HashMap::from([(
                     format!("/{realm_id}/g/{group_id}/data/**"),
@@ -1180,9 +1180,9 @@ pub mod test {
         // Inputs
         //
         let realm_id = aruna_core::structs::RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let auth_doc =
             GroupAuthorizationDocument::new_default_group_doc(user_id, realm_id, group_id);
         let group = Group {
@@ -1202,7 +1202,7 @@ pub mod test {
             user_id,
             realm_id,
         };
-        let role_id = Ulid::new();
+        let role_id = Ulid::r#gen();
         let add_role_input = AddGroupRoleConfig {
             auth_context: auth_context.clone(),
             actor: actor.clone(),
@@ -1216,7 +1216,7 @@ pub mod test {
                         "{}/g/{}/meta/{}",
                         realm_id,
                         group_id.to_string(),
-                        Ulid::new(),
+                        Ulid::r#gen(),
                     ),
                     Permission::READ,
                 )]),
@@ -1285,7 +1285,7 @@ pub mod test {
             AddGroupRoleState::StartTransaction
         );
 
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = add_role_operation.step(Event::Storage(
             aruna_core::events::StorageEvent::TransactionStarted { txn_id },
         ));
@@ -1496,7 +1496,7 @@ pub mod test {
     async fn assigned_users_emit_membership_notifications_for_new_members() {
         let (context, _tempdir) = test_context().await;
         let (actor, group, auth_doc) = setup_group(&context).await;
-        let second_admin = UserId::local(Ulid::new(), actor.realm_id);
+        let second_admin = UserId::local(Ulid::r#gen(), actor.realm_id);
         drive(
             AddUserToGroupOperation::new(AddUserToGroupInput {
                 actor: actor.clone(),
@@ -1509,7 +1509,7 @@ pub mod test {
         .await
         .unwrap();
 
-        let member = UserId::local(Ulid::new(), actor.realm_id);
+        let member = UserId::local(Ulid::r#gen(), actor.realm_id);
         drive(
             AddGroupRoleOperation::new(AddGroupRoleConfig {
                 auth_context: auth_context(&actor),
@@ -1517,7 +1517,7 @@ pub mod test {
                 realm_id: actor.realm_id,
                 group_id: group.group_id,
                 role: Role {
-                    role_id: Ulid::new(),
+                    role_id: Ulid::r#gen(),
                     name: "custom_member".to_string(),
                     permissions: HashMap::from([(
                         format!("/{}/g/{}/data/**", actor.realm_id, group.group_id),
@@ -1558,7 +1558,7 @@ pub mod test {
                 realm_id: actor.realm_id,
                 group_id: group.group_id,
                 role: Role {
-                    role_id: Ulid::new(),
+                    role_id: Ulid::r#gen(),
                     name: "public_viewer".to_string(),
                     permissions: HashMap::from([(
                         format!("/{}/g/{}/data/**", actor.realm_id, group.group_id),

--- a/operations/src/add_realm_role.rs
+++ b/operations/src/add_realm_role.rs
@@ -749,7 +749,7 @@ pub mod test {
                 actor: actor.clone(),
                 realm_id,
                 role: Role {
-                    role_id: Ulid::new(),
+                    role_id: Ulid::r#gen(),
                     name: name.to_string(),
                     permissions: HashMap::from([(
                         format!("/{realm_id}/data/**"),
@@ -782,7 +782,7 @@ pub mod test {
                 actor: actor.clone(),
                 realm_id,
                 role: Role {
-                    role_id: Ulid::new(),
+                    role_id: Ulid::r#gen(),
                     name: "public".to_string(),
                     permissions: HashMap::from([(format!("/{realm_id}/data/**"), permission)]),
                     assigned_users: HashSet::from([UserId::nil(realm_id)]),
@@ -811,7 +811,7 @@ pub mod test {
             actor,
             realm_id,
             role: Role {
-                role_id: Ulid::new(),
+                role_id: Ulid::r#gen(),
                 name: "foreign-nil".to_string(),
                 permissions: HashMap::from([(format!("/{realm_id}/data/**"), Permission::READ)]),
                 assigned_users: HashSet::from([UserId::nil(other_realm_id)]),
@@ -922,7 +922,7 @@ pub mod test {
             effects.first().unwrap(),
             &Effect::Storage(StorageEffect::StartTransaction { read: false })
         );
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         assert_eq!(
             effects.first().unwrap(),
@@ -1134,7 +1134,7 @@ pub mod test {
         };
 
         let realm_id = aruna_core::structs::RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
         let realm_config = CreateRealmConfig {
             actor: Actor {
@@ -1167,7 +1167,7 @@ pub mod test {
             },
             realm_id,
             role: Role {
-                role_id: Ulid::new(),
+                role_id: Ulid::r#gen(),
                 name: "test_role".to_string(),
                 permissions: HashMap::from([(
                     format!("{}/admin/create_group/*", realm_id),

--- a/operations/src/add_user_to_group.rs
+++ b/operations/src/add_user_to_group.rs
@@ -743,7 +743,7 @@ fn apply_admin_reducer_operation(
 ) -> Result<AdminDocumentEvent, AdminDocumentReducerError> {
     let observed = state.clock.clone();
     let event = AdminDocumentEvent {
-        event_id: Ulid::new(),
+        event_id: Ulid::r#gen(),
         target: state.target.clone(),
         origin_node_id: actor.node_id,
         origin_seq: observed.sequence_for(&actor.node_id) + 1,
@@ -969,7 +969,7 @@ pub mod test {
 
         let effects = operation
             .emit_write_auth_doc_and_admin_state(
-                TxnId::new(),
+                TxnId::r#gen(),
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 None,
             )
@@ -1056,7 +1056,7 @@ pub mod test {
         operation.step(Event::SubOperation(
             SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
         ));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
 
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
@@ -1210,7 +1210,7 @@ pub mod test {
             user_id: member_id,
             role_ids: HashSet::from([role_id]),
         });
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
 
         operation
             .emit_write_auth_doc_and_admin_state(
@@ -1276,7 +1276,7 @@ pub mod test {
         };
 
         let realm_id = aruna_core::structs::RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
 
         let realm_config = CreateRealmConfig {
@@ -1319,7 +1319,7 @@ pub mod test {
                 realm_id,
             },
             group_id: group.group_id,
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             role_ids: reader_writer_roles,
         };
 
@@ -1376,7 +1376,7 @@ pub mod test {
         let realm_id = RealmId([0u8; 32]);
         let actor = Actor {
             node_id: node(1),
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         };
         drive(
@@ -1457,7 +1457,7 @@ pub mod test {
         let (context, net_handle, _tmp) = add_context().await;
         let (actor, group, auth_doc) = setup_group(&context).await;
 
-        let second_admin = UserId::local(Ulid::new(), actor.realm_id);
+        let second_admin = UserId::local(Ulid::r#gen(), actor.realm_id);
         drive(
             AddUserToGroupOperation::new(AddUserToGroupInput {
                 actor: actor.clone(),
@@ -1470,7 +1470,7 @@ pub mod test {
         .await
         .unwrap();
 
-        let member = UserId::local(Ulid::new(), actor.realm_id);
+        let member = UserId::local(Ulid::r#gen(), actor.realm_id);
         drive(
             AddUserToGroupOperation::new(AddUserToGroupInput {
                 actor: actor.clone(),
@@ -1524,7 +1524,7 @@ pub mod test {
         operation.step(Event::SubOperation(
             SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
         ));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
@@ -1579,7 +1579,7 @@ pub mod test {
         operation.step(Event::SubOperation(
             SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
         ));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
@@ -1609,7 +1609,7 @@ pub mod test {
     async fn readding_existing_member_emits_nothing() {
         let (context, net_handle, _tmp) = add_context().await;
         let (actor, group, auth_doc) = setup_group(&context).await;
-        let member = UserId::local(Ulid::new(), actor.realm_id);
+        let member = UserId::local(Ulid::r#gen(), actor.realm_id);
 
         drive(
             AddUserToGroupOperation::new(AddUserToGroupInput {

--- a/operations/src/add_user_to_realm_role.rs
+++ b/operations/src/add_user_to_realm_role.rs
@@ -665,7 +665,7 @@ fn apply_admin_reducer_operation(
 ) -> Result<AdminDocumentEvent, AdminDocumentReducerError> {
     let observed = state.clock.clone();
     let event = AdminDocumentEvent {
-        event_id: Ulid::new(),
+        event_id: Ulid::r#gen(),
         target: state.target.clone(),
         origin_node_id: actor.node_id,
         origin_seq: observed.sequence_for(&actor.node_id) + 1,
@@ -854,7 +854,7 @@ pub mod test {
 
         let effects = operation
             .emit_write_auth_doc_and_admin_state(
-                TxnId::new(),
+                TxnId::r#gen(),
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 None,
             )
@@ -953,7 +953,7 @@ pub mod test {
         operation.step(Event::SubOperation(
             SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
         ));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
 
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
@@ -1138,7 +1138,7 @@ pub mod test {
         };
 
         let realm_id = aruna_core::structs::RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
         let realm_config = CreateRealmConfig {
             actor: Actor {
@@ -1182,7 +1182,7 @@ pub mod test {
                 realm_id,
             },
             realm_id,
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             role_ids: admin_role,
         };
 

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -387,7 +387,7 @@ impl AnnounceTopicOperation {
                     base: None,
                     current: DocumentSyncRevision {
                         generation: record.updated_at_ms,
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         actor: self.local_node_id,
                         updated_at_ms: record.updated_at_ms,
                     },
@@ -407,7 +407,7 @@ impl AnnounceTopicOperation {
                     base: None,
                     current: DocumentSyncRevision {
                         generation: now,
-                        event_id: Ulid::new(),
+                        event_id: Ulid::r#gen(),
                         actor: self.local_node_id,
                         updated_at_ms: now,
                     },
@@ -692,8 +692,8 @@ mod tests {
             let lifecycle = MetadataGraphLifecycleRecord::deleted(
                 "urn:graph:announce".to_string(),
                 RealmId::from_bytes([2u8; 32]),
-                GroupId::new(),
-                Ulid::new(),
+                GroupId::r#gen(),
+                Ulid::r#gen(),
                 42,
             );
             let document = DocumentSyncTarget::MetadataGraphLifecycle {
@@ -732,8 +732,8 @@ mod tests {
         let lifecycle = MetadataGraphLifecycleRecord::deleted(
             "urn:graph:placed-announce".to_string(),
             RealmId::from_bytes([2u8; 32]),
-            GroupId::new(),
-            Ulid::new(),
+            GroupId::r#gen(),
+            Ulid::r#gen(),
             42,
         );
         let document = DocumentSyncTarget::MetadataGraphLifecycle {
@@ -891,7 +891,7 @@ mod tests {
     fn every_admin_document_target_refuses_whole_document_announce() {
         let local_node_id = local_node_id();
         let realm_id = RealmId::from_bytes([2u8; 32]);
-        let group_id = GroupId::new();
+        let group_id = GroupId::r#gen();
         let (user_id, _) = user_document();
         let admin_targets = [
             DocumentSyncTarget::Group { group_id },

--- a/operations/src/blob/resolve_blob_permission_paths.rs
+++ b/operations/src/blob/resolve_blob_permission_paths.rs
@@ -270,7 +270,7 @@ mod tests {
             })]
         ));
 
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let effects = op.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         assert_eq!(op.state, ResolveBlobPermissionPathsState::ReadHashAliases);
         assert!(matches!(
@@ -292,7 +292,7 @@ mod tests {
 
         op.start();
         let effects = op.step(Event::Storage(StorageEvent::TransactionStarted {
-            txn_id: Ulid::new(),
+            txn_id: Ulid::r#gen(),
         }));
         assert_eq!(op.state, ResolveBlobPermissionPathsState::ReadHashAliases);
         assert!(matches!(
@@ -347,7 +347,7 @@ mod tests {
         ));
 
         let effects = op.step(Event::Storage(StorageEvent::TransactionCommitted {
-            txn_id: Ulid::new(),
+            txn_id: Ulid::r#gen(),
         }));
         assert!(effects.is_empty());
         assert_eq!(op.state, ResolveBlobPermissionPathsState::Finish);

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -381,7 +381,7 @@ mod tests {
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let local_node_id = iroh::SecretKey::from_bytes(&LOCAL_NODE_SECRET).public();
         let joiner_node_id = iroh::SecretKey::from_bytes(&[5u8; 32]).public();
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
 
         drive(
             CreateRealmOperation::new(CreateRealmConfig {
@@ -401,7 +401,7 @@ mod tests {
         .await
         .unwrap();
 
-        let enrollment_id = Ulid::new();
+        let enrollment_id = Ulid::r#gen();
         drive(
             CreateOnboardingSecretOperation::new(CreateOnboardingSecretInput {
                 record: OnboardingSecretRecord {

--- a/operations/src/check_permissions.rs
+++ b/operations/src/check_permissions.rs
@@ -451,7 +451,7 @@ mod test {
         let realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
         let pubkey = realm_signing_key.verifying_key().to_bytes();
         let realm_id = RealmId::from_bytes(pubkey);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let path = format!("/{}/g/{}", realm_id, group_id.to_string());
         let (parsed_realm_id, parsed_group_id) =
             CheckPermissionsOperation::parse_path(&path).unwrap();
@@ -466,18 +466,18 @@ mod test {
         assert_eq!(realm_id, parsed_realm_id);
         assert!(parsed_group_id.is_none());
 
-        let path = format!("/abcd/g/{}", Ulid::new().to_string());
+        let path = format!("/abcd/g/{}", Ulid::r#gen().to_string());
         assert!(CheckPermissionsOperation::parse_path(&path).is_err());
     }
 
     #[test]
     fn path_restrictions_enforce_whitelist_and_required_permission() {
         let realm_id = RealmId([0u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let pattern = format!("/{realm_id}/g/{group_id}/meta/**");
         let mut operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
             auth_context: AuthContext {
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
                 path_restrictions: Some(vec![PathRestriction {
                     pattern: pattern.clone(),
@@ -509,9 +509,9 @@ mod test {
     fn collect_roles_only_treats_same_realm_nil_as_public() {
         let realm_id = RealmId([1u8; 32]);
         let other_realm_id = RealmId([2u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let role = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "foreign-nil".to_string(),
             permissions: HashMap::from([(
                 format!("/{realm_id}/g/{group_id}/data/**"),
@@ -536,12 +536,12 @@ mod test {
     #[test]
     fn public_grants_are_read_only_when_evaluating_permissions() {
         let realm_id = RealmId([2u8; 32]);
-        let group_id = Ulid::new();
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let group_id = Ulid::r#gen();
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let path = format!("/{realm_id}/g/{group_id}/data/object");
 
         let public_write = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "public-write".to_string(),
             permissions: HashMap::from([(path.clone(), Permission::WRITE)]),
             assigned_users: HashSet::from([UserId::nil(realm_id)]),
@@ -562,7 +562,7 @@ mod test {
         );
 
         let public_direct_write = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "public-direct-write".to_string(),
             permissions: HashMap::from([(path.clone(), Permission::WRITE)]),
             assigned_users: HashSet::from([UserId::nil(realm_id), user_id]),
@@ -578,19 +578,19 @@ mod test {
         );
 
         let public_deny = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "public-deny".to_string(),
             permissions: HashMap::from([(path.clone(), Permission::DENY)]),
             assigned_users: HashSet::from([UserId::nil(realm_id)]),
         };
         let direct_read = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "direct-read".to_string(),
             permissions: HashMap::from([(path.clone(), Permission::READ)]),
             assigned_users: HashSet::from([user_id]),
         };
         let public_direct_deny = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "public-direct-deny".to_string(),
             permissions: HashMap::from([(path.clone(), Permission::DENY)]),
             assigned_users: HashSet::from([UserId::nil(realm_id), user_id]),
@@ -664,7 +664,7 @@ mod test {
         };
 
         let realm_id = RealmId([3u8; 32]);
-        let admin_id = UserId::local(Ulid::new(), realm_id);
+        let admin_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[2u8; 32]).public();
         let actor = Actor {
             node_id,
@@ -718,7 +718,7 @@ mod test {
                 actor: actor.clone(),
                 group_id,
                 role: aruna_core::structs::Role {
-                    role_id: Ulid::new(),
+                    role_id: Ulid::r#gen(),
                     name: "public-read".to_string(),
                     permissions: HashMap::from([(
                         format!("/{realm_id}/g/{group_id}/data/**"),
@@ -766,7 +766,7 @@ mod test {
         // Authenticated strangers inherit public grants — signed access is
         // never weaker than unsigned access.
         let stranger = AuthContext {
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
             path_restrictions: None,
         };
@@ -787,7 +787,7 @@ mod test {
                     actor: actor.clone(),
                     group_id,
                     role: aruna_core::structs::Role {
-                        role_id: Ulid::new(),
+                        role_id: Ulid::r#gen(),
                         name: name.to_string(),
                         permissions: HashMap::from([(
                             format!("/{realm_id}/g/{group_id}/data/**"),
@@ -832,7 +832,7 @@ mod test {
         };
 
         let realm_id = RealmId([0u8; 32]);
-        let admin_id = UserId::local(Ulid::new(), realm_id);
+        let admin_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
 
         let realm_config = CreateRealmConfig {
@@ -859,7 +859,7 @@ mod test {
         .await
         .unwrap();
 
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
 
         let group_config = CreateGroupConfig {
             actor: aruna_core::structs::Actor {
@@ -888,7 +888,7 @@ mod test {
                 "/{}/g/{}/meta/{}",
                 realm_id,
                 group_id.to_string(),
-                Ulid::new().to_string()
+                Ulid::r#gen().to_string()
             ),
             required_permission: Permission::WRITE,
         };
@@ -901,7 +901,7 @@ mod test {
         //
         let perm_config = CheckPermissionsConfig {
             auth_context: aruna_core::structs::AuthContext {
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
                 path_restrictions: None,
             },
@@ -909,7 +909,7 @@ mod test {
                 "/{}/g/{}/data/{}",
                 realm_id,
                 group_id.to_string(),
-                Ulid::new().to_string()
+                Ulid::r#gen().to_string()
             ),
             required_permission: Permission::WRITE,
         };
@@ -929,8 +929,8 @@ mod test {
             path: format!(
                 "/{}/g/{}/data/{}",
                 realm_id,
-                Ulid::new(),
-                Ulid::new().to_string()
+                Ulid::r#gen(),
+                Ulid::r#gen().to_string()
             ),
             required_permission: Permission::WRITE,
         };
@@ -940,7 +940,7 @@ mod test {
         //
         // User is in group and has not sufficient permissions
         //
-        let reader = UserId::local(Ulid::new(), realm_id);
+        let reader = UserId::local(Ulid::r#gen(), realm_id);
         let add_user_input = AddUserToGroupInput {
             actor: Actor {
                 node_id,
@@ -969,7 +969,7 @@ mod test {
                 "/{}/g/{}/meta/{}",
                 realm_id,
                 group_id.to_string(),
-                Ulid::new().to_string()
+                Ulid::r#gen().to_string()
             ),
             required_permission: Permission::WRITE,
         };
@@ -986,7 +986,7 @@ mod test {
         //
         // Test DENY roles
         //
-        let denied_user = UserId::local(Ulid::new(), realm_id);
+        let denied_user = UserId::local(Ulid::r#gen(), realm_id);
         let add_role_input = AddGroupRoleConfig {
             auth_context: aruna_core::structs::AuthContext {
                 user_id,
@@ -1001,7 +1001,7 @@ mod test {
             },
             group_id,
             role: aruna_core::structs::Role {
-                role_id: Ulid::new(),
+                role_id: Ulid::r#gen(),
                 name: "denied".to_string(),
                 permissions: HashMap::from([(
                     format!("{}/g/{}/**", realm_id, group_id),
@@ -1024,7 +1024,7 @@ mod test {
                 "/{}/g/{}/meta/{}",
                 realm_id,
                 group_id.to_string(),
-                Ulid::new().to_string()
+                Ulid::r#gen().to_string()
             ),
             required_permission: Permission::READ,
         };
@@ -1040,7 +1040,7 @@ mod test {
                 realm_id,
                 path_restrictions: None,
             },
-            path: format!("/{}/admin/roles/{}", realm_id, Ulid::new().to_string()),
+            path: format!("/{}/admin/roles/{}", realm_id, Ulid::r#gen().to_string()),
             required_permission: Permission::READ,
         };
         let perm_operation = CheckPermissionsOperation::new(perm_config.clone());
@@ -1055,7 +1055,7 @@ mod test {
                 realm_id,
                 path_restrictions: None,
             },
-            path: format!("/{}/admin/roles/{}", realm_id, Ulid::new().to_string()),
+            path: format!("/{}/admin/roles/{}", realm_id, Ulid::r#gen().to_string()),
             required_permission: Permission::WRITE,
         };
         let perm_operation = CheckPermissionsOperation::new(perm_config.clone());
@@ -1075,7 +1075,7 @@ mod test {
                 }
             })
             .collect();
-        let new_admin = UserId::local(Ulid::new(), realm_id);
+        let new_admin = UserId::local(Ulid::r#gen(), realm_id);
 
         let add_user_input = AddUserToRealmRolesInput {
             actor: Actor {
@@ -1097,7 +1097,7 @@ mod test {
                 realm_id,
                 path_restrictions: None,
             },
-            path: format!("/{}/admin/roles/{}", realm_id, Ulid::new().to_string()),
+            path: format!("/{}/admin/roles/{}", realm_id, Ulid::r#gen().to_string()),
             required_permission: Permission::WRITE,
         };
         let perm_operation = CheckPermissionsOperation::new(perm_config.clone());

--- a/operations/src/claim_initial_realm_admin.rs
+++ b/operations/src/claim_initial_realm_admin.rs
@@ -545,7 +545,7 @@ fn apply_admin_reducer_operation(
 ) -> Result<AdminDocumentEvent, AdminDocumentReducerError> {
     let observed = state.clock.clone();
     let event = AdminDocumentEvent {
-        event_id: Ulid::new(),
+        event_id: Ulid::r#gen(),
         target: state.target.clone(),
         origin_node_id: actor.node_id,
         origin_seq: observed.sequence_for(&actor.node_id) + 1,
@@ -704,7 +704,7 @@ mod tests {
         let mut operation = ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
             actor: actor.clone(),
         });
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = operation
             .emit_write_auth_doc_and_admin_state(
                 txn_id,
@@ -756,7 +756,7 @@ mod tests {
         let mut operation = ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
             actor: actor.clone(),
         });
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = operation
             .emit_write_auth_doc_and_admin_state(
                 txn_id,
@@ -803,7 +803,7 @@ mod tests {
         let mut operation = ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
             actor: claiming_actor.clone(),
         });
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = operation
             .emit_write_auth_doc_and_admin_state(
                 txn_id,
@@ -827,7 +827,7 @@ mod tests {
         let realm_id = RealmId::from_bytes([31u8; 32]);
         let actor = actor(realm_id, 32, 33);
         let (auth_doc, _) = auth_doc_and_admin_role(realm_id);
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let mut operation =
             ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput { actor });
         operation.state = ClaimInitialRealmAdminState::CommitTransaction {
@@ -875,7 +875,7 @@ mod tests {
     #[tokio::test]
     async fn claims_initial_realm_admin_once() {
         let (context, net_handle, realm_id, node_id, _temp_dir) = setup_context().await;
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let result = drive(
             ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
                 actor: Actor {
@@ -902,7 +902,7 @@ mod tests {
             ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
                 actor: Actor {
                     node_id,
-                    user_id: UserId::local(Ulid::new(), realm_id),
+                    user_id: UserId::local(Ulid::r#gen(), realm_id),
                     realm_id,
                 },
             }),

--- a/operations/src/connectors/create_source_connector.rs
+++ b/operations/src/connectors/create_source_connector.rs
@@ -92,7 +92,7 @@ impl CreateSourceConnectorOperation {
         }
 
         let now = SystemTime::now();
-        let connector_id = ulid::Ulid::new();
+        let connector_id = ulid::Ulid::r#gen();
         let connector = SourceConnector::new(
             connector_id,
             self.input.group_id,
@@ -222,7 +222,7 @@ mod tests {
 
         let result = drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {
-                group_id: ulid::Ulid::new(),
+                group_id: ulid::Ulid::r#gen(),
                 created_by: Default::default(),
                 name: "refdata".to_string(),
                 kind: SourceConnectorKind::S3,

--- a/operations/src/connectors/delete_source_connector.rs
+++ b/operations/src/connectors/delete_source_connector.rs
@@ -388,7 +388,7 @@ mod tests {
     async fn create_connector(context: &DriverContext) -> SourceConnector {
         drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {
-                group_id: ulid::Ulid::new(),
+                group_id: ulid::Ulid::r#gen(),
                 created_by: Default::default(),
                 name: "ftp-source".to_string(),
                 kind: SourceConnectorKind::Ftp,
@@ -414,7 +414,7 @@ mod tests {
     async fn create_public_connector(context: &DriverContext) -> SourceConnector {
         drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {
-                group_id: ulid::Ulid::new(),
+                group_id: ulid::Ulid::r#gen(),
                 created_by: Default::default(),
                 name: "http-source".to_string(),
                 kind: SourceConnectorKind::Http,
@@ -432,7 +432,7 @@ mod tests {
     }
 
     async fn write_reference_version(context: &DriverContext, source: VersionSourceBinding) {
-        let version_id = ulid::Ulid::new();
+        let version_id = ulid::Ulid::r#gen();
         let key = VersionKey::new("bucket", "key", version_id)
             .to_bytes()
             .unwrap();
@@ -473,7 +473,7 @@ mod tests {
     fn reference_blob_version(connector_id: Ulid) -> BlobVersion {
         let connector = SourceConnector::new(
             connector_id,
-            Ulid::new(),
+            Ulid::r#gen(),
             "ftp-source".to_string(),
             SourceConnectorKind::Ftp,
             HashMap::new(),

--- a/operations/src/connectors/list_source_connectors.rs
+++ b/operations/src/connectors/list_source_connectors.rs
@@ -167,7 +167,7 @@ mod tests {
             metadata_handle: None,
             task_handle: None,
         };
-        let group_id = ulid::Ulid::new();
+        let group_id = ulid::Ulid::r#gen();
 
         let created = drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {

--- a/operations/src/connectors/replace_source_connector.rs
+++ b/operations/src/connectors/replace_source_connector.rs
@@ -500,7 +500,7 @@ mod tests {
     async fn create_connector(context: &DriverContext) -> SourceConnector {
         drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {
-                group_id: ulid::Ulid::new(),
+                group_id: ulid::Ulid::r#gen(),
                 created_by: Default::default(),
                 name: "ftp-source".to_string(),
                 kind: SourceConnectorKind::Ftp,
@@ -524,7 +524,7 @@ mod tests {
     }
 
     async fn write_reference_version(context: &DriverContext, source: VersionSourceBinding) {
-        let version_id = ulid::Ulid::new();
+        let version_id = ulid::Ulid::r#gen();
         let key = VersionKey::new("bucket", "key", version_id)
             .to_bytes()
             .unwrap();
@@ -579,7 +579,7 @@ mod tests {
     }
 
     fn reference_blob_version(connector_id: Ulid) -> BlobVersion {
-        let connector = replacement_connector(Ulid::new(), connector_id);
+        let connector = replacement_connector(Ulid::r#gen(), connector_id);
         let source = build_version_source_binding(
             StagingStrategy::Reference,
             &connector,
@@ -672,7 +672,7 @@ mod tests {
         });
         operation.state = ReplaceSourceConnectorState::ScanReferenceVersions;
         operation.txn_id = Some(txn_id);
-        operation.replacement = Some(replacement_connector(Ulid::new(), connector_id));
+        operation.replacement = Some(replacement_connector(Ulid::r#gen(), connector_id));
         operation.replacement_secret = Some(connector_secret(connector_id, "bob"));
 
         let effects = operation.step(Event::Storage(StorageEvent::IterResult {
@@ -712,7 +712,7 @@ mod tests {
 
         let created = drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {
-                group_id: ulid::Ulid::new(),
+                group_id: ulid::Ulid::r#gen(),
                 created_by: Default::default(),
                 name: "old".to_string(),
                 kind: SourceConnectorKind::Http,

--- a/operations/src/connectors/resolver.rs
+++ b/operations/src/connectors/resolver.rs
@@ -439,7 +439,7 @@ mod tests {
             metadata_handle: None,
             task_handle: None,
         };
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let created = drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {
@@ -614,7 +614,7 @@ mod tests {
             metadata_handle: None,
             task_handle: None,
         };
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let created = drive(
             CreateSourceConnectorOperation::new(CreateSourceConnectorInput {

--- a/operations/src/consume_onboarding_secret.rs
+++ b/operations/src/consume_onboarding_secret.rs
@@ -388,7 +388,7 @@ mod tests {
             task_handle: None,
         };
 
-        let enrollment_id = Ulid::new();
+        let enrollment_id = Ulid::r#gen();
         let record = OnboardingSecretRecord {
             enrollment_id,
             secret_hash: "abc".to_string(),

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -109,7 +109,7 @@ impl CreateGroupOperation {
 
     #[tracing::instrument(name = "group.create.emit_group", level = "debug", skip(self), fields(state = ?self.state, group_name = %self.config.display_name))]
     fn emit_create_group(&mut self) -> Result<Effects, CreateGroupError> {
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let auth_doc = GroupAuthorizationDocument::new_default_group_doc(
             self.config.actor.user_id,
             self.config.actor.realm_id,
@@ -637,7 +637,7 @@ mod test {
     fn seeds_group_reducer_state_and_admin_outbox_in_order() {
         let realm_id = RealmId::from_bytes([2; 32]);
         let actor = actor(realm_id, 3, 4);
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let mut operation = CreateGroupOperation::new(config(actor.clone()));
         operation.txn_id = Some(txn_id);
 
@@ -768,7 +768,7 @@ mod test {
     fn schedules_outbox_drain_and_finishes_without_direct_replication() {
         let realm_id = RealmId::from_bytes([5; 32]);
         let actor = actor(realm_id, 6, 7);
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let mut operation = operation_ready_to_schedule(actor, txn_id);
 
         let effects = operation.step(Event::Storage(StorageEvent::TransactionCommitted {
@@ -822,7 +822,7 @@ mod test {
         };
 
         let realm_id = aruna_core::structs::RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
         let group_config = CreateGroupConfig {
             actor: Actor {
@@ -901,7 +901,7 @@ mod test {
         };
 
         let realm_id = aruna_core::structs::RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
         let actor = Actor {
             node_id,

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -181,7 +181,7 @@ impl CreateMetadataDocumentOperation {
     }
 
     fn create_event_record(&self, record: &MetadataRegistryRecord) -> MetadataCreateEventRecord {
-        let event_id = Ulid::new();
+        let event_id = Ulid::r#gen();
         let mut record = record.clone();
         record.last_event_id = event_id;
         let occurred_at_ms = record.created_at_ms;
@@ -400,7 +400,7 @@ mod tests {
     fn actor(realm_id: RealmId, key_byte: u8) -> Actor {
         Actor {
             node_id: iroh::SecretKey::from_bytes(&[key_byte; 32]).public(),
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         }
     }
@@ -497,8 +497,8 @@ mod tests {
     fn generated_document_id_validates_then_appends_without_existing_read() {
         let realm_id = RealmId([11u8; 32]);
         let actor = actor(realm_id, 6);
-        let group_id = GroupId::new();
-        let document_id = Ulid::new();
+        let group_id = GroupId::r#gen();
+        let document_id = Ulid::r#gen();
         let mut operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
             actor.clone(),
             group_id,
@@ -515,8 +515,8 @@ mod tests {
     fn create_checks_existing_after_validation_and_uses_local_holder() {
         let realm_id = RealmId([8u8; 32]);
         let actor = actor(realm_id, 1);
-        let group_id = GroupId::new();
-        let document_id = Ulid::new();
+        let group_id = GroupId::r#gen();
+        let document_id = Ulid::r#gen();
         let mut operation =
             CreateMetadataDocumentOperation::new(config(actor.clone(), group_id, document_id));
 
@@ -556,8 +556,8 @@ mod tests {
     fn create_returns_after_event_append_without_persistent_effects() {
         let realm_id = RealmId([12u8; 32]);
         let actor = actor(realm_id, 7);
-        let group_id = GroupId::new();
-        let document_id = Ulid::new();
+        let group_id = GroupId::r#gen();
+        let document_id = Ulid::r#gen();
         let mut operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
             actor.clone(),
             group_id,
@@ -587,8 +587,8 @@ mod tests {
     fn validation_failure_does_not_append_event() {
         let realm_id = RealmId([13u8; 32]);
         let actor = actor(realm_id, 8);
-        let group_id = GroupId::new();
-        let document_id = Ulid::new();
+        let group_id = GroupId::r#gen();
+        let document_id = Ulid::r#gen();
         let mut operation =
             CreateMetadataDocumentOperation::new(config(actor, group_id, document_id));
 
@@ -613,8 +613,8 @@ mod tests {
     fn create_event_append_failure_fails_without_projection_cleanup() {
         let realm_id = RealmId([10u8; 32]);
         let actor = actor(realm_id, 5);
-        let group_id = GroupId::new();
-        let document_id = Ulid::new();
+        let group_id = GroupId::r#gen();
+        let document_id = Ulid::r#gen();
         let mut operation =
             CreateMetadataDocumentOperation::new(config(actor.clone(), group_id, document_id));
 

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -609,7 +609,7 @@ mod test {
     fn seeds_reducer_state_and_admin_outbox() {
         let realm_id = RealmId::from_bytes([2; 32]);
         let actor = actor(realm_id, 3, 4);
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let auth_doc = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
         let realm_admin_role = auth_doc
             .roles
@@ -837,7 +837,7 @@ mod test {
     fn seeds_default_and_everywhere_strategies_with_class_bindings() {
         let realm_id = RealmId::from_bytes([21; 32]);
         let actor = actor(realm_id, 3, 4);
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let mut operation = CreateRealmOperation::new(config(actor.clone()));
         operation.txn_id = Some(txn_id);
         operation.auth_doc = Some(RealmAuthorizationDocument::new_default_realm_doc(realm_id));
@@ -882,7 +882,7 @@ mod test {
     fn schedules_outbox_drain_and_finishes_without_direct_replication() {
         let realm_id = RealmId::from_bytes([5; 32]);
         let actor = actor(realm_id, 6, 7);
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let mut operation = operation_ready_to_schedule(actor, txn_id);
 
         let effects = operation.step(Event::Storage(StorageEvent::TransactionCommitted {
@@ -940,7 +940,7 @@ mod test {
         let pubkey = realm_signing_key.verifying_key().to_bytes();
         let realm_id = RealmId::from_bytes(pubkey);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
-        let realm_admin = UserId::local(Ulid::new(), realm_id);
+        let realm_admin = UserId::local(Ulid::r#gen(), realm_id);
 
         let realm_config = CreateRealmConfig {
             actor: Actor {

--- a/operations/src/create_token.rs
+++ b/operations/src/create_token.rs
@@ -84,7 +84,7 @@ impl CreateTokenOperation {
                     iss: self.config.realm_id.to_string(),
                     iat,
                     exp,
-                    jti: Ulid::new().to_string(),
+                    jti: Ulid::r#gen().to_string(),
                     restrictions: None,
                     issuer_pubkey: None,
                     delegation_signature: None,
@@ -112,7 +112,7 @@ impl CreateTokenOperation {
                     iss: self.config.realm_id.to_string(),
                     iat,
                     exp,
-                    jti: Ulid::new().to_string(),
+                    jti: Ulid::r#gen().to_string(),
                     restrictions: None,
                     issuer_pubkey,
                     delegation_signature: Some(delegation_signature.clone()),
@@ -200,7 +200,7 @@ mod test {
         let token_config = CreateTokenConfig {
             time: chrono::Utc::now().timestamp() as u64,
             expiry: None,
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
             node_capabilities: capabilities,
         };

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -155,7 +155,7 @@ impl DeleteMetadataDocumentOperation {
     ) -> MetadataDocumentLifecycleRecord {
         MetadataDocumentLifecycleRecord::Delete {
             event: MetadataDocumentDeleteRecord {
-                event_id: Ulid::new(),
+                event_id: Ulid::r#gen(),
                 tombstone,
                 deleted_after_event_id: record.last_event_id,
             },
@@ -215,7 +215,7 @@ impl DeleteMetadataDocumentOperation {
         };
         let bytes = postcard::to_allocvec(lifecycle_record)
             .map_err(|error| DeleteMetadataDocumentError::ConversionError(error.into()))?;
-        let outbox_id = Ulid::new();
+        let outbox_id = Ulid::r#gen();
         let change = DocumentSyncChange {
             base: None,
             current: DocumentSyncRevision {
@@ -542,8 +542,11 @@ impl Operation for DeleteMetadataDocumentOperation {
                         return self.fail(DeleteMetadataDocumentError::DocumentNotFound);
                     };
                     self.state = DeleteMetadataDocumentState::WriteAudit;
-                    match write_audit_effect(&self.audit_record(record), Ulid::new(), Some(txn_id))
-                    {
+                    match write_audit_effect(
+                        &self.audit_record(record),
+                        Ulid::r#gen(),
+                        Some(txn_id),
+                    ) {
                         Ok(effect) => smallvec![effect],
                         Err(error) => {
                             self.fail(DeleteMetadataDocumentError::ConversionError(error))
@@ -765,16 +768,16 @@ mod tests {
         let realm_id = RealmId::from_bytes([7u8; 32]);
         aruna_core::structs::Actor {
             node_id: iroh::SecretKey::from_bytes(&[7u8; 32]).public(),
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         }
     }
 
     fn record(actor: &aruna_core::structs::Actor) -> MetadataRegistryRecord {
-        let group_id = Ulid::new();
-        let document_id = Ulid::new();
+        let group_id = Ulid::r#gen();
+        let document_id = Ulid::r#gen();
         let document_path = "datasets/delete-lifecycle";
-        let last_event_id = Ulid::new();
+        let last_event_id = Ulid::r#gen();
         MetadataRegistryRecord {
             realm_id: actor.realm_id,
             group_id,
@@ -917,12 +920,12 @@ mod tests {
             .expect("document lifecycle outbox builds");
         let graph_outbox = outbox_from_effects(
             operation
-                .graph_lifecycle_outbox_effect(&record, Ulid::new())
+                .graph_lifecycle_outbox_effect(&record, Ulid::r#gen())
                 .expect("graph lifecycle outbox builds"),
         );
         let registry_outbox = outbox_from_effects(
             operation
-                .registry_delete_outbox_effect(&record, Ulid::new())
+                .registry_delete_outbox_effect(&record, Ulid::r#gen())
                 .expect("registry delete outbox builds"),
         );
         let DocumentSyncOutboxEvent::Upsert {
@@ -985,7 +988,7 @@ mod tests {
             })]
         ));
 
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         assert!(matches!(
             effects.as_slice(),

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -49,7 +49,7 @@ pub fn new_outbox_record(
     event: DocumentSyncOutboxEvent,
     allow_genesis: bool,
 ) -> DocumentSyncOutboxRecord {
-    new_outbox_record_with_id(Ulid::new(), node_id, target, peers, event, allow_genesis)
+    new_outbox_record_with_id(Ulid::r#gen(), node_id, target, peers, event, allow_genesis)
 }
 
 pub fn new_outbox_record_with_id(

--- a/operations/src/ensure_realm_config.rs
+++ b/operations/src/ensure_realm_config.rs
@@ -428,7 +428,7 @@ fn apply_realm_config_node_ensure(
 ) -> Result<AdminDocumentEvent, AdminDocumentReducerError> {
     let observed = state.clock.clone();
     let event = AdminDocumentEvent {
-        event_id: Ulid::new(),
+        event_id: Ulid::r#gen(),
         target: state.target.clone(),
         origin_node_id: actor.node_id,
         origin_seq: observed.sequence_for(&actor.node_id) + 1,
@@ -600,7 +600,7 @@ mod tests {
             .insert(path.clone(), conflict(&path));
 
         let mut operation = EnsureRealmConfigOperation::new(config(actor.clone(), 7));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.txn_id = Some(txn_id);
         let writes = batch_write(
             operation
@@ -660,7 +660,7 @@ mod tests {
         let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
         document.ensure_node(actor.node_id, RealmNodeKind::Management);
         let mut operation = EnsureRealmConfigOperation::new(config(actor.clone(), 3));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.txn_id = Some(txn_id);
         let writes = batch_write(
             operation
@@ -701,7 +701,7 @@ mod tests {
         document.ensure_node(actor.node_id, RealmNodeKind::Management);
 
         let mut operation = EnsureRealmConfigOperation::new(config(actor.clone(), 3));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.txn_id = Some(txn_id);
         let effects = operation
             .emit_write_document_and_admin_state(
@@ -875,7 +875,7 @@ mod tests {
             reject_kind_mismatch: true,
             ..config(actor.clone(), 3)
         });
-        operation.txn_id = Some(TxnId::new());
+        operation.txn_id = Some(TxnId::r#gen());
 
         let error = operation
             .emit_write_document_and_admin_state(

--- a/operations/src/get_group.rs
+++ b/operations/src/get_group.rs
@@ -305,7 +305,7 @@ mod test {
         };
 
         let actor = Actor {
-            user_id: UserId::local(Ulid::new(), aruna_core::structs::RealmId([0u8; 32])),
+            user_id: UserId::local(Ulid::r#gen(), aruna_core::structs::RealmId([0u8; 32])),
             realm_id: aruna_core::structs::RealmId([0u8; 32]),
             node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
         };

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -364,7 +364,7 @@ async fn reemit_evicted_documents(
     let mut written = 0usize;
     for document in documents {
         let record = new_outbox_record_with_id(
-            document.event_id.unwrap_or_else(ulid::Ulid::new),
+            document.event_id.unwrap_or_else(ulid::Ulid::r#gen),
             node_id,
             document.target,
             Vec::new(),
@@ -610,8 +610,8 @@ mod tests {
             metadata_handle: None,
             task_handle: Some(TaskHandle::new()),
         };
-        let document_id = ulid::Ulid::new();
-        let event_id = ulid::Ulid::new();
+        let document_id = ulid::Ulid::r#gen();
+        let event_id = ulid::Ulid::r#gen();
 
         project_inbound_metadata_create_events(
             &context,

--- a/operations/src/inspect_onboarding_secret.rs
+++ b/operations/src/inspect_onboarding_secret.rs
@@ -237,7 +237,7 @@ mod tests {
             metadata_handle: None,
             task_handle: None,
         };
-        let enrollment_id = Ulid::new();
+        let enrollment_id = Ulid::r#gen();
         drive(
             CreateOnboardingSecretOperation::new(CreateOnboardingSecretInput {
                 record: OnboardingSecretRecord {

--- a/operations/src/list_groups.rs
+++ b/operations/src/list_groups.rs
@@ -278,7 +278,7 @@ mod test {
         for i in 0..100 {
             let group_config = CreateGroupConfig {
                 actor: Actor {
-                    user_id: UserId::local(Ulid::new(), aruna_core::structs::RealmId([0u8; 32])),
+                    user_id: UserId::local(Ulid::r#gen(), aruna_core::structs::RealmId([0u8; 32])),
                     realm_id: aruna_core::structs::RealmId([0u8; 32]),
                     node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
                 },

--- a/operations/src/list_metadata_documents.rs
+++ b/operations/src/list_metadata_documents.rs
@@ -184,10 +184,10 @@ mod tests {
     async fn lists_documents_across_multiple_pages() {
         let temp = tempdir().unwrap();
         let storage_handle = FjallStorage::open(temp.path().to_str().unwrap()).unwrap();
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         for idx in 0..(crate::metadata::repository::LIST_METADATA_PAGE_SIZE + 5) {
-            let document_id = Ulid::new();
+            let document_id = Ulid::r#gen();
             let now = idx as u64;
             let record = MetadataRegistryRecord {
                 realm_id: RealmId([4u8; 32]),
@@ -240,9 +240,9 @@ mod tests {
         let temp = tempdir().unwrap();
         let storage_handle = FjallStorage::open(temp.path().to_str().unwrap()).unwrap();
         let realm_id = RealmId([5u8; 32]);
-        let group_id = Ulid::new();
-        let active_id = Ulid::new();
-        let deleted_id = Ulid::new();
+        let group_id = Ulid::r#gen();
+        let active_id = Ulid::r#gen();
+        let deleted_id = Ulid::r#gen();
 
         let active = metadata_record(realm_id, group_id, active_id, "docs/active");
         let deleted = metadata_record(realm_id, group_id, deleted_id, "docs/deleted");
@@ -292,9 +292,9 @@ mod tests {
     #[test]
     fn filters_deleted_documents_without_per_record_reads() {
         let realm_id = RealmId([6u8; 32]);
-        let group_id = Ulid::new();
-        let active = metadata_record(realm_id, group_id, Ulid::new(), "docs/active");
-        let deleted = metadata_record(realm_id, group_id, Ulid::new(), "docs/deleted");
+        let group_id = Ulid::r#gen();
+        let active = metadata_record(realm_id, group_id, Ulid::r#gen(), "docs/active");
+        let deleted = metadata_record(realm_id, group_id, Ulid::r#gen(), "docs/deleted");
         let lifecycle = MetadataGraphLifecycleRecord::deleted(
             deleted.graph_iri.clone(),
             realm_id,

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -1426,10 +1426,10 @@ mod tests {
     fn document_replica_query_nodes_use_deduplicated_replicas() {
         let local_node_id = iroh::SecretKey::from_bytes(&[21u8; 32]).public();
         let remote_node_id = iroh::SecretKey::from_bytes(&[22u8; 32]).public();
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let record = MetadataRegistryRecord {
             realm_id: RealmId([3u8; 32]),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             document_id,
             document_path: "datasets/query-targets".to_string(),
             graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -4462,7 +4462,7 @@ mod tests {
     async fn remote_metadata_auth_preserves_path_restrictions() {
         let (realm_signing_key, realm_id, user_id) = realm_fixture();
         let restrictions = vec![PathRestriction {
-            pattern: format!("/{realm_id}/g/{}/meta/**", Ulid::new()),
+            pattern: format!("/{realm_id}/g/{}/meta/**", Ulid::r#gen()),
             permission: Permission::READ,
         }];
         let mut claims = token_claims(realm_id, user_id);
@@ -4598,7 +4598,7 @@ mod tests {
     fn realm_fixture() -> (SigningKey, RealmId, UserId) {
         let signing_key = signing_key();
         let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         (signing_key, realm_id, user_id)
     }
 
@@ -4618,7 +4618,7 @@ mod tests {
             iss: realm_id.to_string(),
             iat: now,
             exp: now + 600,
-            jti: Ulid::new().to_string(),
+            jti: Ulid::r#gen().to_string(),
             restrictions: None,
             issuer_pubkey: None,
             delegation_signature: None,
@@ -4636,10 +4636,10 @@ mod tests {
     }
 
     fn registry_record(document_path: &str) -> MetadataRegistryRecord {
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         MetadataRegistryRecord {
             realm_id: RealmId([7u8; 32]),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             document_id,
             document_path: document_path.to_string(),
             graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
@@ -4707,8 +4707,8 @@ mod tests {
 
     #[test]
     fn group_snapshots_are_scoped_and_invalidate_per_group() {
-        let group_a = Ulid::new();
-        let group_b = Ulid::new();
+        let group_a = Ulid::r#gen();
+        let group_b = Ulid::r#gen();
         let mut record_a = registry_record("datasets/a");
         record_a.group_id = group_a;
         let mut record_b = registry_record("datasets/b");
@@ -4847,8 +4847,8 @@ mod tests {
 
     #[test]
     fn rejected_cold_group_fill_filters_fresh_records_for_requested_group() {
-        let group_a = Ulid::new();
-        let group_b = Ulid::new();
+        let group_a = Ulid::r#gen();
+        let group_b = Ulid::r#gen();
         let mut record_a = registry_record("datasets/a");
         record_a.group_id = group_a;
         let mut record_b = registry_record("datasets/b");
@@ -4896,7 +4896,7 @@ mod tests {
         assert!(
             registry_record_for_graph(
                 &records,
-                &MetadataRegistryRecord::graph_iri_for(Ulid::new())
+                &MetadataRegistryRecord::graph_iri_for(Ulid::r#gen())
             )
             .is_none()
         );
@@ -4931,9 +4931,10 @@ mod tests {
         assert!(anonymous.graph_visible(&cache, &public_record.graph_iri));
         assert!(!anonymous.graph_visible(&cache, &private_record.graph_iri));
         assert!(!anonymous.graph_visible(&cache, &deleted_record.graph_iri));
-        assert!(
-            !anonymous.graph_visible(&cache, &MetadataRegistryRecord::graph_iri_for(Ulid::new()))
-        );
+        assert!(!anonymous.graph_visible(
+            &cache,
+            &MetadataRegistryRecord::graph_iri_for(Ulid::r#gen())
+        ));
 
         let member = GraphVisibilityScope {
             records: Arc::new(records.clone()),

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -1070,9 +1070,9 @@ mod tests {
 
     fn create_event() -> MetadataCreateEventRecord {
         let realm_id = RealmId::from_bytes([3u8; 32]);
-        let group_id = Ulid::new();
-        let document_id = Ulid::new();
-        let event_id = Ulid::new();
+        let group_id = Ulid::r#gen();
+        let document_id = Ulid::r#gen();
+        let event_id = Ulid::r#gen();
         let document_path = "datasets/outbox-lifecycle";
         let record = MetadataRegistryRecord {
             realm_id,
@@ -1095,7 +1095,7 @@ mod tests {
         MetadataCreateEventRecord {
             event_id,
             record,
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             node_id: node(1),
             payload: MetadataCreateEventPayload::Scaffold {
                 name: "Lifecycle Outbox".to_string(),
@@ -1580,7 +1580,7 @@ mod tests {
         // An update of the same document reuses its id and path; only the event
         // identity/timestamps advance.
         let mut update = create.clone();
-        update.event_id = Ulid::new();
+        update.event_id = Ulid::r#gen();
         update.record.last_event_id = update.event_id;
         update.record.updated_at_ms = create.record.updated_at_ms + 1;
         update.occurred_at_ms = create.occurred_at_ms + 1;
@@ -1601,12 +1601,12 @@ mod tests {
 
     fn skew_event(updated_at_ms: u64, occurred_at_ms: u64) -> MetadataCreateEventRecord {
         let realm_id = RealmId::from_bytes([1u8; 32]);
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         MetadataCreateEventRecord {
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             record: MetadataRegistryRecord {
                 realm_id,
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 document_id,
                 document_path: "datasets/skew".to_string(),
                 graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
@@ -1615,7 +1615,7 @@ mod tests {
                 holder_node_ids: Vec::new(),
                 created_at_ms: updated_at_ms,
                 updated_at_ms,
-                last_event_id: Ulid::new(),
+                last_event_id: Ulid::r#gen(),
             },
             user_id: UserId::nil(realm_id),
             node_id: iroh::SecretKey::from_bytes(&[2u8; 32]).public(),

--- a/operations/src/metadata/prune_queue.rs
+++ b/operations/src/metadata/prune_queue.rs
@@ -851,7 +851,7 @@ mod tests {
 
     fn registry_record(group_id: Ulid, path: &str) -> MetadataRegistryRecord {
         let realm_id = RealmId::from_bytes([7u8; 32]);
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         MetadataRegistryRecord {
             realm_id,
             group_id,

--- a/operations/src/notifications/emit.rs
+++ b/operations/src/notifications/emit.rs
@@ -60,7 +60,7 @@ impl EmitNotificationsOperation {
         let mut writes: Vec<(KeySpace, Key, Value)> = Vec::with_capacity(self.input.records.len());
         for record in &self.input.records {
             let outbox_record = NotificationOutboxRecord {
-                outbox_id: Ulid::new(),
+                outbox_id: Ulid::r#gen(),
                 record: record.clone(),
             };
             match notification_outbox_write_entry(&outbox_record) {
@@ -205,7 +205,7 @@ mod tests {
             make_user(realm, user),
             NotificationClass::Direct,
             NotificationKind::AddedToGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: make_user(realm, 100),
             },
             1_000,
@@ -312,7 +312,7 @@ mod tests {
             records: vec![make_record(1, 2)],
         });
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         assert!(matches!(
             effects.as_slice(),
@@ -341,7 +341,7 @@ mod tests {
             records: vec![make_record(1, 2)],
         });
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![],
@@ -370,7 +370,7 @@ mod tests {
             records: vec![make_record(1, 2)],
         });
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
 
         let effects = operation.step(Event::Search());
@@ -470,7 +470,7 @@ mod tests {
             records: vec![make_record(1, 2)],
         });
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![],
@@ -502,7 +502,7 @@ mod tests {
             records: vec![make_record(1, 2)],
         });
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![],

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -945,7 +945,7 @@ mod tests {
         )
         .await;
 
-        let recipient = UserId::new(Ulid::new(), realm_id);
+        let recipient = UserId::new(Ulid::r#gen(), realm_id);
         let error = deliver_remote(&c.net, b.net.node_id(), vec![record(recipient, 1)])
             .await
             .expect_err("unknown peer must be rejected");
@@ -974,8 +974,8 @@ mod tests {
         .await;
 
         let records = vec![
-            record(UserId::new(Ulid::new(), realm_id), 1),
-            record(UserId::new(Ulid::new(), other_realm), 2),
+            record(UserId::new(Ulid::r#gen(), realm_id), 1),
+            record(UserId::new(Ulid::r#gen(), other_realm), 2),
         ];
         let error = deliver_remote(&a.net, b.net.node_id(), records)
             .await
@@ -1165,7 +1165,7 @@ mod tests {
         )
         .await;
 
-        let recipient = UserId::new(Ulid::new(), realm_id);
+        let recipient = UserId::new(Ulid::r#gen(), realm_id);
         let deliver_error = deliver_remote(&c.net, b.net.node_id(), vec![record(recipient, 1)])
             .await
             .expect_err("user-kind peer must be rejected");
@@ -1301,7 +1301,7 @@ mod tests {
     #[tokio::test]
     async fn rpc_mark_read_rejects_too_many_ids() {
         let (a, b, recipient) = delivery_pair(75).await;
-        let ids = (0..=MARK_READ_MAX_IDS).map(|_| Ulid::new()).collect();
+        let ids = (0..=MARK_READ_MAX_IDS).map(|_| Ulid::r#gen()).collect();
 
         let error = mark_read_remote(&a.net, b.net.node_id(), recipient, ids, None)
             .await
@@ -1329,7 +1329,7 @@ mod tests {
         )
         .await;
 
-        let recipient = UserId::new(Ulid::new(), realm_id);
+        let recipient = UserId::new(Ulid::r#gen(), realm_id);
         let error = list_remote(&c.net, b.net.node_id(), recipient, None, 10)
             .await
             .expect_err("unknown peer must be rejected on the read path");
@@ -1403,7 +1403,7 @@ mod tests {
         )
         .await;
 
-        let recipient = UserId::new(Ulid::new(), realm_id);
+        let recipient = UserId::new(Ulid::r#gen(), realm_id);
         let sample = record(recipient, 1);
         let per_record = postcard::to_allocvec(&NotificationTransportMessage::DeliverBatch {
             records: vec![sample.clone(), sample.clone()],
@@ -1510,7 +1510,7 @@ mod tests {
             "unexpected reject reason: {list_error}"
         );
 
-        let delete_error = delete_watch_remote(&a.net, b.net.node_id(), owner, Ulid::new())
+        let delete_error = delete_watch_remote(&a.net, b.net.node_id(), owner, Ulid::r#gen())
             .await
             .expect_err("delete on non-holder must be rejected");
         assert!(
@@ -1547,11 +1547,11 @@ mod tests {
     #[test]
     fn inbound_metadata_watch_path_accepts_normalized_nested_document_path() {
         let realm_id = RealmId::from_bytes([79u8; 32]);
-        let actor = UserId::new(Ulid::new(), realm_id);
-        let group_id = Ulid::new();
-        let document_id = Ulid::new();
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
+        let group_id = Ulid::r#gen();
+        let document_id = Ulid::r#gen();
         let mut event = WatchEvent {
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             realm_id,
             kind: WatchEventKind::MetadataCreated,
             path: format!("meta/{group_id}/datasets/project/runs/run-42"),
@@ -1571,7 +1571,7 @@ mod tests {
             Err("watch event metadata path is not canonical".to_string())
         );
 
-        event.path = format!("meta/{}/datasets/project", Ulid::new());
+        event.path = format!("meta/{}/datasets/project", Ulid::r#gen());
         assert_eq!(
             validate_inbound_watch_event(&event, realm_id, 1_000),
             Err("watch event metadata path does not match detail".to_string())
@@ -1581,7 +1581,7 @@ mod tests {
     #[test]
     fn inbound_data_watch_path_requires_matching_group_and_node_identity() {
         let realm_id = RealmId::from_bytes([78u8; 32]);
-        let actor = UserId::new(Ulid::new(), realm_id);
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
         let mut event = upload_event(realm_id, actor, "bucket/object");
 
         assert!(
@@ -1617,7 +1617,7 @@ mod tests {
         .await;
 
         let owner = recipient_for_holder(&config, b.net.node_id(), realm_id);
-        let actor = UserId::new(Ulid::new(), realm_id);
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
         install_watch_authorization(&b, realm_id, owner, &[]).await;
         create_watch_subscription(
             &b.context.storage_handle,
@@ -1712,7 +1712,7 @@ mod tests {
         )
         .await;
 
-        let actor = UserId::new(Ulid::new(), realm_id);
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
         let written = deliver_watch_events_remote(
             &a.net,
             b.net.node_id(),
@@ -1766,7 +1766,7 @@ mod tests {
         .await
         .expect("holder subscription");
 
-        let actor = UserId::new(Ulid::new(), realm_id);
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
         let mut event = upload_event(realm_id, actor, "bucket/object");
         event.kind = WatchEventKind::MetadataCreated;
         let error = deliver_watch_events_remote(&a.net, b.net.node_id(), vec![event])
@@ -1795,7 +1795,7 @@ mod tests {
         )
         .await;
 
-        let owner = UserId::new(Ulid::new(), realm_id);
+        let owner = UserId::new(Ulid::r#gen(), realm_id);
         create_watch_subscription(
             &b.context.storage_handle,
             owner,
@@ -1806,7 +1806,7 @@ mod tests {
         .await
         .expect("holder subscription");
 
-        let actor = UserId::new(Ulid::new(), realm_id);
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
         let error = deliver_watch_events_remote(
             &c.net,
             b.net.node_id(),
@@ -1850,7 +1850,7 @@ mod tests {
             "unexpected response: {empty:?}"
         );
 
-        let actor = UserId::new(Ulid::new(), realm_id);
+        let actor = UserId::new(Ulid::r#gen(), realm_id);
         let mixed = deliver_watch_events_remote(
             &a.net,
             b.net.node_id(),
@@ -1883,7 +1883,7 @@ mod tests {
         )
         .await;
 
-        let owner = UserId::new(Ulid::new(), realm_id);
+        let owner = UserId::new(Ulid::r#gen(), realm_id);
         let error = create_watch_remote(
             &c.net,
             b.net.node_id(),

--- a/operations/src/notifications/list.rs
+++ b/operations/src/notifications/list.rs
@@ -224,7 +224,7 @@ mod tests {
             recipient,
             NotificationClass::Direct,
             NotificationKind::AddedToGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: user(recipient.realm_id.0[0], 200),
             },
             created_at_ms,

--- a/operations/src/notifications/mark_read.rs
+++ b/operations/src/notifications/mark_read.rs
@@ -283,7 +283,7 @@ mod tests {
             recipient,
             NotificationClass::Direct,
             NotificationKind::AddedToGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: user(recipient.realm_id.0[0], 200),
             },
             created_at_ms,
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     fn rejects_too_many_ids() {
         let recipient = user(1, 1);
-        let ids = (0..=MARK_READ_MAX_IDS).map(|_| Ulid::new()).collect();
+        let ids = (0..=MARK_READ_MAX_IDS).map(|_| Ulid::r#gen()).collect();
         let mut operation = MarkReadOperation::new(MarkReadInput {
             recipient,
             ids,

--- a/operations/src/notifications/outbox.rs
+++ b/operations/src/notifications/outbox.rs
@@ -19,7 +19,7 @@ pub const NOTIFICATION_OUTBOX_RETENTION_MS: u64 = 48 * 60 * 60 * 1000;
 
 pub fn new_notification_outbox_record(record: NotificationRecord) -> NotificationOutboxRecord {
     NotificationOutboxRecord {
-        outbox_id: Ulid::new(),
+        outbox_id: Ulid::r#gen(),
         record,
     }
 }
@@ -231,7 +231,7 @@ mod tests {
             UserId::new(Ulid::from_bytes([2u8; 16]), RealmId([1u8; 32])),
             NotificationClass::Direct,
             NotificationKind::AddedToGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: UserId::new(Ulid::from_bytes([3u8; 16]), RealmId([1u8; 32])),
             },
             1_000,

--- a/operations/src/notifications/prune.rs
+++ b/operations/src/notifications/prune.rs
@@ -411,7 +411,7 @@ mod tests {
             recipient,
             class,
             NotificationKind::AddedToGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: user(1, 200),
             },
             created_at_ms,

--- a/operations/src/notifications/routing.rs
+++ b/operations/src/notifications/routing.rs
@@ -191,7 +191,7 @@ mod tests {
             .assigned_users
             .extend([u2, u3]);
         let custom_role = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "custom-admin-label".to_string(),
             permissions: HashMap::new(),
             assigned_users: HashSet::from([ignored]),

--- a/operations/src/notifications/unread.rs
+++ b/operations/src/notifications/unread.rs
@@ -212,7 +212,7 @@ mod tests {
             recipient,
             NotificationClass::Direct,
             NotificationKind::AddedToGroup {
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 actor_user_id: user(recipient.realm_id.0[0], 200),
             },
             created_at_ms,

--- a/operations/src/notifications/watch/emit.rs
+++ b/operations/src/notifications/watch/emit.rs
@@ -151,7 +151,7 @@ mod tests {
     fn upload_event(realm: RealmId, actor: UserId, path: &str) -> WatchEvent {
         let resource = parse_data_watch_resource_path(path).expect("canonical data watch path");
         WatchEvent {
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             realm_id: realm,
             kind: WatchEventKind::DataUploaded,
             path: path.to_string(),
@@ -284,8 +284,8 @@ mod tests {
     async fn empty_table_writes_nothing() {
         let realm = RealmId([1u8; 32]);
         let (_dir, ctx, net) = ctx_with_net(realm, [80u8; 32]).await;
-        let actor = UserId::new(Ulid::new(), realm);
-        let path = data_watch_resource_path(Ulid::new(), net.node_id(), "bucket", "object");
+        let actor = UserId::new(Ulid::r#gen(), realm);
+        let path = data_watch_resource_path(Ulid::r#gen(), net.node_id(), "bucket", "object");
         emit_resource_watch_event(&ctx, upload_event(realm, actor, &path)).await;
         assert!(read_inbox_rows(&ctx).await.is_empty());
     }
@@ -294,7 +294,7 @@ mod tests {
     async fn local_subscription_matches_before_interest_publish() {
         let realm = RealmId([1u8; 32]);
         let (_dir, ctx, net) = ctx_with_net(realm, [84u8; 32]).await;
-        let owner = UserId::new(Ulid::new(), realm);
+        let owner = UserId::new(Ulid::r#gen(), realm);
         let group_id = Ulid::from_bytes([3u8; 16]);
         let prefix = data_watch_resource_path(group_id, net.node_id(), "bucket", "");
         install_authorization(&ctx, realm, group_id, owner).await;
@@ -308,7 +308,7 @@ mod tests {
         .await
         .expect("subscription creates");
 
-        let actor = UserId::new(Ulid::new(), realm);
+        let actor = UserId::new(Ulid::r#gen(), realm);
         let event_path = data_watch_resource_path(group_id, net.node_id(), "bucket", "object");
         emit_resource_watch_event(&ctx, upload_event(realm, actor, &event_path)).await;
 
@@ -331,7 +331,7 @@ mod tests {
     async fn nil_actor_is_skipped() {
         let realm = RealmId([1u8; 32]);
         let (_dir, ctx, net) = ctx_with_net(realm, [82u8; 32]).await;
-        let path = data_watch_resource_path(Ulid::new(), net.node_id(), "bucket", "object");
+        let path = data_watch_resource_path(Ulid::r#gen(), net.node_id(), "bucket", "object");
         net.replace_watch_interest(interest_table(realm, node(9), &path));
 
         emit_resource_watch_event(&ctx, upload_event(realm, UserId::nil(realm), &path)).await;
@@ -342,11 +342,11 @@ mod tests {
     async fn local_expansion_error_is_swallowed() {
         let realm = RealmId([1u8; 32]);
         let (dir, ctx, net) = ctx_with_net(realm, [83u8; 32]).await;
-        let path = data_watch_resource_path(Ulid::new(), net.node_id(), "bucket", "object");
+        let path = data_watch_resource_path(Ulid::r#gen(), net.node_id(), "bucket", "object");
         net.replace_watch_interest(interest_table(realm, net.node_id(), &path));
         drop(dir);
 
-        let actor = UserId::new(Ulid::new(), realm);
+        let actor = UserId::new(Ulid::r#gen(), realm);
         emit_resource_watch_event(&ctx, upload_event(realm, actor, &path)).await;
     }
 }

--- a/operations/src/notifications/watch/expand.rs
+++ b/operations/src/notifications/watch/expand.rs
@@ -211,7 +211,7 @@ mod tests {
         let realm = RealmId([1u8; 32]);
         let (local_node_id, config) = local_config(realm);
         let actor = user(realm, 2);
-        let events = vec![upload_event(realm, actor, Ulid::new(), local_node_id)];
+        let events = vec![upload_event(realm, actor, Ulid::r#gen(), local_node_id)];
         assert_eq!(
             expand_watch_events(&context, realm, &config, local_node_id, &events)
                 .await

--- a/operations/src/notifications/watch/interest.rs
+++ b/operations/src/notifications/watch/interest.rs
@@ -96,7 +96,7 @@ pub fn schedule_watch_interest_publish_effect() -> Effect {
 /// marker whose stored generation still matches the one it observed, so a CRUD
 /// that re-dirties a realm mid-publish keeps its retry signal.
 pub fn watch_interest_dirty_marker_write(realm_id: RealmId) -> (KeySpace, Key, Value) {
-    let generation = ByteView::from(Ulid::new().to_bytes().to_vec());
+    let generation = ByteView::from(Ulid::r#gen().to_bytes().to_vec());
     (
         NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
         ByteView::from(watch_interest_dirty_key(realm_id)),
@@ -851,7 +851,7 @@ mod tests {
         let temp = tempdir().unwrap();
         let ctx = test_ctx(temp.path().to_str().unwrap());
         let owner = user(1, 2);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         create_watch_subscription(
             &ctx.storage_handle,
@@ -873,7 +873,7 @@ mod tests {
         let node_id = node(5);
         let owner = user(1, 2);
         install_realm_config(&ctx, owner.realm_id, &[node_id]).await;
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         install_authorization(&ctx, owner.realm_id, node_id, group_id, owner, &[]).await;
 
         create_watch_subscription(
@@ -935,7 +935,7 @@ mod tests {
         let node_id = node(5);
         let owner = user(1, 2);
         install_realm_config(&ctx, owner.realm_id, &[node_id]).await;
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         install_authorization(&ctx, owner.realm_id, node_id, group_id, owner, &[]).await;
 
         let created = create_watch_subscription(
@@ -979,7 +979,7 @@ mod tests {
         let config = install_realm_config(&ctx, realm_id, &[local_node_id, remote_node_id]).await;
         let local_owner = user_for_holder(realm_id, &config, local_node_id);
         let stale_owner = user_for_holder(realm_id, &config, remote_node_id);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         install_authorization(
             &ctx,
             realm_id,

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -439,7 +439,7 @@ fn watch_upsert_replication(
     local_node_id: aruna_core::NodeId,
     subscription: &WatchSubscription,
 ) -> Result<WatchReplication, WatchSubscriptionError> {
-    let outbox_id = Ulid::new();
+    let outbox_id = Ulid::r#gen();
     let revision = DocumentSyncChange {
         base: None,
         current: DocumentSyncRevision {
@@ -474,7 +474,7 @@ fn watch_delete_replication(
     watch_id: Ulid,
     now_ms: u64,
 ) -> WatchReplication {
-    let outbox_id = Ulid::new();
+    let outbox_id = Ulid::r#gen();
     let revision = DocumentSyncChange {
         base: None,
         current: DocumentSyncRevision {
@@ -754,7 +754,7 @@ mod tests {
         delete_watch_subscription(&storage, owner, created.watch_id)
             .await
             .expect("deleting a missing row is ok");
-        delete_watch_subscription(&storage, owner, Ulid::new())
+        delete_watch_subscription(&storage, owner, Ulid::r#gen())
             .await
             .expect("deleting an unknown id is ok");
 

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -360,7 +360,7 @@ impl ProcessPlacementsOperation {
                         ),
                     };
                     if previous.kind != DocumentSyncChangeKind::Delete {
-                        let refresh_id = ulid::Ulid::new();
+                        let refresh_id = ulid::Ulid::r#gen();
                         let now = aruna_core::util::unix_timestamp_millis();
                         let change = DocumentSyncChange {
                             base: Some(previous.current),
@@ -1189,7 +1189,7 @@ mod tests {
         let record = aruna_core::metadata::MetadataGraphLifecycleRecord::deleted(
             "urn:graph:placement-test".to_string(),
             RealmId::from_bytes([8u8; 32]),
-            aruna_core::types::GroupId::new(),
+            aruna_core::types::GroupId::r#gen(),
             Ulid::from_bytes([9u8; 16]),
             42,
         );

--- a/operations/src/register_or_get_oidc_user.rs
+++ b/operations/src/register_or_get_oidc_user.rs
@@ -469,7 +469,7 @@ fn apply_admin_reducer_operation(
 ) -> Result<AdminDocumentEvent, AdminDocumentReducerError> {
     let observed = state.clock.clone();
     let event = AdminDocumentEvent {
-        event_id: Ulid::new(),
+        event_id: Ulid::r#gen(),
         target: state.target.clone(),
         origin_node_id: actor.node_id,
         origin_seq: observed.sequence_for(&actor.node_id) + 1,
@@ -491,7 +491,7 @@ fn initial_user_document_sync_change(actor: &Actor, placement: PlacementRef) -> 
         base: None,
         current: DocumentSyncRevision {
             generation: updated_at_ms,
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             actor: actor.node_id,
             updated_at_ms,
         },
@@ -533,7 +533,7 @@ mod tests {
             user_id: UserId::nil(realm_id),
             realm_id,
         };
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let mut operation = RegisterOrGetOidcUserOperation::new(RegisterOrGetOidcUserInput {
             actor: actor.clone(),
             issuer: "https://issuer.example".to_string(),
@@ -555,7 +555,7 @@ mod tests {
             Effect::Storage(StorageEffect::StartTransaction { read: false })
         ));
 
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         assert!(matches!(
             effects.first().unwrap(),
@@ -724,7 +724,7 @@ mod tests {
             user_id: UserId::nil(realm_id),
             realm_id,
         };
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let mut operation = RegisterOrGetOidcUserOperation::new(RegisterOrGetOidcUserInput {
             actor: actor.clone(),
             issuer: "https://issuer.example".to_string(),
@@ -735,7 +735,7 @@ mod tests {
         let document_target = DocumentSyncTarget::User { user_id };
 
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
@@ -788,7 +788,7 @@ mod tests {
     #[tokio::test]
     async fn existing_user_is_returned_without_new_announcement() {
         let realm_id = aruna_core::structs::RealmId([5u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let existing_user = User {
             user_id,
             name: "bob".to_string(),
@@ -805,11 +805,11 @@ mod tests {
             issuer: "https://issuer.example".to_string(),
             subject_id: "subject-2".to_string(),
             name: "ignored".to_string(),
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
         });
 
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![

--- a/operations/src/remove_group_role.rs
+++ b/operations/src/remove_group_role.rs
@@ -713,7 +713,7 @@ pub mod test {
 
     async fn setup_group(context: &DriverContext) -> (Actor, Group, GroupAuthorizationDocument) {
         let realm_id = RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
         let actor = Actor {
             node_id,
@@ -786,7 +786,7 @@ pub mod test {
 
         let effects = operation
             .emit_write_group_auth_doc_and_admin_state(
-                TxnId::new(),
+                TxnId::r#gen(),
                 group,
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 None,
@@ -842,7 +842,7 @@ pub mod test {
         let (actor, group, _auth_doc) = setup_group(&context).await;
 
         let role = Role {
-            role_id: Ulid::new(),
+            role_id: Ulid::r#gen(),
             name: "custom_role".to_string(),
             permissions: HashMap::from([(
                 format!("/{}/g/{}/meta/**", actor.realm_id, group.group_id),

--- a/operations/src/remove_user_from_group.rs
+++ b/operations/src/remove_user_from_group.rs
@@ -810,7 +810,7 @@ pub mod test {
 
     async fn setup_group(context: &DriverContext) -> (Actor, Group, GroupAuthorizationDocument) {
         let realm_id = RealmId([0u8; 32]);
-        let user_id = UserId::local(Ulid::new(), realm_id);
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
         let actor = Actor {
             node_id,
@@ -903,7 +903,7 @@ pub mod test {
 
         let effects = operation
             .emit_write_auth_doc_and_admin_state(
-                TxnId::new(),
+                TxnId::r#gen(),
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 None,
             )
@@ -964,7 +964,7 @@ pub mod test {
         let (context, net_handle, _tmp) = test_context().await;
         let (actor, group, auth_doc) = setup_group(&context).await;
 
-        let member_id = UserId::local(Ulid::new(), actor.realm_id);
+        let member_id = UserId::local(Ulid::r#gen(), actor.realm_id);
         let add_input = AddUserToGroupInput {
             actor: actor.clone(),
             group_id: group.group_id,
@@ -1038,7 +1038,7 @@ pub mod test {
         let (context, net_handle, _tmp) = test_context().await;
         let (actor, group, auth_doc) = setup_group(&context).await;
 
-        let member_id = UserId::local(Ulid::new(), actor.realm_id);
+        let member_id = UserId::local(Ulid::r#gen(), actor.realm_id);
         let add_input = AddUserToGroupInput {
             actor: actor.clone(),
             group_id: group.group_id,
@@ -1102,7 +1102,7 @@ pub mod test {
         let (context, net_handle, _tmp) = test_context().await;
         let (actor, group, auth_doc) = setup_group(&context).await;
 
-        let member = UserId::local(Ulid::new(), actor.realm_id);
+        let member = UserId::local(Ulid::r#gen(), actor.realm_id);
         drive(
             AddUserToGroupOperation::new(AddUserToGroupInput {
                 actor: actor.clone(),
@@ -1174,7 +1174,7 @@ pub mod test {
         operation.step(Event::SubOperation(
             SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
         ));
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
@@ -1210,7 +1210,7 @@ pub mod test {
         let (context, net_handle, _tmp) = test_context().await;
         let (actor, group, _auth_doc) = setup_group(&context).await;
 
-        let stranger = UserId::local(Ulid::new(), actor.realm_id);
+        let stranger = UserId::local(Ulid::r#gen(), actor.realm_id);
         drive(
             RemoveUserFromGroupOperation::new(RemoveUserFromGroupInput {
                 actor: actor.clone(),
@@ -1233,7 +1233,7 @@ pub mod test {
         let (context, net_handle, _tmp) = test_context().await;
         let (actor, group, auth_doc) = setup_group(&context).await;
 
-        let member = UserId::local(Ulid::new(), actor.realm_id);
+        let member = UserId::local(Ulid::r#gen(), actor.realm_id);
         let mut both_roles = role_ids_by_name(&auth_doc, "user");
         both_roles.extend(role_ids_by_name(&auth_doc, "admin"));
         drive(

--- a/operations/src/replication/incoming_version_replication.rs
+++ b/operations/src/replication/incoming_version_replication.rs
@@ -1217,8 +1217,8 @@ mod tests {
         BackendLocation {
             root: "/tmp".to_string(),
             storage_bucket: "blob-bucket".to_string(),
-            backend_path: format!("bucket/key_{}", Ulid::new()),
-            ulid: Ulid::new(),
+            backend_path: format!("bucket/key_{}", Ulid::r#gen()),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by: test_user_id(),
@@ -1257,7 +1257,7 @@ mod tests {
         VersionReplicationManifest {
             bucket: "bucket".to_string(),
             key: "dir/file.txt".to_string(),
-            version_id: Ulid::new(),
+            version_id: Ulid::r#gen(),
             kind,
             created_at: SystemTime::now(),
             created_by: test_user_id(),
@@ -1288,7 +1288,7 @@ mod tests {
                 capabilities: Vec::new(),
                 origin_node_id: None,
             },
-            connector_id: Some(Ulid::new()),
+            connector_id: Some(Ulid::r#gen()),
         }
     }
 
@@ -1346,10 +1346,10 @@ mod tests {
     }
 
     fn start_apply_transaction(op: &mut IncomingVersionReplicationOperation) -> Ulid {
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         op.state = IncomingVersionReplicationState::StartTransaction;
         op.negotiation_result = Some(ReplicationNegotiationResult::NeedVersionOnly);
-        op.destination_group_id = Some(Ulid::new());
+        op.destination_group_id = Some(Ulid::r#gen());
 
         let effects = op.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         assert_eq!(op.state, IncomingVersionReplicationState::ReadObjectLookup);
@@ -1365,13 +1365,13 @@ mod tests {
     fn existing_version_does_not_short_circuit_apply() {
         let manifest = make_manifest(ReplicationItemKind::Materialized);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest.clone(),
         );
 
-        let _effects = advance_to_version_lookup(&mut op, Ulid::new());
+        let _effects = advance_to_version_lookup(&mut op, Ulid::r#gen());
 
         let version = BlobVersion::materialized(
             manifest.blob.as_ref().unwrap().hash,
@@ -1397,13 +1397,13 @@ mod tests {
         let mut manifest = make_manifest(ReplicationItemKind::DeleteMarker);
         manifest.current_version_generation = Some(10);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest.clone(),
         );
         let txn_id = start_apply_transaction(&mut op);
-        let existing_pointer = CurrentVersionPointer::new_with_generation(Ulid::new(), 20);
+        let existing_pointer = CurrentVersionPointer::new_with_generation(Ulid::r#gen(), 20);
 
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key: vec![0u8; 4].into(),
@@ -1423,12 +1423,12 @@ mod tests {
         let mut manifest = make_manifest(ReplicationItemKind::DeleteMarker);
         manifest.current_version_generation = None;
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
         );
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         op.state = IncomingVersionReplicationState::StartTransaction;
         op.negotiation_result = Some(ReplicationNegotiationResult::NeedVersionOnly);
 
@@ -1451,7 +1451,7 @@ mod tests {
     fn unparsable_existing_current_pointer_rejects_apply() {
         let manifest = make_manifest(ReplicationItemKind::DeleteMarker);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
@@ -1479,13 +1479,13 @@ mod tests {
         let mut manifest = make_manifest(ReplicationItemKind::DeleteMarker);
         manifest.current_version_generation = Some(1);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest.clone(),
         );
         start_apply_transaction(&mut op);
-        let existing_pointer = CurrentVersionPointer::new_with_generation(Ulid::new(), 2);
+        let existing_pointer = CurrentVersionPointer::new_with_generation(Ulid::r#gen(), 2);
 
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key: vec![0u8; 4].into(),
@@ -1507,13 +1507,13 @@ mod tests {
         manifest.source = Some(source.clone());
         manifest.current_version = false;
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
         );
-        op.txn_id = Some(Ulid::new());
-        op.destination_group_id = Some(Ulid::new());
+        op.txn_id = Some(Ulid::r#gen());
+        op.destination_group_id = Some(Ulid::r#gen());
         op.existing_blob_location = Some(make_location());
 
         let effects = op.write_version();
@@ -1529,14 +1529,14 @@ mod tests {
     fn write_version_indexes_non_current_materialized_version_by_content_hash() {
         let mut manifest = make_manifest(ReplicationItemKind::Materialized);
         manifest.current_version = false;
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest.clone(),
         );
-        op.txn_id = Some(Ulid::new());
+        op.txn_id = Some(Ulid::r#gen());
         op.destination_group_id = Some(group_id);
         op.existing_blob_location = Some(make_location());
 
@@ -1579,7 +1579,7 @@ mod tests {
         manifest.version_id = incoming_version_id;
         manifest.current_version_generation = Some(20);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest.clone(),
@@ -1622,7 +1622,7 @@ mod tests {
         manifest.version_id = incoming_version_id;
         manifest.current_version_generation = Some(7);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest.clone(),
@@ -1658,7 +1658,7 @@ mod tests {
         manifest.version_id = incoming_version_id;
         manifest.current_version_generation = Some(7);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
@@ -1687,7 +1687,7 @@ mod tests {
         let local_node_id = iroh::SecretKey::generate().public();
         let local_realm_id = RealmId::from_bytes([7u8; 32]);
         let op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             local_node_id,
             local_realm_id,
             manifest,
@@ -1710,13 +1710,13 @@ mod tests {
     fn existing_blob_with_manifest_mismatch_requests_blob_transfer() {
         let manifest = make_manifest(ReplicationItemKind::Materialized);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
         );
 
-        let _effects = advance_to_version_lookup(&mut op, Ulid::new());
+        let _effects = advance_to_version_lookup(&mut op, Ulid::r#gen());
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key: vec![0u8; 4].into(),
             value: None,
@@ -1747,13 +1747,13 @@ mod tests {
     fn missing_blob_requests_location_lookup_in_new_keyspace() {
         let manifest = make_manifest(ReplicationItemKind::Materialized);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
         );
 
-        let _effects = advance_to_version_lookup(&mut op, Ulid::new());
+        let _effects = advance_to_version_lookup(&mut op, Ulid::r#gen());
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key: vec![0u8; 4].into(),
             value: None,
@@ -1770,7 +1770,7 @@ mod tests {
     #[test]
     fn received_blob_manifest_mismatch_is_rejected_and_cleaned_up() {
         let manifest = make_manifest(ReplicationItemKind::Materialized);
-        let stream_id = Ulid::new();
+        let stream_id = Ulid::r#gen();
         let mut op = IncomingVersionReplicationOperation::new(
             stream_id,
             iroh::SecretKey::generate().public(),
@@ -1808,7 +1808,7 @@ mod tests {
     #[test]
     fn missing_destination_bucket_is_rejected_during_negotiation() {
         let manifest = make_manifest(ReplicationItemKind::DeleteMarker);
-        let stream_id = Ulid::new();
+        let stream_id = Ulid::r#gen();
         let mut op = IncomingVersionReplicationOperation::new(
             stream_id,
             iroh::SecretKey::generate().public(),
@@ -1849,7 +1849,7 @@ mod tests {
     #[test]
     fn denied_write_permission_is_rejected_during_negotiation() {
         let manifest = make_manifest(ReplicationItemKind::DeleteMarker);
-        let stream_id = Ulid::new();
+        let stream_id = Ulid::r#gen();
         let mut op = IncomingVersionReplicationOperation::new(
             stream_id,
             iroh::SecretKey::generate().public(),
@@ -1860,7 +1860,7 @@ mod tests {
         op.start();
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key: b"bucket".to_vec().into(),
-            value: Some(make_bucket_info(Ulid::new()).to_bytes().unwrap().into()),
+            value: Some(make_bucket_info(Ulid::r#gen()).to_bytes().unwrap().into()),
         }));
         assert_eq!(op.state, IncomingVersionReplicationState::CheckPermissions);
         assert!(matches!(effects[0], Effect::SubOperation(_)));
@@ -1888,7 +1888,7 @@ mod tests {
     fn authorization_errors_are_rejected_during_negotiation() {
         let manifest = make_manifest(ReplicationItemKind::DeleteMarker);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
@@ -1897,7 +1897,7 @@ mod tests {
         op.start();
         op.step(Event::Storage(StorageEvent::ReadResult {
             key: b"bucket".to_vec().into(),
-            value: Some(make_bucket_info(Ulid::new()).to_bytes().unwrap().into()),
+            value: Some(make_bucket_info(Ulid::r#gen()).to_bytes().unwrap().into()),
         }));
 
         let effects = op.step(Event::SubOperation(
@@ -1916,13 +1916,13 @@ mod tests {
     fn delete_marker_requests_version_only() {
         let manifest = make_manifest(ReplicationItemKind::DeleteMarker);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
         );
 
-        let _effects = advance_to_version_lookup(&mut op, Ulid::new());
+        let _effects = advance_to_version_lookup(&mut op, Ulid::r#gen());
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key: vec![0u8; 4].into(),
             value: None,
@@ -1941,13 +1941,13 @@ mod tests {
     fn missing_blob_requests_blob_transfer() {
         let manifest = make_manifest(ReplicationItemKind::Materialized);
         let mut op = IncomingVersionReplicationOperation::new(
-            Ulid::new(),
+            Ulid::r#gen(),
             iroh::SecretKey::generate().public(),
             RealmId::from_bytes([7u8; 32]),
             manifest,
         );
 
-        let _effects = advance_to_version_lookup(&mut op, Ulid::new());
+        let _effects = advance_to_version_lookup(&mut op, Ulid::r#gen());
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key: vec![0u8; 4].into(),
             value: None,
@@ -1974,8 +1974,8 @@ mod tests {
     #[test]
     fn apply_failures_send_explicit_rejection_before_abort() {
         let manifest = make_manifest(ReplicationItemKind::DeleteMarker);
-        let stream_id = Ulid::new();
-        let txn_id = Ulid::new();
+        let stream_id = Ulid::r#gen();
+        let txn_id = Ulid::r#gen();
         let mut op = IncomingVersionReplicationOperation::new(
             stream_id,
             iroh::SecretKey::generate().public(),
@@ -2012,9 +2012,9 @@ mod tests {
     #[test]
     fn received_blobs_are_deleted_after_apply_failure_before_commit() {
         let manifest = make_manifest(ReplicationItemKind::Materialized);
-        let stream_id = Ulid::new();
+        let stream_id = Ulid::r#gen();
         let received = make_location();
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let mut op = IncomingVersionReplicationOperation::new(
             stream_id,
             iroh::SecretKey::generate().public(),
@@ -2063,8 +2063,8 @@ mod tests {
     #[test]
     fn failures_without_received_blob_close_without_delete() {
         let manifest = make_manifest(ReplicationItemKind::DeleteMarker);
-        let stream_id = Ulid::new();
-        let txn_id = Ulid::new();
+        let stream_id = Ulid::r#gen();
+        let txn_id = Ulid::r#gen();
         let mut op = IncomingVersionReplicationOperation::new(
             stream_id,
             iroh::SecretKey::generate().public(),
@@ -2101,7 +2101,7 @@ mod tests {
     #[test]
     fn committed_replication_does_not_delete_received_blob_on_late_failure() {
         let manifest = make_manifest(ReplicationItemKind::Materialized);
-        let stream_id = Ulid::new();
+        let stream_id = Ulid::r#gen();
         let received = make_location();
         let mut op = IncomingVersionReplicationOperation::new(
             stream_id,
@@ -2116,7 +2116,7 @@ mod tests {
         op.apply_committed = true;
 
         let effects = op.step(Event::Storage(StorageEvent::TransactionStarted {
-            txn_id: Ulid::new(),
+            txn_id: Ulid::r#gen(),
         }));
         assert_eq!(op.state, IncomingVersionReplicationState::Error);
         assert_eq!(effects.len(), 1);

--- a/operations/src/replication/protocol.rs
+++ b/operations/src/replication/protocol.rs
@@ -106,7 +106,7 @@ mod tests {
         VersionReplicationManifest {
             bucket: "bucket".to_string(),
             key: "path/file.txt".to_string(),
-            version_id: Ulid::new(),
+            version_id: Ulid::r#gen(),
             kind: ReplicationItemKind::DeleteMarker,
             created_at: SystemTime::now(),
             created_by: test_user_id(),

--- a/operations/src/replication/version_replication.rs
+++ b/operations/src/replication/version_replication.rs
@@ -1402,7 +1402,7 @@ impl Operation for ReplicateObjectVersionOperation {
                             return self.fail(ReplicateObjectVersionError::MissingBlobHash);
                         };
                         self.state = ReplicateObjectVersionState::TransferBlob;
-                        let replication_id = Ulid::new();
+                        let replication_id = Ulid::r#gen();
                         self.blob_replication_id = Some(replication_id);
                         debug!(
                             bucket = %self.request.bucket,
@@ -1583,7 +1583,7 @@ mod tests {
 
     fn bucket_info() -> BucketInfo {
         BucketInfo {
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_at: SystemTime::now(),
             created_by: test_user_id(),
             cors_configuration: None,
@@ -1678,8 +1678,8 @@ mod tests {
         BackendLocation {
             root: "/tmp".to_string(),
             storage_bucket: "blob-bucket".to_string(),
-            backend_path: format!("bucket/key_{}", Ulid::new()),
-            ulid: Ulid::new(),
+            backend_path: format!("bucket/key_{}", Ulid::r#gen()),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by: test_user_id(),
@@ -1750,12 +1750,12 @@ mod tests {
             panic!("expected iteration after exact object lookup")
         };
 
-        let matching_version = Ulid::new();
+        let matching_version = Ulid::r#gen();
         let effects = op.step(Event::Storage(StorageEvent::IterResult {
             values: vec![
                 version_entry("dir/file.txt", matching_version),
-                version_entry("dir/file.txt.bak", Ulid::new()),
-                version_entry("dir/sub/file.txt", Ulid::new()),
+                version_entry("dir/file.txt.bak", Ulid::r#gen()),
+                version_entry("dir/sub/file.txt", Ulid::r#gen()),
             ],
             next_start_after: None,
         }));
@@ -1787,9 +1787,9 @@ mod tests {
 
         let effects = op.step(Event::Storage(StorageEvent::IterResult {
             values: vec![
-                version_entry("dir/file-a", Ulid::new()),
-                version_entry("dir/file/b", Ulid::new()),
-                version_entry("dir/other", Ulid::new()),
+                version_entry("dir/file-a", Ulid::r#gen()),
+                version_entry("dir/file/b", Ulid::r#gen()),
+                version_entry("dir/other", Ulid::r#gen()),
             ],
             next_start_after: None,
         }));
@@ -1804,7 +1804,7 @@ mod tests {
 
     #[test]
     fn multipart_metadata_paginates_across_multiple_iter_pages() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let mut op = ReplicateObjectVersionOperation::new(version_request(version_id));
         let location = materialized_location();
 
@@ -1883,7 +1883,7 @@ mod tests {
 
     #[test]
     fn multipart_metadata_rejects_incomplete_part_set() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let mut op = ReplicateObjectVersionOperation::new(version_request(version_id));
         let location = materialized_location();
 
@@ -1931,7 +1931,7 @@ mod tests {
 
     #[test]
     fn manifest_includes_sender_current_pointer_generation() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let generation = 42;
         let mut op = ReplicateObjectVersionOperation::new(version_request(version_id));
         op.replication_version = Some(ReplicationVersion::Deleted {
@@ -1951,7 +1951,7 @@ mod tests {
 
     #[test]
     fn manifest_includes_source_binding_for_materialized_version() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let source = reference_source_binding();
         let mut op = ReplicateObjectVersionOperation::new(version_request(version_id));
         op.replication_version = Some(ReplicationVersion::Materialized {
@@ -1973,7 +1973,7 @@ mod tests {
 
     #[test]
     fn manifest_omits_source_binding_for_delete_marker() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let mut op = ReplicateObjectVersionOperation::new(version_request(version_id));
         op.replication_version = Some(ReplicationVersion::Deleted {
             created_at: SystemTime::now(),
@@ -1992,7 +1992,7 @@ mod tests {
 
     #[test]
     fn manifest_rejects_unresolved_reference_version() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let source = reference_source_binding();
         let cached_metadata = reference_cached_metadata();
         let created_at = SystemTime::now();
@@ -2015,7 +2015,7 @@ mod tests {
 
     #[test]
     fn reference_versions_are_skipped_without_replication_manifest() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let mut op = ReplicateObjectVersionOperation::new(version_request(version_id));
 
         op.start();
@@ -2034,7 +2034,7 @@ mod tests {
 
     #[test]
     fn on_demand_reference_replication_materializes_before_manifest() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let original_source = Some(reference_source_binding());
         let mut op = ReplicateObjectVersionOperation::new(version_request_with_mode(
             version_id,
@@ -2106,7 +2106,7 @@ mod tests {
 
     #[test]
     fn on_demand_reference_replication_cleans_up_temporary_blob_after_apply() {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let mut op = ReplicateObjectVersionOperation::new(version_request_with_mode(
             version_id,
             ReplicationMode::OnDemand,
@@ -2149,7 +2149,7 @@ mod tests {
             value: None,
         }));
         op.step(Event::Blob(BlobEvent::ConnectionEstablished {
-            stream_id: Ulid::new(),
+            stream_id: Ulid::r#gen(),
         }));
         op.step(Event::Blob(BlobEvent::MessageSent {
             stream_id: op.stream_id.expect("stream id available"),

--- a/operations/src/reserve_onboarding_secret.rs
+++ b/operations/src/reserve_onboarding_secret.rs
@@ -378,7 +378,7 @@ mod tests {
             task_handle: None,
         };
 
-        let enrollment_id = Ulid::new();
+        let enrollment_id = Ulid::r#gen();
         drive(
             CreateOnboardingSecretOperation::new(CreateOnboardingSecretInput {
                 record: OnboardingSecretRecord {
@@ -453,7 +453,7 @@ mod tests {
             task_handle: None,
         };
 
-        let enrollment_id = Ulid::new();
+        let enrollment_id = Ulid::r#gen();
         drive(
             CreateOnboardingSecretOperation::new(CreateOnboardingSecretInput {
                 record: OnboardingSecretRecord {

--- a/operations/src/s3/bucket_cors.rs
+++ b/operations/src/s3/bucket_cors.rs
@@ -535,7 +535,7 @@ mod tests {
 
     fn bucket_info(cors_configuration: Option<BucketCorsConfiguration>) -> BucketInfo {
         BucketInfo {
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_at: SystemTime::UNIX_EPOCH,
             created_by: Default::default(),
             cors_configuration,

--- a/operations/src/s3/complete_multipart_upload.rs
+++ b/operations/src/s3/complete_multipart_upload.rs
@@ -593,7 +593,7 @@ impl CompleteMultipartUploadOperation {
     }
 
     fn write_current_lookup(&mut self, existing: Option<&CurrentVersionPointer>) -> Effects {
-        let version_id = *self.version_id.get_or_insert_with(Ulid::new);
+        let version_id = *self.version_id.get_or_insert_with(Ulid::r#gen);
         let pointer = CurrentVersionPointer::next_for(existing, version_id);
         let alias_context = match self.alias_context() {
             Ok(context) => context,
@@ -1321,14 +1321,14 @@ mod tests {
         CompleteMultipartUploadInput {
             bucket: "bucket".to_string(),
             key: "object".to_string(),
-            upload_id: Ulid::new(),
+            upload_id: Ulid::r#gen(),
             realm_id,
             node_id: iroh::SecretKey::from_bytes(&[7u8; 32]).public(),
             completed_parts: vec![],
             expected_checksums: vec![],
             checksum_type: MultipartChecksumType::FullObject,
             object_size: Some(10),
-            created_by: UserId::local(Ulid::new(), realm_id),
+            created_by: UserId::local(Ulid::r#gen(), realm_id),
             quota_ceiling: Some(30),
         }
     }
@@ -1338,7 +1338,7 @@ mod tests {
             upload_id: input.upload_id,
             bucket: input.bucket.clone(),
             key: input.key.clone(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_by: input.created_by,
             created_at: SystemTime::now(),
             status: MultipartUploadStatus::Completing,
@@ -1353,10 +1353,10 @@ mod tests {
                 root: "/tmp".to_string(),
                 storage_bucket: "multipart".to_string(),
                 backend_path: format!("part-{part_number}"),
-                ulid: Ulid::new(),
+                ulid: Ulid::r#gen(),
                 compressed: false,
                 encrypted: false,
-                created_by: UserId::local(Ulid::new(), RealmId::from_bytes([4u8; 32])),
+                created_by: UserId::local(Ulid::r#gen(), RealmId::from_bytes([4u8; 32])),
                 created_at: SystemTime::now(),
                 staging: false,
                 partial: true,
@@ -1397,17 +1397,17 @@ mod tests {
             root: "/tmp".to_string(),
             storage_bucket: "objects".to_string(),
             backend_path: "object".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
-            created_by: UserId::local(Ulid::new(), RealmId::from_bytes([4u8; 32])),
+            created_by: UserId::local(Ulid::r#gen(), RealmId::from_bytes([4u8; 32])),
             created_at: SystemTime::now(),
             staging: false,
             partial: false,
             blob_size: 10,
             hashes: HashMap::new(),
         });
-        op.version_id = Some(Ulid::new());
+        op.version_id = Some(Ulid::r#gen());
         op.upload_parts = vec![requested.clone(), omitted.clone()];
         op.resolved_parts = vec![requested.clone()];
 
@@ -1432,7 +1432,7 @@ mod tests {
         let input = finalize_input();
         let record = open_upload_record(&input);
         let mut op = CompleteMultipartUploadOperation::new(input);
-        let finalize_txn = TxnId::new();
+        let finalize_txn = TxnId::r#gen();
         op.txn_id = Some(finalize_txn);
         op.upload_record = Some(record);
         op.state = CompleteMultipartUploadState::EnforceQuota;
@@ -1482,7 +1482,7 @@ mod tests {
     fn quota_rejection_abort_failure_preserves_original_error() {
         let input = finalize_input();
         let mut op = CompleteMultipartUploadOperation::new(input);
-        let finalize_txn = TxnId::new();
+        let finalize_txn = TxnId::r#gen();
         op.txn_id = Some(finalize_txn);
         op.state = CompleteMultipartUploadState::EnforceQuota;
 

--- a/operations/src/s3/create_bucket.rs
+++ b/operations/src/s3/create_bucket.rs
@@ -266,7 +266,7 @@ mod test {
         };
 
         let bucket_info = BucketInfo {
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_at: SystemTime::now(),
             created_by: Default::default(),
             cors_configuration: None,

--- a/operations/src/s3/create_multipart_upload.rs
+++ b/operations/src/s3/create_multipart_upload.rs
@@ -95,7 +95,7 @@ impl CreateMultipartUploadOperation {
         };
 
         let record = MultipartUpload {
-            upload_id: Ulid::new(),
+            upload_id: Ulid::r#gen(),
             bucket: self.input.bucket.clone(),
             key: self.input.key.clone(),
             group_id: self.input.group_id,

--- a/operations/src/s3/create_user_access.rs
+++ b/operations/src/s3/create_user_access.rs
@@ -77,7 +77,7 @@ impl CreateUserAccessOperation {
 
     fn handle_init(&mut self) -> Effects {
         if let CreateUserAccessState::Init = self.state {
-            let key_id = Ulid::new().to_string();
+            let key_id = Ulid::r#gen().to_string();
             let access_key = match UserAccess::build_access_key(&self.config.user_identity, &key_id)
             {
                 Ok(access_key) => access_key,
@@ -216,7 +216,7 @@ mod tests {
     #[test]
     fn test_create_user_access_happy_path() {
         let user_identity = make_user_identity();
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let mut op = CreateUserAccessOperation::new(make_config(user_identity, group_id));
 
         // 1. Start -> Should transition to CreateUserAccess and emit Storage::Write
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_create_user_access_invalid_steps() {
         let user_identity = make_user_identity();
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         // 1. Invalid state: start twice -> second start calls abort since state is not Init
         let mut op = CreateUserAccessOperation::new(make_config(user_identity, group_id));
@@ -290,7 +290,7 @@ mod tests {
         let mut op = CreateUserAccessOperation::new(make_config(user_identity, group_id));
         op.start();
         // Feed a ReadResult instead of WriteResult
-        let key = Ulid::new().to_bytes().into();
+        let key = Ulid::r#gen().to_bytes().into();
         let effects = op.step(Event::Storage(StorageEvent::ReadResult {
             key,
             value: None,

--- a/operations/src/s3/delete_bucket.rs
+++ b/operations/src/s3/delete_bucket.rs
@@ -389,7 +389,7 @@ mod test {
             CreateBucketOperation::new(
                 bucket.clone(),
                 BucketInfo {
-                    group_id: Ulid::new(),
+                    group_id: Ulid::r#gen(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
                     cors_configuration: None,
@@ -451,7 +451,7 @@ mod test {
             CreateBucketOperation::new(
                 bucket.clone(),
                 BucketInfo {
-                    group_id: Ulid::new(),
+                    group_id: Ulid::r#gen(),
                     created_at: SystemTime::now(),
                     created_by: aruna_core::UserId::nil(RealmId::from_bytes([0u8; 32])),
                     cors_configuration: None,
@@ -527,7 +527,7 @@ mod test {
                 key_space: S3_BUCKET_KEYSPACE.to_string(),
                 key: bucket.clone().into(),
                 value: BucketInfo {
-                    group_id: Ulid::new(),
+                    group_id: Ulid::r#gen(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
                     cors_configuration: None,
@@ -539,7 +539,7 @@ mod test {
             })
             .await;
 
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let _ = storage_handle
             .send_storage_effect(StorageEffect::Write {
                 key_space: BLOB_HEAD_KEYSPACE.to_string(),
@@ -589,7 +589,7 @@ mod test {
                 key_space: S3_BUCKET_KEYSPACE.to_string(),
                 key: bucket.clone().into(),
                 value: BucketInfo {
-                    group_id: Ulid::new(),
+                    group_id: Ulid::r#gen(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
                     cors_configuration: None,
@@ -603,7 +603,7 @@ mod test {
         let _ = storage_handle
             .send_storage_effect(StorageEffect::Write {
                 key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
-                key: VersionKey::new(&bucket, "deleted-key", Ulid::new())
+                key: VersionKey::new(&bucket, "deleted-key", Ulid::r#gen())
                     .to_bytes()
                     .unwrap()
                     .into(),

--- a/operations/src/s3/delete_object.rs
+++ b/operations/src/s3/delete_object.rs
@@ -657,7 +657,7 @@ impl DeleteObjectOperation {
     }
 
     fn write_tombstone(&mut self) -> Effects {
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         self.version_id = Some(version_id);
         self.deleted_version_created_at = Some(SystemTime::now());
         self.read_current_lookup(version_id)
@@ -852,7 +852,7 @@ mod test {
     use ulid::Ulid;
 
     fn test_user_id() -> aruna_core::UserId {
-        aruna_core::UserId::local(Ulid::new(), RealmId::from_bytes([1u8; 32]))
+        aruna_core::UserId::local(Ulid::r#gen(), RealmId::from_bytes([1u8; 32]))
     }
 
     fn deleted_version_value(user_id: aruna_core::UserId) -> aruna_core::types::Value {
@@ -906,7 +906,7 @@ mod test {
             bucket: "bucket".to_string(),
             key: "key".to_string(),
             version_id: Some(target_version_id),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             realm_id: RealmId::from_bytes([1u8; 32]),
             node_id: iroh::SecretKey::generate().public(),
             deleted_by: user_id,
@@ -921,7 +921,7 @@ mod test {
         ));
 
         let effects = op.step(Event::Storage(StorageEvent::TransactionStarted {
-            txn_id: Ulid::new(),
+            txn_id: Ulid::r#gen(),
         }));
         assert!(matches!(
             effects.as_slice(),
@@ -1073,8 +1073,8 @@ mod test {
             task_handle: None,
         };
 
-        let user_id = aruna_core::UserId::local(Ulid::new(), RealmId::from_bytes([1u8; 32]));
-        let group_id = Ulid::new();
+        let user_id = aruna_core::UserId::local(Ulid::r#gen(), RealmId::from_bytes([1u8; 32]));
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId::from_bytes([1u8; 32]);
         let node_id = context.net_handle.as_ref().unwrap().node_id();
         let put_result = drive(
@@ -1180,7 +1180,7 @@ mod test {
                 key: "to-delete.txt".to_string(),
                 version_id: None,
                 range: None,
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 user_identity: user_id,
             }),
             &context,
@@ -1224,8 +1224,8 @@ mod test {
             task_handle: None,
         };
 
-        let user_id = aruna_core::UserId::local(Ulid::new(), RealmId::from_bytes([1u8; 32]));
-        let group_id = Ulid::new();
+        let user_id = aruna_core::UserId::local(Ulid::r#gen(), RealmId::from_bytes([1u8; 32]));
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId::from_bytes([1u8; 32]);
         let node_id = context.net_handle.as_ref().unwrap().node_id();
         let put_result = drive(
@@ -1347,7 +1347,7 @@ mod test {
                 key: "versioned.txt".to_string(),
                 version_id: None,
                 range: None,
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 user_identity: user_id,
             }),
             &context,
@@ -1396,7 +1396,7 @@ mod test {
                 key: "versioned.txt".to_string(),
                 version_id: None,
                 range: None,
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 user_identity: user_id,
             }),
             &context,

--- a/operations/src/s3/get_object.rs
+++ b/operations/src/s3/get_object.rs
@@ -767,15 +767,15 @@ mod test {
             key: "range.txt".to_string(),
             version_id: None,
             range: Some(ObjectRangeRequest::StartEnd { start: 2, end: 4 }),
-            group_id: Ulid::new(),
-            user_identity: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+            group_id: Ulid::r#gen(),
+            user_identity: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
         });
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let location = BackendLocation {
             root: "/tmp".to_string(),
             storage_bucket: "aruna_test".to_string(),
             backend_path: "s3test/range.txt".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by: Default::default(),
@@ -806,10 +806,10 @@ mod test {
             key: "range.txt".to_string(),
             version_id: None,
             range: Some(ObjectRangeRequest::Suffix { length: 4 }),
-            group_id: Ulid::new(),
-            user_identity: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+            group_id: Ulid::r#gen(),
+            user_identity: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
         });
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let access = ResolvedSourceAccess::OpenDal {
             kind: SourceConnectorKind::Http,
             config: HashMap::new(),
@@ -876,8 +876,8 @@ mod test {
             key: "range.txt".to_string(),
             version_id: None,
             range: Some(ObjectRangeRequest::StartEnd { start: 1, end: 3 }),
-            group_id: Ulid::new(),
-            user_identity: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+            group_id: Ulid::r#gen(),
+            user_identity: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
         });
         operation.source_metadata = Some(SourceMetadata {
             content_length: 10,
@@ -946,10 +946,10 @@ mod test {
 
         let bucket = "s3test".to_string();
         let key = "test.txt".to_string();
-        let blob_ulid = Ulid::new();
+        let blob_ulid = Ulid::r#gen();
         let location = BackendLocation {
             root: temp_root.to_string(),
-            storage_bucket: format!("aruna_{}", Ulid::new()),
+            storage_bucket: format!("aruna_{}", Ulid::r#gen()),
             backend_path: format!("{bucket}/{key}_{blob_ulid}"),
             ulid: blob_ulid,
             compressed: false,
@@ -984,7 +984,7 @@ mod test {
                 })
                 .await;
 
-            let version_id = Ulid::new();
+            let version_id = Ulid::r#gen();
             let _ = storage_handle
                 .send_storage_effect(StorageEffect::Write {
                     key_space: BLOB_HEAD_KEYSPACE.to_string(),
@@ -1037,7 +1037,7 @@ mod test {
             key,
             version_id: None,
             range: None,
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             user_identity: Default::default(),
         });
 
@@ -1092,10 +1092,10 @@ mod test {
 
         let bucket = "s3test".to_string();
         let key = "test.txt".to_string();
-        let blob_ulid = Ulid::new();
+        let blob_ulid = Ulid::r#gen();
         let location = BackendLocation {
             root: temp_root.to_string(),
-            storage_bucket: format!("aruna_{}", Ulid::new()),
+            storage_bucket: format!("aruna_{}", Ulid::r#gen()),
             backend_path: format!("{bucket}/{key}_{blob_ulid}"),
             ulid: blob_ulid,
             compressed: false,
@@ -1129,7 +1129,7 @@ mod test {
                 })
                 .await;
 
-            let version_id = Ulid::new();
+            let version_id = Ulid::r#gen();
             let _ = storage_handle
                 .send_storage_effect(StorageEffect::Write {
                     key_space: BLOB_HEAD_KEYSPACE.to_string(),
@@ -1181,7 +1181,7 @@ mod test {
             key,
             version_id: None,
             range: None,
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             user_identity: Default::default(),
         });
 
@@ -1243,8 +1243,8 @@ mod test {
 
         let bucket = "s3test".to_string();
         let key = "test.txt".to_string();
-        let version_id = Ulid::new();
-        let connector_id = Ulid::new();
+        let version_id = Ulid::r#gen();
+        let connector_id = Ulid::r#gen();
         let cached_metadata = SourceMetadata {
             content_length: 15,
             content_type: Some("text/plain".to_string()),
@@ -1315,8 +1315,8 @@ mod test {
                 key,
                 version_id: None,
                 range: None,
-                group_id: Ulid::new(),
-                user_identity: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+                group_id: Ulid::r#gen(),
+                user_identity: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
             }),
             &driver_ctx,
         )
@@ -1401,7 +1401,7 @@ mod test {
             task_handle: None,
         };
 
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let source = VersionSourceBinding {
             strategy: StagingStrategy::Reference,
             descriptor: PortableSourceDescriptor {
@@ -1412,7 +1412,7 @@ mod test {
                 capabilities: Vec::new(),
                 origin_node_id: None,
             },
-            connector_id: Some(Ulid::new()),
+            connector_id: Some(Ulid::r#gen()),
         };
 
         let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = storage_handle
@@ -1472,8 +1472,8 @@ mod test {
                 key: "refresh.txt".to_string(),
                 version_id: None,
                 range: None,
-                group_id: Ulid::new(),
-                user_identity: UserId::local(Ulid::new(), RealmId([0u8; 32])),
+                group_id: Ulid::r#gen(),
+                user_identity: UserId::local(Ulid::r#gen(), RealmId([0u8; 32])),
             }),
             &driver_ctx,
         )

--- a/operations/src/s3/get_user_access.rs
+++ b/operations/src/s3/get_user_access.rs
@@ -151,11 +151,11 @@ mod test {
 
         let user_identity = Default::default();
         let access_key_id =
-            UserAccess::build_access_key(&user_identity, &Ulid::new().to_string()).unwrap();
+            UserAccess::build_access_key(&user_identity, &Ulid::r#gen().to_string()).unwrap();
         let user_access = UserAccess {
             access_key: access_key_id.clone(),
             user_identity,
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             secret: "SECRET_KEY".to_string(),
             expiry: std::time::SystemTime::now() + std::time::Duration::from_secs(3600),
             path_restrictions: None,

--- a/operations/src/s3/head_object.rs
+++ b/operations/src/s3/head_object.rs
@@ -444,7 +444,7 @@ mod tests {
             root: "/tmp".to_string(),
             storage_bucket: "mybucket".to_string(),
             backend_path: "hello.txt".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_at: SystemTime::now(),
@@ -489,7 +489,7 @@ mod tests {
         };
 
         let location = location_with_hash();
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = storage_handle
             .send_storage_effect(StorageEffect::StartTransaction { read: false })
             .await
@@ -595,7 +595,7 @@ mod tests {
         };
 
         let location = location_with_hash();
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let metadata = BlobVersion::materialized(
             location.get_blake3().unwrap().try_into().unwrap(),
             SystemTime::now(),
@@ -685,7 +685,7 @@ mod tests {
             task_handle: None,
         };
 
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let cached_metadata = SourceMetadata {
             content_length: 11,
             content_type: Some("text/plain".to_string()),
@@ -707,7 +707,7 @@ mod tests {
                 capabilities: Vec::new(),
                 origin_node_id: None,
             },
-            connector_id: Some(Ulid::new()),
+            connector_id: Some(Ulid::r#gen()),
         };
 
         let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = storage_handle

--- a/operations/src/s3/list_buckets.rs
+++ b/operations/src/s3/list_buckets.rs
@@ -199,7 +199,7 @@ mod test {
             task_handle: None,
         };
 
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         for (bucket, bucket_info) in [
             (
                 "alpha".to_string(),
@@ -222,7 +222,7 @@ mod test {
             (
                 "foreign".to_string(),
                 BucketInfo {
-                    group_id: Ulid::new(),
+                    group_id: Ulid::r#gen(),
                     created_at: SystemTime::now(),
                     created_by: Default::default(),
                     cors_configuration: None,

--- a/operations/src/s3/list_objects_v2.rs
+++ b/operations/src/s3/list_objects_v2.rs
@@ -614,11 +614,11 @@ mod test {
             task_handle: None,
         };
 
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId([7u8; 32]);
-        let created_by = UserId::local(Ulid::new(), realm_id);
-        let live_version_id = Ulid::new();
-        let deleted_version_id = Ulid::new();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
+        let live_version_id = Ulid::r#gen();
+        let deleted_version_id = Ulid::r#gen();
         let live_hash = [3u8; 32];
         let created_at = UNIX_EPOCH + Duration::from_secs(5);
 
@@ -662,7 +662,7 @@ mod test {
             root: "/tmp".to_string(),
             storage_bucket: "objects".to_string(),
             backend_path: "path".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by,
@@ -715,8 +715,8 @@ mod test {
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
 
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(
             &storage_handle,
@@ -772,8 +772,8 @@ mod test {
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
 
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(
             &storage_handle,
@@ -829,11 +829,11 @@ mod test {
             task_handle: None,
         };
 
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId([7u8; 32]);
-        let created_by = UserId::local(Ulid::new(), realm_id);
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
         let created_at = UNIX_EPOCH + Duration::from_secs(5);
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         let hash = [3u8; 32];
 
         let _ = storage_handle
@@ -893,8 +893,8 @@ mod test {
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
 
-        let group_id = Ulid::new();
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let group_id = Ulid::r#gen();
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(
             &storage_handle,
@@ -957,7 +957,7 @@ mod test {
             task_handle: None,
         };
 
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let result = drive(
             ListObjectsV2Operation::new(ListObjectsV2Input {
@@ -993,10 +993,10 @@ mod test {
             task_handle: None,
         };
 
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId([7u8; 32]);
-        let created_by = UserId::local(Ulid::new(), realm_id);
-        let version_id = Ulid::new();
+        let created_by = UserId::local(Ulid::r#gen(), realm_id);
+        let version_id = Ulid::r#gen();
         let created_at = UNIX_EPOCH + Duration::from_secs(5);
         let last_refresh = UNIX_EPOCH + Duration::from_secs(20);
 
@@ -1099,7 +1099,7 @@ mod test {
     ) {
         let created_at = UNIX_EPOCH + Duration::from_secs(5);
         for (index, key) in keys.iter().enumerate() {
-            let version_id = Ulid::new();
+            let version_id = Ulid::r#gen();
             let hash = [index as u8 + 1; 32];
             let version = BlobVersion::materialized(hash, created_at, created_by, None);
             let _ = storage_handle
@@ -1132,7 +1132,7 @@ mod test {
                         root: "/tmp".to_string(),
                         storage_bucket: "objects".to_string(),
                         backend_path: format!("path/{key}"),
-                        ulid: Ulid::new(),
+                        ulid: Ulid::r#gen(),
                         compressed: false,
                         encrypted: false,
                         created_by,
@@ -1160,7 +1160,7 @@ mod test {
         let result = drive(
             ListObjectsV2Operation::new(ListObjectsV2Input {
                 bucket: bucket.to_string(),
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 continuation_token: None,
                 max_keys: Some(100),
                 prefix: prefix.map(str::to_string),
@@ -1186,7 +1186,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(
             &storage_handle,
@@ -1209,7 +1209,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(&storage_handle, "bucket", &["rare0", "rare/1"], created_by).await;
 
@@ -1223,7 +1223,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(&storage_handle, "bucket", &["b", "aa", "a/1"], created_by).await;
 
@@ -1237,7 +1237,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(&storage_handle, "bucket", &["a", "b", "c"], created_by).await;
 
@@ -1257,7 +1257,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(&storage_handle, "bucket", &["docs/1", "docs/2"], created_by).await;
 
@@ -1278,7 +1278,7 @@ mod test {
         drive(
             ListObjectsV2Operation::new(ListObjectsV2Input {
                 bucket: bucket.to_string(),
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 continuation_token,
                 max_keys: Some(max_keys),
                 prefix: None,
@@ -1299,7 +1299,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(
             &storage_handle,
@@ -1327,7 +1327,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         seed_materialized_keys(
             &storage_handle,
@@ -1373,7 +1373,7 @@ mod test {
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
 
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
         let created_at = UNIX_EPOCH + Duration::from_secs(5);
         let last_refresh = UNIX_EPOCH + Duration::from_secs(20);
 
@@ -1407,7 +1407,7 @@ mod test {
         let deleted = BlobVersion::deleted(created_at, created_by);
 
         for (key, version) in [("beta", reference), ("gamma", deleted)] {
-            let version_id = Ulid::new();
+            let version_id = Ulid::r#gen();
             let _ = storage_handle
                 .send_storage_effect(StorageEffect::Write {
                     key_space: BLOB_HEAD_KEYSPACE.to_string(),
@@ -1435,7 +1435,7 @@ mod test {
         let result = drive(
             ListObjectsV2Operation::new(ListObjectsV2Input {
                 bucket: "bucket".to_string(),
-                group_id: Ulid::new(),
+                group_id: Ulid::r#gen(),
                 continuation_token: None,
                 max_keys: Some(10),
                 prefix: None,
@@ -1467,7 +1467,7 @@ mod test {
     ) -> ListObjectsV2Input {
         ListObjectsV2Input {
             bucket: "bucket".to_string(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             continuation_token,
             max_keys: Some(max_keys),
             prefix: None,
@@ -1483,7 +1483,7 @@ mod test {
             Effect::Storage(StorageEffect::StartTransaction { .. })
         ));
         operation.step(Event::Storage(StorageEvent::TransactionStarted {
-            txn_id: Ulid::new(),
+            txn_id: Ulid::r#gen(),
         }))
     }
 
@@ -1499,7 +1499,7 @@ mod test {
             panic!("expected initial scan round: {:?}", effects[0]);
         };
 
-        let pointer: aruna_core::types::Value = CurrentVersionPointer::new(Ulid::new())
+        let pointer: aruna_core::types::Value = CurrentVersionPointer::new(Ulid::r#gen())
             .to_bytes()
             .unwrap()
             .into();
@@ -1560,7 +1560,7 @@ mod test {
         let storage_handle =
             storage::FjallStorage::open(temp_handle.path().to_str().unwrap()).unwrap();
         let driver_ctx = driver_context(storage_handle.clone());
-        let created_by = UserId::local(Ulid::new(), RealmId([7u8; 32]));
+        let created_by = UserId::local(Ulid::r#gen(), RealmId([7u8; 32]));
 
         let group_keys: Vec<String> = (0..30).map(|index| format!("dir/{index:02}")).collect();
         let mut keys: Vec<&str> = vec!["a"];

--- a/operations/src/s3/put_object.rs
+++ b/operations/src/s3/put_object.rs
@@ -357,7 +357,7 @@ impl PutObjectOperation {
     }
 
     fn write_current_lookup(&mut self, existing: Option<&CurrentVersionPointer>) -> Effects {
-        let version_id = *self.version_id.get_or_insert_with(Ulid::new);
+        let version_id = *self.version_id.get_or_insert_with(Ulid::r#gen);
         let pointer = CurrentVersionPointer::next_for(existing, version_id);
         let effect = match write_blob_head_effect(&self.alias_context(), pointer, self.txn_id) {
             Ok(effect) => effect,
@@ -879,7 +879,7 @@ mod test {
             root: "/tmp".to_string(),
             storage_bucket: "bucket".to_string(),
             backend_path: "path".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by,
@@ -897,7 +897,7 @@ mod test {
         node_id: aruna_core::NodeId,
     ) -> PutObjectConfig {
         PutObjectConfig {
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             group_id,
             realm_id,
             node_id,
@@ -918,10 +918,10 @@ mod test {
     #[test]
     fn quota_gate_error_aborts_transaction_and_deletes_written_blob() {
         let realm_id = RealmId::from_bytes([1u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let node_id = iroh::SecretKey::generate().public();
         let mut op = PutObjectOperation::new(put_config(realm_id, group_id, node_id));
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let location = test_location(op.config.user_id);
 
         op.state = PutObjectState::EnforceQuota;
@@ -960,10 +960,10 @@ mod test {
     #[test]
     fn usage_update_error_aborts_transaction_and_deletes_written_blob() {
         let realm_id = RealmId::from_bytes([1u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let node_id = iroh::SecretKey::generate().public();
         let mut op = PutObjectOperation::new(put_config(realm_id, group_id, node_id));
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let location = test_location(op.config.user_id);
 
         op.state = PutObjectState::UpdateUsage;
@@ -1006,10 +1006,10 @@ mod test {
     #[test]
     fn commit_transaction_conflict_deletes_written_blob_and_returns_conflict() {
         let realm_id = RealmId::from_bytes([1u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let node_id = iroh::SecretKey::generate().public();
         let mut op = PutObjectOperation::new(put_config(realm_id, group_id, node_id));
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let location = test_location(op.config.user_id);
 
         op.state = PutObjectState::CommitTransaction;
@@ -1066,10 +1066,10 @@ mod test {
         let data = b"hello, world!";
         let stream = tokio_util::io::ReaderStream::new(&data[..]);
         let realm_id = RealmId::from_bytes([1u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let node_id = net_handle.node_id();
         let put_config = PutObjectConfig {
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             group_id,
             realm_id,
             node_id,
@@ -1263,12 +1263,12 @@ mod test {
 
         let data = b"hello, world!";
         let realm_id = RealmId::from_bytes([1u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let node_id = context.net_handle.as_ref().unwrap().node_id();
 
         let first = drive(
             PutObjectOperation::new(PutObjectConfig {
-                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
                 group_id,
                 realm_id,
                 node_id,
@@ -1295,7 +1295,7 @@ mod test {
 
         let second = drive(
             PutObjectOperation::new(PutObjectConfig {
-                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
                 group_id,
                 realm_id,
                 node_id,
@@ -1389,8 +1389,8 @@ mod test {
     fn put_object_current_pointer_generation_increments_from_existing_pointer() {
         let realm_id = RealmId::from_bytes([1u8; 32]);
         let mut op = PutObjectOperation::new(PutObjectConfig {
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
-            group_id: Ulid::new(),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
+            group_id: Ulid::r#gen(),
             realm_id,
             node_id: iroh::SecretKey::generate().public(),
             request: PutObjectInput {
@@ -1405,13 +1405,13 @@ mod test {
             version_source: None,
             quota_ceiling: None,
         });
-        let version_id = Ulid::new();
+        let version_id = Ulid::r#gen();
         op.version_id = Some(version_id);
         op.output = Some(Ok(BackendLocation {
             root: "/tmp".to_string(),
             storage_bucket: "bucket".to_string(),
             backend_path: "path".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_by: op.config.user_id,
@@ -1421,8 +1421,8 @@ mod test {
             blob_size: 1,
             hashes: HashMap::new(),
         }));
-        op.txn_id = Some(Ulid::new());
-        let existing = CurrentVersionPointer::new_with_generation(Ulid::new(), 4);
+        op.txn_id = Some(Ulid::r#gen());
+        let existing = CurrentVersionPointer::new_with_generation(Ulid::r#gen(), 4);
 
         let effects = op.handle_object_lookup_read(Event::Storage(StorageEvent::ReadResult {
             key: vec![0].into(),
@@ -1481,12 +1481,12 @@ mod test {
         };
 
         let realm_id = RealmId::from_bytes([1u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let node_id = context.net_handle.as_ref().unwrap().node_id();
 
         let first = drive(
             PutObjectOperation::new(PutObjectConfig {
-                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
                 group_id,
                 realm_id,
                 node_id,
@@ -1513,7 +1513,7 @@ mod test {
 
         let second = drive(
             PutObjectOperation::new(PutObjectConfig {
-                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
                 group_id,
                 realm_id,
                 node_id,
@@ -1666,8 +1666,8 @@ mod test {
         let data = b"hello, world!";
         let err = drive(
             PutObjectOperation::new(PutObjectConfig {
-                user_id: aruna_core::UserId::local(Ulid::new(), RealmId::from_bytes([1u8; 32])),
-                group_id: Ulid::new(),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), RealmId::from_bytes([1u8; 32])),
+                group_id: Ulid::r#gen(),
                 realm_id: RealmId::from_bytes([1u8; 32]),
                 node_id: context.net_handle.as_ref().unwrap().node_id(),
                 request: PutObjectInput {

--- a/operations/src/s3/refresh_reference_metadata.rs
+++ b/operations/src/s3/refresh_reference_metadata.rs
@@ -887,8 +887,8 @@ mod tests {
             },
             bucket: "bucket".to_string(),
             key: "key".to_string(),
-            version_id: Ulid::new(),
-            created_by: UserId::local(Ulid::new(), realm_id),
+            version_id: Ulid::r#gen(),
+            created_by: UserId::local(Ulid::r#gen(), realm_id),
         }
     }
 

--- a/operations/src/s3/revoke_user_access.rs
+++ b/operations/src/s3/revoke_user_access.rs
@@ -203,7 +203,7 @@ mod tests {
         let user_access = UserAccess {
             access_key: access_key.clone(),
             user_identity: Default::default(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             secret: "secret".to_string(),
             expiry: SystemTime::now() + Duration::from_secs(3600),
             path_restrictions: None,

--- a/operations/src/staging/head_source.rs
+++ b/operations/src/staging/head_source.rs
@@ -363,7 +363,7 @@ mod tests {
     #[tokio::test]
     async fn head_operation_resolves_connector_and_hits_runtime() {
         let test_context = setup_driver_context().await;
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let connector =
             create_http_connector(&test_context.driver_context, group_id, "http://127.0.0.1:1")
                 .await;

--- a/operations/src/staging/read_source.rs
+++ b/operations/src/staging/read_source.rs
@@ -373,7 +373,7 @@ mod tests {
     #[tokio::test]
     async fn read_operation_resolves_connector_and_hits_runtime() {
         let test_context = setup_driver_context().await;
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let connector =
             create_http_connector(&test_context.driver_context, group_id, "http://127.0.0.1:1")
                 .await;

--- a/operations/src/staging/reference.rs
+++ b/operations/src/staging/reference.rs
@@ -90,7 +90,7 @@ pub async fn materialize_reference(
         Some(input.node_id),
         Some(head_result.connector.connector_id),
     );
-    let version_id = Ulid::new();
+    let version_id = Ulid::r#gen();
     let now = SystemTime::now();
 
     let txn_id = match context
@@ -706,13 +706,13 @@ mod tests {
     async fn materialize_reference_retains_historical_hash_path_and_writes_blob_version() {
         let test_context = setup_driver_context().await;
         let context = &test_context.driver_context;
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId::from_bytes([9u8; 32]);
         let node_id = iroh::SecretKey::generate().public();
 
         let initial = drive(
             PutObjectOperation::new(PutObjectConfig {
-                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
                 group_id,
                 realm_id,
                 node_id,
@@ -745,7 +745,7 @@ mod tests {
             context,
             MaterializeReferenceInput {
                 group_id,
-                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
                 node_id,
                 connector_id: connector.connector_id,
@@ -820,7 +820,7 @@ mod tests {
     async fn materialize_reference_rejects_over_quota_without_writing_head_or_usage() {
         let test_context = setup_driver_context().await;
         let context = &test_context.driver_context;
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let realm_id = RealmId::from_bytes([8u8; 32]);
         let node_id = iroh::SecretKey::generate().public();
         let (server, endpoint) = spawn_reference_server("ref-data").await;
@@ -830,7 +830,7 @@ mod tests {
             context,
             MaterializeReferenceInput {
                 group_id,
-                user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+                user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
                 node_id,
                 connector_id: connector.connector_id,

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -2099,7 +2099,7 @@ mod tests {
 
         let b_id = net_b.node_id();
         let recipient = loop {
-            let candidate = UserId::new(Ulid::new(), realm_id);
+            let candidate = UserId::new(Ulid::r#gen(), realm_id);
             if resolve_inbox_holder(&candidate, &config).expect("resolve holder") == Some(b_id) {
                 break candidate;
             }

--- a/operations/src/update_metadata_document.rs
+++ b/operations/src/update_metadata_document.rs
@@ -153,7 +153,7 @@ impl UpdateMetadataDocumentOperation {
     }
 
     fn update_event_record(&self, record: &MetadataRegistryRecord) -> MetadataCreateEventRecord {
-        let event_id = Ulid::new();
+        let event_id = Ulid::r#gen();
         let mut record = record.clone();
         record.last_event_id = event_id;
         let occurred_at_ms = record.updated_at_ms;
@@ -515,14 +515,14 @@ mod tests {
         let realm_id = RealmId::from_bytes([9u8; 32]);
         Actor {
             node_id: iroh::SecretKey::from_bytes(&[9u8; 32]).public(),
-            user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+            user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         }
     }
 
     fn record(actor: &Actor) -> MetadataRegistryRecord {
-        let group_id = Ulid::new();
-        let document_id = Ulid::new();
+        let group_id = Ulid::r#gen();
+        let document_id = Ulid::r#gen();
         let document_path = "datasets/update-atomicity";
         MetadataRegistryRecord {
             realm_id: actor.realm_id,
@@ -708,7 +708,7 @@ mod tests {
     fn replace_rocrate_validates_and_commits_update_intent_before_craqle_mutation() {
         let actor = actor();
         let record = record(&actor);
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let mut operation = UpdateMetadataDocumentOperation::new(config(
             actor,
             &record,
@@ -743,7 +743,7 @@ mod tests {
     fn entity_upsert_appends_durable_update_event_before_materialization() {
         let actor = actor();
         let record = record(&actor);
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let mut operation = UpdateMetadataDocumentOperation::new(config(
             actor,
             &record,
@@ -771,7 +771,7 @@ mod tests {
         let actor = actor();
         let mut record = record(&actor);
         record.holder_node_ids.clear();
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let mut operation = UpdateMetadataDocumentOperation::new(config(
             actor,
             &record,
@@ -858,7 +858,7 @@ mod tests {
     fn commit_failure_does_not_mutate_or_sync_graph() {
         let actor = actor();
         let record = record(&actor);
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let mut operation = UpdateMetadataDocumentOperation::new(config(
             actor,
             &record,

--- a/operations/src/update_user.rs
+++ b/operations/src/update_user.rs
@@ -620,7 +620,7 @@ fn local_user_document_sync_change(
         base: previous_change.map(|change| change.current),
         current: DocumentSyncRevision {
             generation: updated_at_ms.max(minimum_generation),
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             actor: actor.node_id,
             updated_at_ms,
         },
@@ -858,7 +858,7 @@ mod tests {
             }))
         ));
 
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         let target = AdminDocumentTarget::User { user_id };
         let document = DocumentSyncTarget::User { user_id };
@@ -995,7 +995,7 @@ mod tests {
         };
 
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
 
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
@@ -1059,7 +1059,7 @@ mod tests {
         let mut operation = UpdateUserOperation::new(input(realm_id, user_id, user_id));
 
         operation.start();
-        let txn_id = TxnId::new();
+        let txn_id = TxnId::r#gen();
         operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
 
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -95,7 +95,7 @@ impl UsageCounterUpdate {
     /// marker whose stored generation still matches the one it observed, so a
     /// write that re-dirties a marker mid-publish keeps its retry signal.
     fn dirty_marker_writes(&self) -> Vec<(String, Key, Value)> {
-        let generation = ByteView::from(ulid::Ulid::new().to_bytes().to_vec());
+        let generation = ByteView::from(ulid::Ulid::r#gen().to_bytes().to_vec());
         vec![
             (
                 USAGE_NODE_STATS_KEYSPACE.to_string(),
@@ -1307,7 +1307,7 @@ async fn write_usage_snapshot_retry_markers(
         .iter()
         .map(|(key, _)| key.as_ref().to_vec())
         .collect();
-    let generation = Value::from(ulid::Ulid::new().to_bytes().to_vec());
+    let generation = Value::from(ulid::Ulid::r#gen().to_bytes().to_vec());
     let mut writes: Vec<(String, Key, Value)> =
         Vec::with_capacity(published.groups.len() + usize::from(published.global));
     if published.global && !observed_keys.contains(NODE_USAGE_DIRTY_GLOBAL_KEY) {
@@ -1739,7 +1739,7 @@ mod tests {
             root: "/tmp".to_string(),
             storage_bucket: "bucket".to_string(),
             backend_path: "path".to_string(),
-            ulid: Ulid::new(),
+            ulid: Ulid::r#gen(),
             compressed: false,
             encrypted: false,
             created_at: SystemTime::now(),
@@ -1799,8 +1799,8 @@ mod tests {
 
     #[test]
     fn counter_update_applies_deltas_with_synthetic_events() {
-        let group_id = Ulid::new();
-        let txn_id = Ulid::new();
+        let group_id = Ulid::r#gen();
+        let txn_id = Ulid::r#gen();
         let mut update = UsageCounterUpdate::for_group(
             group_id,
             UsageDelta {
@@ -1863,7 +1863,7 @@ mod tests {
     async fn create_bucket_maintains_usage_counters() {
         let temp = tempdir().unwrap();
         let ctx = test_ctx(temp.path().to_str().unwrap());
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         drive(
             CreateBucketOperation::new(
@@ -1892,7 +1892,7 @@ mod tests {
     async fn load_usage_counters_reads_group_and_global_counters() {
         let temp = tempdir().unwrap();
         let ctx = test_ctx(temp.path().to_str().unwrap());
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
         let group = UsageCounters {
             buckets: 1,
             objects: 2,
@@ -1957,8 +1957,8 @@ mod tests {
     async fn rebuild_counts_live_objects_logical_and_stored_bytes() {
         let temp = tempdir().unwrap();
         let ctx = test_ctx(temp.path().to_str().unwrap());
-        let group_a = Ulid::new();
-        let group_b = Ulid::new();
+        let group_a = Ulid::r#gen();
+        let group_b = Ulid::r#gen();
 
         let Event::Storage(StorageEvent::TransactionStarted { txn_id }) = ctx
             .storage_handle
@@ -2008,7 +2008,7 @@ mod tests {
         // alpha/ref.txt: one reference version, live.
         // beta/shared.bin: two materialized versions of the shared blob.
         let write_version = async |bucket: &str, key: &str, version: BlobVersion| {
-            let version_id = Ulid::new();
+            let version_id = Ulid::r#gen();
             ctx.storage_handle
                 .send_storage_effect(StorageEffect::Write {
                     key_space: BLOB_VERSIONS_KEYSPACE.to_string(),
@@ -2078,7 +2078,7 @@ mod tests {
                         capabilities: Vec::new(),
                         origin_node_id: None,
                     },
-                    connector_id: Some(Ulid::new()),
+                    connector_id: Some(Ulid::r#gen()),
                 },
                 SourceMetadata {
                     content_length: 30,
@@ -2135,7 +2135,7 @@ mod tests {
     async fn rebuild_removes_stale_usage_counter_keys() {
         let temp = tempdir().unwrap();
         let ctx = test_ctx(temp.path().to_str().unwrap());
-        let stale_group = Ulid::new();
+        let stale_group = Ulid::r#gen();
         let stale_key = usage_group_key(stale_group);
 
         ctx.storage_handle
@@ -2226,7 +2226,7 @@ mod tests {
     async fn usage_update_writes_dirty_markers_in_transaction() {
         let temp = tempdir().unwrap();
         let ctx = test_ctx(temp.path().to_str().unwrap());
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         drive(
             CreateBucketOperation::new(
@@ -2263,7 +2263,7 @@ mod tests {
         let ctx = test_ctx(temp.path().to_str().unwrap());
         let node_id = node(1);
         let realm_id = RealmId::from_bytes([9u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let counters = UsageCounters {
             buckets: 1,
@@ -2317,7 +2317,7 @@ mod tests {
         let ctx = test_ctx(temp.path().to_str().unwrap());
         let local = node(1);
         let remote = node(2);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let local_counters = UsageCounters {
             logical_bytes: 10,
@@ -2455,7 +2455,7 @@ mod tests {
     async fn clear_consumed_markers_keeps_regenerated_markers() {
         let temp = tempdir().unwrap();
         let ctx = test_ctx(temp.path().to_str().unwrap());
-        let generation_one = Ulid::new().to_bytes().to_vec();
+        let generation_one = Ulid::r#gen().to_bytes().to_vec();
 
         write_node_stat(
             &ctx,
@@ -2470,7 +2470,7 @@ mod tests {
 
         // A concurrent counter update re-dirties the marker with a new generation
         // after it was observed but before it is cleared.
-        let generation_two = Ulid::new().to_bytes().to_vec();
+        let generation_two = Ulid::r#gen().to_bytes().to_vec();
         write_node_stat(
             &ctx,
             NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec(),
@@ -2510,8 +2510,8 @@ mod tests {
         let ctx = test_ctx(temp.path().to_str().unwrap());
         let node_id = node(1);
         let realm_id = RealmId::from_bytes([9u8; 32]);
-        let group_id = Ulid::new();
-        let generation = Ulid::new().to_bytes().to_vec();
+        let group_id = Ulid::r#gen();
+        let generation = Ulid::r#gen().to_bytes().to_vec();
 
         let counters = UsageCounters {
             buckets: 1,
@@ -2568,7 +2568,7 @@ mod tests {
         let ctx = test_ctx(temp.path().to_str().unwrap());
         let node_id = node(1);
         let realm_id = RealmId::from_bytes([9u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let counters = UsageCounters {
             buckets: 1,
@@ -2637,8 +2637,8 @@ mod tests {
         let node_id = node(1);
         let remote = node(2);
         let realm_id = RealmId::from_bytes([9u8; 32]);
-        let group_id = Ulid::new();
-        let generation = Ulid::new().to_bytes().to_vec();
+        let group_id = Ulid::r#gen();
+        let generation = Ulid::r#gen().to_bytes().to_vec();
 
         let counters = UsageCounters {
             buckets: 1,
@@ -2690,7 +2690,7 @@ mod tests {
         let node_id = node(1);
         let remote = node(2);
         let realm_id = RealmId::from_bytes([9u8; 32]);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let counters = UsageCounters {
             buckets: 1,
@@ -2749,8 +2749,8 @@ mod tests {
         let ctx = test_ctx(temp.path().to_str().unwrap());
         let node_id = node(1);
         let realm_id = RealmId::from_bytes([9u8; 32]);
-        let live_group = Ulid::new();
-        let stale_group = Ulid::new();
+        let live_group = Ulid::r#gen();
+        let stale_group = Ulid::r#gen();
 
         // A live group still has a counter key.
         let counters = UsageCounters {
@@ -2809,7 +2809,7 @@ mod tests {
         let ctx = test_ctx(temp.path().to_str().unwrap());
         let local = node(1);
         let remote = node(2);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let local_counters = UsageCounters {
             logical_bytes: 10,

--- a/operations/src/user_subject_index.rs
+++ b/operations/src/user_subject_index.rs
@@ -477,7 +477,7 @@ mod tests {
         let user_id = UserId::local(Ulid::from_bytes([2u8; 16]), realm_id);
         let subject = oidc_subject_key("https://issuer.example", "subject-1").unwrap();
         let current_bytes = user_bytes(user_id, vec![subject.clone()], HashSet::new());
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let mut operation =
             ResolveUserSubjectConflictsOperation::new(ResolveUserSubjectConflictsInput {
                 txn_id,
@@ -535,7 +535,7 @@ mod tests {
         let subject = oidc_subject_key("https://issuer.example", "subject-1").unwrap();
         let winner_bytes = user_bytes(winner_id, vec![subject.clone()], HashSet::new());
         let loser_bytes = user_bytes(loser_id, vec![subject.clone()], HashSet::new());
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
         let mut operation =
             ResolveUserSubjectConflictsOperation::new(ResolveUserSubjectConflictsInput {
                 txn_id,

--- a/operations/tests/auth_validation.rs
+++ b/operations/tests/auth_validation.rs
@@ -182,7 +182,7 @@ async fn rejects_auth_context_conversion_failure() {
 fn realm_fixture() -> (SigningKey, RealmId, UserId) {
     let signing_key = signing_key();
     let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
-    let user_id = UserId::local(Ulid::new(), realm_id);
+    let user_id = UserId::local(Ulid::r#gen(), realm_id);
     (signing_key, realm_id, user_id)
 }
 
@@ -204,7 +204,7 @@ fn token_claims(realm_id: RealmId, user_id: UserId) -> TokenClaims {
         iss: realm_id.to_string(),
         iat: now,
         exp: now + 600,
-        jti: Ulid::new().to_string(),
+        jti: Ulid::r#gen().to_string(),
         restrictions: None,
         issuer_pubkey: None,
         delegation_signature: None,

--- a/operations/tests/group_replication.rs
+++ b/operations/tests/group_replication.rs
@@ -35,7 +35,7 @@ async fn group_creation_replicates_to_all_realm_nodes() -> Result<(), Box<dyn st
 
     let creator = Actor {
         node_id: nodes[0].net.node_id(),
-        user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+        user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
         realm_id,
     };
 

--- a/operations/tests/metadata_cold_start.rs
+++ b/operations/tests/metadata_cold_start.rs
@@ -47,7 +47,7 @@ fn graph_iri(index: usize) -> String {
 }
 
 fn registry_record(group_id: GroupId, index: usize) -> MetadataRegistryRecord {
-    let document_id = Ulid::new();
+    let document_id = Ulid::r#gen();
     MetadataRegistryRecord {
         realm_id: REALM,
         group_id,
@@ -150,7 +150,7 @@ async fn first_query_on_cold_node_with_40k_docs() -> Result<(), BoxError> {
 
     {
         let handle = std::sync::Arc::new(open_handle(metadata_dir.path(), &storage)?);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let seed_started = Instant::now();
         let mut tasks = Vec::new();

--- a/operations/tests/metadata_create_backpressure.rs
+++ b/operations/tests/metadata_create_backpressure.rs
@@ -111,7 +111,7 @@ async fn run_writer(
     let mut latencies = Vec::with_capacity(PER_WRITER);
     let mut batch = Vec::new();
     for index in 0..PER_WRITER {
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let payload = if index % 2 == 0 {
             scaffold_payload(writer, index)
         } else {
@@ -123,7 +123,7 @@ async fn run_writer(
                 CreateMetadataDocumentConfig {
                     actor: Actor {
                         node_id,
-                        user_id: UserId::local(Ulid::new(), realm_id),
+                        user_id: UserId::local(Ulid::r#gen(), realm_id),
                         realm_id,
                     },
                     group_id,
@@ -156,7 +156,7 @@ async fn run_writer(
 async fn run_phase(label: &str, with_drains: bool) -> Result<(), BoxError> {
     let node = spawn_probe_node(with_drains).await?;
     let realm_id = RealmId([55u8; 32]);
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
 
     let started = Instant::now();
     let mut handles = Vec::with_capacity(WRITERS);

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -58,8 +58,8 @@ struct TestContext {
 #[tokio::test]
 async fn metadata_crud_roundtrip_uses_craqle_backend() -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
 
     let created = drive(
         CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
@@ -233,8 +233,8 @@ async fn metadata_crud_roundtrip_uses_craqle_backend() -> Result<(), Box<dyn std
 async fn generated_metadata_create_foreground_storage_effect_count_is_reduced()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let before = test
         .context
         .storage_handle
@@ -276,11 +276,11 @@ async fn generated_metadata_create_foreground_storage_effect_count_is_reduced()
 async fn metadata_event_log_replay_repairs_wal_only_create()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let document_path = "datasets/replay-repair";
     let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
-    let event_id = Ulid::new();
+    let event_id = Ulid::r#gen();
     let record = MetadataRegistryRecord {
         realm_id: test.actor.realm_id,
         group_id,
@@ -363,8 +363,8 @@ async fn metadata_event_log_replay_repairs_wal_only_create()
 async fn scheduled_projection_queue_recovers_event_log_only_create()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -412,8 +412,8 @@ async fn scheduled_projection_queue_recovers_event_log_only_create()
 async fn pending_projection_marker_recovers_event_log_only_create()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -443,8 +443,8 @@ async fn pending_projection_marker_recovers_event_log_only_create()
 async fn targeted_projection_deletes_pending_projection_marker()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -475,8 +475,8 @@ async fn targeted_projection_deletes_pending_projection_marker()
 async fn projection_queue_replay_is_idempotent_for_already_projected_create()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -513,8 +513,8 @@ async fn projection_queue_replay_is_idempotent_for_already_projected_create()
 async fn metadata_event_log_targeted_projection_repairs_only_requested_create()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -522,8 +522,8 @@ async fn metadata_event_log_targeted_projection_repairs_only_requested_create()
         "datasets/targeted-projection",
         "Targeted Dataset",
     );
-    let other_group_id = Ulid::new();
-    let other_document_id = Ulid::new();
+    let other_group_id = Ulid::r#gen();
+    let other_document_id = Ulid::r#gen();
     let (_, other_create_event) = build_create_event(
         &test,
         other_group_id,
@@ -572,8 +572,8 @@ async fn metadata_event_log_targeted_projection_repairs_only_requested_create()
 async fn metadata_event_log_replay_does_not_resurrect_deleted_document()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -595,8 +595,8 @@ async fn metadata_event_log_replay_does_not_resurrect_deleted_document()
 async fn projector_skips_stale_create_when_graph_tombstone_exists()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -622,8 +622,8 @@ async fn projector_skips_stale_create_when_graph_tombstone_exists()
 async fn projector_deletes_stale_registry_when_tombstone_fence_wins()
 -> Result<(), Box<dyn std::error::Error>> {
     let test = build_context_without_net().await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let (record, create_event) = build_create_event(
         &test,
         group_id,
@@ -668,7 +668,7 @@ fn build_create_event(
     name: &str,
 ) -> (MetadataRegistryRecord, MetadataCreateEventRecord) {
     let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
-    let event_id = Ulid::new();
+    let event_id = Ulid::r#gen();
     let record = MetadataRegistryRecord {
         realm_id: test.actor.realm_id,
         group_id,
@@ -965,7 +965,7 @@ async fn build_context() -> Result<TestContext, Box<dyn std::error::Error>> {
     )?;
     let actor = Actor {
         node_id,
-        user_id: aruna_core::UserId::local(Ulid::new(), RealmId([5u8; 32])),
+        user_id: aruna_core::UserId::local(Ulid::r#gen(), RealmId([5u8; 32])),
         realm_id: RealmId([5u8; 32]),
     };
     seed_realm_config(&storage_handle, &actor).await?;
@@ -1001,7 +1001,7 @@ async fn build_context_without_net() -> Result<TestContext, Box<dyn std::error::
     )?;
     let actor = Actor {
         node_id,
-        user_id: aruna_core::UserId::local(Ulid::new(), realm_id),
+        user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
         realm_id,
     };
     seed_realm_config(&storage_handle, &actor).await?;

--- a/operations/tests/metadata_propagation_tail.rs
+++ b/operations/tests/metadata_propagation_tail.rs
@@ -82,7 +82,7 @@ fn propagation_tail_under_sustained_load() -> Result<(), BoxError> {
         let nodes = build_realm_nodes(&realm_id, 3).await?;
         let targets = node_targets(&nodes);
         let contexts: Vec<Arc<DriverContext>> = nodes.iter().map(|n| n.context.clone()).collect();
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let (done_tx, done_rx) = tokio::sync::watch::channel(false);
         let sampler = tokio::spawn(run_sampler(
@@ -201,14 +201,14 @@ async fn run_sampler(
         }
         let slot = index % targets.len();
         let (node_id, context) = targets[slot].clone();
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let t0 = Instant::now();
         let result = drive(
             CreateMetadataDocumentOperation::new_for_generated_document_id(
                 CreateMetadataDocumentConfig {
                     actor: Actor {
                         node_id,
-                        user_id: UserId::local(Ulid::new(), realm_id),
+                        user_id: UserId::local(Ulid::r#gen(), realm_id),
                         realm_id,
                     },
                     group_id,
@@ -339,7 +339,7 @@ async fn run_paced_writer(
         ticker.tick().await;
         let slot = (writer + index) % targets.len();
         let (node_id, context) = &targets[slot];
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let payload = if index % 2 == 0 {
             scaffold_payload(label, writer, index)
         } else {
@@ -350,7 +350,7 @@ async fn run_paced_writer(
                 CreateMetadataDocumentConfig {
                     actor: Actor {
                         node_id: *node_id,
-                        user_id: UserId::local(Ulid::new(), realm_id),
+                        user_id: UserId::local(Ulid::r#gen(), realm_id),
                         realm_id,
                     },
                     group_id,

--- a/operations/tests/metadata_query_concurrency.rs
+++ b/operations/tests/metadata_query_concurrency.rs
@@ -67,7 +67,7 @@ async fn build_harness(backend_pool_size: Option<usize>) -> Result<TestHarness, 
         _metadata_dir: metadata_dir,
         storage,
         handle,
-        group_id: Ulid::new(),
+        group_id: Ulid::r#gen(),
     })
 }
 
@@ -76,7 +76,7 @@ fn registry_record(
     index: usize,
     graph_iri: Option<String>,
 ) -> MetadataRegistryRecord {
-    let document_id = Ulid::new();
+    let document_id = Ulid::r#gen();
     MetadataRegistryRecord {
         realm_id: REALM,
         group_id,
@@ -286,7 +286,7 @@ async fn stale_visibility_cache_serves_reads_and_refreshes_in_background() -> Re
 }
 
 fn visibility_record(group_id: GroupId, path: &str, public: bool) -> MetadataRegistryRecord {
-    let document_id = Ulid::new();
+    let document_id = Ulid::r#gen();
     MetadataRegistryRecord {
         realm_id: REALM,
         group_id,
@@ -414,7 +414,7 @@ async fn search_fills_visible_limit_after_invisible_matches_are_removed() -> Res
         deleted_records.push(deleted.clone());
         records.push(deleted);
 
-        let unregistered_iri = MetadataRegistryRecord::graph_iri_for(Ulid::new());
+        let unregistered_iri = MetadataRegistryRecord::graph_iri_for(Ulid::r#gen());
         let unregistered_name =
             repeated_search_name(marker, &format!("unregistered-{index:02}"), 32);
         create_crate(&harness, &unregistered_iri, &unregistered_name).await?;
@@ -485,7 +485,7 @@ async fn search_honors_explicit_graph_filter_before_visible_limit() -> Result<()
 async fn lazy_visibility_matches_eager_query_and_search_semantics() -> Result<(), BoxError> {
     let harness = build_harness(None).await?;
     let group_id = harness.group_id;
-    let member = aruna_core::UserId::local(Ulid::new(), REALM);
+    let member = aruna_core::UserId::local(Ulid::r#gen(), REALM);
     let actor = Actor {
         node_id: iroh::SecretKey::from_bytes(&[9u8; 32]).public(),
         user_id: member,
@@ -526,7 +526,7 @@ async fn lazy_visibility_matches_eager_query_and_search_semantics() -> Result<()
     let public_record = visibility_record(group_id, "datasets/probe-public", true);
     let private_record = visibility_record(group_id, "datasets/probe-private", false);
     let deleted_record = visibility_record(group_id, "datasets/probe-deleted", true);
-    let unregistered_iri = MetadataRegistryRecord::graph_iri_for(Ulid::new());
+    let unregistered_iri = MetadataRegistryRecord::graph_iri_for(Ulid::r#gen());
     create_crate(&harness, &public_record.graph_iri, "probe public").await?;
     create_crate(&harness, &private_record.graph_iri, "probe private").await?;
     create_crate(&harness, &deleted_record.graph_iri, "probe deleted").await?;
@@ -557,7 +557,7 @@ async fn lazy_visibility_matches_eager_query_and_search_semantics() -> Result<()
         path_restrictions: None,
     };
     let outsider_auth = AuthContext {
-        user_id: aruna_core::UserId::local(Ulid::new(), REALM),
+        user_id: aruna_core::UserId::local(Ulid::r#gen(), REALM),
         realm_id: REALM,
         path_restrictions: None,
     };

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -72,8 +72,8 @@ async fn metadata_creation_replicates_to_all_three_holders()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([41u8; 32]);
     let nodes = build_realm_nodes(&realm_id, 3).await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
 
     let visible_nodes = drive(
         GetRealmNodesOperation::new(realm_id),
@@ -86,7 +86,7 @@ async fn metadata_creation_replicates_to_all_three_holders()
         CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
             actor: Actor {
                 node_id: nodes[0].net.node_id(),
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
             },
             group_id,
@@ -121,8 +121,8 @@ async fn metadata_replan_refreshes_replacement_holder_indexes()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([46u8; 32]);
     let nodes = build_realm_nodes(&realm_id, 4).await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let document_path = "datasets/replan-holder-refresh";
     let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
 
@@ -130,7 +130,7 @@ async fn metadata_replan_refreshes_replacement_holder_indexes()
         CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
             actor: Actor {
                 node_id: nodes[0].net.node_id(),
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
             },
             group_id,
@@ -178,7 +178,7 @@ async fn metadata_replan_refreshes_replacement_holder_indexes()
         UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
             actor: Actor {
                 node_id: nodes[0].net.node_id(),
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
             },
             group_id,
@@ -264,14 +264,14 @@ async fn metadata_updates_and_deletes_apply_to_local_holder()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([42u8; 32]);
     let nodes = build_realm_nodes(&realm_id, 3).await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
 
     let created = drive(
         CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
             actor: Actor {
                 node_id: nodes[0].net.node_id(),
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
             },
             group_id,
@@ -330,7 +330,7 @@ async fn metadata_updates_and_deletes_apply_to_local_holder()
         UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
             actor: Actor {
                 node_id: nodes[0].net.node_id(),
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
             },
             group_id,
@@ -359,7 +359,7 @@ async fn metadata_updates_and_deletes_apply_to_local_holder()
         DeleteMetadataDocumentOperation::new(
             Actor {
                 node_id: nodes[0].net.node_id(),
-                user_id: UserId::local(Ulid::new(), realm_id),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
                 realm_id,
             },
             group_id,
@@ -381,11 +381,11 @@ async fn batched_metadata_create_projection_materializes_many_documents()
     let nodes = vec![spawn_node(realm_id).await?];
     install_realm_config(&nodes, &realm_id).await?;
     let node = &nodes[0];
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let mut events = Vec::new();
 
     for index in 0..8u8 {
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let now = unix_timestamp_millis().saturating_add(index.into());
         let document_path = format!("datasets/batch-{index}");
         let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
@@ -408,9 +408,9 @@ async fn batched_metadata_create_projection_materializes_many_documents()
             last_event_id: Ulid::nil(),
         };
         events.push(MetadataCreateEventRecord {
-            event_id: Ulid::new(),
+            event_id: Ulid::r#gen(),
             record,
-            user_id: UserId::local(Ulid::new(), realm_id),
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
             node_id: node.net.node_id(),
             payload: MetadataCreateEventPayload::Scaffold {
                 name: format!("Batch Dataset {index}"),
@@ -459,10 +459,10 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([44u8; 32]);
     let nodes = build_realm_nodes(&realm_id, 2).await?;
-    let group_id = Ulid::new();
-    let document_id = Ulid::new();
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
     let document_path = "datasets/reordered-delete";
-    let event_id = Ulid::new();
+    let event_id = Ulid::r#gen();
     let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
     let record = MetadataRegistryRecord {
         realm_id,
@@ -485,7 +485,7 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
     let create_event = MetadataCreateEventRecord {
         event_id,
         record: record.clone(),
-        user_id: UserId::local(Ulid::new(), realm_id),
+        user_id: UserId::local(Ulid::r#gen(), realm_id),
         node_id: nodes[0].net.node_id(),
         payload: MetadataCreateEventPayload::Scaffold {
             name: "Reordered Delete".to_string(),
@@ -497,7 +497,7 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
     };
     let tombstone =
         MetadataGraphLifecycleRecord::deleted(graph_iri, realm_id, group_id, document_id, 2);
-    let delete_event_id = Ulid::new();
+    let delete_event_id = Ulid::r#gen();
     let lifecycle = MetadataDocumentLifecycleRecord::Delete {
         event: MetadataDocumentDeleteRecord {
             event_id: delete_event_id,
@@ -533,7 +533,7 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
     };
     publish_document_to_peer(
         &nodes[0],
-        Ulid::new(),
+        Ulid::r#gen(),
         stale_target.clone(),
         postcard::to_allocvec(&create_event)?,
         nodes[1].net.node_id(),

--- a/operations/tests/metadata_throughput.rs
+++ b/operations/tests/metadata_throughput.rs
@@ -72,7 +72,7 @@ fn throughput_gate() -> Result<(), BoxError> {
             let realm_id = RealmId([91u8 + level as u8; 32]);
             let nodes = build_realm_nodes(&realm_id, 3).await?;
             let targets = node_targets(&nodes);
-            let group_id = Ulid::new();
+            let group_id = Ulid::r#gen();
 
             let per_writer = TOTAL_CREATES / writers;
             let label = format!("tp{writers}");
@@ -130,7 +130,7 @@ fn convergence_gate() -> Result<(), BoxError> {
         let realm_id = RealmId([122u8; 32]);
         let nodes = build_realm_nodes(&realm_id, 3).await?;
         let targets = node_targets(&nodes);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let writers = 64usize;
         let per_writer = 16usize;
@@ -194,7 +194,7 @@ fn production_path_convergence_gate() -> Result<(), BoxError> {
         let realm_id = RealmId([124u8; 32]);
         let nodes = build_realm_nodes(&realm_id, 3).await?;
         let targets = node_targets(&nodes);
-        let group_id = Ulid::new();
+        let group_id = Ulid::r#gen();
 
         let writers = 32usize;
         let per_writer = 128usize;
@@ -330,7 +330,7 @@ async fn churn_convergence_body() -> Result<f64, BoxError> {
     wait_for_realm_node_convergence(&nodes, &realm_id).await?;
     install_realm_config(&nodes, &realm_id).await?;
 
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let targets0 = vec![(nodes[0].net.node_id(), nodes[0].context.clone())];
     let initial = run_writer(realm_id, group_id, "seed", 0, 1, targets0.clone()).await?;
     let initial_pair = vec![(initial[0].0, initial[0].1)];
@@ -445,7 +445,7 @@ async fn run_writer(
     for index in 0..count {
         let slot = (writer + index) % targets.len();
         let (node_id, context) = &targets[slot];
-        let document_id = Ulid::new();
+        let document_id = Ulid::r#gen();
         let payload = if index % 2 == 0 {
             scaffold_payload(label, writer, index)
         } else {
@@ -456,7 +456,7 @@ async fn run_writer(
                 CreateMetadataDocumentConfig {
                     actor: Actor {
                         node_id: *node_id,
-                        user_id: UserId::local(Ulid::new(), realm_id),
+                        user_id: UserId::local(Ulid::r#gen(), realm_id),
                         realm_id,
                     },
                     group_id,

--- a/operations/tests/multipart.rs
+++ b/operations/tests/multipart.rs
@@ -231,9 +231,9 @@ fn composite_sha256(parts: &[&[u8]]) -> Vec<u8> {
 async fn completes_multipart_upload_and_persists_object_part_metadata() {
     let context = setup_context().await;
     let realm_id = RealmId::from_bytes([7u8; 32]);
-    let created_by = UserId::local(Ulid::new(), realm_id);
+    let created_by = UserId::local(Ulid::r#gen(), realm_id);
     let node_id = context.driver.net_handle.as_ref().unwrap().node_id();
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let created = drive(
         CreateMultipartUploadOperation::new(CreateMultipartUploadInput {
             bucket: "bucket-a".to_string(),
@@ -509,12 +509,12 @@ async fn completes_multipart_upload_and_persists_object_part_metadata() {
 #[tokio::test]
 async fn upload_part_overwrites_existing_part_and_cleans_old_blob() {
     let context = setup_context().await;
-    let created_by = UserId::local(Ulid::new(), RealmId::from_bytes([7u8; 32]));
+    let created_by = UserId::local(Ulid::r#gen(), RealmId::from_bytes([7u8; 32]));
     let upload_id = drive(
         CreateMultipartUploadOperation::new(CreateMultipartUploadInput {
             bucket: "bucket-a".to_string(),
             key: "overwrite.bin".to_string(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_by,
             checksum_hint: None,
         }),
@@ -576,8 +576,8 @@ async fn upload_part_overwrites_existing_part_and_cleans_old_blob() {
 async fn completes_multipart_upload_retains_previous_current_hash_path_index() {
     let context = setup_context().await;
     let realm_id = RealmId::from_bytes([7u8; 32]);
-    let created_by = UserId::local(Ulid::new(), realm_id);
-    let group_id = Ulid::new();
+    let created_by = UserId::local(Ulid::r#gen(), realm_id);
+    let group_id = Ulid::r#gen();
     let node_id = context.driver.net_handle.as_ref().unwrap().node_id();
 
     let initial = drive(
@@ -761,9 +761,9 @@ async fn completes_multipart_upload_retains_previous_current_hash_path_index() {
 async fn multipart_completion_deduplicates_against_existing_multipart_object() {
     let context = setup_context().await;
     let realm_id = RealmId::from_bytes([7u8; 32]);
-    let created_by = UserId::local(Ulid::new(), realm_id);
+    let created_by = UserId::local(Ulid::r#gen(), realm_id);
     let node_id = context.driver.net_handle.as_ref().unwrap().node_id();
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let part1 = b"hello ";
     let part2 = b"world";
 
@@ -866,9 +866,9 @@ async fn multipart_completion_deduplicates_against_existing_multipart_object() {
 async fn multipart_completion_deduplicates_against_existing_put_object() {
     let context = setup_context().await;
     let realm_id = RealmId::from_bytes([7u8; 32]);
-    let created_by = UserId::local(Ulid::new(), realm_id);
+    let created_by = UserId::local(Ulid::r#gen(), realm_id);
     let node_id = context.driver.net_handle.as_ref().unwrap().node_id();
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let content = b"hello world";
 
     let put = drive(
@@ -955,9 +955,9 @@ async fn multipart_completion_deduplicates_against_existing_put_object() {
 async fn multipart_completion_same_key_same_content_bumps_generation_and_reuses_location() {
     let context = setup_context().await;
     let realm_id = RealmId::from_bytes([7u8; 32]);
-    let created_by = UserId::local(Ulid::new(), realm_id);
+    let created_by = UserId::local(Ulid::r#gen(), realm_id);
     let node_id = context.driver.net_handle.as_ref().unwrap().node_id();
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let part1 = b"hello ";
     let part2 = b"world";
 
@@ -1077,12 +1077,12 @@ async fn multipart_completion_same_key_same_content_bumps_generation_and_reuses_
 #[tokio::test]
 async fn abort_multipart_upload_removes_metadata_and_part_blobs() {
     let context = setup_context().await;
-    let created_by = UserId::local(Ulid::new(), RealmId::from_bytes([7u8; 32]));
+    let created_by = UserId::local(Ulid::r#gen(), RealmId::from_bytes([7u8; 32]));
     let created = drive(
         CreateMultipartUploadOperation::new(CreateMultipartUploadInput {
             bucket: "bucket-a".to_string(),
             key: "abort.bin".to_string(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_by,
             checksum_hint: None,
         }),
@@ -1153,12 +1153,12 @@ async fn abort_multipart_upload_removes_metadata_and_part_blobs() {
 #[tokio::test]
 async fn upload_part_checksum_mismatch_cleans_up_raw_part() {
     let context = setup_context().await;
-    let created_by = UserId::local(Ulid::new(), RealmId::from_bytes([7u8; 32]));
+    let created_by = UserId::local(Ulid::r#gen(), RealmId::from_bytes([7u8; 32]));
     let upload_id = drive(
         CreateMultipartUploadOperation::new(CreateMultipartUploadInput {
             bucket: "bucket-a".to_string(),
             key: "checksum.bin".to_string(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_by,
             checksum_hint: None,
         }),
@@ -1219,14 +1219,14 @@ async fn upload_part_checksum_mismatch_cleans_up_raw_part() {
 async fn delete_object_removes_completed_multipart_metadata() {
     let context = setup_context().await;
     let realm_id = RealmId::from_bytes([7u8; 32]);
-    let created_by = UserId::local(Ulid::new(), realm_id);
+    let created_by = UserId::local(Ulid::r#gen(), realm_id);
     let node_id = context.driver.net_handle.as_ref().unwrap().node_id();
 
     let created = drive(
         CreateMultipartUploadOperation::new(CreateMultipartUploadInput {
             bucket: "bucket-a".to_string(),
             key: "delete-me.bin".to_string(),
-            group_id: Ulid::new(),
+            group_id: Ulid::r#gen(),
             created_by,
             checksum_hint: None,
         }),

--- a/operations/tests/notification_delivery.rs
+++ b/operations/tests/notification_delivery.rs
@@ -222,7 +222,7 @@ async fn placement_is_uniform_across_nodes() -> Result<(), Box<dyn std::error::E
     let nodes = build_realm_nodes(&realm_id, 3).await?;
 
     for _ in 0..20 {
-        let recipient = UserId::local(Ulid::new(), realm_id);
+        let recipient = UserId::local(Ulid::r#gen(), realm_id);
         let mut holders = Vec::with_capacity(nodes.len());
         for node in &nodes {
             holders.push(resolve_holder_on(node, recipient).await?);
@@ -349,8 +349,8 @@ fn added_to_group_record(
         recipient,
         NotificationClass::Direct,
         NotificationKind::AddedToGroup {
-            group_id: Ulid::new(),
-            actor_user_id: UserId::local(Ulid::new(), realm_id),
+            group_id: Ulid::r#gen(),
+            actor_user_id: UserId::local(Ulid::r#gen(), realm_id),
         },
         created_at_ms,
     )
@@ -371,7 +371,7 @@ fn user_with_holder(
     realm_id: RealmId,
 ) -> UserId {
     for _ in 0..10_000 {
-        let candidate = UserId::local(Ulid::new(), realm_id);
+        let candidate = UserId::local(Ulid::r#gen(), realm_id);
         if matches!(resolve_inbox_holder(&candidate, realm_config), Ok(Some(node)) if node == holder)
         {
             return candidate;

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -69,8 +69,8 @@ async fn watch_on_node_a_fires_for_upload_on_node_b_visible_via_node_c()
     let config = realm_config_for(&nodes, realm_id);
     let holder = nodes[0].net.node_id();
     let watcher = user_with_holder(&config, holder, realm_id);
-    let uploader = UserId::local(Ulid::new(), realm_id);
-    let group_id = Ulid::new();
+    let uploader = UserId::local(Ulid::r#gen(), realm_id);
+    let group_id = Ulid::r#gen();
     let data_node_id = nodes[1].net.node_id();
     install_group_authorization(&nodes, realm_id, group_id, watcher).await?;
     let prefix = data_watch_resource_path(group_id, data_node_id, "bucket", "reports/");
@@ -90,7 +90,7 @@ async fn watch_on_node_a_fires_for_upload_on_node_b_visible_via_node_c()
     )
     .await?;
 
-    let event_id = Ulid::new();
+    let event_id = Ulid::r#gen();
     let occurred_at_ms = unix_timestamp_millis();
     let event = upload_event(
         event_id,
@@ -185,8 +185,8 @@ async fn unmatched_event_writes_nothing() -> Result<(), Box<dyn std::error::Erro
     let config = realm_config_for(&nodes, realm_id);
     let holder = nodes[0].net.node_id();
     let watcher = user_with_holder(&config, holder, realm_id);
-    let uploader = UserId::local(Ulid::new(), realm_id);
-    let group_id = Ulid::new();
+    let uploader = UserId::local(Ulid::r#gen(), realm_id);
+    let group_id = Ulid::r#gen();
     let data_node_id = nodes[1].net.node_id();
     install_group_authorization(&nodes, realm_id, group_id, watcher).await?;
     let prefix = data_watch_resource_path(group_id, data_node_id, "bucket", "reports/");
@@ -206,7 +206,7 @@ async fn unmatched_event_writes_nothing() -> Result<(), Box<dyn std::error::Erro
 
     // Path is outside every watched prefix even though real interest exists.
     let event = upload_event(
-        Ulid::new(),
+        Ulid::r#gen(),
         realm_id,
         uploader,
         UploadLocation {
@@ -242,7 +242,7 @@ async fn self_authored_event_notifies_no_one() -> Result<(), Box<dyn std::error:
     let config = realm_config_for(&nodes, realm_id);
     let holder = nodes[0].net.node_id();
     let watcher = user_with_holder(&config, holder, realm_id);
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let data_node_id = nodes[1].net.node_id();
     install_group_authorization(&nodes, realm_id, group_id, watcher).await?;
     let prefix = data_watch_resource_path(group_id, data_node_id, "bucket", "reports/");
@@ -263,7 +263,7 @@ async fn self_authored_event_notifies_no_one() -> Result<(), Box<dyn std::error:
     // Actor == watcher and the path matches, so the origin forwards the event,
     // proving the empty inbox is self-notify suppression rather than a missed match.
     let event = upload_event(
-        Ulid::new(),
+        Ulid::r#gen(),
         realm_id,
         watcher,
         UploadLocation {
@@ -300,7 +300,7 @@ async fn digest_converges_and_retracts_across_nodes() -> Result<(), Box<dyn std:
     let config = realm_config_for(&nodes, realm_id);
     let holder = nodes[2].net.node_id();
     let watcher = user_with_holder(&config, holder, realm_id);
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let prefix = format!("meta/{group_id}/datasets/team");
     let probe = format!("{prefix}/runs/run-42");
     install_group_authorization(&nodes, realm_id, group_id, watcher).await?;
@@ -358,7 +358,7 @@ async fn remote_create_surfaces_cap_conflict_over_the_wire()
     let holder = nodes[0].net.node_id();
     let owner = user_with_holder(&config, holder, realm_id);
     let mask = WatchEventMask::from_kinds([WatchEventKind::DataUploaded]);
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let data_node_id = nodes[1].net.node_id();
 
     // Node B is not the holder, so every create proxies to node A over the wire.
@@ -405,7 +405,7 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
 
     let (watcher, old_holder, new_holder) =
         user_with_changed_holder(&reduced_config, &full_config, realm_id);
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     let data_node_id = nodes[0].net.node_id();
     let prefix = data_watch_resource_path(group_id, data_node_id, "bucket", "reranked/");
     let probe = format!("{prefix}probe");
@@ -477,13 +477,13 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
         vec![subscription.clone()]
     );
 
-    let event_id = Ulid::new();
+    let event_id = Ulid::r#gen();
     emit_resource_watch_event(
         nodes[1].context.as_ref(),
         upload_event(
             event_id,
             realm_id,
-            UserId::local(Ulid::new(), realm_id),
+            UserId::local(Ulid::r#gen(), realm_id),
             UploadLocation {
                 group_id,
                 node_id: data_node_id,
@@ -645,7 +645,7 @@ fn user_with_holder(
     realm_id: RealmId,
 ) -> UserId {
     for _ in 0..10_000 {
-        let candidate = UserId::local(Ulid::new(), realm_id);
+        let candidate = UserId::local(Ulid::r#gen(), realm_id);
         if matches!(resolve_inbox_holder(&candidate, realm_config), Ok(Some(node)) if node == holder)
         {
             return candidate;
@@ -660,7 +660,7 @@ fn user_with_changed_holder(
     realm_id: RealmId,
 ) -> (UserId, NodeId, NodeId) {
     for _ in 0..10_000 {
-        let candidate = UserId::local(Ulid::new(), realm_id);
+        let candidate = UserId::local(Ulid::r#gen(), realm_id);
         let old_holder = resolve_inbox_holder(&candidate, before).unwrap().unwrap();
         let new_holder = resolve_inbox_holder(&candidate, after).unwrap().unwrap();
         if old_holder != new_holder {

--- a/operations/tests/usage_deltas.rs
+++ b/operations/tests/usage_deltas.rs
@@ -85,7 +85,7 @@ async fn setup() -> Harness {
         },
         realm_id,
         node_id,
-        created_by: UserId::local(Ulid::new(), realm_id),
+        created_by: UserId::local(Ulid::r#gen(), realm_id),
     }
 }
 
@@ -342,7 +342,7 @@ async fn assert_matches_rebuild(ctx: &DriverContext) {
 #[tokio::test]
 async fn create_and_delete_bucket_delta() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
 
     create_bucket(&h, "counted", group_id).await;
     assert_eq!(read_global(&h.driver).await.buckets, 1);
@@ -363,7 +363,7 @@ async fn create_and_delete_bucket_delta() {
 #[tokio::test]
 async fn simple_put_object_delta() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let data = b"hello world";
@@ -390,7 +390,7 @@ async fn simple_put_object_delta() {
 #[tokio::test]
 async fn overwrite_put_accumulates_logical_bytes_per_version() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let first = b"first";
@@ -417,7 +417,7 @@ async fn overwrite_put_accumulates_logical_bytes_per_version() {
 #[tokio::test]
 async fn overwrite_put_same_content_double_counts_logical_bytes() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let data = b"identical";
@@ -438,7 +438,7 @@ async fn overwrite_put_same_content_double_counts_logical_bytes() {
 #[tokio::test]
 async fn delete_marker_drops_object_but_keeps_logical_bytes() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let data = b"payload";
@@ -466,7 +466,7 @@ async fn delete_marker_drops_object_but_keeps_logical_bytes() {
 #[tokio::test]
 async fn put_over_delete_marker_revives_object() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let first = b"first-body";
@@ -493,7 +493,7 @@ async fn put_over_delete_marker_revives_object() {
 #[tokio::test]
 async fn permanent_delete_of_live_version_frees_logical_bytes() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let data = b"payload";
@@ -520,7 +520,7 @@ async fn permanent_delete_of_live_version_frees_logical_bytes() {
 #[tokio::test]
 async fn multipart_staging_counts_nothing_until_completion() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let part1 = b"hello ";
@@ -569,7 +569,7 @@ async fn multipart_staging_counts_nothing_until_completion() {
 #[tokio::test]
 async fn aborted_multipart_upload_leaves_counters_untouched() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     let upload_id = create_upload(&h, "bucket", "abort.bin", group_id).await;
@@ -679,7 +679,7 @@ async fn inject_remote_group_snapshot(
 #[tokio::test]
 async fn put_object_gate_allows_under_and_at_ceiling_rejects_over() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
     let ceiling = Some(20);
 
@@ -713,7 +713,7 @@ async fn put_object_gate_allows_under_and_at_ceiling_rejects_over() {
 #[tokio::test]
 async fn put_object_gate_unlimited_when_ceiling_is_none() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     // None => unlimited, no gate regardless of size.
@@ -726,7 +726,7 @@ async fn put_object_gate_unlimited_when_ceiling_is_none() {
 #[tokio::test]
 async fn put_object_gate_honors_grace_headroom() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     // quota 100 with 110% grace => ceiling 110. Writes above the quota but under
@@ -756,8 +756,8 @@ async fn put_object_gate_honors_grace_headroom() {
 #[tokio::test]
 async fn put_object_gate_group_override_takes_precedence_over_default() {
     let h = setup().await;
-    let overridden = Ulid::new();
-    let plain = Ulid::new();
+    let overridden = Ulid::r#gen();
+    let plain = Ulid::r#gen();
     create_bucket(&h, "over-bucket", overridden).await;
     create_bucket(&h, "plain-bucket", plain).await;
 
@@ -808,7 +808,7 @@ async fn put_object_gate_group_override_takes_precedence_over_default() {
 #[tokio::test]
 async fn put_object_gate_counts_remote_node_snapshots() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
     let ceiling = Some(100);
 
@@ -837,7 +837,7 @@ async fn put_object_gate_counts_remote_node_snapshots() {
 #[tokio::test]
 async fn delete_object_is_never_gated_by_quota() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
 
     // Fill the group exactly to a tight ceiling.
@@ -889,7 +889,7 @@ async fn try_complete_multipart(
 #[tokio::test]
 async fn multipart_completion_is_gated_like_put() {
     let h = setup().await;
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     create_bucket(&h, "bucket", group_id).await;
     let ceiling = Some(30);
 

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -49,7 +49,7 @@ async fn node_usage_snapshot_reaches_peer_realm_aggregate() -> Result<(), Box<dy
     let nodes = build_realm_nodes(&realm_id, 2).await?;
     let node_a = &nodes[0];
     let node_b = &nodes[1];
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     bootstrap_node_usage_genesis(node_a, node_b, realm_id).await?;
 
     drive(
@@ -149,7 +149,7 @@ async fn rich_node_usage_snapshot_ingest_is_counter_neutral()
     let nodes = build_realm_nodes(&realm_id, 2).await?;
     let node_a = &nodes[0];
     let node_b = &nodes[1];
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
     bootstrap_node_usage_genesis(node_a, node_b, realm_id).await?;
 
     // Seed node A's live counters with a full, non-trivial usage total, then let
@@ -248,7 +248,7 @@ async fn steady_state_write_publishes_snapshot_without_restart()
     let realm_id = RealmId([53u8; 32]);
     let nodes = build_realm_nodes(&realm_id, 1).await?;
     let node = &nodes[0];
-    let group_id = Ulid::new();
+    let group_id = Ulid::r#gen();
 
     // A normal write commit updates counters and stamps dirty markers, but never
     // schedules a publish itself and never restarts the node.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"

--- a/scripts/compose.yaml
+++ b/scripts/compose.yaml
@@ -1,6 +1,9 @@
+# Development-only stack. Do not use in production.
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.6
+    labels:
+      dev-only: "true"
     command:
       - start-dev
       - --import-realm
@@ -9,7 +12,7 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${ARUNA_KEYCLOAK_ADMIN_USER:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${ARUNA_KEYCLOAK_ADMIN_PASSWORD:-admin}
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - ./keycloak/realm-import:/opt/keycloak/data/import:ro
     healthcheck:

--- a/scripts/keycloak/docker-compose.yml
+++ b/scripts/keycloak/docker-compose.yml
@@ -1,6 +1,9 @@
+# Development-only stack. Do not use in production.
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.6
+    labels:
+      dev-only: "true"
     command:
       - start-dev
       - --import-realm
@@ -9,6 +12,6 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${ARUNA_TEST_DEPLOY_KEYCLOAK_ADMIN_USER:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${ARUNA_TEST_DEPLOY_KEYCLOAK_ADMIN_PASSWORD:-admin}
     ports:
-      - ${ARUNA_TEST_DEPLOY_KEYCLOAK_PORT:-43031}:8080
+      - 127.0.0.1:${ARUNA_TEST_DEPLOY_KEYCLOAK_PORT:-43031}:8080
     volumes:
       - ./realm-import:/opt/keycloak/data/import:ro

--- a/scripts/local_deploy.sh
+++ b/scripts/local_deploy.sh
@@ -66,6 +66,7 @@ compose_database_exists() {
   fi
 
   shopt -s nullglob
+  # shellcheck disable=SC2034 # loop variable only probes for a matching file
   for journal in "$COMPOSE_DATA_DIR"/*.jnl; do
     shopt -u nullglob
     return 0
@@ -95,9 +96,9 @@ strip_ansi_sequences() {
   local prefix
   local rest
 
-  while [[ "$value" == *"$esc["* ]]; do
-    prefix="${value%%"$esc["*}"
-    rest="${value#*"$esc["}"
+  while [[ "$value" == *"${esc}["* ]]; do
+    prefix="${value%%"${esc}["*}"
+    rest="${value#*"${esc}["}"
 
     if [[ "$rest" != *[[:alpha:]]* ]]; then
       break

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -888,7 +888,7 @@ impl FjallStorage {
         fields(read)
     )]
     fn start_transaction(&mut self, read: bool) -> StorageEvent {
-        let txn_id = Ulid::new();
+        let txn_id = Ulid::r#gen();
 
         let txn = if read {
             let txn = self.store.db.read_tx();
@@ -2593,7 +2593,7 @@ mod tests {
             .send_storage_effect(StorageEffect::Read {
                 key_space: "missing".to_string(),
                 key: b"key".to_vec().into(),
-                txn_id: Some(Ulid::new()),
+                txn_id: Some(Ulid::r#gen()),
             })
             .await;
 
@@ -2635,7 +2635,7 @@ mod tests {
 
         let event = handle
             .send_effect(Effect::Storage(StorageEffect::CommitTransaction {
-                txn_id: Ulid::new(),
+                txn_id: Ulid::r#gen(),
             }))
             .await;
 


### PR DESCRIPTION
Closes #348

Makes builds reproducible, adds supply-chain policy, and brings all dependencies to their latest versions.

### Pinning and policy

- Pin craqle by exact rev; pin the toolchain to 1.95.0 (`rust-toolchain.toml`); pin image bases by digest and `iroh-doctor` by version; add `--locked` to CI and Docker builds.
- Add `deny.toml` (advisories, license allowlist, git-source allowlist) and CI jobs for cargo-deny, ShellCheck, and compose-config; sha-pin all GitHub Actions; least-privilege workflow token.
- Exclude untracked local portal assets from the image build context; bind the development Keycloak to loopback.

### Dependency updates

- Compatible bumps with no code impact: iroh and iroh-base to 1.0.2, aws-config 1.9.0, aws-sdk-s3 1.138.0, bytes 1.12.1, crossfire 3.1.19, lru 0.18.1, md5 0.8.1, plus a full lockfile refresh of transitive packages.
- opendal 0.57 to 0.58. The raw backend API was reworked upstream (`Access` becomes `Service`; `AccessorInfo`, `OperatorBuilder` and `finish()` are gone), so the service builder and the fault-injection backend used by the blob close-failure tests are adapted to the new trait.
- ulid 1.2 to 2.0. `Ulid::new()` no longer exists and is replaced by `Ulid::gen()`, spelled `Ulid::r#gen()` because `gen` is a reserved keyword in edition 2024. Display, serde and postcard representations are unchanged, so the HTTP and storage formats are unaffected.
- craqle rev moved to the current upstream main, which changes only craqle's own manifest, lockfile and tests, not its library sources.

ed25519-dalek stays at 2.2.0. iroh declares an exact `=3.0.0-rc.0` requirement, which is in the same major-3 compatibility range as `^3.0.0`, so cargo cannot select a version that satisfies both and the resolve fails outright. Tracked in #396.

### Deployment note

With the `.dockerignore` change, portal-embed image builds must pass `--build-arg PORTAL_EMBED_DIR=<dir outside docker/>` (documented at the Dockerfile ARG); the deploy runbook's portal staging step needs updating before the next cluster image rebuild.

irokle stays on `branch = main` because craqle re-exports its types and a rev-pin would resolve it as a second version; it is pinned in effect via the lockfile plus `--locked`. A true rev-pin requires an upstream craqle change.