### PR TITLE
[feat] Bucket layer for sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "flate2",
  "hex",
  "iroh",
+ "irokle",
  "jsonwebtoken",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -39,6 +39,8 @@ pub enum ServerError {
     BadGateway,
     #[error("Service unavailable")]
     ServiceUnavailable,
+    #[error("{0}")]
+    ServiceUnavailableReason(String),
 }
 
 #[derive(Debug, Error)]
@@ -177,7 +179,10 @@ impl IntoResponse for ServerError {
         let body = ErrorResponse::new(&message).with_code(code);
 
         let mut response = (status, Json(body)).into_response();
-        if matches!(self, ServerError::ServiceUnavailable) {
+        if matches!(
+            self,
+            ServerError::ServiceUnavailable | ServerError::ServiceUnavailableReason(_)
+        ) {
             response.headers_mut().insert(
                 axum::http::header::RETRY_AFTER,
                 axum::http::HeaderValue::from_static("1"),
@@ -198,7 +203,9 @@ impl ServerError {
             ServerError::Conflict(_) => StatusCode::CONFLICT,
             ServerError::BadRequest | ServerError::BadRequestReason(_) => StatusCode::BAD_REQUEST,
             ServerError::BadGateway => StatusCode::BAD_GATEWAY,
-            ServerError::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+            ServerError::ServiceUnavailable | ServerError::ServiceUnavailableReason(_) => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
         }
     }
 
@@ -212,7 +219,9 @@ impl ServerError {
             ServerError::Conflict(_) => "Conflict".to_string(),
             ServerError::BadRequest | ServerError::BadRequestReason(_) => "Bad request".to_string(),
             ServerError::BadGateway => "Bad gateway".to_string(),
-            ServerError::ServiceUnavailable => "Service unavailable".to_string(),
+            ServerError::ServiceUnavailable | ServerError::ServiceUnavailableReason(_) => {
+                "Service unavailable".to_string()
+            }
         }
     }
 

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1431,6 +1431,7 @@ fn protocol_name(alpn: Option<Alpn>) -> Option<String> {
         Alpn::DocumentSync => "document_sync".to_string(),
         Alpn::Metadata => "metadata".to_string(),
         Alpn::Notification => "notification".to_string(),
+        Alpn::Shard => "shard".to_string(),
     })
 }
 

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -939,6 +939,11 @@ fn map_mutate_realm_placement_error(error: MutateRealmPlacementError) -> ServerE
     match error {
         MutateRealmPlacementError::RealmConfigNotFound => ServerError::NotFound,
         MutateRealmPlacementError::InvalidInput(reason) => ServerError::BadRequestReason(reason),
+        error @ (MutateRealmPlacementError::AdminDocumentReducerError(_)
+        | MutateRealmPlacementError::DisjointHolderTransition { .. }
+        | MutateRealmPlacementError::EmptyShardHolders { .. }) => {
+            ServerError::BadRequestReason(error.to_string())
+        }
         MutateRealmPlacementError::StrategyReferenced { strategy_id } => ServerError::Conflict(
             format!("placement strategy {strategy_id} is currently referenced"),
         ),

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -353,6 +353,7 @@ pub struct RealmPlacementStrategy {
     pub replica_count: Option<u32>,
     pub distinct_locations: bool,
     pub affinity: Vec<RealmPlacementAffinityRule>,
+    pub shard_count: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -480,6 +481,7 @@ impl From<&aruna_core::structs::PlacementStrategy> for RealmPlacementStrategy {
                     },
                 })
                 .collect(),
+            shard_count: strategy.shard_count,
         }
     }
 }
@@ -509,6 +511,7 @@ impl RealmPlacementStrategy {
                     },
                 })
                 .collect(),
+            shard_count: self.shard_count,
         })
     }
 }
@@ -1904,6 +1907,7 @@ mod tests {
             replica_count: Some(2),
             distinct_locations: true,
             affinity: Vec::new(),
+            shard_count: 64,
         }
     }
 

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -1596,8 +1596,8 @@ mod tests {
     };
     use aruna_core::storage_entries::metadata_registry_delete_entries;
     use aruna_core::structs::{
-        Group, GroupAuthorizationDocument, NodeCapabilities, RealmAuthorizationDocument,
-        RealmConfigDocument, RealmId, RealmNodeKind, TokenClaims,
+        Group, GroupAuthorizationDocument, NodeCapabilities, PlacementRef,
+        RealmAuthorizationDocument, RealmConfigDocument, RealmId, RealmNodeKind, TokenClaims,
     };
     use aruna_core::task::{PersistedTaskTimer, TaskKey};
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
@@ -2260,6 +2260,7 @@ mod tests {
             graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
             public: true,
             permission_path: "/metadata/query-targets".to_string(),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![remote_node_id, local_node_id, remote_node_id],
             created_at_ms: 0,
             updated_at_ms: 0,

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -55,8 +55,8 @@ use aruna_operations::metadata::MetadataAuthToken;
 #[cfg(test)]
 use aruna_operations::metadata::api::{
     MetadataQueryForm as QueryForm, aggregate_query_results, deduplicate_fanout_nodes,
-    deduplicate_search_hits, document_replica_query_nodes, load_metadata_realm_nodes,
-    metadata_auth_token_from_bearer, query_select_limit,
+    deduplicate_search_hits, load_metadata_realm_nodes, metadata_auth_token_from_bearer,
+    query_select_limit,
 };
 #[cfg(test)]
 use std::time::Duration;
@@ -1596,8 +1596,8 @@ mod tests {
     };
     use aruna_core::storage_entries::metadata_registry_delete_entries;
     use aruna_core::structs::{
-        Group, GroupAuthorizationDocument, NodeCapabilities, PlacementRef,
-        RealmAuthorizationDocument, RealmConfigDocument, RealmId, RealmNodeKind, TokenClaims,
+        Group, GroupAuthorizationDocument, NodeCapabilities, RealmAuthorizationDocument,
+        RealmConfigDocument, RealmId, RealmNodeKind, TokenClaims,
     };
     use aruna_core::task::{PersistedTaskTimer, TaskKey};
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
@@ -2245,39 +2245,6 @@ mod tests {
 
         coordinator.net.shutdown().await;
         remote.net.shutdown().await;
-    }
-
-    #[test]
-    fn document_replica_query_nodes_use_deduplicated_replicas() {
-        let local_node_id = iroh::SecretKey::from_bytes(&[21u8; 32]).public();
-        let remote_node_id = iroh::SecretKey::from_bytes(&[22u8; 32]).public();
-        let document_id = Ulid::r#gen();
-        let record = MetadataRegistryRecord {
-            realm_id: RealmId([3u8; 32]),
-            group_id: Ulid::r#gen(),
-            document_id,
-            document_path: "datasets/query-targets".to_string(),
-            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
-            public: true,
-            permission_path: "/metadata/query-targets".to_string(),
-            placement: PlacementRef::NIL,
-            holder_node_ids: vec![remote_node_id, local_node_id, remote_node_id],
-            created_at_ms: 0,
-            updated_at_ms: 0,
-            last_event_id: Ulid::nil(),
-        };
-
-        assert_eq!(
-            document_replica_query_nodes(&record, local_node_id),
-            vec![remote_node_id, local_node_id]
-        );
-
-        let mut empty_replicas = record;
-        empty_replicas.holder_node_ids.clear();
-        assert_eq!(
-            document_replica_query_nodes(&empty_replicas, local_node_id),
-            vec![local_node_id]
-        );
     }
 
     #[test]

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -13,10 +13,7 @@ use aruna_core::util::unix_timestamp_millis;
 use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentError, CreateMetadataDocumentOperation,
-    CreateMetadataDocumentPayload, create_metadata_document as run_create_metadata_document,
-};
-use aruna_operations::delete_metadata_document::{
-    DeleteMetadataDocumentOperation, delete_metadata_document as run_delete_metadata_document,
+    CreateMetadataDocumentPayload,
 };
 use aruna_operations::driver::drive;
 use aruna_operations::get_metadata_document::load_metadata_record_by_document as load_metadata_record_by_document_from_operations;
@@ -28,13 +25,17 @@ use aruna_operations::metadata::api::{
     export_metadata_rocrate as run_export_metadata_rocrate,
     get_visible_metadata_document as run_get_visible_metadata_document,
     list_visible_metadata_documents as run_list_visible_metadata_documents,
-    query_metadata as run_query_metadata, query_metadata_document as run_query_metadata_document,
-    search_metadata as run_search_metadata,
+    metadata_auth_token_from_bearer, query_metadata as run_query_metadata,
+    query_metadata_document as run_query_metadata_document, search_metadata as run_search_metadata,
+};
+use aruna_operations::metadata::forward::{
+    MetadataWriteError, create_metadata_document_routed as run_create_metadata_document,
+    delete_metadata_document_routed as run_delete_metadata_document,
+    update_metadata_document_routed as run_update_metadata_document,
 };
 use aruna_operations::notifications::watch::emit::emit_resource_watch_event;
 use aruna_operations::update_metadata_document::{
-    UpdateMetadataDocumentConfig, UpdateMetadataDocumentError, UpdateMetadataDocumentMutation,
-    UpdateMetadataDocumentOperation, update_metadata_document as run_update_metadata_document,
+    UpdateMetadataDocumentError, UpdateMetadataDocumentMutation,
 };
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -55,8 +56,7 @@ use aruna_operations::metadata::MetadataAuthToken;
 #[cfg(test)]
 use aruna_operations::metadata::api::{
     MetadataQueryForm as QueryForm, aggregate_query_results, deduplicate_fanout_nodes,
-    deduplicate_search_hits, load_metadata_realm_nodes, metadata_auth_token_from_bearer,
-    query_select_limit,
+    deduplicate_search_hits, load_metadata_realm_nodes, query_select_limit,
 };
 #[cfg(test)]
 use std::time::Duration;
@@ -445,6 +445,7 @@ impl MetadataDocumentListItem {
 pub async fn create_metadata_document(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
+    Extension(bearer_token): Extension<Option<ValidatedArunaBearerTokenCarrier>>,
     Json(request): Json<CreateMetadataRequest>,
 ) -> ServerResult<(StatusCode, Json<CreateMetadataResponse>)> {
     let auth = require_realm_auth(&state, auth)?;
@@ -491,9 +492,10 @@ pub async fn create_metadata_document(
             },
         ),
         ctx.clone(),
+        forwarded_auth_token(bearer_token),
     )
     .await
-    .map_err(map_create_metadata_error)?;
+    .map_err(map_metadata_write_error)?;
     let result = created.record;
 
     // Post-commit, best-effort resource-watch emission. Fire-and-forget: a failed
@@ -627,6 +629,7 @@ pub async fn get_metadata_document(
 pub async fn delete_metadata_document(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
+    Extension(bearer_token): Extension<Option<ValidatedArunaBearerTokenCarrier>>,
     Path(document_id): Path<String>,
 ) -> ServerResult<StatusCode> {
     let auth = require_realm_auth(&state, auth)?;
@@ -636,20 +639,17 @@ pub async fn delete_metadata_document(
 
     let ctx = state.get_ctx();
     run_delete_metadata_document(
-        DeleteMetadataDocumentOperation::new(
-            Actor {
-                node_id: state.get_node_id(),
-                user_id: auth.user_id,
-                realm_id: state.get_realm_id(),
-            },
-            record.group_id,
-            document_id,
-        ),
-        ctx.as_ref(),
-        document_id,
+        &ctx,
+        Actor {
+            node_id: state.get_node_id(),
+            user_id: auth.user_id,
+            realm_id: state.get_realm_id(),
+        },
+        &record,
+        forwarded_auth_token(bearer_token),
     )
     .await
-    .map_err(|err| ServerError::InternalError(err.to_string()))?;
+    .map_err(map_metadata_write_error)?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -813,6 +813,7 @@ pub async fn export_metadata_rocrate(
 pub async fn replace_metadata_rocrate(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
+    Extension(bearer_token): Extension<Option<ValidatedArunaBearerTokenCarrier>>,
     Path(document_id): Path<String>,
     Json(request): Json<ReplaceMetadataRoCrateRequest>,
 ) -> ServerResult<(StatusCode, Json<MetadataDocumentSummary>)> {
@@ -823,23 +824,21 @@ pub async fn replace_metadata_rocrate(
 
     let ctx = state.get_ctx();
     let updated = run_update_metadata_document(
-        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
-            actor: Actor {
-                node_id: state.get_node_id(),
-                user_id: auth.user_id,
-                realm_id: state.get_realm_id(),
-            },
-            group_id: record.group_id,
-            document_id,
-            public: request.public.unwrap_or(record.public),
-            mutation: UpdateMetadataDocumentMutation::ReplaceRoCrate {
-                jsonld: serialize_jsonld_object(&request.rocrate)?,
-            },
-        }),
-        ctx.as_ref(),
+        &ctx,
+        Actor {
+            node_id: state.get_node_id(),
+            user_id: auth.user_id,
+            realm_id: state.get_realm_id(),
+        },
+        &record,
+        request.public,
+        UpdateMetadataDocumentMutation::ReplaceRoCrate {
+            jsonld: serialize_jsonld_object(&request.rocrate)?,
+        },
+        forwarded_auth_token(bearer_token),
     )
     .await
-    .map_err(map_update_metadata_error)?;
+    .map_err(map_metadata_write_error)?;
 
     Ok((
         StatusCode::OK,
@@ -906,6 +905,7 @@ pub async fn replace_metadata_rocrate(
 pub async fn add_metadata_data_entity(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
+    Extension(bearer_token): Extension<Option<ValidatedArunaBearerTokenCarrier>>,
     Path(document_id): Path<String>,
     Json(entity): Json<Value>,
 ) -> ServerResult<(StatusCode, Json<MetadataDocumentSummary>)> {
@@ -916,23 +916,21 @@ pub async fn add_metadata_data_entity(
 
     let ctx = state.get_ctx();
     let updated = run_update_metadata_document(
-        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
-            actor: Actor {
-                node_id: state.get_node_id(),
-                user_id: auth.user_id,
-                realm_id: state.get_realm_id(),
-            },
-            group_id: record.group_id,
-            document_id,
-            public: record.public,
-            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
-                jsonld: serialize_jsonld_entity(&entity)?,
-            },
-        }),
-        ctx.as_ref(),
+        &ctx,
+        Actor {
+            node_id: state.get_node_id(),
+            user_id: auth.user_id,
+            realm_id: state.get_realm_id(),
+        },
+        &record,
+        None,
+        UpdateMetadataDocumentMutation::UpsertDataEntity {
+            jsonld: serialize_jsonld_entity(&entity)?,
+        },
+        forwarded_auth_token(bearer_token),
     )
     .await
-    .map_err(map_update_metadata_error)?;
+    .map_err(map_metadata_write_error)?;
 
     Ok((
         StatusCode::OK,
@@ -995,6 +993,7 @@ pub async fn add_metadata_data_entity(
 pub async fn add_metadata_contextual_entity(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
+    Extension(bearer_token): Extension<Option<ValidatedArunaBearerTokenCarrier>>,
     Path(document_id): Path<String>,
     Json(entity): Json<Value>,
 ) -> ServerResult<(StatusCode, Json<MetadataDocumentSummary>)> {
@@ -1005,23 +1004,21 @@ pub async fn add_metadata_contextual_entity(
 
     let ctx = state.get_ctx();
     let updated = run_update_metadata_document(
-        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
-            actor: Actor {
-                node_id: state.get_node_id(),
-                user_id: auth.user_id,
-                realm_id: state.get_realm_id(),
-            },
-            group_id: record.group_id,
-            document_id,
-            public: record.public,
-            mutation: UpdateMetadataDocumentMutation::UpsertContextualEntity {
-                jsonld: serialize_jsonld_entity(&entity)?,
-            },
-        }),
-        ctx.as_ref(),
+        &ctx,
+        Actor {
+            node_id: state.get_node_id(),
+            user_id: auth.user_id,
+            realm_id: state.get_realm_id(),
+        },
+        &record,
+        None,
+        UpdateMetadataDocumentMutation::UpsertContextualEntity {
+            jsonld: serialize_jsonld_entity(&entity)?,
+        },
+        forwarded_auth_token(bearer_token),
     )
     .await
-    .map_err(map_update_metadata_error)?;
+    .map_err(map_metadata_write_error)?;
 
     Ok((
         StatusCode::OK,
@@ -1291,6 +1288,20 @@ fn serialize_jsonld_entity(value: &Value) -> ServerResult<String> {
     serde_json::to_string(value).map_err(|_| ServerError::BadRequest)
 }
 
+/// A write that could neither be applied locally nor forwarded to a holder is a
+/// loud failure: the caller is told it was not accepted, rather than being
+/// answered `201` for a record that can never replicate.
+fn map_metadata_write_error(error: MetadataWriteError) -> ServerError {
+    match error {
+        MetadataWriteError::Create(error) => map_create_metadata_error(error),
+        MetadataWriteError::Update(error) => map_update_metadata_error(error),
+        MetadataWriteError::Delete(error) => ServerError::InternalError(error.to_string()),
+        MetadataWriteError::Undeliverable(error) => ServerError::ServiceUnavailableReason(format!(
+            "metadata write is undeliverable: {error}"
+        )),
+    }
+}
+
 fn map_create_metadata_error(error: CreateMetadataDocumentError) -> ServerError {
     match error {
         CreateMetadataDocumentError::MetadataError(metadata_error) => {
@@ -1308,6 +1319,14 @@ fn map_update_metadata_error(error: UpdateMetadataDocumentError) -> ServerError 
         }
         other => ServerError::InternalError(other.to_string()),
     }
+}
+
+/// The caller's own bearer token, carried to the holder a write is forwarded to
+/// so it re-runs the same permission checks under the same authority.
+fn forwarded_auth_token(
+    bearer_token: Option<ValidatedArunaBearerTokenCarrier>,
+) -> Option<aruna_operations::metadata::MetadataAuthToken> {
+    metadata_auth_token_from_bearer(bearer_token_to_string(bearer_token).as_deref())
 }
 
 fn map_metadata_error(error: MetadataError) -> ServerError {
@@ -1650,6 +1669,7 @@ mod tests {
         let (_, Json(created)) = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: test.group_id.to_string(),
@@ -1742,6 +1762,7 @@ mod tests {
         let _ = replace_metadata_rocrate(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Path(document_id.clone()),
             Json(ReplaceMetadataRoCrateRequest {
                 rocrate: serde_json::from_str(&paged_jsonld).unwrap(),
@@ -1856,6 +1877,7 @@ mod tests {
         let (_, Json(created)) = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::RoCrate(
                 CreateMetadataRoCrateRequest {
                     group_id: test.group_id.to_string(),
@@ -1895,6 +1917,7 @@ mod tests {
         let _ = add_metadata_contextual_entity(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Path(document_id.clone()),
             Json(json!({
                 "@id": "#person-ada",
@@ -1908,6 +1931,7 @@ mod tests {
         let _ = add_metadata_data_entity(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Path(document_id.clone()),
             Json(json!({
                 "@id": "./data/run-42.raw",
@@ -1945,6 +1969,7 @@ mod tests {
         let (_, Json(created)) = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: test.group_id.to_string(),
@@ -1977,6 +2002,7 @@ mod tests {
         let status = delete_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Path(created.summary.document_id.clone()),
         )
         .await
@@ -2003,6 +2029,7 @@ mod tests {
         let (_, Json(created)) = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: test.group_id.to_string(),
@@ -2116,6 +2143,7 @@ mod tests {
         let (_, Json(created)) = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: test.group_id.to_string(),
@@ -2307,6 +2335,7 @@ mod tests {
         let (_, Json(created)) = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: test.group_id.to_string(),
@@ -2366,6 +2395,7 @@ mod tests {
         let (_, Json(_created)) = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: test.group_id.to_string(),
@@ -2619,6 +2649,7 @@ mod tests {
         let _ = create_metadata_document(
             State(test.state.clone()),
             Extension(Some(test.auth.clone())),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: test.group_id.to_string(),
@@ -2673,6 +2704,7 @@ mod tests {
             let _ = create_metadata_document(
                 State(test.state.clone()),
                 Extension(Some(test.auth.clone())),
+                Extension(None),
                 Json(CreateMetadataRequest::Scaffold(
                     CreateMetadataScaffoldRequest {
                         group_id: test.group_id.to_string(),
@@ -3116,6 +3148,7 @@ mod tests {
         let _ = create_metadata_document(
             State(state),
             Extension(Some(auth)),
+            Extension(None),
             Json(CreateMetadataRequest::Scaffold(
                 CreateMetadataScaffoldRequest {
                     group_id: group_id.to_string(),

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -452,6 +452,13 @@ async fn next_local_stream_step(
 ) -> StreamStep {
     use tokio::sync::broadcast::error::RecvError;
 
+    // An already-elapsed sleep_until is not guaranteed ready on its first poll, so
+    // a continuously ready wake bus could starve the overdue recheck indefinitely.
+    // Resolve it deterministically before the select.
+    if Instant::now() >= recheck_deadline {
+        return StreamStep::Recheck;
+    }
+
     tokio::select! {
         biased;
         // Once overdue, holder re-resolution must win over a continuously ready

--- a/api/tests/document_sync_publish_architecture_guard.rs
+++ b/api/tests/document_sync_publish_architecture_guard.rs
@@ -59,7 +59,8 @@ fn allowed_publish_use(publish_use: &PublishUse) -> bool {
                     Some("publish_events_blocking"),
                     "DocumentSyncPublish::Upsert {"
                         | "DocumentSyncPublish::Delete {"
-                        | "DocumentSyncPublish::AdminOperation { target, event, .. } => {",
+                        | "DocumentSyncPublish::AdminOperation { target, event, .. } => {"
+                        | "DocumentSyncPublish::AdminOperation {",
                 ) | (
                     Some("decode_eviction"),
                     "documents.push(DocumentSyncPublish::Upsert {"

--- a/api/tests/document_sync_publish_architecture_guard.rs
+++ b/api/tests/document_sync_publish_architecture_guard.rs
@@ -75,6 +75,8 @@ fn allowed_publish_use(publish_use: &PublishUse) -> bool {
                     "DocumentSyncPublish::Upsert {"
                         | "DocumentSyncPublish::Delete { target, change, .. } => {"
                         | "DocumentSyncPublish::AdminOperation { target, event, .. } => {"
+                        | "DocumentSyncPublish::Delete {"
+                        | "DocumentSyncPublish::AdminOperation {"
                 )
         }
         _ => false,

--- a/aruna-doctor/src/explorer.rs
+++ b/aruna-doctor/src/explorer.rs
@@ -2,7 +2,7 @@ use crate::error::CliError;
 use aruna::config::PersistedNodeState;
 use aruna_api::server_state::INITIAL_REALM_ADMIN_CLAIMED_KEY;
 use aruna_core::auth::{TOKEN_REVOCATION_LIST_KEY, TRUSTED_REALMS_LIST_KEY};
-use aruna_core::document::{PendingBucketPlacement, bucket_topic_id};
+use aruna_core::document::{PendingShardPlacement, shard_topic_id};
 use aruna_core::id::DhtKeyId;
 use aruna_core::keyspaces::{
     ADMIN_DOCUMENT_CONFLICT_KEYSPACE, ADMIN_DOCUMENT_STATE_KEYSPACE, API_STATE_KEYSPACE,
@@ -86,7 +86,7 @@ struct TopicListEntry {
     topic_id: String,
     strategy_id: String,
     epoch: u64,
-    bucket: u32,
+    shard: u32,
     status: &'static str,
     selected_peer_count: usize,
 }
@@ -489,19 +489,19 @@ impl Serialize for JsonPersistedNodeState {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct JsonPendingDocumentPlacement(PendingBucketPlacement);
+struct JsonPendingDocumentPlacement(PendingShardPlacement);
 
 impl Serialize for JsonPendingDocumentPlacement {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("PendingBucketPlacement", 8)?;
+        let mut state = serializer.serialize_struct("PendingShardPlacement", 8)?;
         state.serialize_field("realm_id", &self.0.realm_id.to_string())?;
         state.serialize_field("topic_id", &placement_topic_id(&self.0))?;
         state.serialize_field("strategy_id", &self.0.placement.strategy_id.to_string())?;
         state.serialize_field("epoch", &self.0.placement.epoch)?;
-        state.serialize_field("bucket", &self.0.placement.bucket)?;
+        state.serialize_field("shard", &self.0.placement.shard)?;
         state.serialize_field(
             "authoritative_node_id",
             &self.0.authoritative_node_id.to_string(),
@@ -520,8 +520,8 @@ impl Serialize for JsonPendingDocumentPlacement {
     }
 }
 
-fn placement_topic_id(placement: &PendingBucketPlacement) -> String {
-    bucket_topic_id(placement.realm_id, &placement.placement).to_string()
+fn placement_topic_id(placement: &PendingShardPlacement) -> String {
+    shard_topic_id(placement.realm_id, &placement.placement).to_string()
 }
 
 #[derive(Debug)]
@@ -1005,7 +1005,7 @@ fn topics_list_output(database_path: &str) -> Result<TopicsListOutput, ExplorerE
             topic_id: placement_topic_id(&placement),
             strategy_id: placement.placement.strategy_id.to_string(),
             epoch: placement.placement.epoch,
-            bucket: placement.placement.bucket,
+            shard: placement.placement.shard,
             status: "under_replicated",
             selected_peer_count: placement.selected_peers.len(),
         })
@@ -1062,7 +1062,7 @@ fn topic_placements_output(
 
 fn load_pending_placements(
     database_path: &str,
-) -> Result<Vec<PendingBucketPlacement>, ExplorerError> {
+) -> Result<Vec<PendingShardPlacement>, ExplorerError> {
     let db = OptimisticTxDatabase::builder(Path::new(database_path)).open()?;
     let keyspace_names = db.list_keyspace_names();
     if !keyspace_names
@@ -1675,7 +1675,7 @@ mod tests {
         let placement_ref = aruna_core::structs::PlacementRef {
             strategy_id: ulid::Ulid::from_bytes([9_u8; 16]),
             epoch: 0,
-            bucket: 5,
+            shard: 5,
         };
         let selected_peer = iroh::SecretKey::from_bytes(&[7_u8; 32]).public();
         let authoritative_node_id = iroh::SecretKey::from_bytes(&[6_u8; 32]).public();

--- a/aruna-doctor/src/explorer.rs
+++ b/aruna-doctor/src/explorer.rs
@@ -2,7 +2,7 @@ use crate::error::CliError;
 use aruna::config::PersistedNodeState;
 use aruna_api::server_state::INITIAL_REALM_ADMIN_CLAIMED_KEY;
 use aruna_core::auth::{TOKEN_REVOCATION_LIST_KEY, TRUSTED_REALMS_LIST_KEY};
-use aruna_core::document::{DocumentSyncTarget, PendingDocumentPlacement};
+use aruna_core::document::{PendingBucketPlacement, bucket_topic_id};
 use aruna_core::id::DhtKeyId;
 use aruna_core::keyspaces::{
     ADMIN_DOCUMENT_CONFLICT_KEYSPACE, ADMIN_DOCUMENT_STATE_KEYSPACE, API_STATE_KEYSPACE,
@@ -84,11 +84,11 @@ struct TopicsListOutput {
 #[derive(Debug, Serialize, PartialEq)]
 struct TopicListEntry {
     topic_id: String,
-    target: JsonDocumentSyncTarget,
+    strategy_id: String,
+    epoch: u64,
+    bucket: u32,
     status: &'static str,
-    desired_holder_count: usize,
-    selected_holder_count: usize,
-    missing_holder_count: usize,
+    selected_peer_count: usize,
 }
 
 #[derive(Debug, Serialize, PartialEq)]
@@ -97,7 +97,7 @@ struct TopicStatusOutput {
     topic_id: String,
     status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    placement: Option<JsonPendingDocumentPlacement>,
+    pending_placement: Option<JsonPendingDocumentPlacement>,
 }
 
 #[derive(Debug, Serialize, PartialEq)]
@@ -489,186 +489,39 @@ impl Serialize for JsonPersistedNodeState {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct JsonPendingDocumentPlacement(PendingDocumentPlacement);
+struct JsonPendingDocumentPlacement(PendingBucketPlacement);
 
 impl Serialize for JsonPendingDocumentPlacement {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("PendingDocumentPlacement", 11)?;
+        let mut state = serializer.serialize_struct("PendingBucketPlacement", 8)?;
         state.serialize_field("realm_id", &self.0.realm_id.to_string())?;
-        state.serialize_field("target", &json_document_sync_target(&self.0.target))?;
         state.serialize_field("topic_id", &placement_topic_id(&self.0))?;
-        state.serialize_field("origin_node_id", &self.0.origin_node_id.to_string())?;
+        state.serialize_field("strategy_id", &self.0.placement.strategy_id.to_string())?;
+        state.serialize_field("epoch", &self.0.placement.epoch)?;
+        state.serialize_field("bucket", &self.0.placement.bucket)?;
         state.serialize_field(
-            "group_id",
-            &self.0.group_id.map(|group_id| group_id.to_string()),
+            "authoritative_node_id",
+            &self.0.authoritative_node_id.to_string(),
         )?;
-        state.serialize_field("metadata_path", &self.0.metadata_path)?;
-        state.serialize_field("desired_holder_count", &self.0.desired_holder_count)?;
         state.serialize_field(
-            "selected_holders",
+            "selected_peers",
             &self
                 .0
-                .selected_holders
+                .selected_peers
                 .iter()
                 .map(std::string::ToString::to_string)
                 .collect::<Vec<_>>(),
         )?;
-        state.serialize_field(
-            "missing_holder_count",
-            &placement_missing_holder_count(&self.0),
-        )?;
         state.serialize_field("updated_at", &self.0.updated_at)?;
-        state.serialize_field("placement", &self.0.placement)?;
         state.end()
     }
 }
 
-fn placement_topic_id(placement: &PendingDocumentPlacement) -> String {
-    placement.target.sync_topic_id().to_string()
-}
-
-fn placement_missing_holder_count(placement: &PendingDocumentPlacement) -> usize {
-    let mut selected_holders = placement.selected_holders.clone();
-    selected_holders.sort_unstable_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
-    selected_holders.dedup();
-    placement
-        .desired_holder_count
-        .saturating_sub(selected_holders.len())
-}
-
-fn placement_status(placement: &PendingDocumentPlacement) -> &'static str {
-    if placement_missing_holder_count(placement) == 0 {
-        "satisfied"
-    } else {
-        "under_replicated"
-    }
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-#[serde(tag = "kind")]
-enum JsonDocumentSyncTarget {
-    Group {
-        group_id: String,
-    },
-    GroupAuthorization {
-        group_id: String,
-    },
-    RealmAuthorization {
-        realm_id: String,
-    },
-    RealmConfig {
-        realm_id: String,
-    },
-    User {
-        user_id: String,
-    },
-    MetadataRegistry {
-        group_id: String,
-        document_id: String,
-    },
-    MetadataCreateEvent {
-        document_id: String,
-        event_id: String,
-    },
-    MetadataDocumentLifecycle {
-        document_id: String,
-    },
-    MetadataGraphLifecycle {
-        graph_iri: String,
-    },
-    NodeUsage {
-        realm_id: String,
-        node_id: String,
-        group_id: Option<String>,
-    },
-    WatchInterest {
-        realm_id: String,
-        node_id: String,
-    },
-    WatchSubscription {
-        owner: String,
-        watch_id: String,
-    },
-    NodeInfo {
-        realm_id: String,
-        node_id: String,
-    },
-}
-
-fn json_document_sync_target(target: &DocumentSyncTarget) -> JsonDocumentSyncTarget {
-    match target {
-        DocumentSyncTarget::Group { group_id } => JsonDocumentSyncTarget::Group {
-            group_id: group_id.to_string(),
-        },
-        DocumentSyncTarget::GroupAuthorization { group_id } => {
-            JsonDocumentSyncTarget::GroupAuthorization {
-                group_id: group_id.to_string(),
-            }
-        }
-        DocumentSyncTarget::RealmAuthorization { realm_id } => {
-            JsonDocumentSyncTarget::RealmAuthorization {
-                realm_id: realm_id.to_string(),
-            }
-        }
-        DocumentSyncTarget::RealmConfig { realm_id } => JsonDocumentSyncTarget::RealmConfig {
-            realm_id: realm_id.to_string(),
-        },
-        DocumentSyncTarget::User { user_id } => JsonDocumentSyncTarget::User {
-            user_id: user_id.to_string(),
-        },
-        DocumentSyncTarget::MetadataRegistry {
-            group_id,
-            document_id,
-        } => JsonDocumentSyncTarget::MetadataRegistry {
-            group_id: group_id.to_string(),
-            document_id: document_id.to_string(),
-        },
-        DocumentSyncTarget::MetadataCreateEvent {
-            document_id,
-            event_id,
-        } => JsonDocumentSyncTarget::MetadataCreateEvent {
-            document_id: document_id.to_string(),
-            event_id: event_id.to_string(),
-        },
-        DocumentSyncTarget::MetadataDocumentLifecycle { document_id } => {
-            JsonDocumentSyncTarget::MetadataDocumentLifecycle {
-                document_id: document_id.to_string(),
-            }
-        }
-        DocumentSyncTarget::MetadataGraphLifecycle { graph_iri } => {
-            JsonDocumentSyncTarget::MetadataGraphLifecycle {
-                graph_iri: graph_iri.clone(),
-            }
-        }
-        DocumentSyncTarget::NodeUsage {
-            realm_id,
-            node_id,
-            group_id,
-        } => JsonDocumentSyncTarget::NodeUsage {
-            realm_id: realm_id.to_string(),
-            node_id: node_id.to_string(),
-            group_id: group_id.map(|group_id| group_id.to_string()),
-        },
-        DocumentSyncTarget::WatchInterest { realm_id, node_id } => {
-            JsonDocumentSyncTarget::WatchInterest {
-                realm_id: realm_id.to_string(),
-                node_id: node_id.to_string(),
-            }
-        }
-        DocumentSyncTarget::WatchSubscription { owner, watch_id } => {
-            JsonDocumentSyncTarget::WatchSubscription {
-                owner: owner.to_string(),
-                watch_id: watch_id.to_string(),
-            }
-        }
-        DocumentSyncTarget::NodeInfo { realm_id, node_id } => JsonDocumentSyncTarget::NodeInfo {
-            realm_id: realm_id.to_string(),
-            node_id: node_id.to_string(),
-        },
-    }
+fn placement_topic_id(placement: &PendingBucketPlacement) -> String {
+    bucket_topic_id(placement.realm_id, &placement.placement).to_string()
 }
 
 #[derive(Debug)]
@@ -1150,11 +1003,11 @@ fn topics_list_output(database_path: &str) -> Result<TopicsListOutput, ExplorerE
         .into_iter()
         .map(|placement| TopicListEntry {
             topic_id: placement_topic_id(&placement),
-            target: json_document_sync_target(&placement.target),
-            status: placement_status(&placement),
-            desired_holder_count: placement.desired_holder_count,
-            selected_holder_count: placement.selected_holders.len(),
-            missing_holder_count: placement_missing_holder_count(&placement),
+            strategy_id: placement.placement.strategy_id.to_string(),
+            epoch: placement.placement.epoch,
+            bucket: placement.placement.bucket,
+            status: "under_replicated",
+            selected_peer_count: placement.selected_peers.len(),
         })
         .collect::<Vec<_>>();
     topics.sort_by(|left, right| left.topic_id.cmp(&right.topic_id));
@@ -1169,20 +1022,21 @@ fn topic_status_output(
     database_path: &str,
     topic_id: &str,
 ) -> Result<TopicStatusOutput, ExplorerError> {
-    let placement = load_pending_placements(database_path)?
+    let pending_placement = load_pending_placements(database_path)?
         .into_iter()
         .find(|placement| placement_topic_id(placement) == topic_id)
         .map(JsonPendingDocumentPlacement);
-    let status = placement
-        .as_ref()
-        .map(|placement| placement_status(&placement.0))
-        .unwrap_or("untracked");
+    let status = if pending_placement.is_some() {
+        "under_replicated"
+    } else {
+        "not_pending"
+    };
 
     Ok(TopicStatusOutput {
         database_path: database_path.to_string(),
         topic_id: topic_id.to_string(),
         status,
-        placement,
+        pending_placement,
     })
 }
 
@@ -1208,7 +1062,7 @@ fn topic_placements_output(
 
 fn load_pending_placements(
     database_path: &str,
-) -> Result<Vec<PendingDocumentPlacement>, ExplorerError> {
+) -> Result<Vec<PendingBucketPlacement>, ExplorerError> {
     let db = OptimisticTxDatabase::builder(Path::new(database_path)).open()?;
     let keyspace_names = db.list_keyspace_names();
     if !keyspace_names
@@ -1517,12 +1371,11 @@ mod tests {
         CRAQLE_GRAPHS_KEYSPACE, CRAQLE_LOG_BATCH_PREFIX, CRAQLE_LOG_KEYSPACE,
         CRAQLE_QUADS_KEYSPACE, CRAQLE_TERMS_KEYSPACE, CraqleStoredBatch, CraqleStoredGraphMeta,
         CraqleStoredQuadOp, DecodedField, DecodedValue, decode_entry, list_entries, list_keyspaces,
-        placement_missing_holder_count, placement_status, raw_field,
+        raw_field,
     };
     use aruna::config::{
         BootOrigin, PersistedNodeIdentity, PersistedNodeState, PersistedNodeStatus,
     };
-    use aruna_core::document::DocumentSyncTarget;
     use aruna_core::id::DhtKeyId;
     use aruna_core::keyspaces::{
         ADMIN_DOCUMENT_CONFLICT_KEYSPACE, ADMIN_DOCUMENT_STATE_KEYSPACE, API_STATE_KEYSPACE,
@@ -1818,41 +1671,22 @@ mod tests {
 
     #[test]
     fn decodes_pending_topic_placement_value() {
-        let target = DocumentSyncTarget::RealmConfig {
-            realm_id: RealmId::from_bytes([4_u8; 32]),
-        };
         let realm_id = RealmId::from_bytes([4_u8; 32]);
-        let selected_holder = iroh::SecretKey::from_bytes(&[7_u8; 32]).public();
-        let origin_node_id = iroh::SecretKey::from_bytes(&[6_u8; 32]).public();
-        let group_id = Ulid::from_bytes([8_u8; 16]);
-        let placement = aruna_operations::sync_placement::new_placement_with_context(
+        let placement_ref = aruna_core::structs::PlacementRef {
+            strategy_id: ulid::Ulid::from_bytes([9_u8; 16]),
+            epoch: 0,
+            bucket: 5,
+        };
+        let selected_peer = iroh::SecretKey::from_bytes(&[7_u8; 32]).public();
+        let authoritative_node_id = iroh::SecretKey::from_bytes(&[6_u8; 32]).public();
+        let placement = aruna_operations::sync_placement::new_placement(
             realm_id,
-            target.clone(),
-            origin_node_id,
-            Some(group_id),
-            Some("datasets/doctor".to_string()),
-            3,
-            vec![selected_holder],
-            aruna_core::structs::PlacementRef::NIL,
+            placement_ref,
+            authoritative_node_id,
+            vec![selected_peer],
         );
-        let json = serde_json::to_value(super::JsonPendingDocumentPlacement(placement.clone()))
-            .expect("placement serializes as JSON");
-        assert_eq!(json["origin_node_id"], origin_node_id.to_string());
-        assert_eq!(json["desired_holder_count"], 3);
-        assert_eq!(json["missing_holder_count"], 2);
-        assert_eq!(placement_status(&placement), "under_replicated");
-        assert_eq!(json["group_id"], group_id.to_string());
-        assert_eq!(json["metadata_path"], "datasets/doctor");
-        assert!(json.get("authoritative_node_id").is_none());
-        let mut completed = placement.clone();
-        completed.selected_holders = vec![
-            selected_holder,
-            origin_node_id,
-            iroh::SecretKey::from_bytes(&[9_u8; 32]).public(),
-        ];
-        assert_eq!(placement_status(&completed), "satisfied");
         let value = postcard::to_allocvec(&placement).unwrap();
-        let key = aruna_operations::sync_placement::placement_key(realm_id, &target);
+        let key = aruna_operations::sync_placement::placement_key(realm_id, &placement_ref);
 
         let decoded = decode_entry(SYNC_PLACEMENT_KEYSPACE, key.as_ref(), &value);
         assert_eq!(
@@ -1864,13 +1698,9 @@ mod tests {
         match decoded.value {
             DecodedValue::PendingDocumentPlacement { data } => {
                 assert_eq!(data.0.realm_id, realm_id);
-                assert_eq!(data.0.target, target);
-                assert_eq!(data.0.origin_node_id, origin_node_id);
-                assert_eq!(data.0.desired_holder_count, 3);
-                assert_eq!(data.0.selected_holders, vec![selected_holder]);
-                assert_eq!(data.0.group_id, Some(group_id));
-                assert_eq!(data.0.metadata_path.as_deref(), Some("datasets/doctor"));
-                assert_eq!(placement_missing_holder_count(&data.0), 2);
+                assert_eq!(data.0.placement, placement_ref);
+                assert_eq!(data.0.authoritative_node_id, authoritative_node_id);
+                assert_eq!(data.0.selected_peers, vec![selected_peer]);
             }
             other => panic!("expected pending topic placement, got {other:?}"),
         }

--- a/aruna/Cargo.toml
+++ b/aruna/Cargo.toml
@@ -15,6 +15,7 @@ aruna-net = { workspace = true }
 aruna-operations = { workspace = true }
 aruna-storage = { workspace = true }
 aruna-tasks = { workspace = true }
+irokle = { workspace = true }
 
 # The rest
 base64 = { workspace = true }

--- a/aruna/src/bootstrap.rs
+++ b/aruna/src/bootstrap.rs
@@ -166,7 +166,7 @@ pub async fn fetch_core_onboarding_documents(
     let realm_id = *realm_id;
 
     // Fetch the shared realm documents first (they include the realm config), so
-    // the bucket-classed user documents can then be routed onto their bucket
+    // the shard-classed user documents can then be routed onto their shard
     // topics via the freshly synced config.
     let mut user_documents = Vec::new();
     for document in onboarding_sync_ticket.payload.documents.clone() {
@@ -186,7 +186,7 @@ pub async fn fetch_core_onboarding_documents(
                 None => aruna_core::structs::PlacementRef::NIL,
             };
             if placement == aruna_core::structs::PlacementRef::NIL {
-                warn!(document = ?document, "Skipping onboarding user document without a bucket placement");
+                warn!(document = ?document, "Skipping onboarding user document without a shard placement");
                 continue;
             }
             let topic = document.sync_topic_id(realm_id, &placement);

--- a/aruna/src/bootstrap.rs
+++ b/aruna/src/bootstrap.rs
@@ -17,6 +17,7 @@ use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::notifications::watch::interest::{
     ensure_local_watch_interest_digest, mark_watch_interest_dirty,
 };
+use aruna_operations::placement::placement_ref_for_target;
 use aruna_operations::replicate_documents::{
     ReplicateDocumentsConfig, ReplicateDocumentsOperation,
 };
@@ -150,7 +151,7 @@ async fn core_document_targets(
 pub async fn fetch_core_onboarding_documents(
     driver_ctx: &DriverContext,
     node_state: &PersistedNodeState,
-    _realm_id: &aruna_core::structs::RealmId,
+    realm_id: &aruna_core::structs::RealmId,
     bootstrap_peer: Option<NodeId>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bootstrap_peer = bootstrap_peer.ok_or("missing bootstrap peer")?;
@@ -162,9 +163,35 @@ pub async fn fetch_core_onboarding_documents(
     let Some(net_handle) = driver_ctx.net_handle.as_ref() else {
         return Err("net handle unavailable".into());
     };
+    let realm_id = *realm_id;
 
+    // Fetch the shared realm documents first (they include the realm config), so
+    // the bucket-classed user documents can then be routed onto their bucket
+    // topics via the freshly synced config.
+    let mut user_documents = Vec::new();
     for document in onboarding_sync_ticket.payload.documents.clone() {
-        sync_document_from_peer(net_handle, document, bootstrap_peer).await?;
+        if matches!(document, DocumentSyncTarget::User { .. }) {
+            user_documents.push(document);
+            continue;
+        }
+        let topic = document.sync_topic_id(realm_id, &aruna_core::structs::PlacementRef::NIL);
+        sync_topic_from_peer(net_handle, topic, bootstrap_peer, &document).await?;
+    }
+
+    if !user_documents.is_empty() {
+        let config = load_realm_config(driver_ctx, realm_id).await;
+        for document in user_documents {
+            let placement = match config.as_ref() {
+                Some(config) => placement_ref_for_target(config, &document, None),
+                None => aruna_core::structs::PlacementRef::NIL,
+            };
+            if placement == aruna_core::structs::PlacementRef::NIL {
+                warn!(document = ?document, "Skipping onboarding user document without a bucket placement");
+                continue;
+            }
+            let topic = document.sync_topic_id(realm_id, &placement);
+            sync_topic_from_peer(net_handle, topic, bootstrap_peer, &document).await?;
+        }
     }
 
     Ok(())
@@ -186,13 +213,14 @@ pub async fn wait_for_onboarding_placement(
                 return Ok::<(), Box<dyn std::error::Error>>(());
             }
 
-            sync_document_from_peer(
+            sync_topic_from_peer(
                 driver_ctx
                     .net_handle
                     .as_ref()
                     .ok_or("net handle unavailable")?,
-                target.clone(),
+                target.sync_topic_id(realm_id, &aruna_core::structs::PlacementRef::NIL),
                 bootstrap_peer,
+                &target,
             )
             .await?;
             tokio::time::sleep(ONBOARDING_PLACEMENT_RETRY_INTERVAL).await;
@@ -214,15 +242,35 @@ fn realm_config_has_node_placement(
     config.has_node(node_id) && config.placement_entry(node_id).is_some()
 }
 
-async fn sync_document_from_peer(
+async fn load_realm_config(
+    driver_ctx: &DriverContext,
+    realm_id: aruna_core::structs::RealmId,
+) -> Option<aruna_core::structs::RealmConfigDocument> {
+    match driver_ctx
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Read {
+            key_space: REALM_CONFIG_KEYSPACE.to_string(),
+            key: ByteView::from(*realm_id.as_bytes()),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => value
+            .and_then(|bytes| aruna_core::structs::RealmConfigDocument::from_bytes(&bytes).ok()),
+        _ => None,
+    }
+}
+
+async fn sync_topic_from_peer(
     net_handle: &aruna_net::NetHandle,
-    document: DocumentSyncTarget,
+    topic: ::irokle::TopicId,
     bootstrap_peer: NodeId,
+    document_for_error: &DocumentSyncTarget,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let document_for_error = document.clone();
+    let document_for_error = document_for_error.clone();
     let sync = net_handle.send_effect(Effect::Net(NetEffect::DocumentSync(
         DocumentSyncEffect::SyncDocument {
-            target: document,
+            topic,
             peers: vec![bootstrap_peer],
         },
     )));

--- a/aruna/src/bootstrap.rs
+++ b/aruna/src/bootstrap.rs
@@ -182,7 +182,7 @@ pub async fn fetch_core_onboarding_documents(
         let config = load_realm_config(driver_ctx, realm_id).await;
         for document in user_documents {
             let placement = match config.as_ref() {
-                Some(config) => placement_ref_for_target(config, &document, None),
+                Some(config) => placement_ref_for_target(config, &document, Default::default()),
                 None => aruna_core::structs::PlacementRef::NIL,
             };
             if placement == aruna_core::structs::PlacementRef::NIL {

--- a/aruna/src/bootstrap.rs
+++ b/aruna/src/bootstrap.rs
@@ -23,6 +23,7 @@ use aruna_operations::replicate_documents::{
 };
 use byteview::ByteView;
 use rand::Rng;
+use std::collections::HashSet;
 use std::time::Duration;
 use tracing::warn;
 
@@ -180,6 +181,7 @@ pub async fn fetch_core_onboarding_documents(
 
     if !user_documents.is_empty() {
         let config = load_realm_config(driver_ctx, realm_id).await;
+        let mut synced_topics = HashSet::new();
         for document in user_documents {
             let placement = match config.as_ref() {
                 Some(config) => placement_ref_for_target(config, &document, Default::default()),
@@ -189,7 +191,11 @@ pub async fn fetch_core_onboarding_documents(
                 warn!(document = ?document, "Skipping onboarding user document without a shard placement");
                 continue;
             }
-            let topic = document.sync_topic_id(realm_id, &placement);
+            let Some(topic) =
+                unique_user_topic(&mut synced_topics, realm_id, &placement, &document)
+            else {
+                continue;
+            };
             sync_topic_from_peer(net_handle, topic, bootstrap_peer, &document).await?;
         }
     }
@@ -259,6 +265,16 @@ async fn load_realm_config(
             .and_then(|bytes| aruna_core::structs::RealmConfigDocument::from_bytes(&bytes).ok()),
         _ => None,
     }
+}
+
+fn unique_user_topic(
+    synced_topics: &mut HashSet<::irokle::TopicId>,
+    realm_id: aruna_core::structs::RealmId,
+    placement: &aruna_core::structs::PlacementRef,
+    document: &DocumentSyncTarget,
+) -> Option<::irokle::TopicId> {
+    let topic = document.sync_topic_id(realm_id, placement);
+    synced_topics.insert(topic).then_some(topic)
 }
 
 async fn sync_topic_from_peer(
@@ -338,7 +354,7 @@ pub async fn ensure_initial_local_onboarding_secret(
 
 #[cfg(test)]
 mod tests {
-    use super::{core_document_targets, realm_config_has_node_placement};
+    use super::{core_document_targets, realm_config_has_node_placement, unique_user_topic};
     use aruna_core::document::DocumentSyncTarget;
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
@@ -351,6 +367,35 @@ mod tests {
     use aruna_storage::FjallStorage;
     use byteview::ByteView;
     use tempfile::tempdir;
+
+    #[test]
+    fn user_topics_deduplicate() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let first = DocumentSyncTarget::User {
+            user_id: aruna_core::UserId::local(ulid::Ulid::from_bytes([2u8; 16]), realm_id),
+        };
+        let second = DocumentSyncTarget::User {
+            user_id: aruna_core::UserId::local(ulid::Ulid::from_bytes([3u8; 16]), realm_id),
+        };
+        let first_shard = aruna_core::structs::PlacementRef {
+            strategy_id: ulid::Ulid::from_bytes([4u8; 16]),
+            epoch: 0,
+            shard: 7,
+        };
+        let second_shard = aruna_core::structs::PlacementRef {
+            shard: 8,
+            ..first_shard
+        };
+        let mut synced_topics = std::collections::HashSet::new();
+
+        assert!(unique_user_topic(&mut synced_topics, realm_id, &first_shard, &first).is_some());
+        assert_eq!(
+            unique_user_topic(&mut synced_topics, realm_id, &first_shard, &second),
+            None
+        );
+        assert!(unique_user_topic(&mut synced_topics, realm_id, &second_shard, &second).is_some());
+        assert_eq!(synced_topics.len(), 2);
+    }
 
     fn context(storage_handle: aruna_storage::StorageHandle) -> DriverContext {
         DriverContext {

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -31,7 +31,7 @@ use aruna_operations::ensure_realm_config::{EnsureRealmConfigConfig, EnsureRealm
 use aruna_operations::incoming::initialize_net_incoming;
 use aruna_operations::metadata::projector::replay_metadata_event_log;
 use aruna_operations::metadata::{MetadataHandle, MetadataHandleOptions, spawn_metadata_warmup};
-use aruna_operations::startup::restore_bucket_subscriptions;
+use aruna_operations::startup::restore_shard_subscriptions;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::StorageHandle;
 use aruna_tasks::TaskHandle;
@@ -302,11 +302,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         warn!(error = %error, "Failed to publish initial node usage snapshots");
     }
 
-    // All startup modes: join the held bucket topics (a freshly onboarded node
-    // pulls existing bucket data from its co-holders here), then create the
-    // geneses of the buckets this node is rank-0 holder of.
-    restore_bucket_subscriptions(&driver_ctx, config.node_id, config.realm_id).await;
-    aruna_operations::process_placements::process_bucket_placements(
+    // All startup modes: join the held shard topics (a freshly onboarded node
+    // pulls existing shard data from its co-holders here), then create the
+    // geneses of the shards this node is rank-0 holder of.
+    restore_shard_subscriptions(&driver_ctx, config.node_id, config.realm_id).await;
+    aruna_operations::process_placements::process_shard_placements(
         &driver_ctx,
         config.realm_id,
         config.node_id,

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -305,7 +305,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // All startup modes: join the held shard topics (a freshly onboarded node
     // pulls existing shard data from its co-holders here), then create the
     // geneses of the shards this node is rank-0 holder of.
-    restore_shard_subscriptions(&driver_ctx, config.node_id, config.realm_id).await;
+    let restore_summary =
+        restore_shard_subscriptions(&driver_ctx, config.node_id, config.realm_id).await;
+    tracing::info!(
+        held_shards = restore_summary.held_shards,
+        shard_topics = restore_summary.shard_topics,
+        shared_topics = restore_summary.shared_topics,
+        "Restored held shard subscriptions",
+    );
     aruna_operations::process_placements::process_shard_placements(
         &driver_ctx,
         config.realm_id,

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -31,8 +31,7 @@ use aruna_operations::ensure_realm_config::{EnsureRealmConfigConfig, EnsureRealm
 use aruna_operations::incoming::initialize_net_incoming;
 use aruna_operations::metadata::projector::replay_metadata_event_log;
 use aruna_operations::metadata::{MetadataHandle, MetadataHandleOptions, spawn_metadata_warmup};
-use aruna_operations::process_placements::{PlacementConfig, ProcessPlacementsOperation};
-use aruna_operations::startup::RestoreTopicSubscriptionsOperation;
+use aruna_operations::startup::restore_bucket_subscriptions;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::StorageHandle;
 use aruna_tasks::TaskHandle;
@@ -251,12 +250,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             mark_node_state_complete(&driver_ctx.storage_handle, &config.node_state).await?;
         }
         StartupMode::Provisioned => {
-            drive(
-                RestoreTopicSubscriptionsOperation::new(config.node_id, config.realm_id),
-                driver_ctx.as_ref(),
-            )
-            .await?;
-
             if matches!(
                 &config.node_capabilities,
                 NodeCapabilities::Management { .. }
@@ -309,15 +302,16 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         warn!(error = %error, "Failed to publish initial node usage snapshots");
     }
 
-    drive(
-        ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id: config.realm_id,
-            local_node_id: config.node_id,
-            retry_after: aruna_operations::sync_placement::SYNC_PLACEMENT_RETRY_AFTER,
-        }),
-        driver_ctx.as_ref(),
+    // All startup modes: join the held bucket topics (a freshly onboarded node
+    // pulls existing bucket data from its co-holders here), then create the
+    // geneses of the buckets this node is rank-0 holder of.
+    restore_bucket_subscriptions(&driver_ctx, config.node_id, config.realm_id).await;
+    aruna_operations::process_placements::process_bucket_placements(
+        &driver_ctx,
+        config.realm_id,
+        config.node_id,
     )
-    .await?;
+    .await;
 
     drive(
         AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -579,9 +579,9 @@ async fn spawn_seed_node_with_mode(mode: NodeServiceMode) -> TestResult<SeedNode
     .map_err(std::io::Error::other)?;
     announce_core_documents(context.as_ref(), net.node_id(), &realm_id, true).await?;
     // Mirrors the startup path in main.rs: the seed is rank-0 holder of every
-    // bucket in its single-node realm and must create the bucket topic geneses
-    // eagerly, or its first bucket-classed writes defer forever.
-    aruna_operations::process_placements::process_bucket_placements(
+    // shard in its single-node realm and must create the shard topic geneses
+    // eagerly, or its first shard-classed writes defer forever.
+    aruna_operations::process_placements::process_shard_placements(
         &context,
         realm_id,
         net.node_id(),
@@ -714,16 +714,16 @@ async fn spawn_joiner_node_with_mode(
     )
     .await?;
     mark_node_state_complete(&joiner_context.storage_handle, &config.node_state).await?;
-    // Mirrors the startup path in main.rs: join the held bucket topics from
-    // co-holders, then create the geneses of buckets this node is now rank-0
+    // Mirrors the startup path in main.rs: join the held shard topics from
+    // co-holders, then create the geneses of shards this node is now rank-0
     // holder of (join-before-create adopts geneses the seed already made).
-    aruna_operations::startup::restore_bucket_subscriptions(
+    aruna_operations::startup::restore_shard_subscriptions(
         &joiner_context,
         config.node_id,
         config.realm_id,
     )
     .await;
-    aruna_operations::process_placements::process_bucket_placements(
+    aruna_operations::process_placements::process_shard_placements(
         &joiner_context,
         config.realm_id,
         config.node_id,

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -578,6 +578,15 @@ async fn spawn_seed_node_with_mode(mode: NodeServiceMode) -> TestResult<SeedNode
     .await
     .map_err(std::io::Error::other)?;
     announce_core_documents(context.as_ref(), net.node_id(), &realm_id, true).await?;
+    // Mirrors the startup path in main.rs: the seed is rank-0 holder of every
+    // bucket in its single-node realm and must create the bucket topic geneses
+    // eagerly, or its first bucket-classed writes defer forever.
+    aruna_operations::process_placements::process_bucket_placements(
+        &context,
+        realm_id,
+        net.node_id(),
+    )
+    .await;
     drive(
         ClaimInitialRealmAdminOperation::new(ClaimInitialRealmAdminInput {
             actor: Actor {
@@ -705,6 +714,21 @@ async fn spawn_joiner_node_with_mode(
     )
     .await?;
     mark_node_state_complete(&joiner_context.storage_handle, &config.node_state).await?;
+    // Mirrors the startup path in main.rs: join the held bucket topics from
+    // co-holders, then create the geneses of buckets this node is now rank-0
+    // holder of (join-before-create adopts geneses the seed already made).
+    aruna_operations::startup::restore_bucket_subscriptions(
+        &joiner_context,
+        config.node_id,
+        config.realm_id,
+    )
+    .await;
+    aruna_operations::process_placements::process_bucket_placements(
+        &joiner_context,
+        config.realm_id,
+        config.node_id,
+    )
+    .await;
     announce_realm_presence(joiner_context.as_ref(), &config.realm_id, config.node_id).await?;
 
     let (base_url, state, server_task) = spawn_rest_server(

--- a/blob/src/bao_tree.rs
+++ b/blob/src/bao_tree.rs
@@ -324,10 +324,7 @@ mod tests {
     #[tokio::test]
     async fn transfer_idle_timeout_returns_timed_out_error() {
         let err = with_transfer_idle_timeout(
-            async {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                Ok::<(), io::Error>(())
-            },
+            std::future::pending::<io::Result<()>>(),
             Duration::from_millis(1),
             "reading bao chunk from network stream",
         )

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -440,7 +440,7 @@ fn parse_replication_init_uses_message_id_when_unknown() {
 #[tokio::test]
 async fn control_plane_timeout_reports_read_timeout() {
     let event = with_control_plane_timeout(
-        tokio::time::sleep(Duration::from_millis(10)),
+        std::future::pending::<()>(),
         Duration::from_millis(1),
         ControlPlaneTimeoutKind::Read,
         "reading replication control message",

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -45,6 +45,8 @@ pub enum AdminDocumentReducerError {
         MAX_PLACEMENT_SHARD_COUNT
     )]
     InvalidPlacementShardCount,
+    #[error("placement strategy shard count cannot be changed")]
+    PlacementShardCountChanged,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -475,6 +477,13 @@ impl AdminDocumentReducerState {
                     || strategy.shard_count > MAX_PLACEMENT_SHARD_COUNT
                 {
                     return Err(AdminDocumentReducerError::InvalidPlacementShardCount);
+                }
+                if self
+                    .materialized_realm_config_placement_strategies()
+                    .get(&strategy.strategy_id)
+                    .is_some_and(|current| current.shard_count != strategy.shard_count)
+                {
+                    return Err(AdminDocumentReducerError::PlacementShardCountChanged);
                 }
                 self.apply_realm_config_placement_field(
                     event,
@@ -4210,6 +4219,54 @@ mod tests {
             BTreeMap::from([(strategy_id, strategy)])
         );
         assert!(state.conflicts.is_empty());
+    }
+
+    #[test]
+    fn strategy_shards_immutable() {
+        let mut state = realm_config_state();
+        let origin = node(1);
+        let strategy_id = Ulid::from_bytes([4; 16]);
+        let initial = placement_strategy(strategy_id, Some(3));
+        let mut renamed = initial.clone();
+        renamed.name = "renamed".to_string();
+
+        assert_eq!(
+            state.apply(&realm_config_event(
+                1,
+                origin,
+                1,
+                AdminDocumentClock::default(),
+                AdminDocumentOperation::RealmConfigPlacementStrategyUpserted { strategy: initial },
+            )),
+            Ok(AdminDocumentApplyStatus::Applied)
+        );
+        assert_eq!(
+            state.apply(&realm_config_event(
+                2,
+                origin,
+                2,
+                AdminDocumentClock::default().with_observed(origin, 1),
+                AdminDocumentOperation::RealmConfigPlacementStrategyUpserted {
+                    strategy: renamed.clone(),
+                },
+            )),
+            Ok(AdminDocumentApplyStatus::Applied)
+        );
+
+        let before = state.clone();
+        let mut changed = renamed;
+        changed.shard_count *= 2;
+        assert_eq!(
+            state.apply(&realm_config_event(
+                3,
+                origin,
+                3,
+                AdminDocumentClock::default().with_observed(origin, 2),
+                AdminDocumentOperation::RealmConfigPlacementStrategyUpserted { strategy: changed },
+            )),
+            Err(AdminDocumentReducerError::PlacementShardCountChanged)
+        );
+        assert_eq!(state, before);
     }
 
     #[test]

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -1675,8 +1675,7 @@ mod tests {
         KIND_LABEL_KEY, LabelMatch, MAX_PLACEMENT_SHARD_COUNT, MetadataReplicationConfig,
         NodePlacementEntry, OidcProviderConfig, Permission, PlacementOverride, PlacementStrategy,
         QuotaConfig, RealmConfigDocument, RealmDiscoveryConfig, RealmId, RealmNodeKind,
-        StrategyBinding,
-        UserGroupCapOverride,
+        StrategyBinding, UserGroupCapOverride,
     };
     use crate::types::{GroupId, RoleId};
     use crate::user_update_validation::UserAttributeValidationError;

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -11,10 +11,10 @@ use crate::admin_documents::{
     AdminDocumentRoleDefinition, AdminDocumentTarget,
 };
 use crate::structs::{
-    Actor, BindingScope, DocumentClass, KIND_LABEL_KEY, MetadataRegistryRecord,
-    MetadataReplicationConfig, NodePlacementEntry, OidcProviderConfig, PlacementOverride,
-    PlacementStrategy, QuotaConfig, RealmConfigDocument, RealmDiscoveryConfig, RealmId,
-    RealmNodeKind, StrategyBinding,
+    Actor, BindingScope, DocumentClass, KIND_LABEL_KEY, MAX_PLACEMENT_SHARD_COUNT,
+    MetadataRegistryRecord, MetadataReplicationConfig, NodePlacementEntry, OidcProviderConfig,
+    PlacementOverride, PlacementStrategy, QuotaConfig, RealmConfigDocument, RealmDiscoveryConfig,
+    RealmId, RealmNodeKind, StrategyBinding,
 };
 use crate::types::{RoleId, UserId};
 use crate::user_update_validation::{
@@ -40,7 +40,10 @@ pub enum AdminDocumentReducerError {
     ReservedPlacementLabel,
     #[error("placement strategy replica count must not be zero")]
     ZeroPlacementReplicaCount,
-    #[error("placement strategy shard count must be a non-zero power of two")]
+    #[error(
+        "placement strategy shard count must be a non-zero power of two no greater than {}",
+        MAX_PLACEMENT_SHARD_COUNT
+    )]
     InvalidPlacementShardCount,
 }
 
@@ -467,7 +470,10 @@ impl AdminDocumentReducerState {
                 if strategy.replica_count == Some(0) {
                     return Err(AdminDocumentReducerError::ZeroPlacementReplicaCount);
                 }
-                if strategy.shard_count == 0 || !strategy.shard_count.is_power_of_two() {
+                if strategy.shard_count == 0
+                    || !strategy.shard_count.is_power_of_two()
+                    || strategy.shard_count > MAX_PLACEMENT_SHARD_COUNT
+                {
                     return Err(AdminDocumentReducerError::InvalidPlacementShardCount);
                 }
                 self.apply_realm_config_placement_field(
@@ -1666,7 +1672,8 @@ mod tests {
     };
     use crate::structs::{
         Actor, AffinityEffect, AffinityRule, BindingScope, DocumentClass, GroupQuotaOverride,
-        KIND_LABEL_KEY, LabelMatch, MetadataReplicationConfig, NodePlacementEntry,
+        KIND_LABEL_KEY, LabelMatch, MAX_PLACEMENT_SHARD_COUNT, MetadataReplicationConfig,
+        NodePlacementEntry,
         OidcProviderConfig, Permission, PlacementOverride, PlacementStrategy, QuotaConfig,
         RealmConfigDocument, RealmDiscoveryConfig, RealmId, RealmNodeKind, StrategyBinding,
         UserGroupCapOverride,
@@ -4227,7 +4234,53 @@ mod tests {
     }
 
     #[test]
-    fn realm_config_placement_strategy_rejects_non_power_of_two_shard_count() {
+    fn realm_config_placement_strategy_accepts_max_shard_count() {
+        let mut state = realm_config_state();
+        let strategy_id = Ulid::from_bytes([4; 16]);
+        let mut strategy = placement_strategy(strategy_id, Some(3));
+        strategy.shard_count = MAX_PLACEMENT_SHARD_COUNT;
+
+        state
+            .apply(&realm_config_event(
+                1,
+                node(1),
+                1,
+                AdminDocumentClock::default(),
+                AdminDocumentOperation::RealmConfigPlacementStrategyUpserted {
+                    strategy: strategy.clone(),
+                },
+            ))
+            .unwrap();
+
+        assert_eq!(
+            state.materialized_realm_config_placement_strategies(),
+            BTreeMap::from([(strategy_id, strategy)])
+        );
+        assert!(state.conflicts.is_empty());
+    }
+
+    #[test]
+    fn realm_config_placement_strategy_rejects_shard_count_above_max() {
+        let mut state = realm_config_state();
+        let before = state.clone();
+        let mut strategy = placement_strategy(Ulid::from_bytes([4; 16]), Some(3));
+        strategy.shard_count = MAX_PLACEMENT_SHARD_COUNT * 2;
+
+        assert_eq!(
+            state.apply(&realm_config_event(
+                1,
+                node(1),
+                1,
+                AdminDocumentClock::default(),
+                AdminDocumentOperation::RealmConfigPlacementStrategyUpserted { strategy },
+            )),
+            Err(AdminDocumentReducerError::InvalidPlacementShardCount)
+        );
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn realm_config_placement_strategy_rejects_zero_and_non_power_of_two_shard_count() {
         let mut state = realm_config_state();
         let before = state.clone();
 

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -40,8 +40,8 @@ pub enum AdminDocumentReducerError {
     ReservedPlacementLabel,
     #[error("placement strategy replica count must not be zero")]
     ZeroPlacementReplicaCount,
-    #[error("placement strategy bucket count must be a non-zero power of two")]
-    InvalidPlacementBucketCount,
+    #[error("placement strategy shard count must be a non-zero power of two")]
+    InvalidPlacementShardCount,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -467,8 +467,8 @@ impl AdminDocumentReducerState {
                 if strategy.replica_count == Some(0) {
                     return Err(AdminDocumentReducerError::ZeroPlacementReplicaCount);
                 }
-                if strategy.bucket_count == 0 || !strategy.bucket_count.is_power_of_two() {
-                    return Err(AdminDocumentReducerError::InvalidPlacementBucketCount);
+                if strategy.shard_count == 0 || !strategy.shard_count.is_power_of_two() {
+                    return Err(AdminDocumentReducerError::InvalidPlacementShardCount);
                 }
                 self.apply_realm_config_placement_field(
                     event,
@@ -3744,7 +3744,7 @@ mod tests {
                 },
                 effect: AffinityEffect::Filter,
             }],
-            bucket_count: 64,
+            shard_count: 64,
         }
     }
 
@@ -4227,13 +4227,13 @@ mod tests {
     }
 
     #[test]
-    fn realm_config_placement_strategy_rejects_non_power_of_two_bucket_count() {
+    fn realm_config_placement_strategy_rejects_non_power_of_two_shard_count() {
         let mut state = realm_config_state();
         let before = state.clone();
 
         for bad in [0u32, 3, 63] {
             let mut strategy = placement_strategy(Ulid::from_bytes([4; 16]), Some(3));
-            strategy.bucket_count = bad;
+            strategy.shard_count = bad;
             assert_eq!(
                 state.apply(&realm_config_event(
                     1,
@@ -4242,8 +4242,8 @@ mod tests {
                     AdminDocumentClock::default(),
                     AdminDocumentOperation::RealmConfigPlacementStrategyUpserted { strategy },
                 )),
-                Err(AdminDocumentReducerError::InvalidPlacementBucketCount),
-                "bucket_count {bad} must be rejected"
+                Err(AdminDocumentReducerError::InvalidPlacementShardCount),
+                "shard_count {bad} must be rejected"
             );
             assert_eq!(state, before);
         }

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -1673,9 +1673,9 @@ mod tests {
     use crate::structs::{
         Actor, AffinityEffect, AffinityRule, BindingScope, DocumentClass, GroupQuotaOverride,
         KIND_LABEL_KEY, LabelMatch, MAX_PLACEMENT_SHARD_COUNT, MetadataReplicationConfig,
-        NodePlacementEntry,
-        OidcProviderConfig, Permission, PlacementOverride, PlacementStrategy, QuotaConfig,
-        RealmConfigDocument, RealmDiscoveryConfig, RealmId, RealmNodeKind, StrategyBinding,
+        NodePlacementEntry, OidcProviderConfig, Permission, PlacementOverride, PlacementStrategy,
+        QuotaConfig, RealmConfigDocument, RealmDiscoveryConfig, RealmId, RealmNodeKind,
+        StrategyBinding,
         UserGroupCapOverride,
     };
     use crate::types::{GroupId, RoleId};

--- a/core/src/admin_document_reducer.rs
+++ b/core/src/admin_document_reducer.rs
@@ -40,6 +40,8 @@ pub enum AdminDocumentReducerError {
     ReservedPlacementLabel,
     #[error("placement strategy replica count must not be zero")]
     ZeroPlacementReplicaCount,
+    #[error("placement strategy bucket count must be a non-zero power of two")]
+    InvalidPlacementBucketCount,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -464,6 +466,9 @@ impl AdminDocumentReducerState {
             ) => {
                 if strategy.replica_count == Some(0) {
                     return Err(AdminDocumentReducerError::ZeroPlacementReplicaCount);
+                }
+                if strategy.bucket_count == 0 || !strategy.bucket_count.is_power_of_two() {
+                    return Err(AdminDocumentReducerError::InvalidPlacementBucketCount);
                 }
                 self.apply_realm_config_placement_field(
                     event,
@@ -3739,6 +3744,7 @@ mod tests {
                 },
                 effect: AffinityEffect::Filter,
             }],
+            bucket_count: 64,
         }
     }
 
@@ -4218,6 +4224,29 @@ mod tests {
             Err(AdminDocumentReducerError::ZeroPlacementReplicaCount)
         );
         assert_eq!(state, before);
+    }
+
+    #[test]
+    fn realm_config_placement_strategy_rejects_non_power_of_two_bucket_count() {
+        let mut state = realm_config_state();
+        let before = state.clone();
+
+        for bad in [0u32, 3, 63] {
+            let mut strategy = placement_strategy(Ulid::from_bytes([4; 16]), Some(3));
+            strategy.bucket_count = bad;
+            assert_eq!(
+                state.apply(&realm_config_event(
+                    1,
+                    node(1),
+                    1,
+                    AdminDocumentClock::default(),
+                    AdminDocumentOperation::RealmConfigPlacementStrategyUpserted { strategy },
+                )),
+                Err(AdminDocumentReducerError::InvalidPlacementBucketCount),
+                "bucket_count {bad} must be rejected"
+            );
+            assert_eq!(state, before);
+        }
     }
 
     #[test]

--- a/core/src/admin_documents.rs
+++ b/core/src/admin_documents.rs
@@ -372,6 +372,7 @@ mod tests {
                 },
                 effect: AffinityEffect::Multiply { permille: 1500 },
             }],
+            bucket_count: 64,
         }
     }
 

--- a/core/src/admin_documents.rs
+++ b/core/src/admin_documents.rs
@@ -372,7 +372,7 @@ mod tests {
                 },
                 effect: AffinityEffect::Multiply { permille: 1500 },
             }],
-            bucket_count: 64,
+            shard_count: 64,
         }
     }
 

--- a/core/src/alpn.rs
+++ b/core/src/alpn.rs
@@ -11,6 +11,8 @@ pub enum Alpn {
     Metadata,
     /// Notification delivery protocol
     Notification,
+    /// Shard holder-manifest exchange protocol
+    Shard,
 }
 
 impl Alpn {
@@ -21,6 +23,7 @@ impl Alpn {
             Alpn::DocumentSync => irokle::net::IROKLE_SYNC_ALPN,
             Alpn::Metadata => b"aruna/metadata/1",
             Alpn::Notification => b"aruna/notification/1",
+            Alpn::Shard => b"aruna/shard/1",
         }
     }
 
@@ -31,6 +34,7 @@ impl Alpn {
             irokle::net::IROKLE_SYNC_ALPN => Some(Alpn::DocumentSync),
             b"aruna/metadata/1" => Some(Alpn::Metadata),
             b"aruna/notification/1" => Some(Alpn::Notification),
+            b"aruna/shard/1" => Some(Alpn::Shard),
             _ => None,
         }
     }
@@ -47,6 +51,7 @@ impl std::fmt::Display for Alpn {
             },
             Alpn::Metadata => write!(f, "aruna/metadata/1"),
             Alpn::Notification => write!(f, "aruna/notification/1"),
+            Alpn::Shard => write!(f, "aruna/shard/1"),
         }
     }
 }
@@ -71,6 +76,7 @@ mod tests {
             Alpn::from_bytes(Alpn::Notification.as_bytes()),
             Some(Alpn::Notification)
         );
+        assert_eq!(Alpn::from_bytes(Alpn::Shard.as_bytes()), Some(Alpn::Shard));
     }
 
     #[test]

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -416,7 +416,7 @@ impl DocumentSyncTarget {
     }
 
     /// Sync topic this target's records ride. Shard-classed targets (group,
-    /// user, metadata) derive one topic per `(strategy, epoch, shard)` from the
+    /// user, metadata) derive one topic per `(strategy, shard)` from the
     /// placement; shared realm-scoped targets keep their per-domain topic and
     /// ignore the placement. A NIL placement on a shard-classed target is a bug
     /// (the emitter failed to stamp a real ref) — it is asserted in debug and
@@ -468,15 +468,16 @@ impl DocumentSyncTarget {
     }
 }
 
-/// Sync topic a shard's records ride, derived purely from the placement
-/// reference (no config lookup at the net layer). Mirrors the `TopicId::hash`
-/// idiom [`DocumentSyncTarget::sync_topic_id`] uses, which routes every
-/// shard-classed target here.
+/// Sync topic a shard's records ride, derived from the realm, strategy, and
+/// shard (no config lookup at the net layer). The epoch slot is canonicalized
+/// to zero so transitions retain their epoch-0 topic identity. Mirrors the
+/// `TopicId::hash` idiom [`DocumentSyncTarget::sync_topic_id`] uses, which
+/// routes every shard-classed target here.
 pub fn shard_topic_id(realm_id: RealmId, placement: &PlacementRef) -> irokle::TopicId {
     let mut bytes = b"aruna-shard-topic-v1".to_vec();
     bytes.extend_from_slice(realm_id.as_bytes());
     bytes.extend_from_slice(&placement.strategy_id.to_bytes());
-    bytes.extend_from_slice(&placement.epoch.to_le_bytes());
+    bytes.extend_from_slice(&0_u64.to_le_bytes());
     bytes.extend_from_slice(&placement.shard.to_be_bytes());
     irokle::TopicId::hash(bytes)
 }
@@ -868,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn shard_topic_id_matches_golden_and_separates_dimensions() {
+    fn shard_topic_identity() {
         let realm_id = test_realm(2);
         let placement = PlacementRef {
             strategy_id: test_ulid(4),
@@ -882,7 +883,7 @@ mod tests {
             "b375275475edc34ab568776cea1fdf4053e57458816e8ed35c5925e3caa07cf4"
         );
 
-        // Each hashed dimension moves the topic.
+        // Realm, strategy, and shard move the topic; an epoch transition does not.
         let other_shard = PlacementRef {
             shard: 6,
             ..placement
@@ -899,7 +900,7 @@ mod tests {
             shard_topic_id(realm_id, &placement),
             shard_topic_id(realm_id, &other_shard)
         );
-        assert_ne!(
+        assert_eq!(
             shard_topic_id(realm_id, &placement),
             shard_topic_id(realm_id, &other_epoch)
         );

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -86,6 +86,31 @@ pub struct PendingShardPlacement {
     pub authoritative_node_id: NodeId,
 }
 
+/// One holder-manifest row: a shard-classed document the local node holds and
+/// the revision it holds it at. A delete keeps the row with the delete
+/// revision (a tombstone), mirroring the lifecycle sidecar. Keyed per entry in
+/// [`SHARD_MANIFEST_KEYSPACE`](crate::keyspaces::SHARD_MANIFEST_KEYSPACE) so the
+/// hot write path never reads-modifies-writes a blob.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardManifestEntry {
+    pub target: DocumentSyncTarget,
+    pub revision: DocumentSyncRevision,
+}
+
+/// A node's authoritative statement of what it holds for one shard: the entry
+/// set (from a prefix scan of the manifest keyspace), the irokle topic digest
+/// and persisted cursor, and provenance. Assembled on demand, never doc-synced
+/// (a new holder fetches a co-holder's over the shard ALPN and compares).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardManifest {
+    pub placement: PlacementRef,
+    pub holder: NodeId,
+    pub entries: Vec<ShardManifestEntry>,
+    pub cursor: Vec<u8>,
+    pub digest: [u8; 32],
+    pub updated_at_ms: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DocumentSyncOutboxRecord {
     pub outbox_id: Ulid,

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -470,9 +470,8 @@ impl DocumentSyncTarget {
 
 /// Sync topic a shard's records ride, derived purely from the placement
 /// reference (no config lookup at the net layer). Mirrors the `TopicId::hash`
-/// idiom [`DocumentSyncTarget::sync_topic_id`] uses. Not yet wired into
-/// `sync_topic_id`: stage 2 flips the sharded targets over to this in a later
-/// commit.
+/// idiom [`DocumentSyncTarget::sync_topic_id`] uses, which routes every
+/// shard-classed target here.
 pub fn shard_topic_id(realm_id: RealmId, placement: &PlacementRef) -> irokle::TopicId {
     let mut bytes = b"aruna-shard-topic-v1".to_vec();
     bytes.extend_from_slice(realm_id.as_bytes());

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -73,17 +73,17 @@ pub enum DocumentSyncTarget {
     },
 }
 
+/// A bucket whose sync topic the local node is an authoritative holder of and
+/// whose co-holder membership is still being topped up. Keyed by
+/// realm ‖ strategy ‖ epoch(le) ‖ bucket(be); one record per bucket, not per
+/// document (every document in the bucket rides the same topic).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PendingDocumentPlacement {
+pub struct PendingBucketPlacement {
     pub realm_id: RealmId,
-    pub target: DocumentSyncTarget,
-    pub group_id: Option<GroupId>,
-    pub metadata_path: Option<String>,
-    pub desired_holder_count: usize,
-    pub selected_holders: Vec<NodeId>,
-    pub updated_at: u64,
-    pub origin_node_id: NodeId,
     pub placement: PlacementRef,
+    pub selected_peers: Vec<NodeId>,
+    pub updated_at: u64,
+    pub authoritative_node_id: NodeId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -123,6 +123,7 @@ pub struct DocumentSyncEvictedDocument {
     pub event_id: Option<Ulid>,
     pub target: DocumentSyncTarget,
     pub event: DocumentSyncOutboxEvent,
+    pub placement: PlacementRef,
     pub allow_genesis: bool,
 }
 
@@ -177,6 +178,7 @@ pub enum DocumentSyncPublish {
     AdminOperation {
         target: DocumentSyncTarget,
         event: Box<AdminDocumentEvent>,
+        placement: PlacementRef,
         allow_genesis: bool,
     },
     Delete {
@@ -371,34 +373,53 @@ impl DocumentSyncTarget {
         }
     }
 
-    pub fn sync_topic_id(&self) -> irokle::TopicId {
+    /// Whether this target's records ride a bucket topic (group, user,
+    /// metadata classes) rather than a shared realm-scoped domain topic.
+    /// Bucket topics are join-only for everyone but the bucket's rank-0
+    /// holder, which creates the genesis eagerly.
+    pub fn uses_bucket_topic(&self) -> bool {
+        matches!(
+            self,
+            Self::Group { .. }
+                | Self::GroupAuthorization { .. }
+                | Self::User { .. }
+                | Self::MetadataRegistry { .. }
+                | Self::MetadataCreateEvent { .. }
+                | Self::MetadataDocumentLifecycle { .. }
+                | Self::MetadataGraphLifecycle { .. }
+        )
+    }
+
+    /// Sync topic this target's records ride. Bucket-classed targets (group,
+    /// user, metadata) derive one topic per `(strategy, epoch, bucket)` from the
+    /// placement; shared realm-scoped targets keep their per-domain topic and
+    /// ignore the placement. A NIL placement on a bucket-classed target is a bug
+    /// (the emitter failed to stamp a real ref) — it is asserted in debug and
+    /// warned in release, never silently accepted.
+    pub fn sync_topic_id(&self, realm_id: RealmId, placement: &PlacementRef) -> irokle::TopicId {
+        if self.uses_bucket_topic() {
+            if *placement == PlacementRef::NIL {
+                debug_assert!(
+                    false,
+                    "bucket-classed target {self:?} derived a topic from a NIL placement"
+                );
+                tracing::warn!(
+                    target = ?self,
+                    "bucket-classed target has a NIL placement; deriving a NIL bucket topic"
+                );
+            }
+            bucket_topic_id(realm_id, placement)
+        } else {
+            self.shared_sync_topic_id()
+        }
+    }
+
+    fn shared_sync_topic_id(&self) -> irokle::TopicId {
         let mut bytes = b"aruna-document-topic-v1".to_vec();
         bytes.extend_from_slice(&self.topic_id().to_bytes());
         match self {
-            Self::Group { .. } => bytes.extend_from_slice(b"/group"),
-            Self::GroupAuthorization { .. } => bytes.extend_from_slice(b"/group-auth"),
             Self::RealmAuthorization { .. } => bytes.extend_from_slice(b"/realm-auth"),
             Self::RealmConfig { .. } => bytes.extend_from_slice(b"/realm-config"),
-            Self::User { user_id } => {
-                bytes.extend_from_slice(b"/user/");
-                bytes.extend_from_slice(&user_id.to_bytes());
-            }
-            Self::MetadataRegistry { document_id, .. } => {
-                bytes.extend_from_slice(b"/metadata/");
-                bytes.extend_from_slice(&document_id.to_bytes());
-            }
-            Self::MetadataCreateEvent { document_id, .. } => {
-                bytes.extend_from_slice(b"/metadata-create-event/");
-                bytes.extend_from_slice(&document_id.to_bytes());
-            }
-            Self::MetadataDocumentLifecycle { document_id } => {
-                bytes.extend_from_slice(b"/metadata-document-lifecycle/");
-                bytes.extend_from_slice(&document_id.to_bytes());
-            }
-            Self::MetadataGraphLifecycle { graph_iri } => {
-                bytes.extend_from_slice(b"/metadata-graph-lifecycle/");
-                bytes.extend_from_slice(graph_iri.as_bytes());
-            }
             // No node id in the suffix: every node's usage snapshot flows over a
             // single shared realm-scoped topic that all realm nodes subscribe to.
             Self::NodeUsage { .. } => bytes.extend_from_slice(b"/node-usage"),
@@ -410,6 +431,13 @@ impl DocumentSyncTarget {
             // Realm-shared: every node's info/heartbeat document rides one topic
             // (no node id in the suffix) so all realm nodes receive every peer's.
             Self::NodeInfo { .. } => bytes.extend_from_slice(b"/node-info"),
+            other => {
+                debug_assert!(
+                    false,
+                    "shared_sync_topic_id on bucket-classed target {other:?}"
+                );
+                bytes.extend_from_slice(b"/bucket-misroute");
+            }
         }
         irokle::TopicId::hash(bytes)
     }
@@ -448,6 +476,7 @@ pub enum DocumentSyncEvent {
     AdminOperation {
         target: DocumentSyncTarget,
         event: Box<AdminDocumentEvent>,
+        placement: PlacementRef,
     },
     Delete {
         event_id: Ulid,
@@ -471,6 +500,16 @@ impl DocumentSyncEvent {
             Self::AdminOperation { event, .. } => event.event_id,
         }
     }
+
+    /// Placement the event rides under: the envelope change's ref for
+    /// `Upsert`/`Delete`, the stamped admin ref for `AdminOperation`. Feeds
+    /// [`DocumentSyncTarget::sync_topic_id`] on both publish and reconcile.
+    pub fn placement(&self) -> PlacementRef {
+        match self {
+            Self::Upsert { change, .. } | Self::Delete { change, .. } => change.placement,
+            Self::AdminOperation { placement, .. } => *placement,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -480,11 +519,11 @@ pub enum DocumentSyncEffect {
         peers: Vec<NodeId>,
     },
     SyncDocument {
-        target: DocumentSyncTarget,
+        topic: irokle::TopicId,
         peers: Vec<NodeId>,
     },
     SyncDocuments {
-        targets: Vec<DocumentSyncTarget>,
+        topics: Vec<irokle::TopicId>,
         peers: Vec<NodeId>,
     },
 }
@@ -729,15 +768,39 @@ mod tests {
     }
 
     #[test]
-    fn document_sync_topic_mapping_scopes_variants_under_shared_domain_topics() {
+    fn bucket_classed_targets_ride_bucket_topics_shared_targets_ride_domain_topics() {
         let group_id = test_ulid(1);
         let realm_id = test_realm(2);
         let document_id = test_ulid(4);
         let event_id = test_ulid(5);
+        let placement_a = PlacementRef {
+            strategy_id: test_ulid(9),
+            epoch: 0,
+            bucket: 3,
+        };
+        let placement_b = PlacementRef {
+            bucket: 4,
+            ..placement_a
+        };
+
+        // Group and its authorization are one logical subject: with the same
+        // placement they ride a single bucket topic, derived purely from it.
         let group = DocumentSyncTarget::Group { group_id };
         let group_auth = DocumentSyncTarget::GroupAuthorization { group_id };
-        let realm_auth = DocumentSyncTarget::RealmAuthorization { realm_id };
-        let realm_config = DocumentSyncTarget::RealmConfig { realm_id };
+        assert_eq!(
+            group.sync_topic_id(realm_id, &placement_a),
+            group_auth.sync_topic_id(realm_id, &placement_a)
+        );
+        assert_eq!(
+            group.sync_topic_id(realm_id, &placement_a),
+            bucket_topic_id(realm_id, &placement_a)
+        );
+        assert_ne!(
+            group.sync_topic_id(realm_id, &placement_a),
+            group.sync_topic_id(realm_id, &placement_b)
+        );
+
+        // The three metadata variants of one document collapse onto its bucket.
         let registry = DocumentSyncTarget::MetadataRegistry {
             group_id,
             document_id,
@@ -747,27 +810,32 @@ mod tests {
             event_id,
         };
         let lifecycle = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-        let user_a = DocumentSyncTarget::User {
-            user_id: UserId::new(test_ulid(6), realm_id),
-        };
-        let user_b = DocumentSyncTarget::User {
-            user_id: UserId::new(test_ulid(7), realm_id),
-        };
+        assert_eq!(
+            registry.sync_topic_id(realm_id, &placement_a),
+            create.sync_topic_id(realm_id, &placement_a)
+        );
+        assert_eq!(
+            registry.sync_topic_id(realm_id, &placement_a),
+            lifecycle.sync_topic_id(realm_id, &placement_a)
+        );
 
-        assert_eq!(group.topic_id(), group_auth.topic_id());
-        assert_ne!(group.sync_topic_id(), group_auth.sync_topic_id());
-
+        // Shared realm-scoped targets keep their per-domain topics and ignore
+        // the placement entirely.
+        let realm_auth = DocumentSyncTarget::RealmAuthorization { realm_id };
+        let realm_config = DocumentSyncTarget::RealmConfig { realm_id };
         assert_eq!(realm_auth.topic_id(), realm_config.topic_id());
-        assert_ne!(realm_auth.sync_topic_id(), realm_config.sync_topic_id());
-
-        assert_eq!(registry.topic_id(), create.topic_id());
-        assert_eq!(registry.topic_id(), lifecycle.topic_id());
-        assert_ne!(registry.sync_topic_id(), create.sync_topic_id());
-        assert_ne!(registry.sync_topic_id(), lifecycle.sync_topic_id());
-        assert_ne!(create.sync_topic_id(), lifecycle.sync_topic_id());
-
-        assert_eq!(user_a.topic_id(), user_b.topic_id());
-        assert_ne!(user_a.sync_topic_id(), user_b.sync_topic_id());
+        assert_ne!(
+            realm_auth.sync_topic_id(realm_id, &placement_a),
+            realm_config.sync_topic_id(realm_id, &placement_a)
+        );
+        assert_eq!(
+            realm_config.sync_topic_id(realm_id, &placement_a),
+            realm_config.sync_topic_id(realm_id, &placement_b)
+        );
+        assert_ne!(
+            realm_config.sync_topic_id(realm_id, &placement_a),
+            bucket_topic_id(realm_id, &placement_a)
+        );
     }
 
     #[test]
@@ -842,9 +910,13 @@ mod tests {
         };
 
         // Both map onto the realm domain topic and the single shared sync topic.
+        let nil = PlacementRef::NIL;
         assert_eq!(global.topic_id(), TopicId::realm(realm_id));
         assert_eq!(global.topic_id(), group.topic_id());
-        assert_eq!(global.sync_topic_id(), group.sync_topic_id());
+        assert_eq!(
+            global.sync_topic_id(realm_id, &nil),
+            group.sync_topic_id(realm_id, &nil)
+        );
 
         // A different node's usage rides the very same shared topic.
         let other = DocumentSyncTarget::NodeUsage {
@@ -852,11 +924,14 @@ mod tests {
             node_id: test_node(9),
             group_id: None,
         };
-        assert_eq!(global.sync_topic_id(), other.sync_topic_id());
+        assert_eq!(
+            global.sync_topic_id(realm_id, &nil),
+            other.sync_topic_id(realm_id, &nil)
+        );
         // But is distinct from the realm-config topic on the same domain.
         assert_ne!(
-            global.sync_topic_id(),
-            DocumentSyncTarget::RealmConfig { realm_id }.sync_topic_id()
+            global.sync_topic_id(realm_id, &nil),
+            DocumentSyncTarget::RealmConfig { realm_id }.sync_topic_id(realm_id, &nil)
         );
 
         assert_eq!(global.storage_keyspace(), USAGE_NODE_STATS_KEYSPACE);
@@ -880,25 +955,29 @@ mod tests {
         let target = DocumentSyncTarget::NodeInfo { realm_id, node_id };
 
         // Rides the realm domain topic and one shared sync topic across nodes.
+        let nil = PlacementRef::NIL;
         assert_eq!(target.topic_id(), TopicId::realm(realm_id));
         let other = DocumentSyncTarget::NodeInfo {
             realm_id,
             node_id: test_node(9),
         };
-        assert_eq!(target.sync_topic_id(), other.sync_topic_id());
+        assert_eq!(
+            target.sync_topic_id(realm_id, &nil),
+            other.sync_topic_id(realm_id, &nil)
+        );
         // Distinct from the node-usage and watch-interest topics on the same realm.
         assert_ne!(
-            target.sync_topic_id(),
+            target.sync_topic_id(realm_id, &nil),
             DocumentSyncTarget::NodeUsage {
                 realm_id,
                 node_id,
                 group_id: None,
             }
-            .sync_topic_id()
+            .sync_topic_id(realm_id, &nil)
         );
         assert_ne!(
-            target.sync_topic_id(),
-            DocumentSyncTarget::WatchInterest { realm_id, node_id }.sync_topic_id()
+            target.sync_topic_id(realm_id, &nil),
+            DocumentSyncTarget::WatchInterest { realm_id, node_id }.sync_topic_id(realm_id, &nil)
         );
 
         assert_eq!(target.storage_keyspace(), NODE_INFO_KEYSPACE);
@@ -929,18 +1008,25 @@ mod tests {
         };
 
         // Rides the realm domain topic and one shared sync topic across nodes.
+        let nil = PlacementRef::NIL;
         assert_eq!(target.topic_id(), TopicId::realm(realm_id));
-        assert_eq!(target.sync_topic_id(), other.sync_topic_id());
-        assert_eq!(target.sync_topic_id(), subscription.sync_topic_id());
+        assert_eq!(
+            target.sync_topic_id(realm_id, &nil),
+            other.sync_topic_id(realm_id, &nil)
+        );
+        assert_eq!(
+            target.sync_topic_id(realm_id, &nil),
+            subscription.sync_topic_id(realm_id, &nil)
+        );
         // Distinct from the node-usage topic that shares the same realm domain.
         assert_ne!(
-            target.sync_topic_id(),
+            target.sync_topic_id(realm_id, &nil),
             DocumentSyncTarget::NodeUsage {
                 realm_id,
                 node_id,
                 group_id: None,
             }
-            .sync_topic_id()
+            .sync_topic_id(realm_id, &nil)
         );
 
         assert_eq!(
@@ -1113,11 +1199,20 @@ mod tests {
 
     #[test]
     fn metadata_document_lifecycle_topic_is_shared_by_upsert_and_delete() {
+        let realm_id = test_realm(2);
         let document_id = test_ulid(4);
+        let placement = PlacementRef {
+            strategy_id: test_ulid(9),
+            epoch: 0,
+            bucket: 2,
+        };
         let upsert_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
         let delete_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
 
         assert_eq!(upsert_target.topic_id(), delete_target.topic_id());
-        assert_eq!(upsert_target.sync_topic_id(), delete_target.sync_topic_id());
+        assert_eq!(
+            upsert_target.sync_topic_id(realm_id, &placement),
+            delete_target.sync_topic_id(realm_id, &placement)
+        );
     }
 }

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -73,12 +73,12 @@ pub enum DocumentSyncTarget {
     },
 }
 
-/// A bucket whose sync topic the local node is an authoritative holder of and
+/// A shard whose sync topic the local node is an authoritative holder of and
 /// whose co-holder membership is still being topped up. Keyed by
-/// realm ‖ strategy ‖ epoch(le) ‖ bucket(be); one record per bucket, not per
-/// document (every document in the bucket rides the same topic).
+/// realm ‖ strategy ‖ epoch(le) ‖ shard(be); one record per shard, not per
+/// document (every document in the shard rides the same topic).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PendingBucketPlacement {
+pub struct PendingShardPlacement {
     pub realm_id: RealmId,
     pub placement: PlacementRef,
     pub selected_peers: Vec<NodeId>,
@@ -373,11 +373,11 @@ impl DocumentSyncTarget {
         }
     }
 
-    /// Whether this target's records ride a bucket topic (group, user,
+    /// Whether this target's records ride a shard topic (group, user,
     /// metadata classes) rather than a shared realm-scoped domain topic.
-    /// Bucket topics are join-only for everyone but the bucket's rank-0
+    /// Shard topics are join-only for everyone but the shard's rank-0
     /// holder, which creates the genesis eagerly.
-    pub fn uses_bucket_topic(&self) -> bool {
+    pub fn uses_shard_topic(&self) -> bool {
         matches!(
             self,
             Self::Group { .. }
@@ -390,25 +390,25 @@ impl DocumentSyncTarget {
         )
     }
 
-    /// Sync topic this target's records ride. Bucket-classed targets (group,
-    /// user, metadata) derive one topic per `(strategy, epoch, bucket)` from the
+    /// Sync topic this target's records ride. Shard-classed targets (group,
+    /// user, metadata) derive one topic per `(strategy, epoch, shard)` from the
     /// placement; shared realm-scoped targets keep their per-domain topic and
-    /// ignore the placement. A NIL placement on a bucket-classed target is a bug
+    /// ignore the placement. A NIL placement on a shard-classed target is a bug
     /// (the emitter failed to stamp a real ref) — it is asserted in debug and
     /// warned in release, never silently accepted.
     pub fn sync_topic_id(&self, realm_id: RealmId, placement: &PlacementRef) -> irokle::TopicId {
-        if self.uses_bucket_topic() {
+        if self.uses_shard_topic() {
             if *placement == PlacementRef::NIL {
                 debug_assert!(
                     false,
-                    "bucket-classed target {self:?} derived a topic from a NIL placement"
+                    "shard-classed target {self:?} derived a topic from a NIL placement"
                 );
                 tracing::warn!(
                     target = ?self,
-                    "bucket-classed target has a NIL placement; deriving a NIL bucket topic"
+                    "shard-classed target has a NIL placement; deriving a NIL shard topic"
                 );
             }
-            bucket_topic_id(realm_id, placement)
+            shard_topic_id(realm_id, placement)
         } else {
             self.shared_sync_topic_id()
         }
@@ -434,26 +434,26 @@ impl DocumentSyncTarget {
             other => {
                 debug_assert!(
                     false,
-                    "shared_sync_topic_id on bucket-classed target {other:?}"
+                    "shared_sync_topic_id on shard-classed target {other:?}"
                 );
-                bytes.extend_from_slice(b"/bucket-misroute");
+                bytes.extend_from_slice(b"/shard-misroute");
             }
         }
         irokle::TopicId::hash(bytes)
     }
 }
 
-/// Sync topic a bucket's records ride, derived purely from the placement
+/// Sync topic a shard's records ride, derived purely from the placement
 /// reference (no config lookup at the net layer). Mirrors the `TopicId::hash`
 /// idiom [`DocumentSyncTarget::sync_topic_id`] uses. Not yet wired into
-/// `sync_topic_id`: stage 2 flips the bucketed targets over to this in a later
+/// `sync_topic_id`: stage 2 flips the sharded targets over to this in a later
 /// commit.
-pub fn bucket_topic_id(realm_id: RealmId, placement: &PlacementRef) -> irokle::TopicId {
-    let mut bytes = b"aruna-bucket-topic-v1".to_vec();
+pub fn shard_topic_id(realm_id: RealmId, placement: &PlacementRef) -> irokle::TopicId {
+    let mut bytes = b"aruna-shard-topic-v1".to_vec();
     bytes.extend_from_slice(realm_id.as_bytes());
     bytes.extend_from_slice(&placement.strategy_id.to_bytes());
     bytes.extend_from_slice(&placement.epoch.to_le_bytes());
-    bytes.extend_from_slice(&placement.bucket.to_be_bytes());
+    bytes.extend_from_slice(&placement.shard.to_be_bytes());
     irokle::TopicId::hash(bytes)
 }
 
@@ -557,7 +557,7 @@ mod tests {
     use super::{
         DocumentSyncApplyDecision, DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncEvent,
         DocumentSyncOutboxEvent, DocumentSyncPublish, DocumentSyncRevision, DocumentSyncTarget,
-        bucket_topic_id, compare_document_sync_revisions, document_sync_apply_decision,
+        compare_document_sync_revisions, document_sync_apply_decision, shard_topic_id,
     };
     use crate::NodeId;
     use crate::TopicId;
@@ -768,7 +768,7 @@ mod tests {
     }
 
     #[test]
-    fn bucket_classed_targets_ride_bucket_topics_shared_targets_ride_domain_topics() {
+    fn shard_classed_targets_ride_shard_topics_shared_targets_ride_domain_topics() {
         let group_id = test_ulid(1);
         let realm_id = test_realm(2);
         let document_id = test_ulid(4);
@@ -776,15 +776,15 @@ mod tests {
         let placement_a = PlacementRef {
             strategy_id: test_ulid(9),
             epoch: 0,
-            bucket: 3,
+            shard: 3,
         };
         let placement_b = PlacementRef {
-            bucket: 4,
+            shard: 4,
             ..placement_a
         };
 
         // Group and its authorization are one logical subject: with the same
-        // placement they ride a single bucket topic, derived purely from it.
+        // placement they ride a single shard topic, derived purely from it.
         let group = DocumentSyncTarget::Group { group_id };
         let group_auth = DocumentSyncTarget::GroupAuthorization { group_id };
         assert_eq!(
@@ -793,14 +793,14 @@ mod tests {
         );
         assert_eq!(
             group.sync_topic_id(realm_id, &placement_a),
-            bucket_topic_id(realm_id, &placement_a)
+            shard_topic_id(realm_id, &placement_a)
         );
         assert_ne!(
             group.sync_topic_id(realm_id, &placement_a),
             group.sync_topic_id(realm_id, &placement_b)
         );
 
-        // The three metadata variants of one document collapse onto its bucket.
+        // The three metadata variants of one document collapse onto its shard.
         let registry = DocumentSyncTarget::MetadataRegistry {
             group_id,
             document_id,
@@ -834,7 +834,7 @@ mod tests {
         );
         assert_ne!(
             realm_config.sync_topic_id(realm_id, &placement_a),
-            bucket_topic_id(realm_id, &placement_a)
+            shard_topic_id(realm_id, &placement_a)
         );
     }
 
@@ -844,23 +844,23 @@ mod tests {
     }
 
     #[test]
-    fn bucket_topic_id_matches_golden_and_separates_dimensions() {
+    fn shard_topic_id_matches_golden_and_separates_dimensions() {
         let realm_id = test_realm(2);
         let placement = PlacementRef {
             strategy_id: test_ulid(4),
             epoch: 0,
-            bucket: 5,
+            shard: 5,
         };
         // Fixed inputs → fixed topic id: the stage-2 cross-node canary. A change
-        // here means co-holders would derive different bucket topics.
+        // here means co-holders would derive different shard topics.
         assert_eq!(
-            bucket_topic_id(realm_id, &placement).to_string(),
-            "9ea950b394474cd820cfce7d0a840232de8cbd34216aeb19a11eb39f21f99048"
+            shard_topic_id(realm_id, &placement).to_string(),
+            "b375275475edc34ab568776cea1fdf4053e57458816e8ed35c5925e3caa07cf4"
         );
 
         // Each hashed dimension moves the topic.
-        let other_bucket = PlacementRef {
-            bucket: 6,
+        let other_shard = PlacementRef {
+            shard: 6,
             ..placement
         };
         let other_epoch = PlacementRef {
@@ -872,20 +872,20 @@ mod tests {
             ..placement
         };
         assert_ne!(
-            bucket_topic_id(realm_id, &placement),
-            bucket_topic_id(realm_id, &other_bucket)
+            shard_topic_id(realm_id, &placement),
+            shard_topic_id(realm_id, &other_shard)
         );
         assert_ne!(
-            bucket_topic_id(realm_id, &placement),
-            bucket_topic_id(realm_id, &other_epoch)
+            shard_topic_id(realm_id, &placement),
+            shard_topic_id(realm_id, &other_epoch)
         );
         assert_ne!(
-            bucket_topic_id(realm_id, &placement),
-            bucket_topic_id(realm_id, &other_strategy)
+            shard_topic_id(realm_id, &placement),
+            shard_topic_id(realm_id, &other_strategy)
         );
         assert_ne!(
-            bucket_topic_id(realm_id, &placement),
-            bucket_topic_id(test_realm(3), &placement)
+            shard_topic_id(realm_id, &placement),
+            shard_topic_id(test_realm(3), &placement)
         );
     }
 
@@ -1204,7 +1204,7 @@ mod tests {
         let placement = PlacementRef {
             strategy_id: test_ulid(9),
             epoch: 0,
-            bucket: 2,
+            shard: 2,
         };
         let upsert_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
         let delete_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -411,6 +411,20 @@ impl DocumentSyncTarget {
     }
 }
 
+/// Sync topic a bucket's records ride, derived purely from the placement
+/// reference (no config lookup at the net layer). Mirrors the `TopicId::hash`
+/// idiom [`DocumentSyncTarget::sync_topic_id`] uses. Not yet wired into
+/// `sync_topic_id`: stage 2 flips the bucketed targets over to this in a later
+/// commit.
+pub fn bucket_topic_id(realm_id: RealmId, placement: &PlacementRef) -> irokle::TopicId {
+    let mut bytes = b"aruna-bucket-topic-v1".to_vec();
+    bytes.extend_from_slice(realm_id.as_bytes());
+    bytes.extend_from_slice(&placement.strategy_id.to_bytes());
+    bytes.extend_from_slice(&placement.epoch.to_le_bytes());
+    bytes.extend_from_slice(&placement.bucket.to_be_bytes());
+    irokle::TopicId::hash(bytes)
+}
+
 fn metadata_graph_lifecycle_topic_id(graph_iri: &str) -> Ulid {
     let hash = blake3::hash(graph_iri.as_bytes());
     let mut bytes = [0u8; 16];
@@ -500,7 +514,7 @@ mod tests {
     use super::{
         DocumentSyncApplyDecision, DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncEvent,
         DocumentSyncOutboxEvent, DocumentSyncPublish, DocumentSyncRevision, DocumentSyncTarget,
-        compare_document_sync_revisions, document_sync_apply_decision,
+        bucket_topic_id, compare_document_sync_revisions, document_sync_apply_decision,
     };
     use crate::NodeId;
     use crate::TopicId;
@@ -509,6 +523,7 @@ mod tests {
         METADATA_EVENT_LOG_KEYSPACE, METADATA_GRAPH_LIFECYCLE_KEYSPACE, METADATA_INDEX_KEYSPACE,
         REALM_CONFIG_KEYSPACE, USER_KEYSPACE,
     };
+    use crate::structs::PlacementRef;
     use crate::structs::RealmId;
     use crate::types::UserId;
     use irokle::Event as _;
@@ -754,6 +769,52 @@ mod tests {
     #[test]
     fn document_sync_event_type_id_is_stable() {
         assert_eq!(DocumentSyncEvent::TYPE_ID, "aruna.document.v2");
+    }
+
+    #[test]
+    fn bucket_topic_id_matches_golden_and_separates_dimensions() {
+        let realm_id = test_realm(2);
+        let placement = PlacementRef {
+            strategy_id: test_ulid(4),
+            epoch: 0,
+            bucket: 5,
+        };
+        // Fixed inputs → fixed topic id: the stage-2 cross-node canary. A change
+        // here means co-holders would derive different bucket topics.
+        assert_eq!(
+            bucket_topic_id(realm_id, &placement).to_string(),
+            "9ea950b394474cd820cfce7d0a840232de8cbd34216aeb19a11eb39f21f99048"
+        );
+
+        // Each hashed dimension moves the topic.
+        let other_bucket = PlacementRef {
+            bucket: 6,
+            ..placement
+        };
+        let other_epoch = PlacementRef {
+            epoch: 1,
+            ..placement
+        };
+        let other_strategy = PlacementRef {
+            strategy_id: test_ulid(5),
+            ..placement
+        };
+        assert_ne!(
+            bucket_topic_id(realm_id, &placement),
+            bucket_topic_id(realm_id, &other_bucket)
+        );
+        assert_ne!(
+            bucket_topic_id(realm_id, &placement),
+            bucket_topic_id(realm_id, &other_epoch)
+        );
+        assert_ne!(
+            bucket_topic_id(realm_id, &placement),
+            bucket_topic_id(realm_id, &other_strategy)
+        );
+        assert_ne!(
+            bucket_topic_id(realm_id, &placement),
+            bucket_topic_id(test_realm(3), &placement)
+        );
     }
 
     #[test]

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -93,6 +93,10 @@ pub struct DocumentSyncOutboxRecord {
     pub target: DocumentSyncTarget,
     pub peers: Vec<NodeId>,
     pub event: DocumentSyncOutboxEvent,
+    /// Placement reference this record rides under: for `Upsert`/`Delete` the
+    /// envelope change's ref, for `AdminOperation` the target's resolved ref.
+    /// Does not affect the outbox FIFO key.
+    pub placement: PlacementRef,
     pub updated_at: u64,
     /// Whether the publisher may mint this document's sync topic genesis when it
     /// is missing. Only the node that originated the document sets this; every

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -7,6 +7,7 @@ pub const METADATA_DOCUMENT_INDEX_KEYSPACE: &str = "metadata_document_index";
 pub const METADATA_HOLDERS_KEYSPACE: &str = "metadata_holders";
 pub const METADATA_AUDIT_KEYSPACE: &str = "metadata_audit";
 pub const METADATA_EVENT_LOG_KEYSPACE: &str = "metadata_event_log";
+pub const METADATA_CREATE_ACCEPTANCE_KEYSPACE: &str = "metadata_create_acceptance";
 pub const METADATA_PENDING_PROJECTION_KEYSPACE: &str = "metadata_pending_projection";
 pub const METADATA_DOCUMENT_LIFECYCLE_KEYSPACE: &str = "metadata_document_lifecycle";
 pub const METADATA_GRAPH_LIFECYCLE_KEYSPACE: &str = "metadata_graph_lifecycle";

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -22,6 +22,7 @@ pub const DOCUMENT_SYNC_OUTBOX_KEYSPACE: &str = "document_sync_outbox";
 pub const DOCUMENT_SYNC_REVISION_KEYSPACE: &str = "document_sync_revisions";
 pub const DOCUMENT_SYNC_CONFLICT_KEYSPACE: &str = "document_sync_conflicts";
 pub const SYNC_PLACEMENT_KEYSPACE: &str = "sync_placements";
+pub const SHARD_MANIFEST_KEYSPACE: &str = "shard_manifest";
 pub const TASK_TIMER_KEYSPACE: &str = "task_timers";
 pub const USER_KEYSPACE: &str = "users";
 pub const USER_SUBJECT_INDEX_KEYSPACE: &str = "user_subject_index";

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -23,6 +23,7 @@ pub const DOCUMENT_SYNC_REVISION_KEYSPACE: &str = "document_sync_revisions";
 pub const DOCUMENT_SYNC_CONFLICT_KEYSPACE: &str = "document_sync_conflicts";
 pub const SYNC_PLACEMENT_KEYSPACE: &str = "sync_placements";
 pub const SHARD_MANIFEST_KEYSPACE: &str = "shard_manifest";
+pub const SHARD_VERIFICATION_KEYSPACE: &str = "shard_verification";
 pub const TASK_TIMER_KEYSPACE: &str = "task_timers";
 pub const USER_KEYSPACE: &str = "users";
 pub const USER_SUBJECT_INDEX_KEYSPACE: &str = "user_subject_index";

--- a/core/src/metadata.rs
+++ b/core/src/metadata.rs
@@ -550,7 +550,7 @@ mod tests {
         MetadataDocumentDeleteRecord, MetadataDocumentLifecycleRecord,
         MetadataGraphLifecycleRecord, MetadataQueryResults, compare_metadata_clocks,
     };
-    use crate::structs::{MetadataRegistryRecord, RealmId};
+    use crate::structs::{MetadataRegistryRecord, PlacementRef, RealmId};
     use crate::{NodeId, UserId};
     use craqle::{ActorId, VectorClock};
     use std::collections::BTreeMap;
@@ -612,6 +612,7 @@ mod tests {
                 document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![node(1)],
             created_at_ms: 1,
             updated_at_ms: 1,

--- a/core/src/storage_entries.rs
+++ b/core/src/storage_entries.rs
@@ -27,8 +27,8 @@ use crate::metadata::{
     MetadataMaterializationStatusRecord,
 };
 use crate::structs::{
-    MetadataRegistryRecord, NotificationOutboxRecord, NotificationRecord, PlacementRef, RealmId,
-    User, WatchSubscription, notification_inbox_key, notification_outbox_key,
+    MetadataRegistryRecord, NotificationOutboxRecord, NotificationRecord, PlacementRef, User,
+    WatchSubscription, notification_inbox_key, notification_outbox_key,
     notification_prune_index_key, watch_subscription_key,
 };
 use crate::types::{GroupId, Key, KeySpace, UserId, Value};

--- a/core/src/storage_entries.rs
+++ b/core/src/storage_entries.rs
@@ -6,7 +6,7 @@ use crate::admin_document_reducer::{AdminDocumentConflict, AdminDocumentReducerS
 use crate::admin_documents::AdminDocumentTarget;
 use crate::document::{
     DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncConflict, DocumentSyncRevision,
-    DocumentSyncTarget, PendingDocumentPlacement,
+    DocumentSyncTarget, ShardManifestEntry,
 };
 use crate::errors::ConversionError;
 use crate::keyspaces::{
@@ -19,7 +19,7 @@ use crate::keyspaces::{
     METADATA_MATERIALIZATION_STATUS_KEYSPACE, METADATA_PENDING_PROJECTION_KEYSPACE,
     NOTIFICATION_INBOX_KEYSPACE, NOTIFICATION_INBOX_PRUNE_INDEX_KEYSPACE,
     NOTIFICATION_OUTBOX_KEYSPACE, NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE,
-    SYNC_PLACEMENT_KEYSPACE, USER_SUBJECT_INDEX_KEYSPACE,
+    SHARD_MANIFEST_KEYSPACE, USER_SUBJECT_INDEX_KEYSPACE,
 };
 use crate::metadata::{
     MetadataCreateEventRecord, MetadataDocumentLifecycleRecord, MetadataGraphLifecycleRecord,
@@ -110,32 +110,6 @@ pub fn metadata_event_log_key(document_id: Ulid, event_id: Ulid) -> Key {
     bytes.extend_from_slice(&document_id.to_bytes());
     bytes.extend_from_slice(&event_id.to_bytes());
     ByteView::from(bytes)
-}
-
-pub fn document_placement_key(realm_id: RealmId, target: &DocumentSyncTarget) -> Key {
-    let mut bytes = realm_id.as_bytes().to_vec();
-    bytes.extend_from_slice(target.sync_topic_id().to_string().as_bytes());
-    ByteView::from(bytes)
-}
-
-pub fn document_placement_write_entry(
-    record: &PendingDocumentPlacement,
-) -> Result<(KeySpace, Key, Value), ConversionError> {
-    Ok((
-        SYNC_PLACEMENT_KEYSPACE.to_string(),
-        document_placement_key(record.realm_id, &record.target),
-        postcard::to_allocvec(record)?.into(),
-    ))
-}
-
-pub fn document_placement_delete_entry(
-    realm_id: RealmId,
-    target: &DocumentSyncTarget,
-) -> (KeySpace, Key) {
-    (
-        SYNC_PLACEMENT_KEYSPACE.to_string(),
-        document_placement_key(realm_id, target),
-    )
 }
 
 pub fn metadata_pending_projection_key(document_id: Ulid, event_id: Ulid) -> Key {
@@ -316,6 +290,64 @@ pub fn document_sync_revision_write_entry(
         document_sync_revision_key(target),
         postcard::to_allocvec(change)?.into(),
     ))
+}
+
+/// Manifest-row key: `strategy(16) ‖ epoch(8, le) ‖ shard(4, be) ‖ per-target
+/// sidecar key`. The 28-byte shard prefix isolates one shard's rows on a scan;
+/// the sidecar tail (keyspace-discriminated, see
+/// [`document_sync_revision_key`]) keeps two targets sharing a storage key from
+/// colliding.
+pub fn shard_manifest_key(placement: &PlacementRef, target: &DocumentSyncTarget) -> Key {
+    let tail = document_sync_target_sidecar_key(target);
+    let mut bytes = Vec::with_capacity(28 + tail.as_ref().len());
+    bytes.extend_from_slice(&shard_manifest_prefix(placement));
+    bytes.extend_from_slice(tail.as_ref());
+    ByteView::from(bytes)
+}
+
+/// The 28-byte shard prefix (`strategy ‖ epoch ‖ shard`) a manifest assembly
+/// scan iterates.
+pub fn shard_manifest_prefix(placement: &PlacementRef) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(28);
+    bytes.extend_from_slice(&placement.strategy_id.to_bytes());
+    bytes.extend_from_slice(&placement.epoch.to_le_bytes());
+    bytes.extend_from_slice(&placement.shard.to_be_bytes());
+    bytes
+}
+
+/// Manifest row for a shard-classed change: upsert or delete both write the row
+/// at `change.current` (a delete leaves a tombstone). `Ok(None)` for shared
+/// realm-scoped targets or a NIL placement (no shard governs the change yet).
+pub fn shard_manifest_write_entry(
+    target: &DocumentSyncTarget,
+    change: &DocumentSyncChange,
+) -> Result<Option<(KeySpace, Key, Value)>, ConversionError> {
+    if !target.uses_shard_topic() || change.placement == PlacementRef::NIL {
+        return Ok(None);
+    }
+    let entry = ShardManifestEntry {
+        target: target.clone(),
+        revision: change.current,
+    };
+    Ok(Some((
+        SHARD_MANIFEST_KEYSPACE.to_string(),
+        shard_manifest_key(&change.placement, target),
+        postcard::to_allocvec(&entry)?.into(),
+    )))
+}
+
+/// Manifest row for a metadata document lifecycle record, built from the same
+/// revision change its sidecar carries so the manifest and the sidecar agree.
+pub fn metadata_document_lifecycle_manifest_write_entry(
+    record: &MetadataDocumentLifecycleRecord,
+    delete_actor: NodeId,
+    placement: PlacementRef,
+) -> Result<Option<(KeySpace, Key, Value)>, ConversionError> {
+    let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+        document_id: record.document_id(),
+    };
+    let change = metadata_document_lifecycle_revision_change(record, delete_actor, placement);
+    shard_manifest_write_entry(&target, &change)
 }
 
 pub fn document_sync_conflict_write_entry(
@@ -615,20 +647,22 @@ mod tests {
         admin_document_reducer_conflict_prefix, admin_document_reducer_state_key,
         admin_document_reducer_state_write_entry, document_sync_conflict_key,
         document_sync_conflict_write_entry, document_sync_revision_key,
-        document_sync_revision_write_entry, stale_admin_document_conflict_delete_entries,
+        document_sync_revision_write_entry, shard_manifest_key, shard_manifest_prefix,
+        shard_manifest_write_entry, stale_admin_document_conflict_delete_entries,
     };
     use crate::admin_document_reducer::{
         AdminDocumentAttributeVersion, AdminDocumentConflict, AdminDocumentConflictValue,
         AdminDocumentReducerState,
     };
     use crate::admin_documents::{AdminDocumentClock, AdminDocumentDot, AdminDocumentTarget};
+    use crate::document::ShardManifestEntry;
     use crate::document::{
         DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncConflict, DocumentSyncRevision,
         DocumentSyncTarget,
     };
     use crate::keyspaces::{
         ADMIN_DOCUMENT_CONFLICT_KEYSPACE, ADMIN_DOCUMENT_STATE_KEYSPACE,
-        DOCUMENT_SYNC_CONFLICT_KEYSPACE, DOCUMENT_SYNC_REVISION_KEYSPACE,
+        DOCUMENT_SYNC_CONFLICT_KEYSPACE, DOCUMENT_SYNC_REVISION_KEYSPACE, SHARD_MANIFEST_KEYSPACE,
     };
     use crate::structs::{PlacementRef, RealmId};
     use crate::{NodeId, UserId};
@@ -777,6 +811,139 @@ mod tests {
         assert_eq!(keyspace, DOCUMENT_SYNC_REVISION_KEYSPACE);
         assert_eq!(key, document_sync_revision_key(&target));
         assert_eq!(decoded, change);
+    }
+
+    fn shard_placement(shard: u32) -> PlacementRef {
+        PlacementRef {
+            strategy_id: Ulid::from_bytes([9; 16]),
+            epoch: 0,
+            shard,
+        }
+    }
+
+    #[test]
+    fn shard_manifest_write_entry_records_upsert_revision() {
+        let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([7; 16]),
+        };
+        let placement = shard_placement(3);
+        let change = DocumentSyncChange {
+            base: None,
+            current: revision(2, 5),
+            kind: DocumentSyncChangeKind::Upsert,
+            placement,
+        };
+
+        let (keyspace, key, value) = shard_manifest_write_entry(&target, &change)
+            .unwrap()
+            .unwrap();
+        assert_eq!(keyspace, SHARD_MANIFEST_KEYSPACE);
+        assert_eq!(key, shard_manifest_key(&placement, &target));
+        let decoded: ShardManifestEntry = postcard::from_bytes(value.as_ref()).unwrap();
+        assert_eq!(decoded.target, target);
+        assert_eq!(decoded.revision, change.current);
+    }
+
+    #[test]
+    fn shard_manifest_delete_keeps_tombstone_revision_at_same_key() {
+        let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([7; 16]),
+        };
+        let placement = shard_placement(3);
+        let upsert = DocumentSyncChange {
+            base: None,
+            current: revision(2, 5),
+            kind: DocumentSyncChangeKind::Upsert,
+            placement,
+        };
+        let delete = DocumentSyncChange {
+            base: Some(upsert.current),
+            current: revision(3, 6),
+            kind: DocumentSyncChangeKind::Delete,
+            placement,
+        };
+
+        let (_, upsert_key, _) = shard_manifest_write_entry(&target, &upsert)
+            .unwrap()
+            .unwrap();
+        let (_, delete_key, delete_value) = shard_manifest_write_entry(&target, &delete)
+            .unwrap()
+            .unwrap();
+
+        // A delete overwrites the same row with the delete revision (a tombstone),
+        // it never removes it.
+        assert_eq!(upsert_key, delete_key);
+        let decoded: ShardManifestEntry = postcard::from_bytes(delete_value.as_ref()).unwrap();
+        assert_eq!(decoded.revision, delete.current);
+    }
+
+    #[test]
+    fn shard_manifest_write_entry_skips_shared_and_nil_placements() {
+        let shared = DocumentSyncTarget::RealmConfig {
+            realm_id: realm_id(2),
+        };
+        let change = DocumentSyncChange {
+            base: None,
+            current: revision(1, 1),
+            kind: DocumentSyncChangeKind::Upsert,
+            placement: shard_placement(3),
+        };
+        // Shared realm-scoped targets never ride a shard, so they get no row.
+        assert!(
+            shard_manifest_write_entry(&shared, &change)
+                .unwrap()
+                .is_none()
+        );
+
+        // A shard-classed target with a NIL placement has no governing shard yet.
+        let shard_target = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([7; 16]),
+        };
+        let nil_change = DocumentSyncChange {
+            placement: PlacementRef::NIL,
+            ..change
+        };
+        assert!(
+            shard_manifest_write_entry(&shard_target, &nil_change)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn shard_manifest_keys_isolate_shards_and_targets() {
+        let a = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([7; 16]),
+        };
+        let b = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([8; 16]),
+        };
+        let shard3 = shard_placement(3);
+        let shard4 = shard_placement(4);
+
+        // Every row for one shard shares the 28-byte shard prefix; a different
+        // shard does not.
+        let prefix3 = shard_manifest_prefix(&shard3);
+        assert!(
+            shard_manifest_key(&shard3, &a)
+                .as_ref()
+                .starts_with(&prefix3)
+        );
+        assert!(
+            shard_manifest_key(&shard3, &b)
+                .as_ref()
+                .starts_with(&prefix3)
+        );
+        assert!(
+            !shard_manifest_key(&shard4, &a)
+                .as_ref()
+                .starts_with(&prefix3)
+        );
+        // Distinct documents in one shard get distinct rows.
+        assert_ne!(
+            shard_manifest_key(&shard3, &a),
+            shard_manifest_key(&shard3, &b)
+        );
     }
 
     #[test]

--- a/core/src/storage_entries.rs
+++ b/core/src/storage_entries.rs
@@ -12,9 +12,10 @@ use crate::errors::ConversionError;
 use crate::keyspaces::{
     ADMIN_DOCUMENT_CONFLICT_KEYSPACE, ADMIN_DOCUMENT_STATE_KEYSPACE,
     DOCUMENT_SYNC_CONFLICT_KEYSPACE, DOCUMENT_SYNC_REVISION_KEYSPACE,
-    METADATA_DOCUMENT_INDEX_KEYSPACE, METADATA_DOCUMENT_LIFECYCLE_KEYSPACE,
-    METADATA_EVENT_LOG_KEYSPACE, METADATA_GRAPH_LIFECYCLE_KEYSPACE,
-    METADATA_GRAPH_PRUNE_JOB_KEYSPACE, METADATA_HOLDERS_KEYSPACE, METADATA_INDEX_KEYSPACE,
+    METADATA_CREATE_ACCEPTANCE_KEYSPACE, METADATA_DOCUMENT_INDEX_KEYSPACE,
+    METADATA_DOCUMENT_LIFECYCLE_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE,
+    METADATA_GRAPH_LIFECYCLE_KEYSPACE, METADATA_GRAPH_PRUNE_JOB_KEYSPACE,
+    METADATA_HOLDERS_KEYSPACE, METADATA_INDEX_KEYSPACE,
     METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE, METADATA_MATERIALIZATION_JOB_KEYSPACE,
     METADATA_MATERIALIZATION_STATUS_KEYSPACE, METADATA_PENDING_PROJECTION_KEYSPACE,
     NOTIFICATION_INBOX_KEYSPACE, NOTIFICATION_INBOX_PRUNE_INDEX_KEYSPACE,
@@ -91,6 +92,10 @@ pub fn metadata_registry_prefix(group_id: GroupId) -> Key {
 
 pub fn metadata_document_key(document_id: Ulid) -> Key {
     ByteView::from(document_id.to_bytes().to_vec())
+}
+
+pub fn metadata_create_acceptance_key(document_id: Ulid) -> Key {
+    metadata_document_key(document_id)
 }
 
 pub fn metadata_graph_lifecycle_key(graph_iri: &str) -> Key {
@@ -228,6 +233,16 @@ pub fn metadata_create_event_write_entry(
     Ok((
         METADATA_EVENT_LOG_KEYSPACE.to_string(),
         metadata_event_log_key(event.record.document_id, event.event_id),
+        postcard::to_allocvec(event)?.into(),
+    ))
+}
+
+pub fn metadata_create_acceptance_write_entry(
+    event: &MetadataCreateEventRecord,
+) -> Result<(KeySpace, Key, Value), ConversionError> {
+    Ok((
+        METADATA_CREATE_ACCEPTANCE_KEYSPACE.to_string(),
+        metadata_create_acceptance_key(event.record.document_id),
         postcard::to_allocvec(event)?.into(),
     ))
 }

--- a/core/src/structs/metadata_registry.rs
+++ b/core/src/structs/metadata_registry.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
 use crate::NodeId;
-use crate::structs::RealmId;
+use crate::structs::{PlacementRef, RealmId};
 use crate::types::{GroupId, UserId};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -14,6 +14,11 @@ pub struct MetadataRegistryRecord {
     pub graph_iri: String,
     pub public: bool,
     pub permission_path: String,
+    /// Bucket chosen by the create-receiving node from the buckets it holds.
+    /// Recorded once, never re-derived: re-choosing under a changed config
+    /// would fork the document across two sync topics. Holders stay derived
+    /// from `(placement, config)`, so a rebalance moves buckets, not documents.
+    pub placement: PlacementRef,
     pub holder_node_ids: Vec<NodeId>,
     pub created_at_ms: u64,
     pub updated_at_ms: u64,

--- a/core/src/structs/placement.rs
+++ b/core/src/structs/placement.rs
@@ -7,6 +7,9 @@ use ulid::Ulid;
 
 pub const DEFAULT_LOCATION: &str = "default";
 pub const DEFAULT_NODE_WEIGHT: u32 = 100;
+/// Default per-strategy bucket fan-out. Power of two so `bucket_for_subject`
+/// can mask with `bucket_count - 1`.
+pub const DEFAULT_BUCKET_COUNT: u32 = 64;
 /// Upper bound for a configurable node weight; onboarding/config inputs clamp
 /// present values into `1..=MAX_NODE_WEIGHT`.
 pub const MAX_NODE_WEIGHT: u32 = 10_000;
@@ -73,6 +76,9 @@ pub struct PlacementStrategy {
     pub replica_count: Option<u32>,
     pub distinct_locations: bool,
     pub affinity: Vec<AffinityRule>,
+    /// Number of sync buckets subjects hash into. Power of two so the topic
+    /// derivation is a pure mask; validated on upsert.
+    pub bucket_count: u32,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -128,6 +134,7 @@ pub struct StrategyBinding {
 pub struct PlacementRef {
     pub strategy_id: Ulid,
     pub epoch: u64,
+    pub bucket: u32,
 }
 
 impl PlacementRef {
@@ -137,7 +144,22 @@ impl PlacementRef {
     pub const NIL: PlacementRef = PlacementRef {
         strategy_id: Ulid::nil(),
         epoch: 0,
+        bucket: 0,
     };
+}
+
+/// Bucket a subject hashes into for `bucket_count` buckets. Blake3 of a domain
+/// tag concatenated with the subject, masked into `0..bucket_count`. All
+/// records of one logical document share a subject (see `subject_bytes`) and so
+/// land in one bucket.
+pub fn bucket_for_subject(subject: &[u8], bucket_count: u32) -> u32 {
+    debug_assert!(bucket_count.is_power_of_two());
+    let mut input = b"aruna-bucket-v1".to_vec();
+    input.extend_from_slice(subject);
+    let hash = blake3::hash(&input);
+    let mut head = [0u8; 4];
+    head.copy_from_slice(&hash.as_bytes()[..4]);
+    u32::from_be_bytes(head) & (bucket_count - 1)
 }
 
 #[cfg(test)]
@@ -204,6 +226,7 @@ mod tests {
                     effect: AffinityEffect::Multiply { permille: 1500 },
                 },
             ],
+            bucket_count: 64,
         };
         let bytes = postcard::to_allocvec(&strategy).unwrap();
         assert_eq!(
@@ -288,11 +311,55 @@ mod tests {
         let placement = PlacementRef {
             strategy_id: Ulid::from_bytes([9u8; 16]),
             epoch: 0,
+            bucket: 7,
         };
         let bytes = postcard::to_allocvec(&placement).unwrap();
         assert_eq!(
             postcard::from_bytes::<PlacementRef>(&bytes).unwrap(),
             placement
         );
+    }
+
+    #[test]
+    fn bucket_for_subject_matches_golden_vectors() {
+        // Fixed subjects → fixed buckets. These are the stage-2 cross-node
+        // canaries: a change here means a document would remap topics.
+        assert_eq!(bucket_for_subject(b"", 64), 18);
+        assert_eq!(bucket_for_subject(b"aruna", 64), 35);
+        assert_eq!(bucket_for_subject(b"aruna", 128), 35);
+        assert_eq!(bucket_for_subject(&[0u8; 16], 64), 37);
+        assert_eq!(bucket_for_subject(&[0u8; 16], 128), 37);
+    }
+
+    #[test]
+    fn bucket_for_subject_stays_in_range() {
+        for count in [1u32, 2, 4, 64, 128, 1024] {
+            for seed in 0u32..256 {
+                let bucket = bucket_for_subject(&seed.to_be_bytes(), count);
+                assert!(bucket < count, "bucket {bucket} out of range for {count}");
+            }
+        }
+    }
+
+    #[test]
+    fn bucket_for_subject_distributes_evenly() {
+        let bucket_count = 64u32;
+        let samples = 10_000u32;
+        let mut counts = vec![0u32; bucket_count as usize];
+        let mut cursor = [0u8; 32];
+        for _ in 0..samples {
+            cursor = *blake3::hash(&cursor).as_bytes();
+            let bucket = bucket_for_subject(&cursor, bucket_count);
+            counts[bucket as usize] += 1;
+        }
+        let expected = samples / bucket_count; // ~156
+        let min = *counts.iter().min().unwrap();
+        let max = *counts.iter().max().unwrap();
+        // Generous band around the mean; a broken mask would collapse or spike.
+        assert!(
+            min > expected / 2,
+            "under-filled bucket: {min} < {expected}"
+        );
+        assert!(max < expected * 2, "over-filled bucket: {max} > {expected}");
     }
 }

--- a/core/src/structs/placement.rs
+++ b/core/src/structs/placement.rs
@@ -7,9 +7,9 @@ use ulid::Ulid;
 
 pub const DEFAULT_LOCATION: &str = "default";
 pub const DEFAULT_NODE_WEIGHT: u32 = 100;
-/// Default per-strategy bucket fan-out. Power of two so `bucket_for_subject`
-/// can mask with `bucket_count - 1`.
-pub const DEFAULT_BUCKET_COUNT: u32 = 64;
+/// Default per-strategy shard fan-out. Power of two so `shard_for_subject`
+/// can mask with `shard_count - 1`.
+pub const DEFAULT_SHARD_COUNT: u32 = 64;
 /// Upper bound for a configurable node weight; onboarding/config inputs clamp
 /// present values into `1..=MAX_NODE_WEIGHT`.
 pub const MAX_NODE_WEIGHT: u32 = 10_000;
@@ -76,9 +76,9 @@ pub struct PlacementStrategy {
     pub replica_count: Option<u32>,
     pub distinct_locations: bool,
     pub affinity: Vec<AffinityRule>,
-    /// Number of sync buckets subjects hash into. Power of two so the topic
+    /// Number of sync shards subjects hash into. Power of two so the topic
     /// derivation is a pure mask; validated on upsert.
-    pub bucket_count: u32,
+    pub shard_count: u32,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -134,7 +134,7 @@ pub struct StrategyBinding {
 pub struct PlacementRef {
     pub strategy_id: Ulid,
     pub epoch: u64,
-    pub bucket: u32,
+    pub shard: u32,
 }
 
 impl PlacementRef {
@@ -144,22 +144,22 @@ impl PlacementRef {
     pub const NIL: PlacementRef = PlacementRef {
         strategy_id: Ulid::nil(),
         epoch: 0,
-        bucket: 0,
+        shard: 0,
     };
 }
 
-/// Bucket a subject hashes into for `bucket_count` buckets. Blake3 of a domain
-/// tag concatenated with the subject, masked into `0..bucket_count`. All
+/// Shard a subject hashes into for `shard_count` shards. Blake3 of a domain
+/// tag concatenated with the subject, masked into `0..shard_count`. All
 /// records of one logical document share a subject (see `subject_bytes`) and so
-/// land in one bucket.
-pub fn bucket_for_subject(subject: &[u8], bucket_count: u32) -> u32 {
-    debug_assert!(bucket_count.is_power_of_two());
-    let mut input = b"aruna-bucket-v1".to_vec();
+/// land in one shard.
+pub fn shard_for_subject(subject: &[u8], shard_count: u32) -> u32 {
+    debug_assert!(shard_count.is_power_of_two());
+    let mut input = b"aruna-shard-v1".to_vec();
     input.extend_from_slice(subject);
     let hash = blake3::hash(&input);
     let mut head = [0u8; 4];
     head.copy_from_slice(&hash.as_bytes()[..4]);
-    u32::from_be_bytes(head) & (bucket_count - 1)
+    u32::from_be_bytes(head) & (shard_count - 1)
 }
 
 #[cfg(test)]
@@ -226,7 +226,7 @@ mod tests {
                     effect: AffinityEffect::Multiply { permille: 1500 },
                 },
             ],
-            bucket_count: 64,
+            shard_count: 64,
         };
         let bytes = postcard::to_allocvec(&strategy).unwrap();
         assert_eq!(
@@ -311,7 +311,7 @@ mod tests {
         let placement = PlacementRef {
             strategy_id: Ulid::from_bytes([9u8; 16]),
             epoch: 0,
-            bucket: 7,
+            shard: 7,
         };
         let bytes = postcard::to_allocvec(&placement).unwrap();
         assert_eq!(
@@ -321,45 +321,42 @@ mod tests {
     }
 
     #[test]
-    fn bucket_for_subject_matches_golden_vectors() {
-        // Fixed subjects → fixed buckets. These are the stage-2 cross-node
+    fn shard_for_subject_matches_golden_vectors() {
+        // Fixed subjects → fixed shards. These are the stage-2 cross-node
         // canaries: a change here means a document would remap topics.
-        assert_eq!(bucket_for_subject(b"", 64), 18);
-        assert_eq!(bucket_for_subject(b"aruna", 64), 35);
-        assert_eq!(bucket_for_subject(b"aruna", 128), 35);
-        assert_eq!(bucket_for_subject(&[0u8; 16], 64), 37);
-        assert_eq!(bucket_for_subject(&[0u8; 16], 128), 37);
+        assert_eq!(shard_for_subject(b"", 64), 30);
+        assert_eq!(shard_for_subject(b"aruna", 64), 20);
+        assert_eq!(shard_for_subject(b"aruna", 128), 84);
+        assert_eq!(shard_for_subject(&[0u8; 16], 64), 4);
+        assert_eq!(shard_for_subject(&[0u8; 16], 128), 4);
     }
 
     #[test]
-    fn bucket_for_subject_stays_in_range() {
+    fn shard_for_subject_stays_in_range() {
         for count in [1u32, 2, 4, 64, 128, 1024] {
             for seed in 0u32..256 {
-                let bucket = bucket_for_subject(&seed.to_be_bytes(), count);
-                assert!(bucket < count, "bucket {bucket} out of range for {count}");
+                let shard = shard_for_subject(&seed.to_be_bytes(), count);
+                assert!(shard < count, "shard {shard} out of range for {count}");
             }
         }
     }
 
     #[test]
-    fn bucket_for_subject_distributes_evenly() {
-        let bucket_count = 64u32;
+    fn shard_for_subject_distributes_evenly() {
+        let shard_count = 64u32;
         let samples = 10_000u32;
-        let mut counts = vec![0u32; bucket_count as usize];
+        let mut counts = vec![0u32; shard_count as usize];
         let mut cursor = [0u8; 32];
         for _ in 0..samples {
             cursor = *blake3::hash(&cursor).as_bytes();
-            let bucket = bucket_for_subject(&cursor, bucket_count);
-            counts[bucket as usize] += 1;
+            let shard = shard_for_subject(&cursor, shard_count);
+            counts[shard as usize] += 1;
         }
-        let expected = samples / bucket_count; // ~156
+        let expected = samples / shard_count; // ~156
         let min = *counts.iter().min().unwrap();
         let max = *counts.iter().max().unwrap();
         // Generous band around the mean; a broken mask would collapse or spike.
-        assert!(
-            min > expected / 2,
-            "under-filled bucket: {min} < {expected}"
-        );
-        assert!(max < expected * 2, "over-filled bucket: {max} > {expected}");
+        assert!(min > expected / 2, "under-filled shard: {min} < {expected}");
+        assert!(max < expected * 2, "over-filled shard: {max} > {expected}");
     }
 }

--- a/core/src/structs/placement.rs
+++ b/core/src/structs/placement.rs
@@ -10,6 +10,8 @@ pub const DEFAULT_NODE_WEIGHT: u32 = 100;
 /// Default per-strategy shard fan-out. Power of two so `shard_for_subject`
 /// can mask with `shard_count - 1`.
 pub const DEFAULT_SHARD_COUNT: u32 = 64;
+/// Maximum per-strategy shard fan-out accepted from placement config.
+pub const MAX_PLACEMENT_SHARD_COUNT: u32 = 4096;
 /// Upper bound for a configurable node weight; onboarding/config inputs clamp
 /// present values into `1..=MAX_NODE_WEIGHT`.
 pub const MAX_NODE_WEIGHT: u32 = 10_000;

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -2,8 +2,8 @@ use crate::NodeId;
 use crate::errors::ConversionError;
 use crate::structs::structs::{Permission, Role};
 use crate::structs::{
-    Actor, BindingScope, DEFAULT_BUCKET_COUNT, DocumentClass, NodePlacementEntry,
-    PlacementOverride, PlacementStrategy, StrategyBinding,
+    Actor, BindingScope, DEFAULT_SHARD_COUNT, DocumentClass, NodePlacementEntry, PlacementOverride,
+    PlacementStrategy, StrategyBinding,
 };
 use crate::types::{GroupId, RoleId, UserId};
 use core::fmt;
@@ -383,7 +383,7 @@ impl RealmConfigDocument {
             replica_count: Some(self.metadata_replication.default_replication_factor),
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: DEFAULT_BUCKET_COUNT,
+            shard_count: DEFAULT_SHARD_COUNT,
         };
         let everywhere_strategy = PlacementStrategy {
             strategy_id: Ulid::r#gen(),
@@ -391,7 +391,7 @@ impl RealmConfigDocument {
             replica_count: None,
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: DEFAULT_BUCKET_COUNT,
+            shard_count: DEFAULT_SHARD_COUNT,
         };
         self.default_strategy_id = Some(default_strategy.strategy_id);
         self.strategy_bindings = vec![

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -2,8 +2,8 @@ use crate::NodeId;
 use crate::errors::ConversionError;
 use crate::structs::structs::{Permission, Role};
 use crate::structs::{
-    Actor, BindingScope, DocumentClass, NodePlacementEntry, PlacementOverride, PlacementStrategy,
-    StrategyBinding,
+    Actor, BindingScope, DEFAULT_BUCKET_COUNT, DocumentClass, NodePlacementEntry,
+    PlacementOverride, PlacementStrategy, StrategyBinding,
 };
 use crate::types::{GroupId, RoleId, UserId};
 use core::fmt;
@@ -383,6 +383,7 @@ impl RealmConfigDocument {
             replica_count: Some(self.metadata_replication.default_replication_factor),
             distinct_locations: false,
             affinity: Vec::new(),
+            bucket_count: DEFAULT_BUCKET_COUNT,
         };
         let everywhere_strategy = PlacementStrategy {
             strategy_id: Ulid::r#gen(),
@@ -390,6 +391,7 @@ impl RealmConfigDocument {
             replica_count: None,
             distinct_locations: false,
             affinity: Vec::new(),
+            bucket_count: DEFAULT_BUCKET_COUNT,
         };
         self.default_strategy_id = Some(default_strategy.strategy_id);
         self.strategy_bindings = vec![

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -373,9 +373,18 @@ impl RealmConfigDocument {
 
     /// Seeds the default placement strategies realm creation installs: a
     /// `default` strategy using the configured metadata replication factor (the
-    /// realm default) plus an `everywhere` strategy bound to the
-    /// `MetadataRegistry` and `Admin` document classes. Replaces any existing
-    /// strategy configuration.
+    /// realm default) plus an `everywhere` strategy bound to the control-document
+    /// classes. Replaces any existing strategy configuration.
+    ///
+    /// Group, user and metadata-registry documents are bound to `everywhere`
+    /// (`replica_count: None`, i.e. every sync-eligible node) rather than to the
+    /// capped default. They are control documents — O(groups + users), not
+    /// O(documents) — and the permission system structurally requires them
+    /// locally: `CheckPermissionsOperation` reads the group authorization
+    /// document from the local `AUTH_KEYSPACE` and hard-fails when it is absent,
+    /// so a node outside a group's replica set could not authorize any request
+    /// touching that group. `DocumentClass::Group` covers the group document and
+    /// its authorization document alike (see `placement::document_class`).
     pub fn seed_default_placement(&mut self) {
         let default_strategy = PlacementStrategy {
             strategy_id: Ulid::r#gen(),
@@ -394,16 +403,18 @@ impl RealmConfigDocument {
             shard_count: DEFAULT_SHARD_COUNT,
         };
         self.default_strategy_id = Some(default_strategy.strategy_id);
-        self.strategy_bindings = vec![
-            StrategyBinding {
-                scope: BindingScope::Class(DocumentClass::MetadataRegistry),
-                strategy_id: everywhere_strategy.strategy_id,
-            },
-            StrategyBinding {
-                scope: BindingScope::Class(DocumentClass::Admin),
-                strategy_id: everywhere_strategy.strategy_id,
-            },
-        ];
+        self.strategy_bindings = [
+            DocumentClass::MetadataRegistry,
+            DocumentClass::Admin,
+            DocumentClass::Group,
+            DocumentClass::User,
+        ]
+        .into_iter()
+        .map(|class| StrategyBinding {
+            scope: BindingScope::Class(class),
+            strategy_id: everywhere_strategy.strategy_id,
+        })
+        .collect();
         self.strategies = vec![default_strategy, everywhere_strategy];
     }
 

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -2,25 +2,13 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::document::DocumentSyncTarget;
 use crate::id::NodeId;
 use crate::structs::RealmId;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TaskKey {
-    RealmPresence {
-        realm_id: RealmId,
-        node_id: NodeId,
-    },
-    SyncPlacements {
-        realm_id: RealmId,
-        node_id: NodeId,
-    },
-    SyncDocument {
-        node_id: NodeId,
-        target: DocumentSyncTarget,
-        peers: Vec<NodeId>,
-    },
+    RealmPresence { realm_id: RealmId, node_id: NodeId },
+    SyncPlacements { realm_id: RealmId, node_id: NodeId },
     DrainDocumentSyncOutbox,
     PublishUsageSnapshots,
     PublishNodeInfo,

--- a/net/src/effect_handlers.rs
+++ b/net/src/effect_handlers.rs
@@ -23,11 +23,11 @@ pub async fn handle_net_effect(
             aruna_core::DocumentSyncEffect::PublishDocuments { documents, peers } => {
                 NetEvent::DocumentSync(document_sync.publish_documents(documents, peers).await)
             }
-            aruna_core::DocumentSyncEffect::SyncDocument { target, peers } => {
-                NetEvent::DocumentSync(document_sync.sync_document_event(target, peers).await)
+            aruna_core::DocumentSyncEffect::SyncDocument { topic, peers } => {
+                NetEvent::DocumentSync(document_sync.sync_document_event(topic, peers).await)
             }
-            aruna_core::DocumentSyncEffect::SyncDocuments { targets, peers } => {
-                NetEvent::DocumentSync(document_sync.sync_documents_event(targets, peers).await)
+            aruna_core::DocumentSyncEffect::SyncDocuments { topics, peers } => {
+                NetEvent::DocumentSync(document_sync.sync_documents_event(topics, peers).await)
             }
         },
         NetEffect::Stream(stream_effect) => handle_stream_effect(stream_effect).await,

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -125,7 +125,7 @@ pub struct DocumentSyncService {
     // receiver once via `take_eviction_receiver` and re-emits the payloads.
     eviction_tx: tokio::sync::mpsc::UnboundedSender<TopicEviction>,
     eviction_rx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<TopicEviction>>>>,
-    // Realm this service serves; bucket-classed targets carry no realm id of
+    // Realm this service serves; shard-classed targets carry no realm id of
     // their own, so their topic derivation reads it from here.
     realm_id: RealmId,
 }
@@ -685,7 +685,7 @@ impl DocumentSyncService {
                 Ok(true) => topic_ids_out.push(topic_id),
                 Ok(false) => {
                     // Join-only: an unknown topic whose genesis is nowhere to be
-                    // found yet (e.g. an empty bucket whose rank-0 holder has not
+                    // found yet (e.g. an empty shard whose rank-0 holder has not
                     // created it) is skipped, not fatal — it arrives via gossip
                     // or a later anti-entropy pass.
                     match self.bootstrap_topic_from_peers(topic_id, &sync_peers).await {
@@ -822,11 +822,11 @@ impl DocumentSyncService {
             };
             let target = event.target().clone();
             let topic_id = target.sync_topic_id(self.realm_id, &event.placement());
-            // Bucket topics are join-only here: only the bucket's rank-0 holder
+            // Shard topics are join-only here: only the shard's rank-0 holder
             // creates the genesis (eagerly, via the placement reconciler), so a
-            // publish onto a genesis-less bucket topic fails and the outbox
+            // publish onto a genesis-less shard topic fails and the outbox
             // drain defers the record instead.
-            let may_create_topic = !target.uses_bucket_topic();
+            let may_create_topic = !target.uses_shard_topic();
             let actor_id = irokle_crate::actor_id_for(topic_id, self.node.peer_id());
             let envelope = EventEnvelope::encode_event(&event)
                 .map_err(|error| NetError::Bootstrap(error.to_string()))?;
@@ -903,7 +903,7 @@ impl DocumentSyncService {
             .is_none();
         if topic_missing && !may_create_topic {
             return Err(NetError::Bootstrap(format!(
-                "bucket topic {topic_id} has no genesis yet; only its rank-0 holder creates it"
+                "shard topic {topic_id} has no genesis yet; only its rank-0 holder creates it"
             )));
         }
         if topic_missing {
@@ -1064,7 +1064,7 @@ impl DocumentSyncService {
     }
 
     /// Whether the topic's genesis is known locally. The outbox drain uses this
-    /// to defer bucket-topic records until the rank-0 holder's genesis arrives.
+    /// to defer shard-topic records until the rank-0 holder's genesis arrives.
     pub fn topic_exists(&self, topic_id: irokle_crate::TopicId) -> Result<bool> {
         self.has_topic(topic_id)
     }
@@ -5505,7 +5505,7 @@ mod tests {
         PlacementRef {
             strategy_id: Ulid::from_parts(99, 7),
             epoch: 0,
-            bucket: 11,
+            shard: 11,
         }
     }
 
@@ -6239,7 +6239,7 @@ mod tests {
             replica_count: Some(3),
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         };
         let binding = StrategyBinding {
             scope: BindingScope::Class(DocumentClass::MetadataRegistry),
@@ -8724,11 +8724,11 @@ mod tests {
         runtime.block_on(async {
             let service = open_restart_service(&root, "child-storage").await;
             let target = restart_target();
-            // Bucket topics are join-only at publish time; this node plays the
-            // bucket's rank-0 holder and creates the genesis eagerly first.
+            // Shard topics are join-only at publish time; this node plays the
+            // shard's rank-0 holder and creates the genesis eagerly first.
             service
                 .ensure_document_sync_topics(&[restart_topic()], Vec::new())
-                .expect("restart bucket topic genesis");
+                .expect("restart shard topic genesis");
             let event = service
                 .publish_documents(
                     vec![DocumentSyncPublish::Upsert {

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -6180,6 +6180,7 @@ mod tests {
             replica_count: Some(3),
             distinct_locations: false,
             affinity: Vec::new(),
+            bucket_count: 64,
         };
         let binding = StrategyBinding {
             scope: BindingScope::Class(DocumentClass::MetadataRegistry),

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -31,7 +31,7 @@ use aruna_core::keyspaces::{
     ADMIN_DOCUMENT_STATE_KEYSPACE, DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
     DOCUMENT_SYNC_REVISION_KEYSPACE, GROUP_KEYSPACE, GROUP_OWNER_INDEX_KEYSPACE,
     METADATA_DOCUMENT_LIFECYCLE_KEYSPACE, NOTIFICATION_WATCH_INTEREST_KEYSPACE,
-    USER_SUBJECT_CLAIMS_KEYSPACE, USER_SUBJECT_INDEX_KEYSPACE,
+    REALM_CONFIG_KEYSPACE, USER_SUBJECT_CLAIMS_KEYSPACE, USER_SUBJECT_INDEX_KEYSPACE,
 };
 use aruna_core::metadata::{
     MetadataCreateEventRecord, MetadataDocumentDeleteRecord, MetadataDocumentLifecycleRecord,
@@ -99,6 +99,10 @@ struct PendingMetadataCreateApply {
     record: MetadataCreateEventRecord,
     bytes: Vec<u8>,
     lifecycle_revision: Option<DocumentSyncChange>,
+}
+
+struct MetadataPlacementFence {
+    config_write: Option<(String, ByteView, Value)>,
 }
 
 #[derive(Default)]
@@ -2514,16 +2518,12 @@ impl DocumentSyncService {
         if pending.is_empty() && cursor_writes.is_empty() {
             return Ok(());
         }
-        let mut writes = Vec::with_capacity(pending.len() + cursor_writes.len());
-        let mut accepted = Vec::with_capacity(pending.len());
+        let mut candidates = Vec::with_capacity(pending.len());
         for apply in pending {
             if self.metadata_create_fenced(&apply.record).await? {
                 continue;
             }
-            let target = DocumentSyncTarget::MetadataCreateEvent {
-                document_id: apply.record.record.document_id,
-                event_id: apply.record.event_id,
-            };
+            let mut entries = Vec::new();
             if let Some(revision) = &apply.lifecycle_revision {
                 if incoming_metadata_document_lifecycle_stale_or_equal(
                     &self.storage,
@@ -2534,26 +2534,73 @@ impl DocumentSyncService {
                 {
                     continue;
                 }
-                writes.push(
+                entries.push(
                     document_sync_revision_write_entry(&apply.target, revision)
                         .map_err(|error| NetError::Bootstrap(error.to_string()))?,
                 );
                 if let Some(manifest) = shard_manifest_write_entry(&apply.target, revision)
                     .map_err(|error| NetError::Bootstrap(error.to_string()))?
                 {
-                    writes.push(manifest);
+                    entries.push(manifest);
                 }
             }
-            writes.push((
-                target.storage_keyspace().to_string(),
-                target.storage_key(),
-                ByteView::from(apply.bytes.clone()),
-            ));
+            let mut event_entries =
+                metadata_create_event_and_pending_projection_write_entries(&apply.record)
+                    .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+            if let Some((_, _, value)) = event_entries.first_mut() {
+                *value = ByteView::from(apply.bytes.clone());
+            }
+            entries.extend(event_entries);
+            candidates.push((apply, entries));
+        }
+
+        let txn_id = start_storage_transaction(&self.storage).await?;
+        let mut writes = Vec::with_capacity(candidates.len() * 3 + cursor_writes.len());
+        let mut config_writes = BTreeMap::new();
+        let mut accepted = Vec::with_capacity(candidates.len());
+        for (apply, entries) in candidates {
+            let fence = match metadata_placement_fence_in_transaction(
+                &self.storage,
+                &apply.record.record,
+                txn_id,
+            )
+            .await
+            {
+                Ok(Some(fence)) => fence,
+                Ok(None) => {
+                    warn!(
+                        realm_id = %apply.record.record.realm_id,
+                        document_id = %apply.record.record.document_id,
+                        strategy_id = %apply.record.record.placement.strategy_id,
+                        "Rejecting replicated metadata create whose placement strategy is unavailable"
+                    );
+                    continue;
+                }
+                Err(error) => {
+                    let _ = self
+                        .storage
+                        .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                        .await;
+                    return Err(error);
+                }
+            };
+            if let Some(config_write) = fence.config_write {
+                config_writes.insert(apply.record.record.realm_id, config_write);
+            }
+            writes.extend(entries);
             accepted.push(apply);
         }
+        writes.extend(config_writes.into_values());
         writes.extend(cursor_writes);
-        if !writes.is_empty() {
-            self.storage_batch_write(writes).await?;
+        if let Err(error) =
+            storage_batch_delete_and_write_in_transaction(&self.storage, txn_id, Vec::new(), writes)
+                .await
+        {
+            let _ = self
+                .storage
+                .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                .await;
+            return Err(error);
         }
         for apply in accepted {
             applied_targets.push(apply.target);
@@ -3129,32 +3176,102 @@ async fn apply_metadata_registry_upsert_to_storage(
         .await;
     }
 
+    let mut base_entries = metadata_registry_write_entries(&record)
+        .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+    if let Some((_, _, value)) = base_entries.first_mut() {
+        *value = primary_bytes.into();
+    }
     let target = DocumentSyncTarget::MetadataRegistry {
         group_id: record.group_id,
         document_id: record.document_id,
     };
-    let existing = storage_read_from(
-        storage,
-        target.storage_keyspace().to_string(),
-        target.storage_key(),
-    )
-    .await?
-    .map(|bytes| postcard::from_bytes::<MetadataRegistryRecord>(&bytes))
-    .transpose()
-    .map_err(|error| NetError::Bootstrap(error.to_string()))?;
-    if existing
-        .as_ref()
-        .is_some_and(|existing| incoming_metadata_registry_stale_or_equal(existing, &record))
-    {
-        return Ok(());
-    }
+    for _ in 0..2 {
+        let txn_id = start_storage_transaction(storage).await?;
+        let fence = match metadata_placement_fence_in_transaction(storage, &record, txn_id).await {
+            Ok(Some(fence)) => fence,
+            Ok(None) => {
+                warn!(
+                    realm_id = %record.realm_id,
+                    document_id = %record.document_id,
+                    strategy_id = %record.placement.strategy_id,
+                    "Rejecting metadata registry record whose placement strategy is unavailable"
+                );
+                let _ = storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Ok(());
+            }
+            Err(error) => {
+                let _ = storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Err(error);
+            }
+        };
+        let existing_value = match storage_read_from_transaction(
+            storage,
+            target.storage_keyspace().to_string(),
+            target.storage_key(),
+            Some(txn_id),
+        )
+        .await
+        {
+            Ok(value) => value,
+            Err(error) => {
+                let _ = storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Err(error);
+            }
+        };
+        let existing = match existing_value
+            .map(|bytes| postcard::from_bytes::<MetadataRegistryRecord>(&bytes))
+            .transpose()
+        {
+            Ok(existing) => existing,
+            Err(error) => {
+                let _ = storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Err(NetError::Bootstrap(error.to_string()));
+            }
+        };
+        if existing
+            .as_ref()
+            .is_some_and(|existing| incoming_metadata_registry_stale_or_equal(existing, &record))
+        {
+            let _ = storage
+                .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                .await;
+            return Ok(());
+        }
 
-    let mut entries = metadata_registry_write_entries(&record)
-        .map_err(|error| NetError::Bootstrap(error.to_string()))?;
-    if let Some((_, _, value)) = entries.first_mut() {
-        *value = primary_bytes.into();
+        let mut entries = base_entries.clone();
+        if let Some(config_write) = fence.config_write {
+            entries.push(config_write);
+        }
+        match storage_batch_delete_and_write_in_transaction(storage, txn_id, Vec::new(), entries)
+            .await
+        {
+            Ok(()) => return Ok(()),
+            Err(NetError::Dht(message))
+                if message == StorageError::TransactionConflict.to_string() =>
+            {
+                let _ = storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+            }
+            Err(error) => {
+                let _ = storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Err(error);
+            }
+        }
     }
-    storage_batch_write_to(storage, entries).await
+    Err(NetError::Dht(
+        "metadata registry admission conflicted twice".to_string(),
+    ))
 }
 
 async fn apply_metadata_graph_lifecycle_to_storage(
@@ -4224,6 +4341,45 @@ async fn metadata_create_fenced_in_storage(
         return Ok(event.event_id <= delete.deleted_after_event_id);
     }
     metadata_graph_deleted_in_storage(storage, &event.record.graph_iri).await
+}
+
+async fn metadata_placement_fence_in_transaction(
+    storage: &StorageHandle,
+    record: &MetadataRegistryRecord,
+    txn_id: TxnId,
+) -> Result<Option<MetadataPlacementFence>> {
+    let target = DocumentSyncTarget::RealmConfig {
+        realm_id: record.realm_id,
+    };
+    let value = storage_read_from_transaction(
+        storage,
+        REALM_CONFIG_KEYSPACE.to_string(),
+        target.storage_key(),
+        Some(txn_id),
+    )
+    .await?;
+    let Some(value) = value else {
+        return if record.placement == PlacementRef::NIL {
+            Ok(Some(MetadataPlacementFence { config_write: None }))
+        } else {
+            Ok(None)
+        };
+    };
+    let config = RealmConfigDocument::from_bytes(&value)
+        .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+    if config.realm_id != record.realm_id
+        || (record.placement != PlacementRef::NIL
+            && config.strategy(&record.placement.strategy_id).is_none())
+    {
+        return Ok(None);
+    }
+    Ok(Some(MetadataPlacementFence {
+        config_write: Some((
+            REALM_CONFIG_KEYSPACE.to_string(),
+            target.storage_key(),
+            value,
+        )),
+    }))
 }
 
 async fn storage_read_from(
@@ -9300,6 +9456,65 @@ mod tests {
         assert_eq!(primary, local);
         assert_eq!(document_index, local);
         assert_eq!(holders, local.holder_node_ids);
+    }
+
+    #[tokio::test]
+    async fn registry_strategy_fenced() {
+        let (_dir, storage) = test_storage();
+        let group_id = Ulid::from_parts(2_100, 1);
+        let document_id = Ulid::from_parts(2_101, 1);
+        let mut record = registry_record(
+            group_id,
+            document_id,
+            "datasets/missing-strategy",
+            100,
+            Ulid::from_parts(2_102, 1),
+        );
+        record.placement = PlacementRef {
+            strategy_id: Ulid::from_parts(2_103, 1),
+            epoch: 0,
+            shard: 1,
+        };
+        let mut config = RealmConfigDocument::default_for_realm(record.realm_id, Vec::new());
+        config.seed_default_placement();
+        let config_target = DocumentSyncTarget::RealmConfig {
+            realm_id: record.realm_id,
+        };
+        storage_batch_write_to(
+            &storage,
+            vec![(
+                config_target.storage_keyspace().to_string(),
+                config_target.storage_key(),
+                config
+                    .to_bytes(&test_actor(
+                        1,
+                        UserId::nil(record.realm_id),
+                        record.realm_id,
+                    ))
+                    .expect("realm config serializes")
+                    .into(),
+            )],
+        )
+        .await
+        .expect("realm config writes");
+
+        apply_metadata_registry_upsert_to_storage(
+            &storage,
+            record.clone(),
+            postcard::to_allocvec(&record).expect("registry serializes"),
+        )
+        .await
+        .expect("invalid strategy is rejected without wedging reconciliation");
+
+        assert!(
+            read_storage_value(
+                &storage,
+                METADATA_INDEX_KEYSPACE,
+                metadata_registry_key(group_id, document_id),
+            )
+            .await
+            .is_none()
+        );
     }
 
     #[tokio::test]

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -10754,6 +10754,13 @@ mod tests {
         let group_id = Ulid::from_parts(1_631, 1);
         let group_target = DocumentSyncTarget::GroupAuthorization { group_id };
         let group_placement = admin_test_placement();
+        // Shard topics are join-only at publish; create the genesis eagerly.
+        service
+            .ensure_document_sync_topics(
+                &[group_target.sync_topic_id(realm_id, &group_placement)],
+                Vec::new(),
+            )
+            .expect("group shard topic genesis");
         let group_role_id = Ulid::from_parts(1_632, 1);
         let mut group_role = test_admin_event(
             Ulid::from_parts(1_633, 1),

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -109,6 +109,19 @@ struct PublishEventsOutcome {
     retry_error: Option<String>,
 }
 
+/// Outcome of probing a shard's co-holders for an existing genesis before a
+/// rank-0 holder considers creating a fresh one. A genesis may be created only
+/// when every co-holder was reached (`unreachable` empty) and none advertised
+/// the topic (`known_by_co_holder` does not contain it); an unreachable
+/// co-holder might hold a genesis, so creation must be withheld to avoid a fork.
+#[derive(Clone, Debug, Default)]
+pub struct ShardGenesisProbe {
+    /// Probed topics at least one reached co-holder already has a genesis for.
+    pub known_by_co_holder: BTreeSet<irokle_crate::TopicId>,
+    /// Co-holders that could not be reached (empty ⇒ every co-holder answered).
+    pub unreachable: Vec<NodeId>,
+}
+
 #[derive(Clone)]
 pub struct DocumentSyncService {
     node: irokle_crate::Irokle<irokle_crate::FjallStorage>,
@@ -1394,6 +1407,65 @@ impl DocumentSyncService {
                 "no peers available to bootstrap document sync topic {topic_id}"
             ))
         }))
+    }
+
+    /// Probes each co-holder for an existing genesis of `topics` without
+    /// adopting anything: a rank-0 holder uses this to decide whether creating a
+    /// fresh genesis is safe (see [`ShardGenesisProbe`]). A co-holder that could
+    /// not be reached is recorded so the caller withholds creation for it.
+    pub async fn probe_shard_topic_geneses(
+        &self,
+        topics: Vec<irokle_crate::TopicId>,
+        co_holders: Vec<NodeId>,
+    ) -> ShardGenesisProbe {
+        let mut probe = ShardGenesisProbe::default();
+        if topics.is_empty() {
+            return probe;
+        }
+        // Callers pass co-holders with the local node already excluded.
+        for node_id in &co_holders {
+            let peer = node_id_to_peer_id(node_id);
+            match self.probe_topics_on_peer(&topics, peer).await {
+                Ok(advertised) => probe.known_by_co_holder.extend(advertised),
+                Err(error) => {
+                    debug!(%node_id, error = %error, "co-holder unreachable while probing shard genesis");
+                    probe.unreachable.push(*node_id);
+                }
+            }
+        }
+        probe
+    }
+
+    async fn probe_topics_on_peer(
+        &self,
+        topics: &[irokle_crate::TopicId],
+        peer: PeerId,
+    ) -> Result<BTreeSet<irokle_crate::TopicId>> {
+        let peer_addr = peer_id_to_endpoint_addr(peer)?;
+        let wanted: BTreeSet<irokle_crate::TopicId> = topics.iter().copied().collect();
+        let mut advertised = BTreeSet::new();
+        for chunk in topics.chunks(DOCUMENT_SYNC_BATCH_SYNC_TOPIC_LIMIT) {
+            let opens: Vec<SyncMessage> = chunk
+                .iter()
+                .map(|topic| SyncMessage::Open(self.node.sync_open(*topic)))
+                .collect();
+            let responses = timeout(
+                DOCUMENT_SYNC_PEER_SYNC_TIMEOUT,
+                self.net.sync_with(peer_addr.clone(), &opens),
+            )
+            .await
+            .map_err(|_| NetError::Timeout(DOCUMENT_SYNC_PEER_SYNC_TIMEOUT))?
+            .map_err(NetError::from)?;
+            for response in responses {
+                if let SyncMessage::Summary(summary) = response
+                    && wanted.contains(&summary.topic_id)
+                    && !remote_summary_is_empty(&summary)
+                {
+                    advertised.insert(summary.topic_id);
+                }
+            }
+        }
+        Ok(advertised)
     }
 
     async fn bootstrap_topic_from_peer(

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -111,13 +111,19 @@ struct PublishEventsOutcome {
 
 /// Outcome of probing a shard's co-holders for an existing genesis before a
 /// rank-0 holder considers creating a fresh one. A genesis may be created only
-/// when every co-holder was reached (`unreachable` empty) and none advertised
-/// the topic (`known_by_co_holder` does not contain it); an unreachable
-/// co-holder might hold a genesis, so creation must be withheld to avoid a fork.
+/// when every co-holder was reached (`unreachable` empty), none advertised the
+/// topic (`known_by_co_holder`), and every reached co-holder positively
+/// confirmed it unknown (not in `unconfirmed`). An unreachable co-holder — or a
+/// reached one that refused the topic (holds it but the prober may not open it
+/// yet) — might hold a genesis, so creation must be withheld to avoid a fork.
 #[derive(Clone, Debug, Default)]
 pub struct ShardGenesisProbe {
     /// Probed topics at least one reached co-holder already has a genesis for.
     pub known_by_co_holder: BTreeSet<irokle_crate::TopicId>,
+    /// Probed topics a reached co-holder neither advertised nor positively
+    /// confirmed unknown: it holds the topic but the prober may not open it yet,
+    /// so a fresh genesis would fork. Possibly-existing ⇒ creation withheld.
+    pub unconfirmed: BTreeSet<irokle_crate::TopicId>,
     /// Co-holders that could not be reached (empty ⇒ every co-holder answered).
     pub unreachable: Vec<NodeId>,
 }
@@ -1422,11 +1428,27 @@ impl DocumentSyncService {
         if topics.is_empty() {
             return probe;
         }
+        let wanted: BTreeSet<irokle_crate::TopicId> = topics.iter().copied().collect();
         // Callers pass co-holders with the local node already excluded.
         for node_id in &co_holders {
             let peer = node_id_to_peer_id(node_id);
             match self.probe_topics_on_peer(&topics, peer).await {
-                Ok(advertised) => probe.known_by_co_holder.extend(advertised),
+                Ok(peer_probe) => {
+                    probe
+                        .known_by_co_holder
+                        .extend(peer_probe.known.iter().copied());
+                    // A reached co-holder that neither advertised a topic nor
+                    // positively confirmed it unknown refused it: it holds the
+                    // genesis but the prober may not open it yet. Withhold, never
+                    // treat as topic-unknown — a fresh genesis would fork.
+                    for topic in &wanted {
+                        if !peer_probe.known.contains(topic)
+                            && !peer_probe.confirmed_unknown.contains(topic)
+                        {
+                            probe.unconfirmed.insert(*topic);
+                        }
+                    }
+                }
                 Err(error) => {
                     debug!(%node_id, error = %error, "co-holder unreachable while probing shard genesis");
                     probe.unreachable.push(*node_id);
@@ -1440,10 +1462,10 @@ impl DocumentSyncService {
         &self,
         topics: &[irokle_crate::TopicId],
         peer: PeerId,
-    ) -> Result<BTreeSet<irokle_crate::TopicId>> {
+    ) -> Result<PeerTopicProbe> {
         let peer_addr = peer_id_to_endpoint_addr(peer)?;
         let wanted: BTreeSet<irokle_crate::TopicId> = topics.iter().copied().collect();
-        let mut advertised = BTreeSet::new();
+        let mut probe = PeerTopicProbe::default();
         for chunk in topics.chunks(DOCUMENT_SYNC_BATCH_SYNC_TOPIC_LIMIT) {
             let opens: Vec<SyncMessage> = chunk
                 .iter()
@@ -1456,16 +1478,9 @@ impl DocumentSyncService {
             .await
             .map_err(|_| NetError::Timeout(DOCUMENT_SYNC_PEER_SYNC_TIMEOUT))?
             .map_err(NetError::from)?;
-            for response in responses {
-                if let SyncMessage::Summary(summary) = response
-                    && wanted.contains(&summary.topic_id)
-                    && !remote_summary_is_empty(&summary)
-                {
-                    advertised.insert(summary.topic_id);
-                }
-            }
+            probe.merge(classify_probe_responses(&wanted, responses));
         }
-        Ok(advertised)
+        Ok(probe)
     }
 
     async fn bootstrap_topic_from_peer(
@@ -5499,6 +5514,46 @@ fn remote_summary_is_empty(summary: &irokle_crate::sync::SyncSummary) -> bool {
     summary.event_type_id.is_none() && summary.heads.is_empty()
 }
 
+/// Per-peer outcome of probing shard topics: which topics the peer holds a
+/// genesis for (`known`) and which it positively confirmed it has none of
+/// (`confirmed_unknown`). A probed topic in neither was refused — the peer holds
+/// it but the prober may not open it yet, so it must not be treated as unknown.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct PeerTopicProbe {
+    known: BTreeSet<irokle_crate::TopicId>,
+    confirmed_unknown: BTreeSet<irokle_crate::TopicId>,
+}
+
+impl PeerTopicProbe {
+    fn merge(&mut self, other: PeerTopicProbe) {
+        self.known.extend(other.known);
+        self.confirmed_unknown.extend(other.confirmed_unknown);
+    }
+}
+
+/// Buckets a peer's Open responses for the `wanted` topics: a non-empty summary
+/// ⇒ the peer holds a genesis; an empty summary (untyped, headless) ⇒ positive
+/// confirmation the peer has none; a topic with no summary is left out of both,
+/// meaning the peer refused it (holds it but the prober may not open it yet).
+fn classify_probe_responses(
+    wanted: &BTreeSet<irokle_crate::TopicId>,
+    responses: Vec<SyncMessage>,
+) -> PeerTopicProbe {
+    let mut probe = PeerTopicProbe::default();
+    for response in responses {
+        if let SyncMessage::Summary(summary) = response
+            && wanted.contains(&summary.topic_id)
+        {
+            if remote_summary_is_empty(&summary) {
+                probe.confirmed_unknown.insert(summary.topic_id);
+            } else {
+                probe.known.insert(summary.topic_id);
+            }
+        }
+    }
+    probe
+}
+
 fn peer_id_to_endpoint_addr(peer_id: PeerId) -> Result<iroh::EndpointAddr> {
     let endpoint_id = iroh::EndpointId::from_bytes(peer_id.as_bytes())
         .map_err(|error| NetError::Bootstrap(error.to_string()))?;
@@ -8784,14 +8839,57 @@ mod tests {
         event_type_id: Option<String>,
         heads: BTreeSet<irokle_crate::OpId>,
     ) -> irokle_crate::sync::SyncSummary {
+        summary_for(topic(9), event_type_id, heads)
+    }
+
+    fn summary_for(
+        topic_id: irokle_crate::TopicId,
+        event_type_id: Option<String>,
+        heads: BTreeSet<irokle_crate::OpId>,
+    ) -> irokle_crate::sync::SyncSummary {
         irokle_crate::sync::SyncSummary {
-            topic_id: topic(9),
+            topic_id,
             event_type_id,
             fingerprint: [0; 32],
             heads,
             actor_clock: irokle_crate::ActorClock::default(),
             actor_tips: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn classify_probe_buckets_empty_summary_as_confirmed_unknown() {
+        let wanted = BTreeSet::from([topic(1), topic(2), topic(3)]);
+        let responses = vec![
+            // Empty summary: positive confirmation the peer has no genesis.
+            SyncMessage::Summary(summary_for(topic(1), None, BTreeSet::new())),
+            // Typed summary: the peer holds a genesis.
+            SyncMessage::Summary(summary_for(
+                topic(2),
+                Some(DocumentSyncEvent::TYPE_ID.to_string()),
+                BTreeSet::new(),
+            )),
+            // topic(3) omitted entirely: refused (held, prober not a member).
+        ];
+        let probe = classify_probe_responses(&wanted, responses);
+        assert_eq!(probe.confirmed_unknown, BTreeSet::from([topic(1)]));
+        assert_eq!(probe.known, BTreeSet::from([topic(2)]));
+        assert!(!probe.confirmed_unknown.contains(&topic(3)));
+        assert!(!probe.known.contains(&topic(3)));
+    }
+
+    #[test]
+    fn classify_probe_ignores_summaries_for_unwanted_topics() {
+        let wanted = BTreeSet::from([topic(1)]);
+        let responses = vec![SyncMessage::Summary(summary_for(
+            topic(5),
+            None,
+            BTreeSet::new(),
+        ))];
+        assert_eq!(
+            classify_probe_responses(&wanted, responses),
+            PeerTopicProbe::default()
+        );
     }
 
     #[test]

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -92,6 +92,9 @@ const DOCUMENT_SYNC_INBOUND_SYNC_STREAM_BYTES: usize = 256 * 1024 * 1024;
 const DOCUMENT_SYNC_FRAME_LEN_LIMIT: usize = 16 * 1024 * 1024;
 const MAX_DEFERRED_TOPICS: usize = 1_024;
 const MAX_DEFERRED_TOPICS_PER_DEPENDENCY: usize = 256;
+/// Bounds concurrent co-holder genesis probes so a large holder set cannot open
+/// an unbounded number of simultaneous sync streams.
+const SHARD_GENESIS_PROBE_CONCURRENCY: usize = 8;
 
 #[derive(Debug)]
 struct PendingMetadataCreateApply {
@@ -1603,6 +1606,8 @@ impl DocumentSyncService {
         topics: Vec<irokle_crate::TopicId>,
         co_holders: Vec<NodeId>,
     ) -> ShardGenesisProbe {
+        use futures::StreamExt as _;
+
         let mut probe = ShardGenesisProbe::default();
         if topics.is_empty() {
             return probe;
@@ -1610,13 +1615,15 @@ impl DocumentSyncService {
         let wanted: BTreeSet<irokle_crate::TopicId> = topics.iter().copied().collect();
         // Callers pass co-holders with the local node already excluded.
         let topic_ids = &topics;
-        let probes = co_holders.iter().copied().map(|node_id| async move {
+        let probes = futures::stream::iter(co_holders.iter().copied().map(|node_id| async move {
             let peer = node_id_to_peer_id(&node_id);
             (node_id, self.probe_topics_on_peer(topic_ids, peer).await)
-        });
-        // Poll every independent peer probe together, then aggregate in the
-        // co-holder input order preserved by join_all.
-        for (node_id, result) in futures::future::join_all(probes).await {
+        }))
+        .buffer_unordered(SHARD_GENESIS_PROBE_CONCURRENCY);
+        // Poll a bounded number of peer probes together; aggregation is order
+        // independent (set unions plus an unreachable list).
+        let probe_results: Vec<_> = probes.collect().await;
+        for (node_id, result) in probe_results {
             match result {
                 Ok(peer_probe) => {
                     probe

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -109,6 +109,24 @@ struct PublishEventsOutcome {
     retry_error: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+struct ShardPublisherPolicy {
+    current: BTreeSet<irokle_crate::ActorId>,
+    // Existing history remains applicable across holder replacement. Once a
+    // topic is local, only former-holder ops above this cutover clock are stale.
+    history_cutoff: Option<irokle_crate::ActorClock>,
+}
+
+impl ShardPublisherPolicy {
+    fn allows(&self, actor_id: &irokle_crate::ActorId, actor_seq: u64) -> bool {
+        self.current.contains(actor_id)
+            || self
+                .history_cutoff
+                .as_ref()
+                .is_none_or(|cutoff| actor_seq <= cutoff.get(actor_id))
+    }
+}
+
 /// Outcome of probing a shard's co-holders for an existing genesis before a
 /// rank-0 holder considers creating a fresh one. A genesis may be created only
 /// when every co-holder was reached (`unreachable` empty), none advertised the
@@ -136,6 +154,7 @@ pub struct DocumentSyncService {
     persist_policy: FjallPersistPolicy,
     storage: StorageHandle,
     default_peers: Arc<RwLock<BTreeSet<PeerId>>>,
+    shard_publishers: Arc<RwLock<BTreeMap<irokle_crate::TopicId, ShardPublisherPolicy>>>,
     storage_path: PathBuf,
     reconcile_lock: Arc<tokio::sync::Mutex<()>>,
     // Genesis tie-break evictions from every admission path (irokle's own
@@ -226,6 +245,7 @@ impl DocumentSyncService {
             persist_policy,
             storage,
             default_peers: Arc::new(RwLock::new(default_peers)),
+            shard_publishers: Arc::new(RwLock::new(BTreeMap::new())),
             storage_path,
             reconcile_lock: Arc::new(tokio::sync::Mutex::new(())),
             eviction_tx,
@@ -484,6 +504,144 @@ impl DocumentSyncService {
                         topic_id,
                         actor_id,
                         TopicControl::AddPeer { peer },
+                        self.node.signer(),
+                    )
+                    .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+            }
+            self.net.schedule_topic_recheck(topic_id)?;
+        }
+
+        self.flush_database()
+    }
+
+    /// Reconciles shard-only topic membership to the authoritative current
+    /// holder set. The publisher cutover is installed before controls are
+    /// emitted, so later events from a removed holder cannot apply while
+    /// pre-cutover replacement history remains usable. Shared topics and the
+    /// default peer set are intentionally untouched.
+    pub async fn reconcile_shard_membership(
+        &self,
+        topics: &[irokle_crate::TopicId],
+        holders: Vec<NodeId>,
+    ) -> Result<()> {
+        if topics.is_empty() {
+            return Ok(());
+        }
+
+        let _reconcile_guard = self.reconcile_lock.lock().await;
+        let holder_peers: BTreeSet<PeerId> = holders
+            .into_iter()
+            .map(|node_id| node_id_to_peer_id(&node_id))
+            .collect();
+        let local_peer = self.node.peer_id();
+        if !holder_peers.contains(&local_peer) {
+            return Err(NetError::Bootstrap(
+                "local node is not an authoritative shard holder".to_string(),
+            ));
+        }
+
+        let mut seen_topics = BTreeSet::new();
+        let topics: Vec<irokle_crate::TopicId> = topics
+            .iter()
+            .copied()
+            .filter(|topic_id| seen_topics.insert(*topic_id))
+            .collect();
+        let mut states = Vec::with_capacity(topics.len());
+        let mut policies = Vec::with_capacity(topics.len());
+        let mut missing_topic = None;
+        for topic_id in topics {
+            let state = self
+                .node
+                .storage()
+                .topic_state(&topic_id)
+                .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+            let current = holder_peers
+                .iter()
+                .copied()
+                .map(|peer| irokle_crate::actor_id_for(topic_id, peer))
+                .collect();
+            match state {
+                Some(state) => {
+                    if state.event_type_id != DocumentSyncEvent::TYPE_ID {
+                        return Err(NetError::Bootstrap(format!(
+                            "Document sync topic {topic_id} has event type {}, expected {}",
+                            state.event_type_id,
+                            DocumentSyncEvent::TYPE_ID
+                        )));
+                    }
+                    let history_cutoff = self
+                        .node
+                        .storage()
+                        .actor_clock(&topic_id)
+                        .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+                    policies.push((
+                        topic_id,
+                        ShardPublisherPolicy {
+                            current,
+                            history_cutoff: Some(history_cutoff),
+                        },
+                    ));
+                    states.push((topic_id, state));
+                }
+                None => {
+                    missing_topic.get_or_insert(topic_id);
+                    policies.push((
+                        topic_id,
+                        ShardPublisherPolicy {
+                            current,
+                            history_cutoff: None,
+                        },
+                    ));
+                }
+            }
+        }
+        self.shard_publishers.write().extend(policies);
+        let sync_peers: BTreeSet<PeerId> = holder_peers
+            .iter()
+            .copied()
+            .filter(|peer| *peer != local_peer)
+            .collect();
+        self.allow_sync_peers(&sync_peers)?;
+        if let Some(topic_id) = missing_topic {
+            return Err(NetError::Bootstrap(format!(
+                "document sync topic {topic_id} is missing"
+            )));
+        }
+
+        let oplog = Oplog::with_storage(self.node.storage().clone());
+        for (topic_id, state) in states {
+            let missing_peers = holder_peers
+                .iter()
+                .copied()
+                .filter(|peer| *peer != local_peer && !state.members.contains(peer))
+                .collect::<Vec<_>>();
+            let stale_peers = state
+                .members
+                .iter()
+                .copied()
+                .filter(|peer| !holder_peers.contains(peer))
+                .collect::<Vec<_>>();
+            if missing_peers.is_empty() && stale_peers.is_empty() {
+                continue;
+            }
+
+            let actor_id = irokle_crate::actor_id_for(topic_id, local_peer);
+            for peer in missing_peers {
+                oplog
+                    .create_control_op(
+                        topic_id,
+                        actor_id,
+                        TopicControl::AddPeer { peer },
+                        self.node.signer(),
+                    )
+                    .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+            }
+            for peer in stale_peers {
+                oplog
+                    .create_control_op(
+                        topic_id,
+                        actor_id,
+                        TopicControl::RemovePeer { peer },
                         self.node.signer(),
                     )
                     .map_err(|error| NetError::Bootstrap(error.to_string()))?;
@@ -1706,7 +1864,20 @@ impl DocumentSyncService {
             let mut deferred_creates = false;
             let mut deferred_admin_events = Vec::new();
             let mut satisfied_admin_dependencies = BTreeSet::new();
-            for (event, actor_id) in events {
+            for (event, actor_id, actor_seq) in events {
+                if self
+                    .shard_publishers
+                    .read()
+                    .get(&topic_id)
+                    .is_some_and(|policy| !policy.allows(&actor_id, actor_seq))
+                {
+                    warn!(
+                        %topic_id,
+                        %actor_id,
+                        "Rejecting shard event from a publisher outside the current holder set"
+                    );
+                    continue;
+                }
                 let target_topic_id = event
                     .target()
                     .sync_topic_id(self.realm_id, &event.placement());
@@ -2245,21 +2416,22 @@ impl DocumentSyncService {
 
     /// Returns the decoded document events above the applied cursor, reading
     /// only the unapplied portion of the topic history where possible. Each
-    /// event is paired with the authenticated `actor_id` of the op that carried
-    /// it: irokle admits an op only after verifying its signature against
-    /// `body.author` and enforcing `actor_id == actor_id_for(topic, author)`, so
-    /// the returned actor id is a trustworthy proxy for the signed publisher.
+    /// event is paired with the authenticated actor id and sequence of the op
+    /// that carried it: irokle admits an op only after verifying its signature
+    /// against `body.author` and enforcing
+    /// `actor_id == actor_id_for(topic, author)`, so the returned actor id is a
+    /// trustworthy proxy for the signed publisher.
     fn document_events_after(
         &self,
         topic_id: irokle_crate::TopicId,
         cursor: &irokle_crate::ActorClock,
-    ) -> Result<Vec<(DocumentSyncEvent, irokle_crate::ActorId)>> {
+    ) -> Result<Vec<(DocumentSyncEvent, irokle_crate::ActorId, u64)>> {
         match self.node.open_topic::<DocumentSyncEvent>(topic_id) {
             Ok(topic) => Ok(topic
                 .history_after(cursor, HistoryOrder::OldestFirst)
                 .map_err(|error| NetError::Bootstrap(error.to_string()))?
                 .into_iter()
-                .map(|record| (record.event, record.meta.actor_id))
+                .map(|record| (record.event, record.meta.actor_id, record.meta.actor_seq))
                 .collect()),
             // Topics we hold ops for without being a listed member still
             // reconcile via the full history.
@@ -2277,6 +2449,7 @@ impl DocumentSyncService {
                         continue;
                     }
                     let actor_id = op.signed.body.actor_id;
+                    let actor_seq = op.signed.body.actor_seq;
                     let TopicPayload::Event(envelope) = op.signed.body.payload else {
                         continue;
                     };
@@ -2285,6 +2458,7 @@ impl DocumentSyncService {
                             .decode_event::<DocumentSyncEvent>()
                             .map_err(|error| NetError::Bootstrap(error.to_string()))?,
                         actor_id,
+                        actor_seq,
                     ));
                 }
                 Ok(events)
@@ -11631,5 +11805,218 @@ mod tests {
         );
 
         service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shard_membership_exact() {
+        let (_dir, storage) = test_storage();
+        let doc = tempfile::tempdir().expect("document sync dir");
+        let realm_id = restart_realm();
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(80).await,
+            storage,
+            doc.path().join("document-sync"),
+            &[node(81), node(82)],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+            realm_id,
+        )
+        .expect("document sync service opens");
+        let local_node = service.local_node_id().expect("local node id");
+        let current_node = node(81);
+        let stale_node = node(82);
+        let shard_topic = restart_topic();
+        let shared_topic = DocumentSyncTarget::RealmConfig { realm_id }
+            .sync_topic_id(realm_id, &PlacementRef::NIL);
+
+        service
+            .ensure_document_sync_topics(&[shard_topic], vec![current_node, stale_node])
+            .expect("shard topic exists");
+        service
+            .ensure_document_sync_topics(&[shared_topic], vec![stale_node])
+            .expect("shared topic exists");
+
+        service
+            .reconcile_shard_membership(&[shard_topic], vec![local_node, current_node])
+            .await
+            .expect("shard membership reconciles");
+
+        let shard_state = service
+            .node()
+            .storage()
+            .topic_state(&shard_topic)
+            .expect("shard state reads")
+            .expect("shard state exists");
+        assert!(
+            shard_state
+                .members
+                .contains(&node_id_to_peer_id(&local_node))
+        );
+        assert!(
+            shard_state
+                .members
+                .contains(&node_id_to_peer_id(&current_node))
+        );
+        assert!(
+            !shard_state
+                .members
+                .contains(&node_id_to_peer_id(&stale_node))
+        );
+
+        let shared_state = service
+            .node()
+            .storage()
+            .topic_state(&shared_topic)
+            .expect("shared state reads")
+            .expect("shared state exists");
+        assert!(
+            shared_state
+                .members
+                .contains(&node_id_to_peer_id(&stale_node)),
+            "exact shard reconciliation must not alter shared topics"
+        );
+        assert!(
+            service
+                .default_peers
+                .read()
+                .contains(&node_id_to_peer_id(&stale_node)),
+            "former shard holders remain available as default network peers"
+        );
+
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn stale_publisher_rejected() {
+        let (_receiver_dir, receiver_storage) = test_storage();
+        let (_publisher_dir, publisher_storage) = test_storage();
+        let receiver_doc = tempfile::tempdir().expect("receiver document sync dir");
+        let publisher_doc = tempfile::tempdir().expect("publisher document sync dir");
+        let realm_id = restart_realm();
+        let receiver = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(83).await,
+            receiver_storage.clone(),
+            receiver_doc.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+            realm_id,
+        )
+        .expect("receiver opens");
+        let publisher = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(84).await,
+            publisher_storage,
+            publisher_doc.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+            realm_id,
+        )
+        .expect("publisher opens");
+        let receiver_node = receiver.local_node_id().expect("receiver node id");
+        let publisher_node = publisher.local_node_id().expect("publisher node id");
+        let topic_id = restart_topic();
+
+        receiver
+            .ensure_document_sync_topics(&[topic_id], vec![publisher_node])
+            .expect("receiver creates shard topic");
+        let receiver_ops = irokle_crate::oplog::topological(receiver.node().storage(), &topic_id)
+            .expect("receiver history reads");
+        publisher
+            .node()
+            .receive_sync_data_from_evicting(
+                node_id_to_peer_id(&receiver_node),
+                SyncData {
+                    topic_id,
+                    ops: receiver_ops,
+                },
+            )
+            .expect("publisher adopts shard genesis");
+
+        let published = publisher
+            .publish_documents(
+                vec![DocumentSyncPublish::Upsert {
+                    event_id: restart_event_id(),
+                    target: restart_target(),
+                    bytes: restart_payload(),
+                    change: revision_change(),
+                    allow_genesis: false,
+                }],
+                vec![receiver_node],
+            )
+            .await;
+        assert!(matches!(
+            published,
+            DocumentSyncNetEvent::DocumentsPublished { .. }
+        ));
+        let publisher_ops = irokle_crate::oplog::topological(publisher.node().storage(), &topic_id)
+            .expect("publisher history reads");
+        receiver
+            .reconcile_shard_membership(&[topic_id], vec![receiver_node])
+            .await
+            .expect("former holder is removed");
+        receiver
+            .node()
+            .receive_sync_data_from_evicting(
+                node_id_to_peer_id(&publisher_node),
+                SyncData {
+                    topic_id,
+                    ops: publisher_ops,
+                },
+            )
+            .expect("receiver admits the publisher's pre-removal causal history");
+        let result = receiver
+            .reconcile_document_topics([topic_id])
+            .await
+            .expect("stale publisher event is skipped");
+        assert!(
+            result.targets.is_empty(),
+            "a former holder's shard event must not apply"
+        );
+        assert!(
+            read_storage_value(
+                &receiver_storage,
+                restart_target().storage_keyspace(),
+                restart_target().storage_key(),
+            )
+            .await
+            .is_none(),
+            "rejected event must not mutate document storage"
+        );
+
+        let cursor_bytes = read_storage_value(
+            &receiver_storage,
+            DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+            topic_cursor_key(topic_id),
+        )
+        .await
+        .expect("cursor persisted");
+        let cursor: irokle_crate::ActorClock =
+            postcard::from_bytes(&cursor_bytes).expect("cursor decodes");
+        let topic_clock = receiver
+            .node()
+            .storage()
+            .actor_clock(&topic_id)
+            .expect("topic clock reads");
+        assert!(
+            cursor.dominates(&topic_clock),
+            "rejected stale-holder event must not wedge reconciliation"
+        );
+        let retained_events =
+            irokle_crate::oplog::topological(receiver.node().storage(), &topic_id)
+                .expect("retained history reads")
+                .into_iter()
+                .filter(|op| matches!(&op.signed.body.payload, TopicPayload::Event(_)))
+                .count();
+        assert_eq!(
+            retained_events, 1,
+            "membership changes retain event history"
+        );
+
+        publisher.shutdown().await;
+        receiver.shutdown().await;
     }
 }

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -39,12 +39,12 @@ use aruna_core::metadata::{
 };
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
-    admin_document_reducer_state_write_entry, document_placement_delete_entry,
-    document_sync_revision_key, document_sync_revision_write_entry,
+    admin_document_reducer_state_write_entry, document_sync_revision_key,
+    document_sync_revision_write_entry,
     metadata_create_event_and_pending_projection_write_entries, metadata_document_lifecycle_key,
     metadata_document_lifecycle_write_entry, metadata_graph_lifecycle_key,
     metadata_graph_lifecycle_write_entry, metadata_graph_prune_job_write_entry,
-    metadata_registry_delete_entries, metadata_registry_write_entries,
+    metadata_registry_delete_entries, metadata_registry_write_entries, shard_manifest_write_entry,
     stale_admin_document_conflict_delete_entries, subject_index_key, subject_index_value,
 };
 use aruna_core::structs::{
@@ -2262,6 +2262,11 @@ impl DocumentSyncService {
                     document_sync_revision_write_entry(&apply.target, revision)
                         .map_err(|error| NetError::Bootstrap(error.to_string()))?,
                 );
+                if let Some(manifest) = shard_manifest_write_entry(&apply.target, revision)
+                    .map_err(|error| NetError::Bootstrap(error.to_string()))?
+                {
+                    writes.push(manifest);
+                }
             }
             writes.push((
                 target.storage_keyspace().to_string(),
@@ -2930,12 +2935,11 @@ async fn apply_metadata_registry_delete_to_storage(
     if metadata_document_delete_matches_registry(&delete, group_id, document_id)
         && !metadata_registry_live_after_delete(storage, group_id, document_id, &delete).await?
     {
-        let mut deletes = metadata_registry_delete_entries(group_id, document_id);
-        deletes.push(document_placement_delete_entry(
-            delete.tombstone.realm_id,
-            &DocumentSyncTarget::MetadataDocumentLifecycle { document_id },
-        ));
-        storage_batch_delete_to(storage, deletes).await?;
+        storage_batch_delete_to(
+            storage,
+            metadata_registry_delete_entries(group_id, document_id),
+        )
+        .await?;
     }
     Ok(())
 }
@@ -3857,6 +3861,11 @@ async fn metadata_document_lifecycle_write_entries_if_current(
         document_sync_revision_write_entry(&target, change)
             .map_err(|error| NetError::Bootstrap(error.to_string()))?,
     );
+    if let Some(manifest) = shard_manifest_write_entry(&target, &revision)
+        .map_err(|error| NetError::Bootstrap(error.to_string()))?
+    {
+        entries.push(manifest);
+    }
     Ok(Some(entries))
 }
 

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -125,6 +125,9 @@ pub struct DocumentSyncService {
     // receiver once via `take_eviction_receiver` and re-emits the payloads.
     eviction_tx: tokio::sync::mpsc::UnboundedSender<TopicEviction>,
     eviction_rx: Arc<Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<TopicEviction>>>>,
+    // Realm this service serves; bucket-classed targets carry no realm id of
+    // their own, so their topic derivation reads it from here.
+    realm_id: RealmId,
 }
 
 impl std::fmt::Debug for DocumentSyncService {
@@ -137,6 +140,7 @@ impl std::fmt::Debug for DocumentSyncService {
 }
 
 impl DocumentSyncService {
+    #[allow(clippy::too_many_arguments)]
     pub fn open(
         endpoint: iroh::Endpoint,
         storage: StorageHandle,
@@ -144,6 +148,7 @@ impl DocumentSyncService {
         peer_nodes: &[NodeId],
         alpns: Vec<Vec<u8>>,
         runtime: irokle_crate::net::IrohRuntimeConfig,
+        realm_id: RealmId,
     ) -> Result<Self> {
         Self::open_with_persist_policy(
             endpoint,
@@ -153,9 +158,11 @@ impl DocumentSyncService {
             alpns,
             runtime,
             FjallPersistPolicy::default(),
+            realm_id,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn open_with_persist_policy(
         endpoint: iroh::Endpoint,
         storage: StorageHandle,
@@ -164,6 +171,7 @@ impl DocumentSyncService {
         alpns: Vec<Vec<u8>>,
         runtime: irokle_crate::net::IrohRuntimeConfig,
         persist_policy: FjallPersistPolicy,
+        realm_id: RealmId,
     ) -> Result<Self> {
         let storage_path = storage_path.as_ref().to_path_buf();
         let default_peers: BTreeSet<PeerId> = peer_nodes.iter().map(node_id_to_peer_id).collect();
@@ -203,6 +211,7 @@ impl DocumentSyncService {
             reconcile_lock: Arc::new(tokio::sync::Mutex::new(())),
             eviction_tx,
             eviction_rx: Arc::new(Mutex::new(Some(eviction_rx))),
+            realm_id,
         })
     }
 
@@ -255,11 +264,16 @@ impl DocumentSyncService {
                 }
             };
             match event {
-                DocumentSyncEvent::AdminOperation { target, event } => {
+                DocumentSyncEvent::AdminOperation {
+                    target,
+                    event,
+                    placement,
+                } => {
                     documents.push(DocumentSyncEvictedDocument {
                         event_id: None,
                         target,
                         event: DocumentSyncOutboxEvent::AdminOperation { event },
+                        placement,
                         allow_genesis: false,
                     });
                 }
@@ -280,6 +294,7 @@ impl DocumentSyncService {
                     documents.push(DocumentSyncEvictedDocument {
                         event_id: Some(event_id),
                         target,
+                        placement: change.placement,
                         event: DocumentSyncOutboxEvent::Upsert { bytes, change },
                         allow_genesis: false,
                     });
@@ -300,6 +315,7 @@ impl DocumentSyncService {
                     documents.push(DocumentSyncEvictedDocument {
                         event_id: Some(event_id),
                         target,
+                        placement: change.placement,
                         event: DocumentSyncOutboxEvent::Delete { change },
                         allow_genesis: false,
                     });
@@ -396,10 +412,10 @@ impl DocumentSyncService {
 
     pub fn allow_document_sync_peers(
         &self,
-        targets: &[DocumentSyncTarget],
+        topics: &[irokle_crate::TopicId],
         peers: Vec<NodeId>,
     ) -> Result<()> {
-        if targets.is_empty() {
+        if topics.is_empty() {
             return Ok(());
         }
 
@@ -410,8 +426,7 @@ impl DocumentSyncService {
         self.allow_sync_peers(&sync_peers)?;
 
         let mut seen_topics = BTreeSet::new();
-        for target in targets {
-            let topic_id = target.sync_topic_id();
+        for topic_id in topics.iter().copied() {
             if !seen_topics.insert(topic_id) {
                 continue;
             }
@@ -422,9 +437,7 @@ impl DocumentSyncService {
                 .topic_state(&topic_id)
                 .map_err(|error| NetError::Bootstrap(error.to_string()))?
                 .ok_or_else(|| {
-                    NetError::Bootstrap(format!(
-                        "document sync topic {topic_id} for target {target:?} is missing"
-                    ))
+                    NetError::Bootstrap(format!("document sync topic {topic_id} is missing"))
                 })?;
 
             if state.event_type_id != DocumentSyncEvent::TYPE_ID {
@@ -464,10 +477,10 @@ impl DocumentSyncService {
 
     pub fn ensure_document_sync_topics(
         &self,
-        targets: &[DocumentSyncTarget],
+        topics: &[irokle_crate::TopicId],
         peers: Vec<NodeId>,
     ) -> Result<()> {
-        if targets.is_empty() {
+        if topics.is_empty() {
             return Ok(());
         }
 
@@ -475,12 +488,9 @@ impl DocumentSyncService {
         self.allow_sync_peers(&sync_peers)?;
 
         let mut seen_topics = BTreeSet::new();
-        for target in targets {
-            if seen_topics.insert(target.sync_topic_id()) {
-                // Called on the realm node that already holds these documents to
-                // admit an onboarding peer, so it may create any still-missing
-                // topic genesis for documents it originated/holds.
-                self.ensure_topic(target, &sync_peers, true)?;
+        for topic_id in topics.iter().copied() {
+            if seen_topics.insert(topic_id) {
+                self.ensure_topic(topic_id, &sync_peers, true)?;
             }
         }
 
@@ -596,14 +606,13 @@ impl DocumentSyncService {
 
     pub async fn sync_document_event(
         &self,
-        target: DocumentSyncTarget,
+        topic_id: irokle_crate::TopicId,
         peers: Vec<NodeId>,
     ) -> DocumentSyncNetEvent {
-        let topic_id = target.sync_topic_id();
         let sync_peers = self.sync_peers(peers);
         if let Err(error) = self.allow_sync_peers(&sync_peers) {
             return DocumentSyncNetEvent::Error {
-                target: Some(target),
+                target: None,
                 error: error.to_string(),
             };
         }
@@ -611,7 +620,7 @@ impl DocumentSyncService {
             Ok(true) => {
                 if let Err(error) = self.sync_topic(topic_id, sync_peers).await {
                     return DocumentSyncNetEvent::Error {
-                        target: Some(target),
+                        target: None,
                         error: error.to_string(),
                     };
                 }
@@ -619,21 +628,21 @@ impl DocumentSyncService {
             Ok(false) => {
                 if let Err(error) = self.bootstrap_topic_from_peers(topic_id, &sync_peers).await {
                     return DocumentSyncNetEvent::Error {
-                        target: Some(target),
+                        target: None,
                         error: error.to_string(),
                     };
                 }
             }
             Err(error) => {
                 return DocumentSyncNetEvent::Error {
-                    target: Some(target),
+                    target: None,
                     error: error.to_string(),
                 };
             }
         }
         if let Err(error) = self.flush_database() {
             return DocumentSyncNetEvent::Error {
-                target: Some(target),
+                target: None,
                 error: error.to_string(),
             };
         }
@@ -645,7 +654,7 @@ impl DocumentSyncService {
                 metadata_graph_tombstones: result.metadata_graph_tombstones,
             },
             Err(error) => DocumentSyncNetEvent::Error {
-                target: Some(target),
+                target: None,
                 error: error.to_string(),
             },
         }
@@ -653,11 +662,11 @@ impl DocumentSyncService {
 
     pub async fn sync_documents_event(
         &self,
-        targets: Vec<DocumentSyncTarget>,
+        topic_ids: Vec<irokle_crate::TopicId>,
         peers: Vec<NodeId>,
     ) -> DocumentSyncNetEvent {
         let sync_started = Instant::now();
-        let target_count = targets.len();
+        let target_count = topic_ids.len();
         let sync_peers = self.sync_peers(peers);
         if let Err(error) = self.allow_sync_peers(&sync_peers) {
             return DocumentSyncNetEvent::Error {
@@ -667,27 +676,28 @@ impl DocumentSyncService {
         }
 
         let mut seen_topics = BTreeSet::new();
-        let mut topics: Vec<(irokle_crate::TopicId, DocumentSyncTarget)> = Vec::new();
-        for target in targets {
-            let topic_id = target.sync_topic_id();
+        let mut topic_ids_out: Vec<irokle_crate::TopicId> = Vec::new();
+        for topic_id in topic_ids {
             if !seen_topics.insert(topic_id) {
                 continue;
             }
             match self.has_topic(topic_id) {
-                Ok(true) => topics.push((topic_id, target)),
+                Ok(true) => topic_ids_out.push(topic_id),
                 Ok(false) => {
-                    if let Err(error) = self.bootstrap_topic_from_peers(topic_id, &sync_peers).await
-                    {
-                        return DocumentSyncNetEvent::Error {
-                            target: Some(target),
-                            error: error.to_string(),
-                        };
+                    // Join-only: an unknown topic whose genesis is nowhere to be
+                    // found yet (e.g. an empty bucket whose rank-0 holder has not
+                    // created it) is skipped, not fatal — it arrives via gossip
+                    // or a later anti-entropy pass.
+                    match self.bootstrap_topic_from_peers(topic_id, &sync_peers).await {
+                        Ok(()) => topic_ids_out.push(topic_id),
+                        Err(error) => {
+                            debug!(%topic_id, error = %error, "skipping unbootstrappable document sync topic");
+                        }
                     }
-                    topics.push((topic_id, target));
                 }
                 Err(error) => {
                     return DocumentSyncNetEvent::Error {
-                        target: Some(target),
+                        target: None,
                         error: error.to_string(),
                     };
                 }
@@ -695,10 +705,7 @@ impl DocumentSyncService {
         }
 
         let bootstrap_elapsed = sync_started.elapsed();
-        let topic_ids = topics
-            .iter()
-            .map(|(topic_id, _)| *topic_id)
-            .collect::<Vec<_>>();
+        let topic_ids = topic_ids_out;
         let peer_sync_started = Instant::now();
         if let Err(error) = self.sync_topics(topic_ids.clone(), sync_peers).await {
             return DocumentSyncNetEvent::Error {
@@ -802,23 +809,35 @@ impl DocumentSyncService {
                     target,
                     change,
                 },
-                DocumentSyncPublish::AdminOperation { target, event, .. } => {
-                    DocumentSyncEvent::AdminOperation { target, event }
-                }
+                DocumentSyncPublish::AdminOperation {
+                    target,
+                    event,
+                    placement,
+                    ..
+                } => DocumentSyncEvent::AdminOperation {
+                    target,
+                    event,
+                    placement,
+                },
             };
             let target = event.target().clone();
-            let topic_id = target.sync_topic_id();
+            let topic_id = target.sync_topic_id(self.realm_id, &event.placement());
+            // Bucket topics are join-only here: only the bucket's rank-0 holder
+            // creates the genesis (eagerly, via the placement reconciler), so a
+            // publish onto a genesis-less bucket topic fails and the outbox
+            // drain defers the record instead.
+            let may_create_topic = !target.uses_bucket_topic();
             let actor_id = irokle_crate::actor_id_for(topic_id, self.node.peer_id());
             let envelope = EventEnvelope::encode_event(&event)
                 .map_err(|error| NetError::Bootstrap(error.to_string()))?;
             let op = match self.publish_event_op(
                 &oplog,
-                &target,
                 topic_id,
                 actor_id,
                 envelope,
                 sync_peers,
                 allow_genesis,
+                may_create_topic,
                 &mut fast_path,
                 &mut fallback,
             ) {
@@ -839,6 +858,15 @@ impl DocumentSyncService {
                 .or_default()
                 .observe(op.signed.body.actor_id, op.signed.body.actor_seq);
         }
+        // Member fan-out for publishes without an explicit peer set (admin
+        // operations): the drain's sync stage only pushes to record peers, so
+        // on an already-existing topic these ops would otherwise wait for an
+        // incidental recheck. Peer-addressed publishes keep their drain sync.
+        if sync_peers.is_empty() {
+            for topic_id in outcome.published.keys() {
+                self.net.schedule_topic_recheck(*topic_id)?;
+            }
+        }
         let published_count = outcome.published_indices.len();
         info!(
             event = "pipeline.publish.summary",
@@ -858,30 +886,35 @@ impl DocumentSyncService {
     fn publish_event_op(
         &self,
         oplog: &Oplog<irokle_crate::FjallStorage>,
-        target: &DocumentSyncTarget,
         topic_id: irokle_crate::TopicId,
         actor_id: irokle_crate::ActorId,
         envelope: EventEnvelope,
         sync_peers: &BTreeSet<PeerId>,
         allow_genesis: bool,
+        may_create_topic: bool,
         fast_path: &mut usize,
         fallback: &mut usize,
     ) -> Result<irokle_crate::Op> {
-        // Fast path for brand-new topics: genesis + first event admitted in a
-        // single storage transaction. Any failure (e.g. a concurrent admission
-        // won the genesis race) falls back to the existing two-step flow.
         let topic_missing = self
             .node
             .storage()
             .topic_state(&topic_id)
             .map_err(|error| NetError::Bootstrap(error.to_string()))?
             .is_none();
+        if topic_missing && !may_create_topic {
+            return Err(NetError::Bootstrap(format!(
+                "bucket topic {topic_id} has no genesis yet; only its rank-0 holder creates it"
+            )));
+        }
         if topic_missing {
             // Only the document's origin may mint its topic genesis. Any other
             // publisher waits (retryable) for that genesis to replicate in.
             if !allow_genesis {
                 return Err(NetError::TopicNotReady(topic_id.to_string()));
             }
+            // Fast path for brand-new topics: genesis + first event admitted in
+            // a single storage transaction. Any failure (e.g. a concurrent
+            // admission won the genesis race) falls back to the two-step flow.
             let genesis = TopicGenesis {
                 event_type_id: DocumentSyncEvent::TYPE_ID.to_string(),
                 initial_peers: sync_peers.clone(),
@@ -905,7 +938,9 @@ impl DocumentSyncService {
                 }
             }
         }
-        let topic_id = self.ensure_topic(target, sync_peers, allow_genesis)?;
+        if may_create_topic {
+            self.ensure_topic(topic_id, sync_peers, allow_genesis)?;
+        }
         oplog
             .create_event_op(topic_id, actor_id, envelope, self.node.signer())
             .map_err(|error| NetError::Bootstrap(error.to_string()))
@@ -956,11 +991,10 @@ impl DocumentSyncService {
 
     fn ensure_topic(
         &self,
-        target: &DocumentSyncTarget,
+        topic_id: irokle_crate::TopicId,
         peers: &BTreeSet<PeerId>,
         allow_genesis: bool,
     ) -> Result<irokle_crate::TopicId> {
-        let topic_id = target.sync_topic_id();
         let mut genesis_error = None;
         for _ in 0..2 {
             if let Some(state) = self
@@ -1027,6 +1061,12 @@ impl DocumentSyncService {
                 .map(|error| error.to_string())
                 .unwrap_or_else(|| format!("failed to ensure document sync topic {topic_id}")),
         ))
+    }
+
+    /// Whether the topic's genesis is known locally. The outbox drain uses this
+    /// to defer bucket-topic records until the rank-0 holder's genesis arrives.
+    pub fn topic_exists(&self, topic_id: irokle_crate::TopicId) -> Result<bool> {
+        self.has_topic(topic_id)
     }
 
     fn has_topic(&self, topic_id: irokle_crate::TopicId) -> Result<bool> {
@@ -1574,7 +1614,9 @@ impl DocumentSyncService {
             let mut deferred_admin_events = Vec::new();
             let mut satisfied_admin_dependencies = BTreeSet::new();
             for (event, actor_id) in events {
-                let target_topic_id = event.target().sync_topic_id();
+                let target_topic_id = event
+                    .target()
+                    .sync_topic_id(self.realm_id, &event.placement());
                 if target_topic_id != topic_id {
                     warn!(
                         %topic_id,
@@ -2250,7 +2292,7 @@ impl DocumentSyncService {
             DocumentSyncEvent::Delete { target, change, .. } => {
                 self.apply_delete(target, change).await
             }
-            DocumentSyncEvent::AdminOperation { target, event } => {
+            DocumentSyncEvent::AdminOperation { target, event, .. } => {
                 apply_admin_document_operation_to_storage(&self.storage, target, *event).await
             }
         }
@@ -5430,7 +5472,7 @@ mod tests {
         DocumentSyncTarget::RealmConfig {
             realm_id: RealmId::from_bytes([seed; 32]),
         }
-        .sync_topic_id()
+        .sync_topic_id(RealmId::from_bytes([seed; 32]), &PlacementRef::NIL)
     }
 
     fn node(seed: u8) -> NodeId {
@@ -5453,6 +5495,22 @@ mod tests {
         DocumentSyncTarget::MetadataGraphLifecycle {
             graph_iri: "urn:aruna:restart-contract".to_string(),
         }
+    }
+
+    fn restart_realm() -> RealmId {
+        RealmId::from_bytes([99; 32])
+    }
+
+    fn restart_placement() -> PlacementRef {
+        PlacementRef {
+            strategy_id: Ulid::from_parts(99, 7),
+            epoch: 0,
+            bucket: 11,
+        }
+    }
+
+    fn restart_topic() -> irokle_crate::TopicId {
+        restart_target().sync_topic_id(restart_realm(), &restart_placement())
     }
 
     fn restart_event_id() -> Ulid {
@@ -5480,7 +5538,7 @@ mod tests {
                 updated_at_ms: 1_727_000_000_101,
             },
             kind: DocumentSyncChangeKind::Upsert,
-            placement: aruna_core::structs::PlacementRef::NIL,
+            placement: restart_placement(),
         }
     }
 
@@ -5513,6 +5571,7 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            restart_realm(),
         )
         .expect("document sync service opens")
     }
@@ -8665,6 +8724,11 @@ mod tests {
         runtime.block_on(async {
             let service = open_restart_service(&root, "child-storage").await;
             let target = restart_target();
+            // Bucket topics are join-only at publish time; this node plays the
+            // bucket's rank-0 holder and creates the genesis eagerly first.
+            service
+                .ensure_document_sync_topics(&[restart_topic()], Vec::new())
+                .expect("restart bucket topic genesis");
             let event = service
                 .publish_documents(
                     vec![DocumentSyncPublish::Upsert {
@@ -8717,7 +8781,7 @@ mod tests {
         let service = open_restart_service(root, "parent-storage").await;
         let topic = service
             .node()
-            .open_topic::<DocumentSyncEvent>(target.sync_topic_id())
+            .open_topic::<DocumentSyncEvent>(restart_topic())
             .expect("published topic reopens after restart");
         let history = topic
             .history(HistoryOrder::OldestFirst)
@@ -9654,6 +9718,7 @@ mod tests {
                 vec![DocumentSyncPublish::AdminOperation {
                     target: target.clone(),
                     event: Box::new(admin_a),
+                    placement: PlacementRef::NIL,
                     allow_genesis: true,
                 }],
                 vec![node_b],
@@ -9668,6 +9733,7 @@ mod tests {
                 vec![DocumentSyncPublish::AdminOperation {
                     target: target.clone(),
                     event: Box::new(admin_b),
+                    placement: PlacementRef::NIL,
                     allow_genesis: true,
                 }],
                 vec![node_a],
@@ -9793,6 +9859,7 @@ mod tests {
             reemitted.event_id.is_none(),
             "admin outbox re-emission uses the embedded admin event id"
         );
+        assert_eq!(reemitted.placement, PlacementRef::NIL);
         match &reemitted.event {
             DocumentSyncOutboxEvent::AdminOperation { event } => {
                 assert_eq!(
@@ -9886,6 +9953,7 @@ mod tests {
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(admin_event),
+                        placement: PlacementRef::NIL,
                         allow_genesis: true,
                     },
                 ],
@@ -11184,6 +11252,7 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            RealmId::from_bytes([53u8; 32]),
         )
         .expect("document sync service opens");
 
@@ -11194,7 +11263,7 @@ mod tests {
             node_id: local_node,
             group_id: None,
         };
-        let topic_id = target.sync_topic_id();
+        let topic_id = target.sync_topic_id(realm_id, &PlacementRef::NIL);
 
         let change = |kind| DocumentSyncChange {
             base: None,

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -40,16 +40,16 @@ use aruna_core::metadata::{
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, document_sync_revision_key,
-    document_sync_revision_write_entry,
-    metadata_create_event_and_pending_projection_write_entries, metadata_document_lifecycle_key,
-    metadata_document_lifecycle_write_entry, metadata_graph_lifecycle_key,
-    metadata_graph_lifecycle_write_entry, metadata_graph_prune_job_write_entry,
-    metadata_registry_delete_entries, metadata_registry_write_entries, shard_manifest_write_entry,
+    document_sync_revision_write_entry, metadata_create_event_and_pending_projection_write_entries,
+    metadata_document_lifecycle_key, metadata_document_lifecycle_write_entry,
+    metadata_graph_lifecycle_key, metadata_graph_lifecycle_write_entry,
+    metadata_graph_prune_job_write_entry, metadata_registry_delete_entries,
+    metadata_registry_write_entries, shard_manifest_write_entry,
     stale_admin_document_conflict_delete_entries, subject_index_key, subject_index_value,
 };
 use aruna_core::structs::{
     Group, GroupAuthorizationDocument, KIND_LABEL_KEY, MetadataRegistryRecord,
-    NOTIFICATION_WATCH_MAX_PREFIX_LEN, NodeInfoDocument, NodeUsageSnapshot,
+    NOTIFICATION_WATCH_MAX_PREFIX_LEN, NodeInfoDocument, NodeUsageSnapshot, PlacementRef,
     RealmAuthorizationDocument, RealmConfigDocument, RealmId, RealmNodeKind, Role, User,
     WatchEventMask, WatchInterestDigest, WatchSubscription, group_owner_index_key,
     node_usage_key_node_id, watch_interest_dirty_key, watch_interest_key_node_id,
@@ -2030,13 +2030,19 @@ impl DocumentSyncService {
                         );
                         continue;
                     }
-                    DocumentSyncEvent::AdminOperation { target, event } => {
+                    DocumentSyncEvent::AdminOperation {
+                        target,
+                        event,
+                        placement,
+                    } => {
                         match validate_replicated_admin_event(
                             &self.storage,
                             topic_id,
                             actor_id,
                             &target,
                             &event,
+                            self.realm_id,
+                            &placement,
                         )
                         .await?
                         {
@@ -2059,8 +2065,9 @@ impl DocumentSyncService {
                                     %reason,
                                     "Deferring admin operation until prerequisite state is available"
                                 );
-                                deferred_admin_events
-                                    .push((target, *event, actor_id, dependency, reason));
+                                deferred_admin_events.push((
+                                    target, *event, placement, actor_id, dependency, reason,
+                                ));
                                 continue;
                             }
                         }
@@ -2088,13 +2095,15 @@ impl DocumentSyncService {
             loop {
                 let mut progressed = false;
                 let mut retry = Vec::new();
-                for (target, event, actor_id, _dependency, _previous_reason) in pending {
+                for (target, event, placement, actor_id, _dependency, _previous_reason) in pending {
                     match validate_replicated_admin_event(
                         &self.storage,
                         topic_id,
                         actor_id,
                         &target,
                         &event,
+                        self.realm_id,
+                        &placement,
                     )
                     .await?
                     {
@@ -2118,12 +2127,12 @@ impl DocumentSyncService {
                             "Rejecting deferred admin operation after prerequisite replay"
                         ),
                         AdminEventValidation::Deferred { dependency, reason } => {
-                            retry.push((target, event, actor_id, dependency, reason))
+                            retry.push((target, event, placement, actor_id, dependency, reason))
                         }
                     }
                 }
                 if !progressed {
-                    for (_, event, _, dependency, reason) in retry {
+                    for (_, event, _, _, dependency, reason) in retry {
                         if let Some(dependency) = dependency {
                             cross_topic_dependencies.insert(dependency);
                         } else {
@@ -3948,7 +3957,7 @@ async fn metadata_document_lifecycle_write_entries_if_current(
         document_sync_revision_write_entry(&target, change)
             .map_err(|error| NetError::Bootstrap(error.to_string()))?,
     );
-    if let Some(manifest) = shard_manifest_write_entry(&target, &revision)
+    if let Some(manifest) = shard_manifest_write_entry(&target, change)
         .map_err(|error| NetError::Bootstrap(error.to_string()))?
     {
         entries.push(manifest);
@@ -4402,10 +4411,12 @@ async fn validate_replicated_admin_event(
     authenticated_actor_id: irokle_crate::ActorId,
     target: &DocumentSyncTarget,
     event: &AdminDocumentEvent,
+    realm_id: RealmId,
+    placement: &PlacementRef,
 ) -> Result<AdminEventValidation> {
     let reject = |reason: &str| Ok(AdminEventValidation::Rejected(reason.to_string()));
 
-    if target.sync_topic_id() != topic_id {
+    if target.sync_topic_id(realm_id, placement) != topic_id {
         return reject("document sync target does not belong to the reconciled topic");
     }
     if event.origin_node_id != event.actor.node_id {
@@ -5813,6 +5824,14 @@ mod tests {
         }
     }
 
+    fn admin_test_placement() -> PlacementRef {
+        PlacementRef {
+            strategy_id: Ulid::from_parts(9_990, 1),
+            epoch: 0,
+            shard: 0,
+        }
+    }
+
     fn test_admin_event(
         event_id: Ulid,
         target: AdminDocumentTarget,
@@ -6523,6 +6542,7 @@ mod tests {
             replica_count: Some(3),
             distinct_locations: false,
             affinity: Vec::new(),
+            shard_count: 64,
         };
         apply_admin_document_operation_to_storage(
             &storage,
@@ -9417,26 +9437,11 @@ mod tests {
             Ulid::from_parts(43, 1),
             record.last_event_id,
         );
-        let realm_id = RealmId::from_bytes([42; 32]);
-        let placement_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-        let placement = aruna_core::document::PendingDocumentPlacement {
-            realm_id,
-            target: placement_target.clone(),
-            group_id: Some(group_id),
-            metadata_path: Some(record.document_path.clone()),
-            desired_holder_count: 1,
-            selected_holders: record.holder_node_ids.clone(),
-            updated_at: 1,
-            origin_node_id: node(1),
-            placement: aruna_core::structs::PlacementRef::NIL,
-        };
         storage_batch_write_to(
             &storage,
             vec![
                 metadata_document_lifecycle_write_entry(&lifecycle)
                     .expect("lifecycle entry builds"),
-                aruna_core::storage_entries::document_placement_write_entry(&placement)
-                    .expect("placement entry builds"),
             ],
         )
         .await
@@ -9473,15 +9478,6 @@ mod tests {
             .await
             .is_none()
         );
-        assert!(
-            read_storage_value(
-                &storage,
-                aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE,
-                aruna_core::storage_entries::document_placement_key(realm_id, &placement_target,),
-            )
-            .await
-            .is_none()
-        );
     }
 
     #[tokio::test]
@@ -9497,6 +9493,7 @@ mod tests {
         let placement = aruna_core::structs::PlacementRef {
             strategy_id: Ulid::from_parts(4, 4),
             epoch: 7,
+            shard: 3,
         };
         let change = aruna_core::storage_entries::metadata_document_lifecycle_revision_change(
             &lifecycle,
@@ -9599,6 +9596,7 @@ mod tests {
         local_change.placement = aruna_core::structs::PlacementRef {
             strategy_id: Ulid::from_parts(25, 1),
             epoch: 9,
+            shard: 5,
         };
         assert!(
             apply_metadata_document_lifecycle_to_storage(&storage, &local_delete, local_change,)
@@ -10301,7 +10299,8 @@ mod tests {
         ];
 
         for (target, event) in cases {
-            let topic_id = target.sync_topic_id();
+            let placement = admin_test_placement();
+            let topic_id = target.sync_topic_id(realm_id, &placement);
             let impersonator = irokle_crate::actor_id_for(topic_id, node_id_to_peer_id(&node(64)));
             assert!(
                 matches!(
@@ -10311,6 +10310,8 @@ mod tests {
                         impersonator,
                         &target,
                         &event,
+                        realm_id,
+                        &placement,
                     )
                     .await
                     .expect("storage succeeds"),
@@ -10327,7 +10328,7 @@ mod tests {
         let realm_id = RealmId::from_bytes([65; 32]);
         let nil_actor = test_actor(65, UserId::nil(realm_id), realm_id);
         let config_target = DocumentSyncTarget::RealmConfig { realm_id };
-        let config_topic = config_target.sync_topic_id();
+        let config_topic = config_target.sync_topic_id(realm_id, &PlacementRef::NIL);
         let publisher =
             irokle_crate::actor_id_for(config_topic, node_id_to_peer_id(&nil_actor.node_id));
         let ensure = test_admin_event(
@@ -10347,6 +10348,8 @@ mod tests {
                 publisher,
                 &config_target,
                 &ensure,
+                realm_id,
+                &PlacementRef::NIL,
             )
             .await
             .expect("storage succeeds"),
@@ -10373,6 +10376,8 @@ mod tests {
                 publisher,
                 &config_target,
                 &description,
+                realm_id,
+                &PlacementRef::NIL,
             )
             .await
             .expect("storage succeeds"),
@@ -10382,7 +10387,7 @@ mod tests {
 
         let (_auth_dir, auth_storage) = test_storage();
         let auth_target = DocumentSyncTarget::RealmAuthorization { realm_id };
-        let auth_topic = auth_target.sync_topic_id();
+        let auth_topic = auth_target.sync_topic_id(realm_id, &PlacementRef::NIL);
         let auth_publisher =
             irokle_crate::actor_id_for(auth_topic, node_id_to_peer_id(&nil_actor.node_id));
         let genesis_role = test_admin_event(
@@ -10406,6 +10411,8 @@ mod tests {
                 auth_publisher,
                 &auth_target,
                 &genesis_role,
+                realm_id,
+                &PlacementRef::NIL,
             )
             .await
             .expect("storage succeeds"),
@@ -10453,7 +10460,8 @@ mod tests {
                 ),
             ),
         ] {
-            let topic_id = target.sync_topic_id();
+            let placement = admin_test_placement();
+            let topic_id = target.sync_topic_id(realm_id, &placement);
             let publisher =
                 irokle_crate::actor_id_for(topic_id, node_id_to_peer_id(&server_actor.node_id));
             assert!(matches!(
@@ -10463,6 +10471,8 @@ mod tests {
                     publisher,
                     &target,
                     &event,
+                    realm_id,
+                    &placement,
                 )
                 .await
                 .expect("storage succeeds"),
@@ -10490,7 +10500,8 @@ mod tests {
         .await
         .expect("config writes");
         let target = DocumentSyncTarget::User { user_id };
-        let topic_id = target.sync_topic_id();
+        let placement = admin_test_placement();
+        let topic_id = target.sync_topic_id(realm_id, &placement);
         let publisher = irokle_crate::actor_id_for(topic_id, node_id_to_peer_id(&actor.node_id));
 
         let wrong_target = test_admin_event(
@@ -10505,9 +10516,17 @@ mod tests {
             },
         );
         assert!(matches!(
-            validate_replicated_admin_event(&storage, topic_id, publisher, &target, &wrong_target,)
-                .await
-                .expect("storage succeeds"),
+            validate_replicated_admin_event(
+                &storage,
+                topic_id,
+                publisher,
+                &target,
+                &wrong_target,
+                realm_id,
+                &placement,
+            )
+            .await
+            .expect("storage succeeds"),
             AdminEventValidation::Rejected(_)
         ));
 
@@ -10522,9 +10541,11 @@ mod tests {
             },
         );
         assert!(matches!(
-            validate_replicated_admin_event(&storage, topic_id, publisher, &target, &malformed,)
-                .await
-                .expect("storage succeeds"),
+            validate_replicated_admin_event(
+                &storage, topic_id, publisher, &target, &malformed, realm_id, &placement,
+            )
+            .await
+            .expect("storage succeeds"),
             AdminEventValidation::Rejected(_)
         ));
         assert_eq!(
@@ -10538,6 +10559,7 @@ mod tests {
     async fn reconcile_retries_admin_events_deferred_before_realm_config() {
         let (_storage_dir, storage) = test_storage();
         let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([68; 32]);
         let service = DocumentSyncService::open_with_persist_policy(
             test_endpoint(68).await,
             storage.clone(),
@@ -10546,18 +10568,18 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("document sync service opens");
 
-        let realm_id = RealmId::from_bytes([68; 32]);
         let admin_user_id = UserId::local(Ulid::from_parts(1_625, 1), realm_id);
         let bootstrap_actor = test_actor(68, UserId::nil(realm_id), realm_id);
         let admin_actor = test_actor(68, admin_user_id, realm_id);
         let role_id = Ulid::from_parts(1_626, 1);
         let auth_target = DocumentSyncTarget::RealmAuthorization { realm_id };
-        let auth_topic = auth_target.sync_topic_id();
+        let auth_topic = auth_target.sync_topic_id(realm_id, &PlacementRef::NIL);
         let config_target = DocumentSyncTarget::RealmConfig { realm_id };
-        let config_topic = config_target.sync_topic_id();
+        let config_topic = config_target.sync_topic_id(realm_id, &PlacementRef::NIL);
         assert_ne!(auth_topic, config_topic);
 
         let role = test_admin_event(
@@ -10622,6 +10644,7 @@ mod tests {
                 .map(|event| DocumentSyncPublish::AdminOperation {
                     target: target.clone(),
                     event,
+                    placement: PlacementRef::NIL,
                     allow_genesis: true,
                 })
                 .collect();
@@ -10632,7 +10655,7 @@ mod tests {
             service
                 .storage_write(
                     DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
-                    topic_cursor_key(target.sync_topic_id()),
+                    topic_cursor_key(target.sync_topic_id(realm_id, &PlacementRef::NIL)),
                     ByteView::from(
                         postcard::to_allocvec(&irokle_crate::ActorClock::default())
                             .expect("clock serializes"),
@@ -10730,6 +10753,7 @@ mod tests {
 
         let group_id = Ulid::from_parts(1_631, 1);
         let group_target = DocumentSyncTarget::GroupAuthorization { group_id };
+        let group_placement = admin_test_placement();
         let group_role_id = Ulid::from_parts(1_632, 1);
         let mut group_role = test_admin_event(
             Ulid::from_parts(1_633, 1),
@@ -10764,11 +10788,13 @@ mod tests {
                         DocumentSyncPublish::AdminOperation {
                             target: group_target.clone(),
                             event: Box::new(group_role),
+                            placement: group_placement,
                             allow_genesis: true,
                         },
                         DocumentSyncPublish::AdminOperation {
                             target: group_target.clone(),
                             event: Box::new(group_create),
+                            placement: group_placement,
                             allow_genesis: true,
                         },
                     ],
@@ -10780,7 +10806,7 @@ mod tests {
         service
             .storage_write(
                 DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
-                topic_cursor_key(group_target.sync_topic_id()),
+                topic_cursor_key(group_target.sync_topic_id(realm_id, &group_placement)),
                 postcard::to_allocvec(&irokle_crate::ActorClock::default())
                     .expect("clock serializes")
                     .into(),
@@ -10788,7 +10814,7 @@ mod tests {
             .await
             .expect("group cursor resets");
         service
-            .reconcile_document_topics([group_target.sync_topic_id()])
+            .reconcile_document_topics([group_target.sync_topic_id(realm_id, &group_placement)])
             .await
             .expect("same-topic group prerequisite is retried");
         assert!(
@@ -10805,6 +10831,7 @@ mod tests {
     async fn reconcile_skips_rejected_admin_ops_and_advances_cursor() {
         let (_storage_dir, storage) = test_storage();
         let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([63; 32]);
         let service = DocumentSyncService::open_with_persist_policy(
             test_endpoint(63).await,
             storage.clone(),
@@ -10813,10 +10840,10 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("document sync service opens");
 
-        let realm_id = RealmId::from_bytes([63; 32]);
         let other_realm_id = RealmId::from_bytes([64; 32]);
         let user_id = UserId::local(Ulid::from_parts(1_630, 1), realm_id);
         let local_actor = test_actor(63, user_id, realm_id);
@@ -10827,7 +10854,7 @@ mod tests {
         );
 
         let target = DocumentSyncTarget::RealmConfig { realm_id };
-        let topic_id = target.sync_topic_id();
+        let topic_id = target.sync_topic_id(realm_id, &PlacementRef::NIL);
         let mut config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
         config.ensure_node(local_actor.node_id, RealmNodeKind::Management);
         config.ensure_node(claimed_actor.node_id, RealmNodeKind::Management);
@@ -10884,6 +10911,7 @@ mod tests {
                     replica_count: Some(0),
                     distinct_locations: false,
                     affinity: Vec::new(),
+                    shard_count: 64,
                 },
             },
         );
@@ -10918,26 +10946,31 @@ mod tests {
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(wrong_realm_event),
+                        placement: PlacementRef::NIL,
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(impersonated_event),
+                        placement: PlacementRef::NIL,
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(reducer_invalid_event),
+                        placement: PlacementRef::NIL,
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(valid_event),
+                        placement: PlacementRef::NIL,
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(unrelated_event),
+                        placement: PlacementRef::NIL,
                         allow_genesis: true,
                     },
                 ],

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -530,10 +530,15 @@ impl DocumentSyncService {
     /// emitted, so later events from a removed holder cannot apply while
     /// pre-cutover replacement history remains usable. Shared topics and the
     /// default peer set are intentionally untouched.
+    ///
+    /// A `history_cutoff` is only frozen for topics in `verified_topics`: until a
+    /// node has durably verified a shard, its local clock is not a trustworthy
+    /// cutover boundary, so former-holder history is left admissible ([BR-030]).
     pub async fn reconcile_shard_membership(
         &self,
         topics: &[irokle_crate::TopicId],
         holders: Vec<NodeId>,
+        verified_topics: &BTreeSet<irokle_crate::TopicId>,
     ) -> Result<()> {
         if topics.is_empty() {
             return Ok(());
@@ -580,16 +585,21 @@ impl DocumentSyncService {
                             DocumentSyncEvent::TYPE_ID
                         )));
                     }
-                    let history_cutoff = self
-                        .node
-                        .storage()
-                        .actor_clock(&topic_id)
-                        .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+                    let history_cutoff = if verified_topics.contains(&topic_id) {
+                        Some(
+                            self.node
+                                .storage()
+                                .actor_clock(&topic_id)
+                                .map_err(|error| NetError::Bootstrap(error.to_string()))?,
+                        )
+                    } else {
+                        None
+                    };
                     policies.push((
                         topic_id,
                         ShardPublisherPolicy {
                             current,
-                            history_cutoff: Some(history_cutoff),
+                            history_cutoff,
                         },
                     ));
                     states.push((topic_id, state));
@@ -12732,7 +12742,11 @@ mod tests {
             .expect("shared topic exists");
 
         service
-            .reconcile_shard_membership(&[shard_topic], vec![local_node, current_node])
+            .reconcile_shard_membership(
+                &[shard_topic],
+                vec![local_node, current_node],
+                &BTreeSet::new(),
+            )
             .await
             .expect("shard membership reconciles");
 
@@ -12849,7 +12863,11 @@ mod tests {
         let publisher_ops = irokle_crate::oplog::topological(publisher.node().storage(), &topic_id)
             .expect("publisher history reads");
         receiver
-            .reconcile_shard_membership(&[topic_id], vec![receiver_node])
+            .reconcile_shard_membership(
+                &[topic_id],
+                vec![receiver_node],
+                &BTreeSet::from([topic_id]),
+            )
             .await
             .expect("former holder is removed");
         receiver
@@ -12912,5 +12930,68 @@ mod tests {
 
         publisher.shutdown().await;
         receiver.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn cutoff_gated_by_verification() {
+        // An unverified shard freezes no former-holder history cutoff; a verified
+        // shard does. The local clock is only a trustworthy cutover boundary once
+        // the shard is durably verified.
+        let (_dir, storage) = test_storage();
+        let doc = tempfile::tempdir().expect("document sync dir");
+        let realm_id = restart_realm();
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(85).await,
+            storage,
+            doc.path().join("document-sync"),
+            &[node(86)],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+            realm_id,
+        )
+        .expect("service opens");
+        let local_node = service.local_node_id().expect("local node id");
+        let co_holder = node(86);
+        let topic = restart_topic();
+        service
+            .ensure_document_sync_topics(&[topic], vec![co_holder])
+            .expect("shard topic exists");
+
+        service
+            .reconcile_shard_membership(&[topic], vec![local_node, co_holder], &BTreeSet::new())
+            .await
+            .expect("membership reconciles");
+        assert!(
+            service
+                .shard_publishers
+                .read()
+                .get(&topic)
+                .expect("publisher policy installed")
+                .history_cutoff
+                .is_none(),
+            "an unverified shard must not freeze a history cutoff"
+        );
+
+        service
+            .reconcile_shard_membership(
+                &[topic],
+                vec![local_node, co_holder],
+                &BTreeSet::from([topic]),
+            )
+            .await
+            .expect("membership reconciles");
+        assert!(
+            service
+                .shard_publishers
+                .read()
+                .get(&topic)
+                .expect("publisher policy installed")
+                .history_cutoff
+                .is_some(),
+            "a verified shard must freeze a history cutoff"
+        );
+
+        service.shutdown().await;
     }
 }

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -9768,11 +9768,14 @@ mod tests {
         .expect("document sync service opens");
 
         let local_node = service.local_node_id().expect("local node id");
-        let blocked_target = DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: Ulid::from_parts(62, 1),
+        let blocked_target = DocumentSyncTarget::NodeUsage {
+            realm_id,
+            node_id: local_node,
+            group_id: None,
         };
-        let ready_target = DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: Ulid::from_parts(62, 2),
+        let ready_target = DocumentSyncTarget::WatchInterest {
+            realm_id,
+            node_id: local_node,
         };
         let blocked_topic = blocked_target.sync_topic_id(realm_id, &placement);
         let ready_topic = ready_target.sync_topic_id(realm_id, &placement);

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -90,11 +90,12 @@ pub const DOCUMENT_SYNC_BATCH_SYNC_TOPIC_LIMIT: usize = 1_024;
 const DOCUMENT_SYNC_INBOUND_SYNC_MESSAGE_LIMIT: usize = 4_096;
 const DOCUMENT_SYNC_INBOUND_SYNC_STREAM_BYTES: usize = 256 * 1024 * 1024;
 const DOCUMENT_SYNC_FRAME_LEN_LIMIT: usize = 16 * 1024 * 1024;
-const MAX_DEFERRED_ADMIN_TOPICS: usize = 1_024;
-const MAX_DEFERRED_ADMIN_TOPICS_PER_DEPENDENCY: usize = 256;
+const MAX_DEFERRED_TOPICS: usize = 1_024;
+const MAX_DEFERRED_TOPICS_PER_DEPENDENCY: usize = 256;
 
 #[derive(Debug)]
 struct PendingMetadataCreateApply {
+    topic_id: irokle_crate::TopicId,
     target: DocumentSyncTarget,
     record: MetadataCreateEventRecord,
     bytes: Vec<u8>,
@@ -103,6 +104,12 @@ struct PendingMetadataCreateApply {
 
 struct MetadataPlacementFence {
     config_write: Option<(String, ByteView, Value)>,
+}
+
+enum MetadataPlacementOutcome<T> {
+    Accepted(T),
+    Deferred(DocumentSyncDependency),
+    Rejected,
 }
 
 #[derive(Default)]
@@ -1776,13 +1783,10 @@ impl DocumentSyncService {
         topic_ids: impl IntoIterator<Item = irokle_crate::TopicId>,
     ) -> Result<DocumentSyncReconcileResult> {
         let _reconcile_guard = self.reconcile_lock.lock().await;
-        let mut deferred_admin_topics: BTreeMap<
-            AdminEventDependency,
-            BTreeSet<irokle_crate::TopicId>,
-        > = self
-            .storage_read(
+        let mut deferred_topics: BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>> =
+            self.storage_read(
                 DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
-                deferred_admin_topics_key(),
+                deferred_topics_key(),
             )
             .await?
             .map(|bytes| postcard::from_bytes(&bytes))
@@ -1797,25 +1801,13 @@ impl DocumentSyncService {
             }
         }
         let mut satisfied_persisted_dependencies = Vec::new();
-        for dependency in deferred_admin_topics.keys().copied().collect::<Vec<_>>() {
-            let available = match dependency {
-                AdminEventDependency::RealmConfig(realm_id) => {
-                    read_admin_realm_config(&self.storage, realm_id)
-                        .await?
-                        .is_some()
-                }
-                AdminEventDependency::RealmAuthorization(realm_id) => {
-                    read_admin_realm_authorization(&self.storage, realm_id)
-                        .await?
-                        .is_some()
-                }
-            };
-            if available {
+        for dependency in deferred_topics.keys().copied().collect::<Vec<_>>() {
+            if document_sync_dependency_available(&self.storage, dependency).await? {
                 satisfied_persisted_dependencies.push(dependency);
             }
         }
         for dependency in satisfied_persisted_dependencies {
-            if let Some(topics) = deferred_admin_topics.remove(&dependency) {
+            if let Some(topics) = deferred_topics.remove(&dependency) {
                 for topic_id in topics {
                     if queued_topics.insert(topic_id) {
                         topic_queue.push_back(topic_id);
@@ -1826,10 +1818,13 @@ impl DocumentSyncService {
         let mut applied_targets = Vec::new();
         let mut metadata_create_events = Vec::new();
         let mut metadata_graph_tombstones = Vec::new();
-        let mut pending_metadata_creates = Vec::new();
-        let mut deferred_cursor_writes = Vec::new();
+        let mut pending_metadata_creates: Vec<PendingMetadataCreateApply> = Vec::new();
+        let mut deferred_cursor_writes: Vec<(irokle_crate::TopicId, (String, ByteView, Value))> =
+            Vec::new();
         while let Some(topic_id) = topic_queue.pop_front() {
             queued_topics.remove(&topic_id);
+            pending_metadata_creates.retain(|pending| pending.topic_id != topic_id);
+            deferred_cursor_writes.retain(|(pending_topic_id, _)| *pending_topic_id != topic_id);
             let Some(topic) = self
                 .node
                 .storage()
@@ -1868,6 +1863,7 @@ impl DocumentSyncService {
             let mut deferred_creates = false;
             let mut deferred_admin_events = Vec::new();
             let mut satisfied_admin_dependencies = BTreeSet::new();
+            let mut cross_topic_dependencies = BTreeSet::new();
             for (event, actor_id, actor_seq) in events {
                 if self
                     .shard_publishers
@@ -2047,11 +2043,51 @@ impl DocumentSyncService {
                         self.apply_upsert(target.clone(), bytes, change).await?;
                         applied_targets.push(target);
                     }
+                    DocumentSyncEvent::Upsert {
+                        target:
+                            target @ DocumentSyncTarget::MetadataRegistry {
+                                group_id,
+                                document_id,
+                            },
+                        bytes,
+                        ..
+                    } => {
+                        let record: MetadataRegistryRecord = postcard::from_bytes(&bytes)
+                            .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+                        if record.group_id != group_id || record.document_id != document_id {
+                            return Err(NetError::Bootstrap(format!(
+                                "replicated metadata registry target {group_id}/{document_id} does not match payload {}/{}",
+                                record.group_id, record.document_id
+                            )));
+                        }
+                        let realm_id = record.realm_id;
+                        let strategy_id = record.placement.strategy_id;
+                        match self.apply_metadata_registry_upsert(record, bytes).await? {
+                            MetadataPlacementOutcome::Accepted(()) => applied_targets.push(target),
+                            MetadataPlacementOutcome::Deferred(dependency) => {
+                                warn!(
+                                    %topic_id,
+                                    %realm_id,
+                                    %document_id,
+                                    %strategy_id,
+                                    "Deferring metadata registry record until its placement strategy is available"
+                                );
+                                cross_topic_dependencies.insert(dependency);
+                            }
+                            MetadataPlacementOutcome::Rejected => warn!(
+                                %topic_id,
+                                %realm_id,
+                                %document_id,
+                                %strategy_id,
+                                "Rejecting metadata registry record with mismatched placement configuration"
+                            ),
+                        }
+                    }
                     event @ DocumentSyncEvent::Upsert {
                         target: DocumentSyncTarget::MetadataCreateEvent { .. },
                         ..
                     } => {
-                        let pending = self.pending_metadata_create_apply(event)?;
+                        let pending = self.pending_metadata_create_apply(topic_id, event)?;
                         pending_metadata_creates.push(pending);
                         deferred_creates = true;
                     }
@@ -2077,6 +2113,7 @@ impl DocumentSyncService {
                                 let bytes = postcard::to_allocvec(&record)
                                     .map_err(|error| NetError::Bootstrap(error.to_string()))?;
                                 pending_metadata_creates.push(PendingMetadataCreateApply {
+                                    topic_id,
                                     target,
                                     lifecycle_revision: Some(change),
                                     record,
@@ -2253,15 +2290,15 @@ impl DocumentSyncService {
                             }
                         }
 
+                        let dependencies =
+                            satisfied_document_sync_dependencies(&target, event.as_ref());
                         apply_admin_document_operation_to_storage(
                             &self.storage,
                             target.clone(),
                             *event,
                         )
                         .await?;
-                        if let Some(dependency) = satisfied_admin_dependency(&target) {
-                            satisfied_admin_dependencies.insert(dependency);
-                        }
+                        satisfied_admin_dependencies.extend(dependencies);
                         applied_targets.push(target);
                     }
                     event => {
@@ -2271,7 +2308,6 @@ impl DocumentSyncService {
                     }
                 }
             }
-            let mut cross_topic_dependencies = BTreeSet::new();
             let mut pending = deferred_admin_events;
             loop {
                 let mut progressed = false;
@@ -2289,15 +2325,15 @@ impl DocumentSyncService {
                     .await?
                     {
                         AdminEventValidation::Accepted => {
+                            let dependencies =
+                                satisfied_document_sync_dependencies(&target, &event);
                             apply_admin_document_operation_to_storage(
                                 &self.storage,
                                 target.clone(),
                                 event,
                             )
                             .await?;
-                            if let Some(dependency) = satisfied_admin_dependency(&target) {
-                                satisfied_admin_dependencies.insert(dependency);
-                            }
+                            satisfied_admin_dependencies.extend(dependencies);
                             applied_targets.push(target);
                             progressed = true;
                         }
@@ -2333,30 +2369,16 @@ impl DocumentSyncService {
                 }
             }
             if !cross_topic_dependencies.is_empty() {
-                remove_deferred_admin_topic(&mut deferred_admin_topics, topic_id);
+                remove_deferred_topic(&mut deferred_topics, topic_id);
                 let mut registered_dependency = false;
                 for dependency in cross_topic_dependencies {
-                    let total_topics = deferred_admin_topics
-                        .values()
-                        .map(BTreeSet::len)
-                        .sum::<usize>();
-                    let dependency_topics = deferred_admin_topics
-                        .get(&dependency)
-                        .map(BTreeSet::len)
-                        .unwrap_or_default();
-                    if total_topics < MAX_DEFERRED_ADMIN_TOPICS
-                        && dependency_topics < MAX_DEFERRED_ADMIN_TOPICS_PER_DEPENDENCY
-                    {
-                        deferred_admin_topics
-                            .entry(dependency)
-                            .or_default()
-                            .insert(topic_id);
+                    if register_deferred_topic(&mut deferred_topics, dependency, topic_id) {
                         registered_dependency = true;
                     } else {
                         warn!(
                             %topic_id,
                             ?dependency,
-                            "Dropping admin dependency registration because the deferred-topic registry is full"
+                            "Dropping document dependency registration because the deferred-topic registry is full"
                         );
                     }
                 }
@@ -2370,9 +2392,12 @@ impl DocumentSyncService {
             );
             if deferred_creates {
                 deferred_cursor_writes.push((
-                    DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
-                    cursor_key,
-                    value,
+                    topic_id,
+                    (
+                        DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                        cursor_key,
+                        value,
+                    ),
                 ));
             } else {
                 self.storage_write(
@@ -2383,10 +2408,10 @@ impl DocumentSyncService {
                 .await?;
             }
             let retry_topics = {
-                remove_deferred_admin_topic(&mut deferred_admin_topics, topic_id);
+                remove_deferred_topic(&mut deferred_topics, topic_id);
                 satisfied_admin_dependencies
                     .into_iter()
-                    .filter_map(|dependency| deferred_admin_topics.remove(&dependency))
+                    .filter_map(|dependency| deferred_topics.remove(&dependency))
                     .flatten()
                     .collect::<Vec<_>>()
             };
@@ -2396,21 +2421,32 @@ impl DocumentSyncService {
                 }
             }
         }
+        let persisted_deferred_topics = postcard::to_allocvec(&deferred_topics)
+            .map_err(|error| NetError::Bootstrap(error.to_string()))?;
         self.storage_write(
             DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
-            deferred_admin_topics_key(),
-            postcard::to_allocvec(&deferred_admin_topics)
-                .map_err(|error| NetError::Bootstrap(error.to_string()))?
-                .into(),
+            deferred_topics_key(),
+            persisted_deferred_topics.clone().into(),
         )
         .await?;
         self.apply_metadata_create_batch(
             pending_metadata_creates,
             deferred_cursor_writes,
+            &mut deferred_topics,
             &mut applied_targets,
             &mut metadata_create_events,
         )
         .await?;
+        let updated_deferred_topics = postcard::to_allocvec(&deferred_topics)
+            .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+        if updated_deferred_topics != persisted_deferred_topics {
+            self.storage_write(
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                deferred_topics_key(),
+                updated_deferred_topics.into(),
+            )
+            .await?;
+        }
         Ok(DocumentSyncReconcileResult {
             targets: applied_targets,
             metadata_create_events,
@@ -2473,6 +2509,7 @@ impl DocumentSyncService {
 
     fn pending_metadata_create_apply(
         &self,
+        topic_id: irokle_crate::TopicId,
         event: DocumentSyncEvent,
     ) -> Result<PendingMetadataCreateApply> {
         let (document_id, target_event_id, bytes) = match event {
@@ -2498,6 +2535,7 @@ impl DocumentSyncService {
             )));
         }
         Ok(PendingMetadataCreateApply {
+            topic_id,
             target: DocumentSyncTarget::MetadataCreateEvent {
                 document_id,
                 event_id: target_event_id,
@@ -2511,7 +2549,8 @@ impl DocumentSyncService {
     async fn apply_metadata_create_batch(
         &self,
         pending: Vec<PendingMetadataCreateApply>,
-        cursor_writes: Vec<(String, ByteView, Value)>,
+        cursor_writes: Vec<(irokle_crate::TopicId, (String, ByteView, Value))>,
+        deferred_topics: &mut BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>>,
         applied_targets: &mut Vec<DocumentSyncTarget>,
         metadata_create_events: &mut Vec<MetadataCreateEventRecord>,
     ) -> Result<()> {
@@ -2558,6 +2597,8 @@ impl DocumentSyncService {
         let mut writes = Vec::with_capacity(candidates.len() * 3 + cursor_writes.len());
         let mut config_writes = BTreeMap::new();
         let mut accepted = Vec::with_capacity(candidates.len());
+        let mut accepted_candidates = Vec::with_capacity(candidates.len());
+        let mut deferred_cursor_topics = BTreeSet::new();
         for (apply, entries) in candidates {
             let fence = match metadata_placement_fence_in_transaction(
                 &self.storage,
@@ -2566,13 +2607,33 @@ impl DocumentSyncService {
             )
             .await
             {
-                Ok(Some(fence)) => fence,
-                Ok(None) => {
+                Ok(MetadataPlacementOutcome::Accepted(fence)) => fence,
+                Ok(MetadataPlacementOutcome::Deferred(dependency)) => {
                     warn!(
+                        topic_id = %apply.topic_id,
                         realm_id = %apply.record.record.realm_id,
                         document_id = %apply.record.record.document_id,
                         strategy_id = %apply.record.record.placement.strategy_id,
-                        "Rejecting replicated metadata create whose placement strategy is unavailable"
+                        "Deferring replicated metadata create until its placement strategy is available"
+                    );
+                    if register_deferred_topic(deferred_topics, dependency, apply.topic_id) {
+                        deferred_cursor_topics.insert(apply.topic_id);
+                    } else {
+                        warn!(
+                            topic_id = %apply.topic_id,
+                            ?dependency,
+                            "Dropping metadata placement dependency because the deferred-topic registry is full"
+                        );
+                    }
+                    continue;
+                }
+                Ok(MetadataPlacementOutcome::Rejected) => {
+                    warn!(
+                        topic_id = %apply.topic_id,
+                        realm_id = %apply.record.record.realm_id,
+                        document_id = %apply.record.record.document_id,
+                        strategy_id = %apply.record.record.placement.strategy_id,
+                        "Rejecting replicated metadata create with mismatched placement configuration"
                     );
                     continue;
                 }
@@ -2584,14 +2645,22 @@ impl DocumentSyncService {
                     return Err(error);
                 }
             };
-            if let Some(config_write) = fence.config_write {
+            accepted_candidates.push((apply, entries, fence.config_write));
+        }
+        for (apply, entries, config_write) in accepted_candidates {
+            if deferred_cursor_topics.contains(&apply.topic_id) {
+                continue;
+            }
+            if let Some(config_write) = config_write {
                 config_writes.insert(apply.record.record.realm_id, config_write);
             }
             writes.extend(entries);
             accepted.push(apply);
         }
         writes.extend(config_writes.into_values());
-        writes.extend(cursor_writes);
+        writes.extend(cursor_writes.into_iter().filter_map(|(topic_id, write)| {
+            (!deferred_cursor_topics.contains(&topic_id)).then_some(write)
+        }));
         if let Err(error) =
             storage_batch_delete_and_write_in_transaction(&self.storage, txn_id, Vec::new(), writes)
                 .await
@@ -2698,7 +2767,8 @@ impl DocumentSyncService {
                     record.group_id, record.document_id
                 )));
             }
-            return self.apply_metadata_registry_upsert(record, bytes).await;
+            self.apply_metadata_registry_upsert(record, bytes).await?;
+            return Ok(());
         }
         if let DocumentSyncTarget::MetadataGraphLifecycle { graph_iri } = target {
             let record: MetadataGraphLifecycleRecord = postcard::from_bytes(&bytes)
@@ -2755,7 +2825,7 @@ impl DocumentSyncService {
         &self,
         record: MetadataRegistryRecord,
         primary_bytes: Vec<u8>,
-    ) -> Result<()> {
+    ) -> Result<MetadataPlacementOutcome<()>> {
         apply_metadata_registry_upsert_to_storage(&self.storage, record, primary_bytes).await
     }
 
@@ -3167,13 +3237,14 @@ async fn apply_metadata_registry_upsert_to_storage(
     storage: &StorageHandle,
     record: MetadataRegistryRecord,
     primary_bytes: Vec<u8>,
-) -> Result<()> {
+) -> Result<MetadataPlacementOutcome<()>> {
     if metadata_graph_deleted_in_storage(storage, &record.graph_iri).await? {
-        return storage_batch_delete_to(
+        storage_batch_delete_to(
             storage,
             metadata_registry_delete_entries(record.group_id, record.document_id),
         )
-        .await;
+        .await?;
+        return Ok(MetadataPlacementOutcome::Accepted(()));
     }
 
     let mut base_entries = metadata_registry_write_entries(&record)
@@ -3188,18 +3259,18 @@ async fn apply_metadata_registry_upsert_to_storage(
     for _ in 0..2 {
         let txn_id = start_storage_transaction(storage).await?;
         let fence = match metadata_placement_fence_in_transaction(storage, &record, txn_id).await {
-            Ok(Some(fence)) => fence,
-            Ok(None) => {
-                warn!(
-                    realm_id = %record.realm_id,
-                    document_id = %record.document_id,
-                    strategy_id = %record.placement.strategy_id,
-                    "Rejecting metadata registry record whose placement strategy is unavailable"
-                );
+            Ok(MetadataPlacementOutcome::Accepted(fence)) => fence,
+            Ok(MetadataPlacementOutcome::Deferred(dependency)) => {
                 let _ = storage
                     .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
                     .await;
-                return Ok(());
+                return Ok(MetadataPlacementOutcome::Deferred(dependency));
+            }
+            Ok(MetadataPlacementOutcome::Rejected) => {
+                let _ = storage
+                    .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+                    .await;
+                return Ok(MetadataPlacementOutcome::Rejected);
             }
             Err(error) => {
                 let _ = storage
@@ -3243,7 +3314,7 @@ async fn apply_metadata_registry_upsert_to_storage(
             let _ = storage
                 .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
                 .await;
-            return Ok(());
+            return Ok(MetadataPlacementOutcome::Accepted(()));
         }
 
         let mut entries = base_entries.clone();
@@ -3253,7 +3324,7 @@ async fn apply_metadata_registry_upsert_to_storage(
         match storage_batch_delete_and_write_in_transaction(storage, txn_id, Vec::new(), entries)
             .await
         {
-            Ok(()) => return Ok(()),
+            Ok(()) => return Ok(MetadataPlacementOutcome::Accepted(())),
             Err(NetError::Dht(message))
                 if message == StorageError::TransactionConflict.to_string() =>
             {
@@ -4347,7 +4418,14 @@ async fn metadata_placement_fence_in_transaction(
     storage: &StorageHandle,
     record: &MetadataRegistryRecord,
     txn_id: TxnId,
-) -> Result<Option<MetadataPlacementFence>> {
+) -> Result<MetadataPlacementOutcome<MetadataPlacementFence>> {
+    let dependency = DocumentSyncDependency::PlacementStrategy {
+        realm_id: record.realm_id,
+        strategy_id: record.placement.strategy_id,
+    };
+    if record.placement != PlacementRef::NIL && record.placement.strategy_id.is_nil() {
+        return Ok(MetadataPlacementOutcome::Rejected);
+    }
     let target = DocumentSyncTarget::RealmConfig {
         realm_id: record.realm_id,
     };
@@ -4360,20 +4438,24 @@ async fn metadata_placement_fence_in_transaction(
     .await?;
     let Some(value) = value else {
         return if record.placement == PlacementRef::NIL {
-            Ok(Some(MetadataPlacementFence { config_write: None }))
+            Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence {
+                config_write: None,
+            }))
         } else {
-            Ok(None)
+            Ok(MetadataPlacementOutcome::Deferred(dependency))
         };
     };
     let config = RealmConfigDocument::from_bytes(&value)
         .map_err(|error| NetError::Bootstrap(error.to_string()))?;
-    if config.realm_id != record.realm_id
-        || (record.placement != PlacementRef::NIL
-            && config.strategy(&record.placement.strategy_id).is_none())
-    {
-        return Ok(None);
+    if config.realm_id != record.realm_id {
+        return Ok(MetadataPlacementOutcome::Rejected);
     }
-    Ok(Some(MetadataPlacementFence {
+    if record.placement != PlacementRef::NIL
+        && config.strategy(&record.placement.strategy_id).is_none()
+    {
+        return Ok(MetadataPlacementOutcome::Deferred(dependency));
+    }
+    Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence {
         config_write: Some((
             REALM_CONFIG_KEYSPACE.to_string(),
             target.storage_key(),
@@ -4704,9 +4786,13 @@ enum AdminOperationFamily {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-enum AdminEventDependency {
+enum DocumentSyncDependency {
     RealmConfig(RealmId),
     RealmAuthorization(RealmId),
+    PlacementStrategy {
+        realm_id: RealmId,
+        strategy_id: Ulid,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -4714,25 +4800,89 @@ enum AdminEventValidation {
     Accepted,
     Rejected(String),
     Deferred {
-        dependency: Option<AdminEventDependency>,
+        dependency: Option<DocumentSyncDependency>,
         reason: String,
     },
 }
 
-fn satisfied_admin_dependency(target: &DocumentSyncTarget) -> Option<AdminEventDependency> {
+fn satisfied_document_sync_dependencies(
+    target: &DocumentSyncTarget,
+    event: &AdminDocumentEvent,
+) -> Vec<DocumentSyncDependency> {
+    let mut dependencies = Vec::new();
     match target {
         DocumentSyncTarget::RealmConfig { realm_id } => {
-            Some(AdminEventDependency::RealmConfig(*realm_id))
+            dependencies.push(DocumentSyncDependency::RealmConfig(*realm_id));
+            if let AdminDocumentOperation::RealmConfigPlacementStrategyUpserted { strategy } =
+                &event.op
+            {
+                dependencies.push(DocumentSyncDependency::PlacementStrategy {
+                    realm_id: *realm_id,
+                    strategy_id: strategy.strategy_id,
+                });
+            }
         }
         DocumentSyncTarget::RealmAuthorization { realm_id } => {
-            Some(AdminEventDependency::RealmAuthorization(*realm_id))
+            dependencies.push(DocumentSyncDependency::RealmAuthorization(*realm_id));
         }
-        _ => None,
+        _ => {}
+    }
+    dependencies
+}
+
+async fn document_sync_dependency_available(
+    storage: &StorageHandle,
+    dependency: DocumentSyncDependency,
+) -> Result<bool> {
+    match dependency {
+        DocumentSyncDependency::RealmConfig(realm_id) => {
+            Ok(read_admin_realm_config(storage, realm_id).await?.is_some())
+        }
+        DocumentSyncDependency::RealmAuthorization(realm_id) => {
+            Ok(read_admin_realm_authorization(storage, realm_id)
+                .await?
+                .is_some())
+        }
+        DocumentSyncDependency::PlacementStrategy {
+            realm_id,
+            strategy_id,
+        } => Ok(read_admin_realm_config(storage, realm_id)
+            .await?
+            .is_some_and(|config| {
+                config.realm_id == realm_id && config.strategy(&strategy_id).is_some()
+            })),
     }
 }
 
-fn remove_deferred_admin_topic(
-    deferred_topics: &mut BTreeMap<AdminEventDependency, BTreeSet<irokle_crate::TopicId>>,
+fn register_deferred_topic(
+    deferred_topics: &mut BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>>,
+    dependency: DocumentSyncDependency,
+    topic_id: irokle_crate::TopicId,
+) -> bool {
+    if deferred_topics
+        .get(&dependency)
+        .is_some_and(|topics| topics.contains(&topic_id))
+    {
+        return true;
+    }
+    let total_topics = deferred_topics.values().map(BTreeSet::len).sum::<usize>();
+    let dependency_topics = deferred_topics
+        .get(&dependency)
+        .map(BTreeSet::len)
+        .unwrap_or_default();
+    if total_topics >= MAX_DEFERRED_TOPICS
+        || dependency_topics >= MAX_DEFERRED_TOPICS_PER_DEPENDENCY
+    {
+        return false;
+    }
+    deferred_topics
+        .entry(dependency)
+        .or_default()
+        .insert(topic_id)
+}
+
+fn remove_deferred_topic(
+    deferred_topics: &mut BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>>,
     topic_id: irokle_crate::TopicId,
 ) {
     for topics in deferred_topics.values_mut() {
@@ -5118,7 +5268,7 @@ async fn validate_realm_authorization_admin_authority(
         AdminEventValidation::Accepted
     } else {
         AdminEventValidation::Deferred {
-            dependency: Some(AdminEventDependency::RealmConfig(realm_id)),
+            dependency: Some(DocumentSyncDependency::RealmConfig(realm_id)),
             reason: "current realm config is unavailable".to_string(),
         }
     })
@@ -5136,7 +5286,7 @@ async fn validate_group_admin_authority(
     let realm_id = event.actor.realm_id;
     let Some(config) = read_admin_realm_config(storage, realm_id).await? else {
         return Ok(AdminEventValidation::Deferred {
-            dependency: Some(AdminEventDependency::RealmConfig(realm_id)),
+            dependency: Some(DocumentSyncDependency::RealmConfig(realm_id)),
             reason: "current realm config is unavailable".to_string(),
         });
     };
@@ -5222,7 +5372,7 @@ async fn validate_group_admin_authority(
     };
     let Some(realm_auth) = realm_auth else {
         return Ok(AdminEventValidation::Deferred {
-            dependency: Some(AdminEventDependency::RealmAuthorization(realm_id)),
+            dependency: Some(DocumentSyncDependency::RealmAuthorization(realm_id)),
             reason: "realm authorization state is unavailable".to_string(),
         });
     };
@@ -5269,7 +5419,7 @@ async fn validate_user_admin_authority(
     let realm_id = user_id.realm_id;
     let Some(config) = read_admin_realm_config(storage, realm_id).await? else {
         return Ok(AdminEventValidation::Deferred {
-            dependency: Some(AdminEventDependency::RealmConfig(realm_id)),
+            dependency: Some(DocumentSyncDependency::RealmConfig(realm_id)),
             reason: "current realm config is unavailable".to_string(),
         });
     };
@@ -5320,7 +5470,7 @@ async fn validate_user_admin_authority(
     } else {
         let Some(auth) = read_admin_realm_authorization(storage, realm_id).await? else {
             return Ok(AdminEventValidation::Deferred {
-                dependency: Some(AdminEventDependency::RealmAuthorization(realm_id)),
+                dependency: Some(DocumentSyncDependency::RealmAuthorization(realm_id)),
                 reason: "realm authorization state is unavailable".to_string(),
             });
         };
@@ -5523,7 +5673,8 @@ fn topic_cursor_key(topic_id: irokle_crate::TopicId) -> ByteView {
     ByteView::from(key)
 }
 
-fn deferred_admin_topics_key() -> ByteView {
+fn deferred_topics_key() -> ByteView {
+    // Retain the original key so previously persisted admin dependencies decode.
     ByteView::from(b"deferred-admin-topics".to_vec())
 }
 
@@ -9518,6 +9669,270 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_placement_defers() {
+        let (_storage_dir, storage) = test_storage();
+        let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([42; 32]);
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(76).await,
+            storage.clone(),
+            doc_dir.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+            realm_id,
+        )
+        .expect("document sync service opens");
+        let local_node = service.local_node_id().expect("local node id");
+        let actor = test_actor(
+            76,
+            UserId::local(Ulid::from_parts(2_110, 1), realm_id),
+            realm_id,
+        );
+        assert_eq!(actor.node_id, local_node);
+
+        let mut config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        config.ensure_node(local_node, RealmNodeKind::Management);
+        let config_target = DocumentSyncTarget::RealmConfig { realm_id };
+        storage_batch_write_to(
+            &storage,
+            vec![target_write_entry(
+                config_target.clone(),
+                config
+                    .to_bytes(&actor)
+                    .expect("realm config serializes")
+                    .into(),
+            )],
+        )
+        .await
+        .expect("realm config writes");
+
+        let strategy = PlacementStrategy {
+            strategy_id: Ulid::from_parts(2_111, 1),
+            name: "deferred".to_string(),
+            replica_count: Some(1),
+            distinct_locations: false,
+            affinity: Vec::new(),
+            shard_count: 64,
+        };
+        let placement = PlacementRef {
+            strategy_id: strategy.strategy_id,
+            epoch: 0,
+            shard: 4,
+        };
+        let group_id = Ulid::from_parts(2_112, 1);
+        let document_id = Ulid::from_parts(2_113, 1);
+        let create_event_id = Ulid::from_parts(2_114, 1);
+        let mut record = registry_record(
+            group_id,
+            document_id,
+            "datasets/deferred",
+            100,
+            create_event_id,
+        );
+        record.placement = placement;
+        let mut create = metadata_create_event(group_id, document_id, 100, create_event_id, 76);
+        create.record = record.clone();
+        let registry_target = DocumentSyncTarget::MetadataRegistry {
+            group_id,
+            document_id,
+        };
+        let create_target = DocumentSyncTarget::MetadataCreateEvent {
+            document_id,
+            event_id: create_event_id,
+        };
+        let metadata_topic = registry_target.sync_topic_id(realm_id, &placement);
+        service
+            .ensure_document_sync_topics(&[metadata_topic], Vec::new())
+            .expect("metadata shard topic genesis");
+        let change = |event_id| DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id,
+                actor: local_node,
+                updated_at_ms: 100,
+            },
+            kind: DocumentSyncChangeKind::Upsert,
+            placement,
+        };
+        let published = service
+            .publish_documents(
+                vec![
+                    DocumentSyncPublish::Upsert {
+                        event_id: Ulid::from_parts(2_115, 1),
+                        target: registry_target.clone(),
+                        bytes: postcard::to_allocvec(&record).expect("registry serializes"),
+                        change: change(Ulid::from_parts(2_115, 1)),
+                        allow_genesis: true,
+                    },
+                    DocumentSyncPublish::Upsert {
+                        event_id: Ulid::from_parts(2_116, 1),
+                        target: create_target.clone(),
+                        bytes: postcard::to_allocvec(&create).expect("create serializes"),
+                        change: change(Ulid::from_parts(2_116, 1)),
+                        allow_genesis: true,
+                    },
+                ],
+                Vec::new(),
+            )
+            .await;
+        assert!(
+            matches!(published, DocumentSyncNetEvent::DocumentsPublished { .. }),
+            "metadata publish failed: {published:?}"
+        );
+        service
+            .storage_write(
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                topic_cursor_key(metadata_topic),
+                postcard::to_allocvec(&irokle_crate::ActorClock::default())
+                    .expect("clock serializes")
+                    .into(),
+            )
+            .await
+            .expect("metadata cursor resets");
+
+        let deferred = service
+            .reconcile_document_topics([metadata_topic])
+            .await
+            .expect("metadata reconciliation defers");
+        assert!(deferred.metadata_create_events.is_empty());
+        assert!(
+            read_storage_value(
+                &storage,
+                METADATA_INDEX_KEYSPACE,
+                metadata_registry_key(group_id, document_id),
+            )
+            .await
+            .is_none()
+        );
+        assert!(
+            read_storage_value(
+                &storage,
+                METADATA_EVENT_LOG_KEYSPACE,
+                metadata_event_log_key(document_id, create_event_id),
+            )
+            .await
+            .is_none()
+        );
+        let deferred_cursor: irokle_crate::ActorClock = postcard::from_bytes(
+            &read_storage_value(
+                &storage,
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+                topic_cursor_key(metadata_topic),
+            )
+            .await
+            .expect("deferred cursor remains stored"),
+        )
+        .expect("cursor decodes");
+        let metadata_clock = service
+            .node()
+            .storage()
+            .actor_clock(&metadata_topic)
+            .expect("metadata topic clock");
+        assert!(!deferred_cursor.dominates(&metadata_clock));
+        let deferred_topics: BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>> =
+            postcard::from_bytes(
+                &read_storage_value(
+                    &storage,
+                    DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+                    deferred_topics_key(),
+                )
+                .await
+                .expect("deferred topic registry is persisted"),
+            )
+            .expect("deferred topic registry decodes");
+        assert_eq!(
+            deferred_topics
+                .get(&DocumentSyncDependency::PlacementStrategy {
+                    realm_id,
+                    strategy_id: strategy.strategy_id,
+                })
+                .and_then(|topics| topics.get(&metadata_topic)),
+            Some(&metadata_topic)
+        );
+
+        let config_topic = config_target.sync_topic_id(realm_id, &PlacementRef::NIL);
+        let strategy_event = test_admin_event(
+            Ulid::from_parts(2_117, 1),
+            AdminDocumentTarget::RealmConfig { realm_id },
+            &actor,
+            1,
+            AdminDocumentOperation::RealmConfigPlacementStrategyUpserted {
+                strategy: strategy.clone(),
+            },
+        );
+        let published = service
+            .publish_documents(
+                vec![DocumentSyncPublish::AdminOperation {
+                    target: config_target.clone(),
+                    event: Box::new(strategy_event),
+                    placement: PlacementRef::NIL,
+                    allow_genesis: true,
+                }],
+                Vec::new(),
+            )
+            .await;
+        assert!(
+            matches!(published, DocumentSyncNetEvent::DocumentsPublished { .. }),
+            "strategy publish failed: {published:?}"
+        );
+        service
+            .storage_write(
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                topic_cursor_key(config_topic),
+                postcard::to_allocvec(&irokle_crate::ActorClock::default())
+                    .expect("clock serializes")
+                    .into(),
+            )
+            .await
+            .expect("config cursor resets");
+
+        let applied = service
+            .reconcile_document_topics([config_topic])
+            .await
+            .expect("strategy reconciliation retries metadata");
+        assert!(applied.targets.contains(&registry_target));
+        assert!(applied.targets.contains(&create_target));
+        assert_eq!(applied.metadata_create_events, vec![create.clone()]);
+        assert_registry_record_present(&storage, &record).await;
+        let stored_create = read_storage_value(
+            &storage,
+            METADATA_EVENT_LOG_KEYSPACE,
+            metadata_event_log_key(document_id, create_event_id),
+        )
+        .await
+        .expect("create event exists");
+        assert_eq!(
+            postcard::from_bytes::<MetadataCreateEventRecord>(&stored_create)
+                .expect("create event decodes"),
+            create
+        );
+        let applied_cursor: irokle_crate::ActorClock = postcard::from_bytes(
+            &read_storage_value(
+                &storage,
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+                topic_cursor_key(metadata_topic),
+            )
+            .await
+            .expect("applied cursor is stored"),
+        )
+        .expect("cursor decodes");
+        assert!(applied_cursor.dominates(&metadata_clock));
+        assert!(
+            service
+                .reconcile_document_topics([metadata_topic])
+                .await
+                .expect("accepted metadata is idempotent")
+                .metadata_create_events
+                .is_empty()
+        );
+
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn document_sync_fencing_metadata_registry_stale_delete_preserves_newer_live_indexes() {
         let (_dir, storage) = test_storage();
         let group_id = Ulid::from_parts(1_560, 1);
@@ -11091,12 +11506,12 @@ mod tests {
             .actor_clock(&auth_topic)
             .expect("auth topic clock");
         assert!(!deferred_cursor.dominates(&auth_clock));
-        let deferred_topics: BTreeMap<AdminEventDependency, BTreeSet<irokle_crate::TopicId>> =
+        let deferred_topics: BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>> =
             postcard::from_bytes(
                 &read_storage_value(
                     &storage,
                     DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
-                    deferred_admin_topics_key(),
+                    deferred_topics_key(),
                 )
                 .await
                 .expect("deferred topic registry is persisted"),
@@ -11104,7 +11519,7 @@ mod tests {
             .expect("deferred topic registry decodes");
         assert_eq!(
             deferred_topics
-                .get(&AdminEventDependency::RealmConfig(realm_id))
+                .get(&DocumentSyncDependency::RealmConfig(realm_id))
                 .and_then(|topics| topics.get(&auth_topic)),
             Some(&auth_topic)
         );

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -5599,9 +5599,9 @@ mod tests {
     use aruna_core::structs::{
         Actor, BindingScope, DocumentClass, Group, GroupAuthorizationDocument, GroupQuotaOverride,
         MetadataReplicationConfig, NodePlacementEntry, OidcProviderConfig, Permission,
-        PlacementOverride, PlacementStrategy, QuotaConfig, RealmAuthorizationDocument,
-        RealmConfigDocument, RealmDiscoveryConfig, RealmId, RealmNodeKind, Role,
-        StaticRealmEndpoint, StrategyBinding, UserGroupCapOverride,
+        PlacementOverride, PlacementRef, PlacementStrategy, QuotaConfig,
+        RealmAuthorizationDocument, RealmConfigDocument, RealmDiscoveryConfig, RealmId,
+        RealmNodeKind, Role, StaticRealmEndpoint, StrategyBinding, UserGroupCapOverride,
     };
     use std::collections::{BTreeMap, HashMap, HashSet};
     use std::{env, process::Command};
@@ -5756,6 +5756,7 @@ mod tests {
                 document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![node(1)],
             created_at_ms: 1,
             updated_at_ms,

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -10041,8 +10041,8 @@ mod tests {
             winner_genesis
         );
 
-        // The evicted admin event re-emits with its original event id preserved
-        // and allow_genesis cleared.
+        // The evicted admin event re-emits with its original event id and
+        // placement preserved, and allow_genesis cleared.
         let reemitted = loser.decode_eviction(evictions.into_iter().next().unwrap());
         assert_eq!(reemitted.len(), 1);
         let reemitted = &reemitted[0];
@@ -10055,7 +10055,7 @@ mod tests {
             reemitted.event_id.is_none(),
             "admin outbox re-emission uses the embedded admin event id"
         );
-        assert_eq!(reemitted.placement, PlacementRef::NIL);
+        assert_eq!(reemitted.placement, placement);
         match &reemitted.event {
             DocumentSyncOutboxEvent::AdminOperation { event } => {
                 assert_eq!(

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -2370,11 +2370,11 @@ impl DocumentSyncService {
             }
             if !cross_topic_dependencies.is_empty() {
                 remove_deferred_topic(&mut deferred_topics, topic_id);
-                let mut registered_dependency = false;
                 for dependency in cross_topic_dependencies {
-                    if register_deferred_topic(&mut deferred_topics, dependency, topic_id) {
-                        registered_dependency = true;
-                    } else {
+                    if matches!(
+                        register_deferred_topic(&mut deferred_topics, dependency, topic_id),
+                        DeferredTopicRegistrationOutcome::CapacityExceeded
+                    ) {
                         warn!(
                             %topic_id,
                             ?dependency,
@@ -2382,9 +2382,9 @@ impl DocumentSyncService {
                         );
                     }
                 }
-                if registered_dependency {
-                    continue;
-                }
+                // Registry capacity limits retry discovery, not whether an
+                // unresolved topic is safe to mark as applied.
+                continue;
             }
             let value = ByteView::from(
                 postcard::to_allocvec(&cursor)
@@ -2616,9 +2616,11 @@ impl DocumentSyncService {
                         strategy_id = %apply.record.record.placement.strategy_id,
                         "Deferring replicated metadata create until its placement strategy is available"
                     );
-                    if register_deferred_topic(deferred_topics, dependency, apply.topic_id) {
-                        deferred_cursor_topics.insert(apply.topic_id);
-                    } else {
+                    deferred_cursor_topics.insert(apply.topic_id);
+                    if matches!(
+                        register_deferred_topic(deferred_topics, dependency, apply.topic_id),
+                        DeferredTopicRegistrationOutcome::CapacityExceeded
+                    ) {
                         warn!(
                             topic_id = %apply.topic_id,
                             ?dependency,
@@ -4795,6 +4797,13 @@ enum DocumentSyncDependency {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeferredTopicRegistrationOutcome {
+    Inserted,
+    AlreadyRegistered,
+    CapacityExceeded,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum AdminEventValidation {
     Accepted,
@@ -4858,12 +4867,12 @@ fn register_deferred_topic(
     deferred_topics: &mut BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>>,
     dependency: DocumentSyncDependency,
     topic_id: irokle_crate::TopicId,
-) -> bool {
+) -> DeferredTopicRegistrationOutcome {
     if deferred_topics
         .get(&dependency)
         .is_some_and(|topics| topics.contains(&topic_id))
     {
-        return true;
+        return DeferredTopicRegistrationOutcome::AlreadyRegistered;
     }
     let total_topics = deferred_topics.values().map(BTreeSet::len).sum::<usize>();
     let dependency_topics = deferred_topics
@@ -4873,12 +4882,13 @@ fn register_deferred_topic(
     if total_topics >= MAX_DEFERRED_TOPICS
         || dependency_topics >= MAX_DEFERRED_TOPICS_PER_DEPENDENCY
     {
-        return false;
+        return DeferredTopicRegistrationOutcome::CapacityExceeded;
     }
     deferred_topics
         .entry(dependency)
         .or_default()
-        .insert(topic_id)
+        .insert(topic_id);
+    DeferredTopicRegistrationOutcome::Inserted
 }
 
 fn remove_deferred_topic(
@@ -9666,6 +9676,260 @@ mod tests {
             .await
             .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn capacity_retains_cursors() {
+        let (_storage_dir, storage) = test_storage();
+        let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([42; 32]);
+        let service = DocumentSyncService::open_with_persist_policy(
+            test_endpoint(77).await,
+            storage.clone(),
+            doc_dir.path().join("document-sync"),
+            &[],
+            vec![Alpn::DocumentSync.as_bytes().to_vec()],
+            irokle_crate::net::IrohRuntimeConfig::default(),
+            FjallPersistPolicy::Buffer,
+            realm_id,
+        )
+        .expect("document sync service opens");
+        let local_node = service.local_node_id().expect("local node id");
+        let actor = test_actor(
+            77,
+            UserId::local(Ulid::from_parts(2_120, 1), realm_id),
+            realm_id,
+        );
+        assert_eq!(actor.node_id, local_node);
+
+        let mut config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        config.ensure_node(local_node, RealmNodeKind::Management);
+        storage_batch_write_to(
+            &storage,
+            vec![target_write_entry(
+                DocumentSyncTarget::RealmConfig { realm_id },
+                config
+                    .to_bytes(&actor)
+                    .expect("realm config serializes")
+                    .into(),
+            )],
+        )
+        .await
+        .expect("realm config writes");
+
+        let strategy_id = Ulid::from_parts(2_121, 1);
+        assert!(config.strategy(&strategy_id).is_none());
+        let registry_placement = PlacementRef {
+            strategy_id,
+            epoch: 0,
+            shard: 4,
+        };
+        let create_placement = PlacementRef {
+            strategy_id,
+            epoch: 0,
+            shard: 5,
+        };
+        let registry_group_id = Ulid::from_parts(2_122, 1);
+        let registry_document_id = Ulid::from_parts(2_123, 1);
+        let registry_event_id = Ulid::from_parts(2_124, 1);
+        let mut registry = registry_record(
+            registry_group_id,
+            registry_document_id,
+            "datasets/capacity-registry",
+            100,
+            registry_event_id,
+        );
+        registry.placement = registry_placement;
+        let registry_target = DocumentSyncTarget::MetadataRegistry {
+            group_id: registry_group_id,
+            document_id: registry_document_id,
+        };
+
+        let create_group_id = Ulid::from_parts(2_125, 1);
+        let create_document_id = Ulid::from_parts(2_126, 1);
+        let create_event_id = Ulid::from_parts(2_127, 1);
+        let mut create = metadata_create_event(
+            create_group_id,
+            create_document_id,
+            100,
+            create_event_id,
+            77,
+        );
+        create.record.placement = create_placement;
+        let create_target = DocumentSyncTarget::MetadataCreateEvent {
+            document_id: create_document_id,
+            event_id: create_event_id,
+        };
+        let registry_topic = registry_target.sync_topic_id(realm_id, &registry_placement);
+        let create_topic = create_target.sync_topic_id(realm_id, &create_placement);
+        service
+            .ensure_document_sync_topics(&[registry_topic, create_topic], Vec::new())
+            .expect("metadata shard topic genesis");
+        let change = |event_id, placement| DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id,
+                actor: local_node,
+                updated_at_ms: 100,
+            },
+            kind: DocumentSyncChangeKind::Upsert,
+            placement,
+        };
+        let published = service
+            .publish_documents(
+                vec![
+                    DocumentSyncPublish::Upsert {
+                        event_id: registry_event_id,
+                        target: registry_target,
+                        bytes: postcard::to_allocvec(&registry).expect("registry serializes"),
+                        change: change(registry_event_id, registry_placement),
+                        allow_genesis: true,
+                    },
+                    DocumentSyncPublish::Upsert {
+                        event_id: create_event_id,
+                        target: create_target,
+                        bytes: postcard::to_allocvec(&create).expect("create serializes"),
+                        change: change(create_event_id, create_placement),
+                        allow_genesis: true,
+                    },
+                ],
+                Vec::new(),
+            )
+            .await;
+        assert!(
+            matches!(published, DocumentSyncNetEvent::DocumentsPublished { .. }),
+            "metadata publish failed: {published:?}"
+        );
+        for topic_id in [registry_topic, create_topic] {
+            assert_ne!(
+                service
+                    .node()
+                    .storage()
+                    .actor_clock(&topic_id)
+                    .expect("metadata topic clock"),
+                irokle_crate::ActorClock::default(),
+                "metadata topic must contain its published event"
+            );
+            service
+                .storage_write(
+                    DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                    topic_cursor_key(topic_id),
+                    postcard::to_allocvec(&irokle_crate::ActorClock::default())
+                        .expect("clock serializes")
+                        .into(),
+                )
+                .await
+                .expect("metadata cursor resets");
+        }
+
+        let dependency = DocumentSyncDependency::PlacementStrategy {
+            realm_id,
+            strategy_id,
+        };
+        assert!(
+            !document_sync_dependency_available(&storage, dependency)
+                .await
+                .expect("placement dependency checks")
+        );
+        let mut filler_topics = BTreeSet::new();
+        for index in 0..MAX_DEFERRED_TOPICS_PER_DEPENDENCY {
+            let mut filler_realm = [0xA5; 32];
+            filler_realm[..8].copy_from_slice(&(index as u64).to_be_bytes());
+            let filler_realm = RealmId::from_bytes(filler_realm);
+            filler_topics.insert(
+                DocumentSyncTarget::RealmConfig {
+                    realm_id: filler_realm,
+                }
+                .sync_topic_id(filler_realm, &PlacementRef::NIL),
+            );
+        }
+        assert_eq!(filler_topics.len(), MAX_DEFERRED_TOPICS_PER_DEPENDENCY);
+        assert!(!filler_topics.contains(&registry_topic));
+        assert!(!filler_topics.contains(&create_topic));
+        let deferred_topics = BTreeMap::from([(dependency, filler_topics)]);
+        let mut capacity_probe = deferred_topics.clone();
+        let existing_topic = *capacity_probe
+            .get(&dependency)
+            .and_then(BTreeSet::first)
+            .expect("full dependency has a topic");
+        assert_eq!(
+            register_deferred_topic(&mut capacity_probe, dependency, existing_topic),
+            DeferredTopicRegistrationOutcome::AlreadyRegistered
+        );
+        assert_eq!(
+            register_deferred_topic(&mut capacity_probe, dependency, registry_topic),
+            DeferredTopicRegistrationOutcome::CapacityExceeded
+        );
+        service
+            .storage_write(
+                DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE.to_string(),
+                deferred_topics_key(),
+                postcard::to_allocvec(&deferred_topics)
+                    .expect("deferred topics serialize")
+                    .into(),
+            )
+            .await
+            .expect("full deferred topic registry writes");
+
+        service
+            .reconcile_document_topics([registry_topic, create_topic])
+            .await
+            .expect("metadata reconciliation remains retryable at capacity");
+        let deferred_topics: BTreeMap<DocumentSyncDependency, BTreeSet<irokle_crate::TopicId>> =
+            postcard::from_bytes(
+                &read_storage_value(
+                    &storage,
+                    DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+                    deferred_topics_key(),
+                )
+                .await
+                .expect("deferred topic registry remains stored"),
+            )
+            .expect("deferred topic registry decodes");
+        assert_eq!(
+            deferred_topics.get(&dependency).map(BTreeSet::len),
+            Some(MAX_DEFERRED_TOPICS_PER_DEPENDENCY)
+        );
+        let registered_dependencies = deferred_topics
+            .iter()
+            .filter(|(_, topics)| {
+                topics.contains(&registry_topic) || topics.contains(&create_topic)
+            })
+            .map(|(dependency, _)| *dependency)
+            .collect::<Vec<_>>();
+        assert!(
+            registered_dependencies.is_empty(),
+            "expected full {dependency:?}; topics registered under {registered_dependencies:?}"
+        );
+        for topic_id in [registry_topic, create_topic] {
+            let cursor: irokle_crate::ActorClock = postcard::from_bytes(
+                &read_storage_value(
+                    &storage,
+                    DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE,
+                    topic_cursor_key(topic_id),
+                )
+                .await
+                .expect("deferred cursor remains stored"),
+            )
+            .expect("cursor decodes");
+            assert_eq!(
+                cursor,
+                irokle_crate::ActorClock::default(),
+                "capacity-blocked metadata dependency changed cursor for {topic_id}"
+            );
+            let topic_clock = service
+                .node()
+                .storage()
+                .actor_clock(&topic_id)
+                .expect("metadata topic clock");
+            assert!(
+                !cursor.dominates(&topic_clock),
+                "capacity-blocked metadata dependency advanced cursor for {topic_id}"
+            );
+        }
+
+        service.shutdown().await;
     }
 
     #[tokio::test]

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -9753,6 +9753,8 @@ mod tests {
     async fn topic_not_ready_publish_does_not_block_ready_batch_record() {
         let (_storage_dir, storage) = test_storage();
         let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([62; 32]);
+        let placement = aruna_core::structs::PlacementRef::NIL;
         let service = DocumentSyncService::open_with_persist_policy(
             test_endpoint(62).await,
             storage,
@@ -9761,6 +9763,7 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("document sync service opens");
 
@@ -9771,8 +9774,8 @@ mod tests {
         let ready_target = DocumentSyncTarget::MetadataDocumentLifecycle {
             document_id: Ulid::from_parts(62, 2),
         };
-        let blocked_topic = blocked_target.sync_topic_id();
-        let ready_topic = ready_target.sync_topic_id();
+        let blocked_topic = blocked_target.sync_topic_id(realm_id, &placement);
+        let ready_topic = ready_target.sync_topic_id(realm_id, &placement);
         let change = DocumentSyncChange {
             base: None,
             current: DocumentSyncRevision {
@@ -9782,7 +9785,7 @@ mod tests {
                 updated_at_ms: 1,
             },
             kind: DocumentSyncChangeKind::Upsert,
-            placement: aruna_core::structs::PlacementRef::NIL,
+            placement,
         };
 
         let published = service

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -1430,9 +1430,15 @@ impl DocumentSyncService {
         }
         let wanted: BTreeSet<irokle_crate::TopicId> = topics.iter().copied().collect();
         // Callers pass co-holders with the local node already excluded.
-        for node_id in &co_holders {
-            let peer = node_id_to_peer_id(node_id);
-            match self.probe_topics_on_peer(&topics, peer).await {
+        let topic_ids = &topics;
+        let probes = co_holders.iter().copied().map(|node_id| async move {
+            let peer = node_id_to_peer_id(&node_id);
+            (node_id, self.probe_topics_on_peer(topic_ids, peer).await)
+        });
+        // Poll every independent peer probe together, then aggregate in the
+        // co-holder input order preserved by join_all.
+        for (node_id, result) in futures::future::join_all(probes).await {
+            match result {
                 Ok(peer_probe) => {
                     probe
                         .known_by_co_holder
@@ -1451,7 +1457,7 @@ impl DocumentSyncService {
                 }
                 Err(error) => {
                     debug!(%node_id, error = %error, "co-holder unreachable while probing shard genesis");
-                    probe.unreachable.push(*node_id);
+                    probe.unreachable.push(node_id);
                 }
             }
         }

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -9675,6 +9675,7 @@ mod tests {
     async fn missing_topic_publish_requires_allow_genesis() {
         let (_storage_dir, storage) = test_storage();
         let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([61u8; 32]);
         let service = DocumentSyncService::open_with_persist_policy(
             test_endpoint(61).await,
             storage.clone(),
@@ -9683,14 +9684,16 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("document sync service opens");
 
         let local_node = service.local_node_id().expect("local node id");
-        let target = DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: Ulid::r#gen(),
+        let target = DocumentSyncTarget::NodeInfo {
+            realm_id,
+            node_id: local_node,
         };
-        let topic_id = target.sync_topic_id();
+        let topic_id = target.sync_topic_id(realm_id, &PlacementRef::NIL);
         let change = DocumentSyncChange {
             base: None,
             current: DocumentSyncRevision {
@@ -9839,6 +9842,7 @@ mod tests {
         let (_dir_b, storage_b) = test_storage();
         let doc_a = tempfile::tempdir().expect("doc a");
         let doc_b = tempfile::tempdir().expect("doc b");
+        let realm_id = RealmId::from_bytes([71; 32]);
         let service_a = DocumentSyncService::open_with_persist_policy(
             test_endpoint(71).await,
             storage_a,
@@ -9847,6 +9851,7 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("service a opens");
         let service_b = DocumentSyncService::open_with_persist_policy(
@@ -9857,17 +9862,22 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("service b opens");
 
         let node_a = service_a.local_node_id().expect("node a id");
         let node_b = service_b.local_node_id().expect("node b id");
 
-        let realm_id = RealmId::from_bytes([71; 32]);
         let user_id = UserId::local(Ulid::from_parts(7, 1), realm_id);
         let target = DocumentSyncTarget::User { user_id };
         let admin_target = AdminDocumentTarget::User { user_id };
-        let topic_id = target.sync_topic_id();
+        let placement = PlacementRef {
+            strategy_id: Ulid::from_parts(71, 7),
+            epoch: 0,
+            shard: 1,
+        };
+        let topic_id = target.sync_topic_id(realm_id, &placement);
 
         let event_a_id = Ulid::from_parts(0xA1, 1);
         let event_b_id = Ulid::from_parts(0xB2, 2);
@@ -9890,14 +9900,21 @@ mod tests {
             },
         );
 
-        // Each side lists the other in its genesis peer set, so the loser is a
-        // member of the winner's topic after the reset.
+        // Shard-classed admin topics are created eagerly; each side lists the
+        // other in its genesis peer set so the loser is a member after reset.
+        service_a
+            .ensure_document_sync_topics(&[topic_id], vec![node_b])
+            .expect("service a topic genesis");
+        service_b
+            .ensure_document_sync_topics(&[topic_id], vec![node_a])
+            .expect("service b topic genesis");
+
         let published_a = service_a
             .publish_documents(
                 vec![DocumentSyncPublish::AdminOperation {
                     target: target.clone(),
                     event: Box::new(admin_a),
-                    placement: PlacementRef::NIL,
+                    placement,
                     allow_genesis: true,
                 }],
                 vec![node_b],
@@ -9912,7 +9929,7 @@ mod tests {
                 vec![DocumentSyncPublish::AdminOperation {
                     target: target.clone(),
                     event: Box::new(admin_b),
-                    placement: PlacementRef::NIL,
+                    placement,
                     allow_genesis: true,
                 }],
                 vec![node_a],
@@ -10058,6 +10075,7 @@ mod tests {
     async fn reconcile_skips_whole_document_admin_sync_events() {
         let (_storage_dir, storage) = test_storage();
         let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([54u8; 32]);
         let service = DocumentSyncService::open_with_persist_policy(
             test_endpoint(54).await,
             storage.clone(),
@@ -10066,13 +10084,21 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("document sync service opens");
 
-        let realm_id = RealmId::from_bytes([54u8; 32]);
         let user_id = UserId::local(Ulid::from_parts(1_400, 1), realm_id);
         let target = DocumentSyncTarget::User { user_id };
-        let topic_id = target.sync_topic_id();
+        let placement = PlacementRef {
+            strategy_id: Ulid::from_parts(54, 7),
+            epoch: 0,
+            shard: 1,
+        };
+        let topic_id = target.sync_topic_id(realm_id, &placement);
+        service
+            .ensure_document_sync_topics(&[topic_id], Vec::new())
+            .expect("admin shard topic genesis");
 
         let change = |kind| DocumentSyncChange {
             base: None,
@@ -10083,7 +10109,7 @@ mod tests {
                 updated_at_ms: 1,
             },
             kind,
-            placement: aruna_core::structs::PlacementRef::NIL,
+            placement,
         };
         let actor = test_actor(54, user_id, realm_id);
         assert_eq!(
@@ -10132,7 +10158,7 @@ mod tests {
                     DocumentSyncPublish::AdminOperation {
                         target: target.clone(),
                         event: Box::new(admin_event),
-                        placement: PlacementRef::NIL,
+                        placement,
                         allow_genesis: true,
                     },
                 ],
@@ -11117,6 +11143,7 @@ mod tests {
 
         let (_storage_dir, storage) = test_storage();
         let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([55u8; 32]);
         let service = DocumentSyncService::open_with_persist_policy(
             test_endpoint(55).await,
             storage.clone(),
@@ -11125,13 +11152,13 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("document sync service opens");
 
         let local_node = service.local_node_id().expect("local node id");
         let forged_node = node(88);
         assert_ne!(local_node, forged_node);
-        let realm_id = RealmId::from_bytes([55u8; 32]);
         let target = DocumentSyncTarget::WatchInterest {
             realm_id,
             node_id: local_node,
@@ -11140,8 +11167,11 @@ mod tests {
             realm_id,
             node_id: forged_node,
         };
-        let topic_id = target.sync_topic_id();
-        assert_eq!(topic_id, forged_target.sync_topic_id());
+        let topic_id = target.sync_topic_id(realm_id, &PlacementRef::NIL);
+        assert_eq!(
+            topic_id,
+            forged_target.sync_topic_id(realm_id, &PlacementRef::NIL)
+        );
 
         let change = || DocumentSyncChange {
             base: None,
@@ -11263,6 +11293,7 @@ mod tests {
 
         let (_storage_dir, storage) = test_storage();
         let doc_dir = tempfile::tempdir().expect("doc dir");
+        let realm_id = RealmId::from_bytes([56u8; 32]);
         let service = DocumentSyncService::open_with_persist_policy(
             test_endpoint(56).await,
             storage.clone(),
@@ -11271,13 +11302,13 @@ mod tests {
             vec![Alpn::DocumentSync.as_bytes().to_vec()],
             irokle_crate::net::IrohRuntimeConfig::default(),
             FjallPersistPolicy::Buffer,
+            realm_id,
         )
         .expect("document sync service opens");
 
         let local_node = service.local_node_id().expect("local node id");
         let forged_node = node(89);
         assert_ne!(local_node, forged_node);
-        let realm_id = RealmId::from_bytes([56u8; 32]);
         let target = DocumentSyncTarget::WatchInterest {
             realm_id,
             node_id: local_node,
@@ -11286,8 +11317,11 @@ mod tests {
             realm_id,
             node_id: forged_node,
         };
-        let topic_id = target.sync_topic_id();
-        assert_eq!(topic_id, forged_target.sync_topic_id());
+        let topic_id = target.sync_topic_id(realm_id, &PlacementRef::NIL);
+        assert_eq!(
+            topic_id,
+            forged_target.sync_topic_id(realm_id, &PlacementRef::NIL)
+        );
 
         let change = |kind| DocumentSyncChange {
             base: None,
@@ -11338,6 +11372,7 @@ mod tests {
                     DocumentSyncPublish::AdminOperation {
                         target: forged_target.clone(),
                         event: Box::new(admin_event),
+                        placement: PlacementRef::NIL,
                         allow_genesis: true,
                     },
                     DocumentSyncPublish::Upsert {

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -52,7 +52,7 @@ use tracing::{Instrument, Span, debug, warn};
 pub use ::irokle::net::IrohRuntimeConfig;
 pub use connection_pool::Monitor;
 pub use dht::DhtHandle;
-pub use document_sync::DocumentSyncService;
+pub use document_sync::{DocumentSyncService, ShardGenesisProbe};
 pub use error::{NetError, Result};
 
 const DHT_SIGNED_MAX_CLOCK_SKEW_SECS: u64 = 300;
@@ -863,6 +863,20 @@ impl NetHandle {
     /// Whether a document sync topic's genesis is known locally.
     pub fn document_sync_topic_exists(&self, topic: ::irokle::TopicId) -> Result<bool> {
         self.inner.document_sync.topic_exists(topic)
+    }
+
+    /// Probes a shard's co-holders for an existing genesis of `topics` (see
+    /// [`ShardGenesisProbe`]). A rank-0 holder uses the result to create a fresh
+    /// genesis only when every co-holder was reached and none had the topic.
+    pub async fn probe_shard_topic_geneses(
+        &self,
+        topics: Vec<::irokle::TopicId>,
+        co_holders: Vec<NodeId>,
+    ) -> ShardGenesisProbe {
+        self.inner
+            .document_sync
+            .probe_shard_topic_geneses(topics, co_holders)
+            .await
     }
 
     /// Shard-topic anti-entropy for the startup restore and placement

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -2341,6 +2341,7 @@ mod tests {
                 realm_id: RealmId::from_bytes([seed; 32]),
             },
             event: aruna_core::document::DocumentSyncOutboxEvent::Delete { change },
+            placement: aruna_core::structs::PlacementRef::NIL,
             allow_genesis: false,
         }
     }

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -850,6 +850,19 @@ impl NetHandle {
             .allow_document_sync_peers(topics, peers)
     }
 
+    /// Reconciles shard-only topics to their exact current holder membership and
+    /// publisher policy. Shared topic membership and default peers are unchanged.
+    pub async fn reconcile_shard_membership(
+        &self,
+        topics: &[::irokle::TopicId],
+        holders: Vec<NodeId>,
+    ) -> Result<()> {
+        self.inner
+            .document_sync
+            .reconcile_shard_membership(topics, holders)
+            .await
+    }
+
     pub fn ensure_document_sync_topics(
         &self,
         topics: &[::irokle::TopicId],

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -864,7 +864,7 @@ impl NetHandle {
         self.inner.document_sync.topic_exists(topic)
     }
 
-    /// Bucket-topic anti-entropy for the startup restore and placement
+    /// Shard-topic anti-entropy for the startup restore and placement
     /// reconciler: ensures the topics locally, syncs them with `peers`, and
     /// reconciles the applied events.
     pub async fn sync_document_topics(

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -575,6 +575,7 @@ impl NetHandle {
             app_alpns,
             config.document_sync_runtime.unwrap_or_default(),
             config.fjall_persist_policy,
+            config.realm_id,
         )?);
 
         let streams = Arc::new(StreamsService::new(
@@ -840,22 +841,41 @@ impl NetHandle {
 
     pub fn allow_document_sync_peers(
         &self,
-        targets: &[DocumentSyncTarget],
+        topics: &[::irokle::TopicId],
         peers: Vec<NodeId>,
     ) -> Result<()> {
         self.inner
             .document_sync
-            .allow_document_sync_peers(targets, peers)
+            .allow_document_sync_peers(topics, peers)
     }
 
     pub fn ensure_document_sync_topics(
         &self,
-        targets: &[DocumentSyncTarget],
+        topics: &[::irokle::TopicId],
         peers: Vec<NodeId>,
     ) -> Result<()> {
         self.inner
             .document_sync
-            .ensure_document_sync_topics(targets, peers)
+            .ensure_document_sync_topics(topics, peers)
+    }
+
+    /// Whether a document sync topic's genesis is known locally.
+    pub fn document_sync_topic_exists(&self, topic: ::irokle::TopicId) -> Result<bool> {
+        self.inner.document_sync.topic_exists(topic)
+    }
+
+    /// Bucket-topic anti-entropy for the startup restore and placement
+    /// reconciler: ensures the topics locally, syncs them with `peers`, and
+    /// reconciles the applied events.
+    pub async fn sync_document_topics(
+        &self,
+        topics: Vec<::irokle::TopicId>,
+        peers: Vec<NodeId>,
+    ) -> aruna_core::document::DocumentSyncNetEvent {
+        self.inner
+            .document_sync
+            .sync_documents_event(topics, peers)
+            .await
     }
 
     pub async fn handle_document_sync_stream(

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -856,10 +856,11 @@ impl NetHandle {
         &self,
         topics: &[::irokle::TopicId],
         holders: Vec<NodeId>,
+        verified_topics: &std::collections::BTreeSet<::irokle::TopicId>,
     ) -> Result<()> {
         self.inner
             .document_sync
-            .reconcile_shard_membership(topics, holders)
+            .reconcile_shard_membership(topics, holders, verified_topics)
             .await
     }
 

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -445,6 +445,7 @@ impl NetHandle {
             Alpn::DocumentSync.as_bytes().to_vec(),
             Alpn::Metadata.as_bytes().to_vec(),
             Alpn::Notification.as_bytes().to_vec(),
+            Alpn::Shard.as_bytes().to_vec(),
         ];
 
         let mut endpoint_builder = Endpoint::builder(presets::Minimal)

--- a/net/src/streams.rs
+++ b/net/src/streams.rs
@@ -243,7 +243,8 @@ pub async fn run_accept_loop(
                             alpn @ (Alpn::Bao
                             | Alpn::DocumentSync
                             | Alpn::Metadata
-                            | Alpn::Notification),
+                            | Alpn::Notification
+                            | Alpn::Shard),
                         ) => {
                             if alpn == Alpn::DocumentSync {
                                 document_sync.register_inbound_connection(&conn);

--- a/operations/src/add_group_role.rs
+++ b/operations/src/add_group_role.rs
@@ -391,6 +391,9 @@ impl AddGroupRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/add_group_role.rs
+++ b/operations/src/add_group_role.rs
@@ -6,13 +6,18 @@ use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
-use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE, GROUP_KEYSPACE};
+use aruna_core::keyspaces::{
+    ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE, GROUP_KEYSPACE, REALM_CONFIG_KEYSPACE,
+};
 use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
-use aruna_core::structs::{Actor, AuthContext, Group, GroupAuthorizationDocument, RealmId, Role};
+use aruna_core::structs::{
+    Actor, AuthContext, Group, GroupAuthorizationDocument, PlacementRef, RealmConfigDocument,
+    RealmId, Role,
+};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, GroupId, Key, KeySpace, TxnId, UserId};
 use aruna_core::util::unix_timestamp_millis;
@@ -28,6 +33,7 @@ use crate::document_sync_outbox::{
 };
 use crate::notifications::emit::emit_notifications_effect;
 use crate::notifications::routing::{RoutingContext, route_resource_event};
+use crate::placement::placement_ref_for_target;
 use crate::replicate_documents::replicate_documents_effect;
 use aruna_core::structs::Permission;
 use aruna_core::structs::ResourceEvent;
@@ -284,6 +290,10 @@ impl AddGroupRoleOperation {
                     ADMIN_DOCUMENT_STATE_KEYSPACE.to_string(),
                     admin_document_reducer_state_key(&target),
                 ),
+                (
+                    REALM_CONFIG_KEYSPACE.to_string(),
+                    ByteView::from(*self.input.actor.realm_id.as_bytes()),
+                ),
             ],
             txn_id: Some(txn_id),
         })])
@@ -303,10 +313,15 @@ impl AddGroupRoleOperation {
                 got,
             );
         };
-        let [(_, auth_doc_value), (_, reducer_state_value)] = values.as_slice() else {
+        let [
+            (_, auth_doc_value),
+            (_, reducer_state_value),
+            (_, realm_config_value),
+        ] = values.as_slice()
+        else {
             return self.unexpected_event(
                 self.state.clone(),
-                "Event::Storage(StorageEvent::BatchReadResult) with auth doc and admin state values",
+                "Event::Storage(StorageEvent::BatchReadResult) with auth doc, admin state, and realm config values",
                 got,
             );
         };
@@ -316,6 +331,7 @@ impl AddGroupRoleOperation {
             group,
             auth_doc_value.clone(),
             reducer_state_value.clone(),
+            realm_config_value.clone(),
         ) {
             Ok(effects) => effects,
             Err(err) => self.fail(err),
@@ -328,6 +344,7 @@ impl AddGroupRoleOperation {
         mut group: Group,
         auth_doc: Option<ByteView>,
         reducer_state_value: Option<ByteView>,
+        realm_config_value: Option<ByteView>,
     ) -> Result<Effects, AddGroupRoleError> {
         let mut auth_doc = GroupAuthorizationDocument::from_bytes(
             &auth_doc.ok_or_else(|| AddGroupRoleError::GroupNotFound)?,
@@ -382,6 +399,12 @@ impl AddGroupRoleOperation {
         let document_target = DocumentSyncTarget::GroupAuthorization {
             group_id: self.input.group_id,
         };
+        let placement = realm_config_value
+            .as_deref()
+            .map(RealmConfigDocument::from_bytes)
+            .transpose()?
+            .map(|config| placement_ref_for_target(&config, &document_target, Default::default()))
+            .unwrap_or(PlacementRef::NIL);
         for event in &admin_events {
             let record = new_outbox_record_with_id(
                 event.event_id,
@@ -391,9 +414,7 @@ impl AddGroupRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
-                // No realm config in reach here; the stage-2 topic flip resolves
-                // the real ref for this target.
-                aruna_core::structs::PlacementRef::NIL,
+                placement,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
@@ -949,7 +970,9 @@ pub mod test {
     };
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
-    use aruna_core::keyspaces::{AUTH_KEYSPACE, GROUP_KEYSPACE, NOTIFICATION_OUTBOX_KEYSPACE};
+    use aruna_core::keyspaces::{
+        AUTH_KEYSPACE, GROUP_KEYSPACE, NOTIFICATION_OUTBOX_KEYSPACE, REALM_CONFIG_KEYSPACE,
+    };
     use aruna_core::operation::Operation;
     use aruna_core::storage_entries::{
         admin_document_reducer_conflict_key, admin_document_reducer_state_key,
@@ -1322,6 +1345,10 @@ pub mod test {
                         ADMIN_DOCUMENT_STATE_KEYSPACE.to_string(),
                         admin_document_reducer_state_key(&target),
                     ),
+                    (
+                        REALM_CONFIG_KEYSPACE.to_string(),
+                        realm_id.as_bytes().to_vec().into(),
+                    ),
                 ],
                 txn_id: Some(txn_id)
             })
@@ -1345,6 +1372,7 @@ pub mod test {
                         admin_document_reducer_state_key(&target),
                         Some(postcard::to_allocvec(&previous_state).unwrap().into()),
                     ),
+                    (realm_id.as_bytes().to_vec().into(), None),
                 ],
             },
         ));

--- a/operations/src/add_realm_role.rs
+++ b/operations/src/add_realm_role.rs
@@ -324,6 +324,9 @@ impl AddRealmRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/add_user_to_group.rs
+++ b/operations/src/add_user_to_group.rs
@@ -331,6 +331,9 @@ impl AddUserToGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/add_user_to_group.rs
+++ b/operations/src/add_user_to_group.rs
@@ -6,14 +6,15 @@ use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
-use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE};
+use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE, REALM_CONFIG_KEYSPACE};
 use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
 use aruna_core::structs::{
-    Actor, AuthContext, GroupAuthorizationDocument, Permission, ResourceEvent,
+    Actor, AuthContext, GroupAuthorizationDocument, Permission, PlacementRef, RealmConfigDocument,
+    ResourceEvent,
 };
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, GroupId, Key, KeySpace, RoleId, TxnId, UserId};
@@ -30,6 +31,7 @@ use crate::document_sync_outbox::{
 };
 use crate::notifications::emit::emit_notifications_effect;
 use crate::notifications::routing::{RoutingContext, route_resource_event};
+use crate::placement::placement_ref_for_target;
 use crate::replicate_documents::replicate_documents_effect;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -211,6 +213,10 @@ impl AddUserToGroupOperation {
                     ADMIN_DOCUMENT_STATE_KEYSPACE.to_string(),
                     admin_document_reducer_state_key(&target),
                 ),
+                (
+                    REALM_CONFIG_KEYSPACE.to_string(),
+                    ByteView::from(*self.input.actor.realm_id.as_bytes()),
+                ),
             ],
             txn_id: Some(txn_id),
         })])
@@ -225,10 +231,15 @@ impl AddUserToGroupOperation {
                 got,
             );
         };
-        let [(_, auth_doc_value), (_, reducer_state_value)] = values.as_slice() else {
+        let [
+            (_, auth_doc_value),
+            (_, reducer_state_value),
+            (_, realm_config_value),
+        ] = values.as_slice()
+        else {
             return self.unexpected_event(
                 self.state.clone(),
-                "Event::Storage(StorageEvent::BatchReadResult) with auth doc and admin state values",
+                "Event::Storage(StorageEvent::BatchReadResult) with auth doc, admin state, and realm config values",
                 got,
             );
         };
@@ -237,6 +248,7 @@ impl AddUserToGroupOperation {
             txn_id,
             auth_doc_value.clone(),
             reducer_state_value.clone(),
+            realm_config_value.clone(),
         ) {
             Ok(effects) => effects,
             Err(err) => self.fail(err),
@@ -248,6 +260,7 @@ impl AddUserToGroupOperation {
         txn_id: TxnId,
         auth_doc: Option<ByteView>,
         reducer_state_value: Option<ByteView>,
+        realm_config_value: Option<ByteView>,
     ) -> Result<Effects, AddUserToGroupError> {
         let mut auth_doc = GroupAuthorizationDocument::from_bytes(
             &auth_doc.ok_or_else(|| AddUserToGroupError::AuthDocNotFound)?,
@@ -322,6 +335,12 @@ impl AddUserToGroupOperation {
         let document_target = DocumentSyncTarget::GroupAuthorization {
             group_id: self.input.group_id,
         };
+        let placement = realm_config_value
+            .as_deref()
+            .map(RealmConfigDocument::from_bytes)
+            .transpose()?
+            .map(|config| placement_ref_for_target(&config, &document_target, Default::default()))
+            .unwrap_or(PlacementRef::NIL);
         for event in &admin_events {
             let record = new_outbox_record_with_id(
                 event.event_id,
@@ -331,9 +350,7 @@ impl AddUserToGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
-                // No realm config in reach here; the stage-2 topic flip resolves
-                // the real ref for this target.
-                aruna_core::structs::PlacementRef::NIL,
+                placement,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
@@ -782,7 +799,7 @@ pub mod test {
     };
     use aruna_core::structs::{
         Actor, Group, GroupAuthorizationDocument, NotificationOutboxRecord, NotificationRecord,
-        Permission, RealmId, Role,
+        Permission, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind, Role,
     };
     use aruna_core::task::TaskEvent;
     use aruna_core::task::TaskKey;
@@ -975,6 +992,7 @@ pub mod test {
                 TxnId::r#gen(),
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 None,
+                None,
             )
             .unwrap();
         let outbox_records: Vec<DocumentSyncOutboxRecord> = match effects.first().unwrap() {
@@ -1053,6 +1071,18 @@ pub mod test {
             role_ids: HashSet::from([role_id]),
         };
         let target = AdminDocumentTarget::Group { group_id };
+        let document_target = DocumentSyncTarget::GroupAuthorization { group_id };
+        let mut realm_config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+        realm_config.seed_default_placement();
+        for seed in 20..24u8 {
+            realm_config.ensure_node(node(seed), RealmNodeKind::Server);
+        }
+        let expected_placement = crate::placement::placement_ref_for_target(
+            &realm_config,
+            &document_target,
+            Default::default(),
+        );
+        assert_ne!(expected_placement, PlacementRef::NIL);
         let mut operation = AddUserToGroupOperation::new(input);
 
         operation.start();
@@ -1071,6 +1101,10 @@ pub mod test {
                 (
                     admin_document_reducer_state_key(&target),
                     Some(postcard::to_allocvec(&previous_state).unwrap().into()),
+                ),
+                (
+                    realm_id.as_bytes().to_vec().into(),
+                    Some(realm_config.to_bytes(&actor).unwrap().into()),
                 ),
             ],
         }));
@@ -1114,10 +1148,8 @@ pub mod test {
             other => panic!("unexpected write effect: {other:?}"),
         };
         assert_eq!(outbox_records.len(), 1);
-        assert_eq!(
-            outbox_records[0].target,
-            DocumentSyncTarget::GroupAuthorization { group_id }
-        );
+        assert_eq!(outbox_records[0].target, document_target);
+        assert_eq!(outbox_records[0].placement, expected_placement);
         assert!(matches!(
             &outbox_records[0].event,
             DocumentSyncOutboxEvent::AdminOperation { event }
@@ -1220,6 +1252,7 @@ pub mod test {
                 txn_id,
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 Some(postcard::to_allocvec(&reducer_state).unwrap().into()),
+                None,
             )
             .unwrap();
         assert!(matches!(
@@ -1536,6 +1569,7 @@ pub mod test {
                     Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 ),
                 (admin_document_reducer_state_key(&target), None),
+                (realm_id.as_bytes().to_vec().into(), None),
             ],
         }));
         operation.step(Event::Storage(StorageEvent::BatchWriteResult {
@@ -1591,6 +1625,7 @@ pub mod test {
                     Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 ),
                 (admin_document_reducer_state_key(&target), None),
+                (realm_id.as_bytes().to_vec().into(), None),
             ],
         }));
         operation.step(Event::Storage(StorageEvent::BatchWriteResult {

--- a/operations/src/add_user_to_realm_role.rs
+++ b/operations/src/add_user_to_realm_role.rs
@@ -307,6 +307,9 @@ impl AddUserToRealmRolesOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -277,11 +277,14 @@ impl AnnounceTopicOperation {
     ) -> Effects {
         self.current = Some(document.clone());
         self.state = AnnounceTopicState::WriteOutbox;
+        // Announce only ever emits Upsert here, so the record mirrors the
+        // change's placement; the admin fallback is unused.
         let record = new_outbox_record(
             self.local_node_id,
             document,
             self.peers.clone(),
             event,
+            PlacementRef::NIL,
             self.allow_genesis,
         );
         if self.require_delivery {

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -1,12 +1,12 @@
 use std::collections::VecDeque;
 
 use aruna_core::document::{
-    DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncOutboxEvent, DocumentSyncOutboxRecord,
-    DocumentSyncRevision, DocumentSyncTarget,
+    DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncOutboxEvent, DocumentSyncRevision,
+    DocumentSyncTarget,
 };
-use aruna_core::effects::{Effect, IterStart, NetEffect, StorageEffect};
+use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, NetEvent, StorageEvent};
+use aruna_core::events::{Event, StorageEvent};
 use aruna_core::metadata::MetadataError;
 use aruna_core::metadata::{
     MetadataCreateEventRecord, MetadataDocumentLifecycleRecord, MetadataGraphLifecycleRecord,
@@ -18,7 +18,6 @@ use aruna_core::structs::PlacementRef;
 use aruna_core::structs::RealmId;
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, UserId};
-use aruna_core::{DocumentSyncEffect, DocumentSyncNetEvent};
 use aruna_core::{NodeId, TopicId, USER_KEYSPACE};
 use smallvec::smallvec;
 use thiserror::Error;
@@ -52,8 +51,6 @@ pub struct AnnounceTopicOperation {
     document_bytes: Option<Vec<u8>>,
     placement: PlacementRef,
     allow_genesis: bool,
-    require_delivery: bool,
-    transfer_outbox: Option<DocumentSyncOutboxRecord>,
     state: AnnounceTopicState,
     pending: VecDeque<PendingDocumentSync>,
     current: Option<DocumentSyncTarget>,
@@ -67,9 +64,6 @@ enum AnnounceTopicState {
     ListUsers,
     WriteOutbox,
     ScheduleSync,
-    PublishDocument,
-    SyncDocument,
-    DeleteTransferredOutbox,
     Finish,
     Error,
 }
@@ -139,8 +133,6 @@ impl AnnounceTopicOperation {
             document_bytes: None,
             placement,
             allow_genesis,
-            require_delivery: false,
-            transfer_outbox: None,
             state: AnnounceTopicState::Init,
             pending: VecDeque::new(),
             current: None,
@@ -164,33 +156,11 @@ impl AnnounceTopicOperation {
             document_bytes: Some(bytes),
             placement: PlacementRef::NIL,
             allow_genesis,
-            require_delivery: false,
-            transfer_outbox: None,
             state: AnnounceTopicState::Init,
             pending: VecDeque::new(),
             current: None,
             output: None,
         }
-    }
-
-    pub(crate) fn new_for_document_transfer_with_peers_and_placement(
-        topic: TopicId,
-        local_node_id: NodeId,
-        document: DocumentSyncTarget,
-        peers: Vec<NodeId>,
-        placement: PlacementRef,
-        allow_genesis: bool,
-    ) -> Self {
-        let mut operation = Self::new_for_document_with_peers_and_placement(
-            topic,
-            local_node_id,
-            Some(document),
-            peers,
-            placement,
-            allow_genesis,
-        );
-        operation.require_delivery = true;
-        operation
     }
 
     fn unexpected_event(&mut self, expected: &'static str, got: String) -> Effects {
@@ -208,16 +178,6 @@ impl AnnounceTopicOperation {
         self.state = AnnounceTopicState::Error;
         self.output = Some(Err(error));
         smallvec![]
-    }
-
-    fn fail_transfer(&mut self, error: AnnounceTopicError) -> Effects {
-        self.state = AnnounceTopicState::Error;
-        self.output = Some(Err(error));
-        if self.transfer_outbox.is_some() {
-            smallvec![schedule_outbox_drain_effect()]
-        } else {
-            smallvec![]
-        }
     }
 
     fn finish(&mut self) -> Effects {
@@ -254,22 +214,6 @@ impl AnnounceTopicOperation {
         )
     }
 
-    fn publish_persisted_outbox_effect(&mut self) -> Effects {
-        let Some(record) = self.transfer_outbox.as_ref() else {
-            return self.unexpected_event(
-                "persisted document sync outbox record",
-                "missing transfer outbox record".to_string(),
-            );
-        };
-        self.state = AnnounceTopicState::PublishDocument;
-        smallvec![Effect::Net(NetEffect::DocumentSync(
-            DocumentSyncEffect::PublishDocuments {
-                documents: vec![crate::task_incoming::document_publish_from_outbox(record)],
-                peers: self.peers.clone(),
-            }
-        ))]
-    }
-
     fn write_document_outbox_event_effect(
         &mut self,
         document: DocumentSyncTarget,
@@ -287,9 +231,6 @@ impl AnnounceTopicOperation {
             PlacementRef::NIL,
             self.allow_genesis,
         );
-        if self.require_delivery {
-            self.transfer_outbox = Some(record.clone());
-        }
         match write_outbox_effect(&record) {
             Ok(effect) => smallvec![effect],
             Err(error) => self.fail(AnnounceTopicError::ConversionError(error.into())),
@@ -425,14 +366,7 @@ impl AnnounceTopicOperation {
         match self.pending.pop_front() {
             Some(PendingDocumentSync::Document { document, bytes }) => {
                 if let Some(bytes) = bytes {
-                    if self.require_delivery && self.peers.is_empty() {
-                        match self.document_upsert_change(&document, &bytes) {
-                            Ok(_) => self.finish(),
-                            Err(error) => self.fail(error),
-                        }
-                    } else {
-                        self.write_document_outbox_effect(document, bytes)
-                    }
+                    self.write_document_outbox_effect(document, bytes)
                 } else {
                     self.current = Some(document.clone());
                     self.state = AnnounceTopicState::ReadDocument;
@@ -477,25 +411,9 @@ impl Operation for AnnounceTopicOperation {
                         );
                     };
                     let Some(bytes) = value else {
-                        if self.require_delivery {
-                            return self.fail(AnnounceTopicError::DocumentSync(format!(
-                                "required transfer source is missing for {document:?}"
-                            )));
-                        }
                         return self.next_effect();
                     };
-                    if self.require_delivery {
-                        if self.peers.is_empty() {
-                            match self.document_upsert_change(&document, &bytes) {
-                                Ok(_) => self.finish(),
-                                Err(error) => self.fail(error),
-                            }
-                        } else {
-                            self.write_document_outbox_effect(document, bytes.to_vec())
-                        }
-                    } else {
-                        self.write_document_outbox_effect(document, bytes.to_vec())
-                    }
+                    self.write_document_outbox_effect(document, bytes.to_vec())
                 }
                 Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
                 other => self.unexpected_event("storage read result", format!("{other:?}")),
@@ -542,9 +460,6 @@ impl Operation for AnnounceTopicOperation {
                             "missing current document".to_string(),
                         );
                     }
-                    if self.require_delivery {
-                        return self.publish_persisted_outbox_effect();
-                    }
                     self.state = AnnounceTopicState::ScheduleSync;
                     smallvec![schedule_outbox_drain_effect()]
                 }
@@ -566,67 +481,6 @@ impl Operation for AnnounceTopicOperation {
                 other => {
                     self.unexpected_event("document sync timer schedule", format!("{other:?}"))
                 }
-            },
-            AnnounceTopicState::PublishDocument => match event {
-                Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::DocumentsPublished {
-                    ..
-                })) => {
-                    let Some(document) = self.current.clone() else {
-                        return self.unexpected_event(
-                            "tracked document sync target",
-                            "missing current document".to_string(),
-                        );
-                    };
-                    self.state = AnnounceTopicState::SyncDocument;
-                    smallvec![Effect::Net(NetEffect::DocumentSync(
-                        DocumentSyncEffect::SyncDocument {
-                            target: document,
-                            peers: self.peers.clone(),
-                        }
-                    ))]
-                }
-                Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
-                    error, ..
-                })) => self.fail_transfer(AnnounceTopicError::DocumentSync(error)),
-                Event::Net(NetEvent::Error(error)) => {
-                    self.fail_transfer(AnnounceTopicError::DocumentSync(format!("{error:?}")))
-                }
-                other => self.fail_transfer(AnnounceTopicError::DocumentSync(format!(
-                    "unexpected document publish result: {other:?}"
-                ))),
-            },
-            AnnounceTopicState::SyncDocument => match event {
-                Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::DocumentsReconciled {
-                    ..
-                })) => {
-                    let Some(record) = self.transfer_outbox.as_ref() else {
-                        return self.unexpected_event(
-                            "persisted document sync outbox record",
-                            "missing transfer outbox record".to_string(),
-                        );
-                    };
-                    self.state = AnnounceTopicState::DeleteTransferredOutbox;
-                    smallvec![crate::document_sync_outbox::delete_outbox_effect(record)]
-                }
-                Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
-                    error, ..
-                })) => self.fail_transfer(AnnounceTopicError::DocumentSync(error)),
-                Event::Net(NetEvent::Error(error)) => {
-                    self.fail_transfer(AnnounceTopicError::DocumentSync(format!("{error:?}")))
-                }
-                other => self.fail_transfer(AnnounceTopicError::DocumentSync(format!(
-                    "unexpected document sync result: {other:?}"
-                ))),
-            },
-            AnnounceTopicState::DeleteTransferredOutbox => match event {
-                Event::Storage(StorageEvent::DeleteResult { .. }) => {
-                    self.transfer_outbox = None;
-                    self.finish()
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail_transfer(error.into()),
-                other => self.fail_transfer(AnnounceTopicError::DocumentSync(format!(
-                    "unexpected transfer outbox delete result: {other:?}"
-                ))),
             },
             AnnounceTopicState::Finish | AnnounceTopicState::Error | AnnounceTopicState::Init => {
                 smallvec![]
@@ -770,125 +624,6 @@ mod tests {
             panic!("expected revisioned upsert");
         };
         assert_eq!(change.placement, placement);
-    }
-
-    fn document_lifecycle_fixture() -> (DocumentSyncTarget, Vec<u8>) {
-        let document_id = Ulid::from_bytes([7; 16]);
-        let lifecycle = MetadataDocumentLifecycleRecord::Delete {
-            event: aruna_core::metadata::MetadataDocumentDeleteRecord {
-                event_id: Ulid::from_bytes([8; 16]),
-                tombstone: MetadataGraphLifecycleRecord::deleted(
-                    "urn:graph:transfer".to_string(),
-                    RealmId::from_bytes([2; 32]),
-                    GroupId::from_bytes([6; 16]),
-                    document_id,
-                    42,
-                ),
-                deleted_after_event_id: Ulid::from_bytes([5; 16]),
-            },
-        };
-        (
-            DocumentSyncTarget::MetadataDocumentLifecycle { document_id },
-            postcard::to_allocvec(&lifecycle).expect("lifecycle serializes"),
-        )
-    }
-
-    #[test]
-    fn required_document_transfer_fails_without_source() {
-        let (document, _) = document_lifecycle_fixture();
-        let mut operation =
-            AnnounceTopicOperation::new_for_document_transfer_with_peers_and_placement(
-                document.topic_id(),
-                local_node_id(),
-                document,
-                vec![iroh::SecretKey::from_bytes(&[2; 32]).public()],
-                PlacementRef::NIL,
-                false,
-            );
-
-        assert!(matches!(
-            operation.start().as_slice(),
-            [Effect::Storage(StorageEffect::Read { .. })]
-        ));
-        let effects = operation.step(Event::Storage(StorageEvent::ReadResult {
-            key: Key::from(Vec::new()),
-            value: None,
-        }));
-
-        assert!(effects.is_empty());
-        assert!(operation.is_complete());
-        assert!(matches!(
-            operation.finalize(),
-            Err(AnnounceTopicError::DocumentSync(error))
-                if error.contains("required transfer source is missing")
-        ));
-    }
-
-    #[test]
-    fn required_document_transfer_waits_for_peer_reconciliation() {
-        let (document, bytes) = document_lifecycle_fixture();
-        let peer = iroh::SecretKey::from_bytes(&[2; 32]).public();
-        let mut operation =
-            AnnounceTopicOperation::new_for_document_transfer_with_peers_and_placement(
-                document.topic_id(),
-                local_node_id(),
-                document.clone(),
-                vec![peer],
-                PlacementRef::NIL,
-                false,
-            );
-        operation.start();
-
-        let effects = operation.step(Event::Storage(StorageEvent::ReadResult {
-            key: Key::from(Vec::new()),
-            value: Some(bytes.into()),
-        }));
-        let outbox = written_outbox_record(effects.as_slice());
-        assert_eq!(outbox.target, document);
-        assert_eq!(outbox.peers, vec![peer]);
-        let effects = operation.step(Event::Storage(StorageEvent::WriteResult {
-            key: crate::document_sync_outbox::outbox_key(&outbox),
-        }));
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Net(NetEffect::DocumentSync(
-                DocumentSyncEffect::PublishDocuments { peers, .. }
-            ))] if peers == &vec![peer]
-        ));
-        let effects = operation.step(Event::Net(NetEvent::DocumentSync(
-            DocumentSyncNetEvent::DocumentsPublished {
-                targets: vec![document.clone()],
-            },
-        )));
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Net(NetEffect::DocumentSync(
-                DocumentSyncEffect::SyncDocument { target, peers }
-            ))] if target == &document && peers == &vec![peer]
-        ));
-        assert!(!operation.is_complete());
-
-        let effects = operation.step(Event::Net(NetEvent::DocumentSync(
-            DocumentSyncNetEvent::DocumentsReconciled {
-                applied: 0,
-                targets: Vec::new(),
-                metadata_create_events: Vec::new(),
-                metadata_graph_tombstones: Vec::new(),
-            },
-        )));
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Storage(StorageEffect::Delete { key_space, key, .. })]
-                if key_space == DOCUMENT_SYNC_OUTBOX_KEYSPACE
-                    && key == &crate::document_sync_outbox::outbox_key(&outbox)
-        ));
-        assert!(!operation.is_complete());
-        let effects = operation.step(Event::Storage(StorageEvent::DeleteResult {
-            key: crate::document_sync_outbox::outbox_key(&outbox),
-        }));
-        assert!(effects.is_empty());
-        assert!(operation.is_complete());
-        assert_eq!(operation.finalize(), Ok(()));
     }
 
     #[test]

--- a/operations/src/announce.rs
+++ b/operations/src/announce.rs
@@ -746,6 +746,7 @@ mod tests {
         let placement = PlacementRef {
             strategy_id: Ulid::from_bytes([8; 16]),
             epoch: 3,
+            shard: 5,
         };
         let mut operation = AnnounceTopicOperation::new_for_document_with_peers_and_placement(
             document.topic_id(),

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -334,7 +334,9 @@ async fn onboarding_sync_topics(
                 continue;
             }
             let placement = match config.as_ref() {
-                Some(config) => crate::placement::placement_ref_for_target(config, document, None),
+                Some(config) => {
+                    crate::placement::placement_ref_for_target(config, document, Default::default())
+                }
                 None => PlacementRef::NIL,
             };
             if placement == PlacementRef::NIL {
@@ -735,7 +737,9 @@ mod tests {
         let state = net_handle
             .document_sync_node()
             .storage()
-            .topic_state(&target.sync_topic_id())
+            .topic_state(
+                &target.sync_topic_id(fixture.realm_id, &aruna_core::structs::PlacementRef::NIL),
+            )
             .unwrap()
             .expect("issuer node-info topic admitted during finalize");
         assert!(state.members.contains(&irokle::PeerId::from_bytes(

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -131,7 +131,8 @@ pub async fn bootstrap_onboarding_finalize(
     .await?;
     let encoded_ticket = ticket.encode()?;
 
-    let onboarding_topics = onboarding_sync_topics(&context, input.realm_id, &ticket).await?;
+    let onboarding_topics =
+        onboarding_sync_topics(&context, input.realm_id, input.node_id, &ticket).await?;
     let net_handle = context
         .net_handle
         .as_ref()
@@ -317,13 +318,15 @@ struct OnboardingSyncTopics {
 }
 
 /// Derives the sync topics for a ticket's documents so the issuer can add the
-/// joiner to them: shared realm targets ignore the placement, user documents
-/// ride their shard topic (resolved from the issuer's realm config). Shared
-/// and shard topics are returned separately because only shared topics may be
-/// created by the issuer; shard topics are join-only.
+/// joiner to them: shared realm targets ignore the placement, while user
+/// documents ride their shard topic only when the joiner holds that placement
+/// under the issuer's realm config. Shared and shard topics are returned
+/// separately because only shared topics may be created by the issuer; shard
+/// topics are join-only.
 async fn onboarding_sync_topics(
     context: &Arc<DriverContext>,
     realm_id: RealmId,
+    joiner_node_id: NodeId,
     ticket: &aruna_core::onboarding::OnboardingSyncTicket,
 ) -> Result<OnboardingSyncTopics, BootstrapOnboardingFinalizeError> {
     use aruna_core::document::DocumentSyncTarget;
@@ -348,9 +351,11 @@ async fn onboarding_sync_topics(
                     *user_id,
                 ));
             }
-            topics
-                .shard
-                .push(document.sync_topic_id(realm_id, &placement));
+            if crate::placement::holds_placement(&config, &placement, joiner_node_id) {
+                topics
+                    .shard
+                    .push(document.sync_topic_id(realm_id, &placement));
+            }
         } else {
             topics
                 .shared
@@ -384,8 +389,8 @@ mod tests {
         OnboardingSyncTicket,
     };
     use aruna_core::structs::{
-        Actor, KIND_LABEL_KEY, NotificationKind, NotificationOutboxRecord,
-        RealmAuthorizationDocument, RealmId,
+        Actor, BindingScope, DocumentClass, KIND_LABEL_KEY, NotificationKind,
+        NotificationOutboxRecord, RealmAuthorizationDocument, RealmId, RealmNodeKind,
     };
     use aruna_core::types::UserId;
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
@@ -778,7 +783,13 @@ mod tests {
         .unwrap();
 
         assert!(matches!(
-            onboarding_sync_topics(&fixture.context, fixture.realm_id, &ticket).await,
+            onboarding_sync_topics(
+                &fixture.context,
+                fixture.realm_id,
+                fixture.joiner_node_id,
+                &ticket,
+            )
+            .await,
             Err(BootstrapOnboardingFinalizeError::UserPlacementUnavailable(id)) if id == user_id
         ));
 
@@ -792,11 +803,109 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(
-            onboarding_sync_topics(&fixture.context, missing_realm_id, &missing_ticket).await,
+            onboarding_sync_topics(
+                &fixture.context,
+                missing_realm_id,
+                fixture.joiner_node_id,
+                &missing_ticket,
+            )
+            .await,
             Err(BootstrapOnboardingFinalizeError::GetRealmConfig(
                 GetRealmConfigError::DocumentNotFound
             ))
         ));
+    }
+
+    #[tokio::test]
+    async fn nonholder_shard_excluded() {
+        let fixture = setup_finalize_fixture().await;
+        let mut config = drive(
+            GetRealmConfigOperation::new(fixture.realm_id),
+            fixture.context.as_ref(),
+        )
+        .await
+        .unwrap();
+        config.ensure_node(fixture.joiner_node_id, RealmNodeKind::Server);
+        let user_strategy_id = config
+            .strategy_bindings
+            .iter()
+            .find(|binding| binding.scope == BindingScope::Class(DocumentClass::User))
+            .unwrap()
+            .strategy_id;
+        config
+            .strategies
+            .iter_mut()
+            .find(|strategy| strategy.strategy_id == user_strategy_id)
+            .unwrap()
+            .replica_count = Some(1);
+
+        let actor = Actor {
+            node_id: fixture.local_node_id,
+            user_id: UserId::nil(fixture.realm_id),
+            realm_id: fixture.realm_id,
+        };
+        let config_target = DocumentSyncTarget::RealmConfig {
+            realm_id: fixture.realm_id,
+        };
+        let event = fixture
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: config_target.storage_keyspace().to_string(),
+                key: config_target.storage_key(),
+                value: config.to_bytes(&actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+
+        let mut held = None;
+        let mut nonholder = None;
+        for seed in 0u16..=u16::MAX {
+            let mut bytes = [0u8; 16];
+            bytes[..2].copy_from_slice(&seed.to_be_bytes());
+            let target = DocumentSyncTarget::User {
+                user_id: UserId::local(Ulid::from_bytes(bytes), fixture.realm_id),
+            };
+            let placement =
+                crate::placement::placement_ref_for_target(&config, &target, Default::default());
+            if crate::placement::holds_placement(&config, &placement, fixture.joiner_node_id) {
+                held.get_or_insert(target);
+            } else {
+                nonholder.get_or_insert(target);
+            }
+            if held.is_some() && nonholder.is_some() {
+                break;
+            }
+        }
+        let held = held.expect("joiner holds a capped user shard");
+        let nonholder = nonholder.expect("joiner does not hold every capped user shard");
+        let held_placement =
+            crate::placement::placement_ref_for_target(&config, &held, Default::default());
+        let ticket = OnboardingSyncTicket::issue(
+            &fixture.realm_signing_key,
+            &fixture.realm_id,
+            fixture.joiner_node_id,
+            100,
+            vec![nonholder, held.clone()],
+        )
+        .unwrap();
+
+        let topics = onboarding_sync_topics(
+            &fixture.context,
+            fixture.realm_id,
+            fixture.joiner_node_id,
+            &ticket,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            topics.shard,
+            vec![held.sync_topic_id(fixture.realm_id, &held_placement)]
+        );
     }
 
     #[tokio::test]

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -32,7 +32,7 @@ use crate::mutate_realm_placement::{
 use crate::notifications::emit::{EmitNotificationsInput, EmitNotificationsOperation};
 use crate::notifications::routing::{RoutingContext, route_resource_event};
 use crate::notifications::watch::interest::mark_watch_interest_dirty;
-use crate::process_placements::process_bucket_placements;
+use crate::process_placements::process_shard_placements;
 use crate::read_realm_authorization::ReadRealmAuthorizationOperation;
 use crate::reserve_onboarding_secret::{
     ReserveOnboardingSecretError, ReserveOnboardingSecretInput, ReserveOnboardingSecretOperation,
@@ -132,13 +132,13 @@ pub async fn bootstrap_onboarding_finalize(
         .as_ref()
         .ok_or(BootstrapOnboardingFinalizeError::NetHandleUnavailable)?;
     // Shared realm topics may be created here (the issuer is a legitimate
-    // origin for them); bucket topics are join-only — their genesis comes from
-    // the bucket's rank-0 holder, so the joiner is only added as a member.
+    // origin for them); shard topics are join-only — their genesis comes from
+    // the shard's rank-0 holder, so the joiner is only added as a member.
     net_handle
         .ensure_document_sync_topics(&onboarding_topics.shared, vec![input.node_id])
         .map_err(|error| BootstrapOnboardingFinalizeError::PeerAdmission(error.to_string()))?;
     let mut all_topics = onboarding_topics.shared;
-    all_topics.extend(onboarding_topics.bucket);
+    all_topics.extend(onboarding_topics.shard);
     net_handle
         .allow_document_sync_peers(&all_topics, vec![input.node_id])
         .map_err(|error| BootstrapOnboardingFinalizeError::PeerAdmission(error.to_string()))?;
@@ -303,19 +303,19 @@ async fn process_pending_placements(
     input: &BootstrapOnboardingFinalizeInput,
     context: &Arc<DriverContext>,
 ) {
-    process_bucket_placements(context, input.realm_id, input.local_node_id).await;
+    process_shard_placements(context, input.realm_id, input.local_node_id).await;
 }
 
 struct OnboardingSyncTopics {
     shared: Vec<::irokle::TopicId>,
-    bucket: Vec<::irokle::TopicId>,
+    shard: Vec<::irokle::TopicId>,
 }
 
 /// Derives the sync topics for a ticket's documents so the issuer can add the
 /// joiner to them: shared realm targets ignore the placement, user documents
-/// ride their bucket topic (resolved from the issuer's realm config). Shared
-/// and bucket topics are returned separately because only shared topics may be
-/// created by the issuer; bucket topics are join-only.
+/// ride their shard topic (resolved from the issuer's realm config). Shared
+/// and shard topics are returned separately because only shared topics may be
+/// created by the issuer; shard topics are join-only.
 async fn onboarding_sync_topics(
     context: &Arc<DriverContext>,
     realm_id: RealmId,
@@ -326,10 +326,10 @@ async fn onboarding_sync_topics(
     let config = load_realm_config_document(context, realm_id).await;
     let mut topics = OnboardingSyncTopics {
         shared: Vec::new(),
-        bucket: Vec::new(),
+        shard: Vec::new(),
     };
     for document in &ticket.payload.documents {
-        if document.uses_bucket_topic() {
+        if document.uses_shard_topic() {
             if !matches!(document, DocumentSyncTarget::User { .. }) {
                 continue;
             }
@@ -341,7 +341,7 @@ async fn onboarding_sync_topics(
                 continue;
             }
             topics
-                .bucket
+                .shard
                 .push(document.sync_topic_id(realm_id, &placement));
         } else {
             topics

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -32,7 +32,7 @@ use crate::mutate_realm_placement::{
 use crate::notifications::emit::{EmitNotificationsInput, EmitNotificationsOperation};
 use crate::notifications::routing::{RoutingContext, route_resource_event};
 use crate::notifications::watch::interest::mark_watch_interest_dirty;
-use crate::process_placements::{PlacementConfig, PlacementError, ProcessPlacementsOperation};
+use crate::process_placements::process_bucket_placements;
 use crate::read_realm_authorization::ReadRealmAuthorizationOperation;
 use crate::reserve_onboarding_secret::{
     ReserveOnboardingSecretError, ReserveOnboardingSecretInput, ReserveOnboardingSecretOperation,
@@ -74,8 +74,6 @@ pub enum BootstrapOnboardingFinalizeError {
     #[error(transparent)]
     SetNodePlacement(#[from] MutateRealmPlacementError),
     #[error(transparent)]
-    Placement(#[from] PlacementError),
-    #[error(transparent)]
     IssueTicket(#[from] IssueOnboardingSyncTicketError),
     #[error(transparent)]
     Consume(#[from] ConsumeOnboardingSecretError),
@@ -112,7 +110,7 @@ pub async fn bootstrap_onboarding_finalize(
 
     ensure_realm_node_with_retries(&input, reserved.mode, context.as_ref()).await?;
     set_joiner_placement_entry(&input, placement_entry, context.as_ref()).await?;
-    process_pending_placements(&input, context.as_ref()).await?;
+    process_pending_placements(&input, &context).await;
 
     let ticket = drive(
         IssueOnboardingSyncTicketOperation::new(IssueOnboardingSyncTicketInput {
@@ -128,15 +126,21 @@ pub async fn bootstrap_onboarding_finalize(
     .await?;
     let encoded_ticket = ticket.encode()?;
 
+    let onboarding_topics = onboarding_sync_topics(&context, input.realm_id, &ticket).await;
     let net_handle = context
         .net_handle
         .as_ref()
         .ok_or(BootstrapOnboardingFinalizeError::NetHandleUnavailable)?;
+    // Shared realm topics may be created here (the issuer is a legitimate
+    // origin for them); bucket topics are join-only — their genesis comes from
+    // the bucket's rank-0 holder, so the joiner is only added as a member.
     net_handle
-        .ensure_document_sync_topics(&ticket.payload.documents, vec![input.node_id])
+        .ensure_document_sync_topics(&onboarding_topics.shared, vec![input.node_id])
         .map_err(|error| BootstrapOnboardingFinalizeError::PeerAdmission(error.to_string()))?;
+    let mut all_topics = onboarding_topics.shared;
+    all_topics.extend(onboarding_topics.bucket);
     net_handle
-        .allow_document_sync_peers(&ticket.payload.documents, vec![input.node_id])
+        .allow_document_sync_peers(&all_topics, vec![input.node_id])
         .map_err(|error| BootstrapOnboardingFinalizeError::PeerAdmission(error.to_string()))?;
 
     let consumed = drive(
@@ -297,23 +301,77 @@ async fn set_joiner_placement_entry(
 
 async fn process_pending_placements(
     input: &BootstrapOnboardingFinalizeInput,
-    context: &DriverContext,
-) -> Result<(), PlacementError> {
-    match drive(
-        ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id: input.realm_id,
-            local_node_id: input.local_node_id,
-            retry_after: crate::sync_placement::SYNC_PLACEMENT_RETRY_AFTER,
-        }),
-        context,
-    )
-    .await
-    {
-        Ok(_) => Ok(()),
-        Err(error) => {
-            warn!(error = %error, "Failed to process pending document-sync placements during onboarding");
-            Err(error)
+    context: &Arc<DriverContext>,
+) {
+    process_bucket_placements(context, input.realm_id, input.local_node_id).await;
+}
+
+struct OnboardingSyncTopics {
+    shared: Vec<::irokle::TopicId>,
+    bucket: Vec<::irokle::TopicId>,
+}
+
+/// Derives the sync topics for a ticket's documents so the issuer can add the
+/// joiner to them: shared realm targets ignore the placement, user documents
+/// ride their bucket topic (resolved from the issuer's realm config). Shared
+/// and bucket topics are returned separately because only shared topics may be
+/// created by the issuer; bucket topics are join-only.
+async fn onboarding_sync_topics(
+    context: &Arc<DriverContext>,
+    realm_id: RealmId,
+    ticket: &aruna_core::onboarding::OnboardingSyncTicket,
+) -> OnboardingSyncTopics {
+    use aruna_core::document::DocumentSyncTarget;
+    use aruna_core::structs::PlacementRef;
+    let config = load_realm_config_document(context, realm_id).await;
+    let mut topics = OnboardingSyncTopics {
+        shared: Vec::new(),
+        bucket: Vec::new(),
+    };
+    for document in &ticket.payload.documents {
+        if document.uses_bucket_topic() {
+            if !matches!(document, DocumentSyncTarget::User { .. }) {
+                continue;
+            }
+            let placement = match config.as_ref() {
+                Some(config) => crate::placement::placement_ref_for_target(config, document, None),
+                None => PlacementRef::NIL,
+            };
+            if placement == PlacementRef::NIL {
+                continue;
+            }
+            topics
+                .bucket
+                .push(document.sync_topic_id(realm_id, &placement));
+        } else {
+            topics
+                .shared
+                .push(document.sync_topic_id(realm_id, &PlacementRef::NIL));
         }
+    }
+    topics
+}
+
+async fn load_realm_config_document(
+    context: &Arc<DriverContext>,
+    realm_id: RealmId,
+) -> Option<aruna_core::structs::RealmConfigDocument> {
+    use aruna_core::document::DocumentSyncTarget;
+    use aruna_core::effects::StorageEffect;
+    use aruna_core::events::{Event, StorageEvent};
+    let target = DocumentSyncTarget::RealmConfig { realm_id };
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: target.storage_keyspace().to_string(),
+            key: target.storage_key(),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => value
+            .and_then(|bytes| aruna_core::structs::RealmConfigDocument::from_bytes(&bytes).ok()),
+        _ => None,
     }
 }
 

--- a/operations/src/bootstrap_onboarding_finalize.rs
+++ b/operations/src/bootstrap_onboarding_finalize.rs
@@ -21,6 +21,7 @@ use crate::driver::{DriverContext, drive};
 use crate::ensure_realm_config::{
     EnsureRealmConfigConfig, EnsureRealmConfigError, EnsureRealmConfigOperation,
 };
+use crate::get_realm_config::{GetRealmConfigError, GetRealmConfigOperation};
 use crate::issue_onboarding_sync_ticket::{
     IssueOnboardingSyncTicketError, IssueOnboardingSyncTicketInput,
     IssueOnboardingSyncTicketOperation, ONBOARDING_SYNC_TICKET_TTL_SECS,
@@ -74,6 +75,8 @@ pub enum BootstrapOnboardingFinalizeError {
     #[error(transparent)]
     SetNodePlacement(#[from] MutateRealmPlacementError),
     #[error(transparent)]
+    GetRealmConfig(#[from] GetRealmConfigError),
+    #[error(transparent)]
     IssueTicket(#[from] IssueOnboardingSyncTicketError),
     #[error(transparent)]
     Consume(#[from] ConsumeOnboardingSecretError),
@@ -87,6 +90,8 @@ pub enum BootstrapOnboardingFinalizeError {
     ReservedNodeLabel,
     #[error("placement location must be at most 64 characters")]
     NodeLocationTooLong,
+    #[error("ticketed user {0} has no placement")]
+    UserPlacementUnavailable(UserId),
 }
 
 pub async fn bootstrap_onboarding_finalize(
@@ -126,7 +131,7 @@ pub async fn bootstrap_onboarding_finalize(
     .await?;
     let encoded_ticket = ticket.encode()?;
 
-    let onboarding_topics = onboarding_sync_topics(&context, input.realm_id, &ticket).await;
+    let onboarding_topics = onboarding_sync_topics(&context, input.realm_id, &ticket).await?;
     let net_handle = context
         .net_handle
         .as_ref()
@@ -320,10 +325,10 @@ async fn onboarding_sync_topics(
     context: &Arc<DriverContext>,
     realm_id: RealmId,
     ticket: &aruna_core::onboarding::OnboardingSyncTicket,
-) -> OnboardingSyncTopics {
+) -> Result<OnboardingSyncTopics, BootstrapOnboardingFinalizeError> {
     use aruna_core::document::DocumentSyncTarget;
     use aruna_core::structs::PlacementRef;
-    let config = load_realm_config_document(context, realm_id).await;
+    let config = drive(GetRealmConfigOperation::new(realm_id), context.as_ref()).await?;
     let mut topics = OnboardingSyncTopics {
         shared: Vec::new(),
         shard: Vec::new(),
@@ -333,14 +338,15 @@ async fn onboarding_sync_topics(
             if !matches!(document, DocumentSyncTarget::User { .. }) {
                 continue;
             }
-            let placement = match config.as_ref() {
-                Some(config) => {
-                    crate::placement::placement_ref_for_target(config, document, Default::default())
-                }
-                None => PlacementRef::NIL,
-            };
+            let placement =
+                crate::placement::placement_ref_for_target(&config, document, Default::default());
             if placement == PlacementRef::NIL {
-                continue;
+                let DocumentSyncTarget::User { user_id } = document else {
+                    unreachable!("shard onboarding documents are restricted to users");
+                };
+                return Err(BootstrapOnboardingFinalizeError::UserPlacementUnavailable(
+                    *user_id,
+                ));
             }
             topics
                 .shard
@@ -351,44 +357,21 @@ async fn onboarding_sync_topics(
                 .push(document.sync_topic_id(realm_id, &PlacementRef::NIL));
         }
     }
-    topics
-}
-
-async fn load_realm_config_document(
-    context: &Arc<DriverContext>,
-    realm_id: RealmId,
-) -> Option<aruna_core::structs::RealmConfigDocument> {
-    use aruna_core::document::DocumentSyncTarget;
-    use aruna_core::effects::StorageEffect;
-    use aruna_core::events::{Event, StorageEvent};
-    let target = DocumentSyncTarget::RealmConfig { realm_id };
-    match context
-        .storage_handle
-        .send_storage_effect(StorageEffect::Read {
-            key_space: target.storage_keyspace().to_string(),
-            key: target.storage_key(),
-            txn_id: None,
-        })
-        .await
-    {
-        Event::Storage(StorageEvent::ReadResult { value, .. }) => value
-            .and_then(|bytes| aruna_core::structs::RealmConfigDocument::from_bytes(&bytes).ok()),
-        _ => None,
-    }
+    Ok(topics)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         BootstrapOnboardingFinalizeError, BootstrapOnboardingFinalizeInput,
-        bootstrap_onboarding_finalize, emit_node_onboarded_notification,
+        bootstrap_onboarding_finalize, emit_node_onboarded_notification, onboarding_sync_topics,
     };
     use crate::create_onboarding_secret::{
         CreateOnboardingSecretInput, CreateOnboardingSecretOperation,
     };
     use crate::create_realm::{CreateRealmConfig, CreateRealmOperation};
     use crate::driver::{DriverContext, drive};
-    use crate::get_realm_config::GetRealmConfigOperation;
+    use crate::get_realm_config::{GetRealmConfigError, GetRealmConfigOperation};
     use crate::onboarding_secret_state::secret_state_key;
     use crate::reserve_onboarding_secret::ReserveOnboardingSecretError;
     use aruna_core::NodeId;
@@ -621,6 +604,37 @@ mod tests {
             .await;
     }
 
+    async fn clear_placement_strategies(fixture: &FinalizeFixture) {
+        let mut config = drive(
+            GetRealmConfigOperation::new(fixture.realm_id),
+            fixture.context.as_ref(),
+        )
+        .await
+        .unwrap();
+        config.strategies.clear();
+        let actor = Actor {
+            node_id: fixture.local_node_id,
+            user_id: UserId::nil(fixture.realm_id),
+            realm_id: fixture.realm_id,
+        };
+        let target = DocumentSyncTarget::RealmConfig {
+            realm_id: fixture.realm_id,
+        };
+        let event = fixture
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: target.storage_keyspace().to_string(),
+                key: target.storage_key(),
+                value: config.to_bytes(&actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+    }
+
     async fn read_outbox_rows(
         storage_handle: &storage::StorageHandle,
     ) -> Vec<NotificationOutboxRecord> {
@@ -747,6 +761,42 @@ mod tests {
         )));
 
         net_handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn topic_errors_propagate() {
+        let fixture = setup_finalize_fixture().await;
+        clear_placement_strategies(&fixture).await;
+        let user_id = UserId::local(Ulid::from_bytes([44u8; 16]), fixture.realm_id);
+        let ticket = OnboardingSyncTicket::issue(
+            &fixture.realm_signing_key,
+            &fixture.realm_id,
+            fixture.joiner_node_id,
+            100,
+            vec![DocumentSyncTarget::User { user_id }],
+        )
+        .unwrap();
+
+        assert!(matches!(
+            onboarding_sync_topics(&fixture.context, fixture.realm_id, &ticket).await,
+            Err(BootstrapOnboardingFinalizeError::UserPlacementUnavailable(id)) if id == user_id
+        ));
+
+        let missing_realm_id = RealmId::from_bytes([9u8; 32]);
+        let missing_ticket = OnboardingSyncTicket::issue(
+            &fixture.realm_signing_key,
+            &missing_realm_id,
+            fixture.joiner_node_id,
+            100,
+            Vec::new(),
+        )
+        .unwrap();
+        assert!(matches!(
+            onboarding_sync_topics(&fixture.context, missing_realm_id, &missing_ticket).await,
+            Err(BootstrapOnboardingFinalizeError::GetRealmConfig(
+                GetRealmConfigError::DocumentNotFound
+            ))
+        ));
     }
 
     #[tokio::test]

--- a/operations/src/claim_initial_realm_admin.rs
+++ b/operations/src/claim_initial_realm_admin.rs
@@ -241,6 +241,9 @@ impl ClaimInitialRealmAdminOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -229,6 +229,9 @@ impl CreateGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 true,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -9,13 +9,16 @@ use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
-use aruna_core::keyspaces::{AUTH_KEYSPACE, GROUP_KEYSPACE, GROUP_OWNER_INDEX_KEYSPACE};
+use aruna_core::keyspaces::{
+    AUTH_KEYSPACE, GROUP_KEYSPACE, GROUP_OWNER_INDEX_KEYSPACE, REALM_CONFIG_KEYSPACE,
+};
 use aruna_core::operation::Operation;
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_write_entry,
 };
 use aruna_core::structs::{
-    Actor, Group, GroupAuthorizationDocument, Role, group_owner_index_key, group_owner_index_prefix,
+    Actor, Group, GroupAuthorizationDocument, PlacementRef, RealmConfigDocument, Role,
+    group_owner_index_key, group_owner_index_prefix,
 };
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, UserId, Value};
@@ -25,6 +28,8 @@ use std::collections::HashSet;
 use thiserror::Error;
 use tracing::trace;
 use ulid::Ulid;
+
+use crate::placement::placement_ref_for_target;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CreateGroupConfig {
@@ -41,6 +46,7 @@ pub struct CreateGroupOperation {
     config: CreateGroupConfig,
     group: Option<Group>,
     auth_doc: Option<GroupAuthorizationDocument>,
+    realm_config: Option<RealmConfigDocument>,
     state: CreateGroupState,
     txn_id: Option<Ulid>,
     output: Option<Result<(Group, GroupAuthorizationDocument), CreateGroupError>>,
@@ -65,6 +71,7 @@ impl CreateGroupOperation {
             config,
             group: None,
             auth_doc: None,
+            realm_config: None,
             state: CreateGroupState::Init,
             txn_id: None,
             output: None,
@@ -219,6 +226,11 @@ impl CreateGroupOperation {
         }
 
         let document_target = DocumentSyncTarget::GroupAuthorization { group_id };
+        let placement = self
+            .realm_config
+            .as_ref()
+            .map(|config| placement_ref_for_target(config, &document_target, Default::default()))
+            .unwrap_or(PlacementRef::NIL);
         let mut writes = vec![admin_document_reducer_state_write_entry(&reducer_state)?];
         for event in admin_events {
             let record = new_outbox_record_with_id(
@@ -229,9 +241,7 @@ impl CreateGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event),
                 },
-                // No realm config in reach here; the stage-2 topic flip resolves
-                // the real ref for this target.
-                aruna_core::structs::PlacementRef::NIL,
+                placement,
                 true,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
@@ -312,6 +322,35 @@ impl CreateGroupOperation {
         };
 
         self.txn_id = Some(txn_id);
+        self.state = CreateGroupState::ReadRealmConfig;
+        smallvec![Effect::Storage(StorageEffect::Read {
+            key_space: REALM_CONFIG_KEYSPACE.to_string(),
+            key: ByteView::from(*self.config.actor.realm_id.as_bytes()),
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    fn handle_read_realm_config(&mut self, event: Event) -> Effects {
+        let got = format!("{event:?}");
+        let Event::Storage(StorageEvent::ReadResult { value, .. }) = event else {
+            return self.unexpected_event(
+                CreateGroupState::ReadRealmConfig,
+                "Event::Storage(StorageEvent::ReadResult)",
+                got,
+            );
+        };
+        self.realm_config = match value
+            .as_deref()
+            .map(RealmConfigDocument::from_bytes)
+            .transpose()
+        {
+            Ok(config) => config,
+            Err(error) => {
+                let cleanup_effects = self.abort();
+                return self.fail_with_cleanup(error.into(), cleanup_effects);
+            }
+        };
+
         match self.config.owner_cap {
             Some(0) => {
                 let cleanup_effects = self.abort();
@@ -453,6 +492,7 @@ fn sorted_user_ids(user_ids: &HashSet<UserId>) -> Vec<UserId> {
 pub enum CreateGroupState {
     Init,
     StartTransaction,
+    ReadRealmConfig,
     CountOwnedGroups,
     CreateGroup,
     WriteOwnerIndex,
@@ -514,6 +554,7 @@ impl Operation for CreateGroupOperation {
 
         match self.state {
             CreateGroupState::StartTransaction => self.handle_start_transaction(event),
+            CreateGroupState::ReadRealmConfig => self.handle_read_realm_config(event),
             CreateGroupState::CountOwnedGroups => self.handle_count_owned_groups(event),
             CreateGroupState::CreateGroup => self.handle_create_group(event),
             CreateGroupState::WriteOwnerIndex => self.handle_write_owner_index(event),

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use aruna_core::NodeId;
+use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::Effect;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::metadata::{
@@ -8,16 +9,22 @@ use aruna_core::metadata::{
     MetadataEffect, MetadataError, MetadataEvent, MetadataGraphPolicy, MetadataRequestDurability,
 };
 use aruna_core::operation::Operation;
-use aruna_core::structs::{Actor, MetadataRegistryRecord};
+use aruna_core::structs::{Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument};
 use aruna_core::types::{Effects, GroupId};
 use chrono::Utc;
 use smallvec::smallvec;
 use thiserror::Error;
+use tracing::warn;
 use ulid::Ulid;
 
+use crate::document_repository::read_effect;
 use crate::driver::{DriverContext, drive};
 use crate::metadata::projector::schedule_pending_metadata_projection_drain;
 use crate::metadata::repository::{read_registry_by_document_effect, write_create_event_effect};
+use crate::placement::{
+    PlacementResolutionContext, choose_origin_bucket, placement_ref_for_target,
+    strategy_for_target, subject_bytes,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateMetadataDocumentConfig {
@@ -74,6 +81,7 @@ enum CreateMetadataDocumentState {
     Init,
     ValidateGraph,
     CheckExisting,
+    ReadRealmConfig,
     AppendCreateEvent,
     Finish,
     Error,
@@ -140,7 +148,53 @@ impl CreateMetadataDocumentOperation {
         vec![self.config.actor.node_id]
     }
 
-    fn build_record(&self, holder_node_ids: Vec<NodeId>) -> MetadataRegistryRecord {
+    fn lifecycle_target(&self) -> DocumentSyncTarget {
+        DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: self.config.document_id,
+        }
+    }
+
+    /// The document's bucket, chosen once here by the receiving node from the
+    /// buckets it holds. Stamped at event-append time only: the projector
+    /// re-runs on replay, and re-choosing under a changed config would fork the
+    /// document across two topics.
+    fn choose_placement(&self, config: Option<&RealmConfigDocument>) -> PlacementRef {
+        let Some(config) = config else {
+            return PlacementRef::NIL;
+        };
+        let target = self.lifecycle_target();
+        let document_path =
+            MetadataRegistryRecord::normalize_document_path(&self.config.document_path);
+        let context = PlacementResolutionContext {
+            group_id: Some(self.config.group_id),
+            metadata_path: Some(document_path.as_str()),
+        };
+        let Some((strategy, _)) = strategy_for_target(config, &target, context) else {
+            return PlacementRef::NIL;
+        };
+        match choose_origin_bucket(
+            config,
+            strategy,
+            self.config.actor.node_id,
+            &subject_bytes(&target),
+        ) {
+            Some(placement) => placement,
+            None => {
+                warn!(
+                    document_id = %self.config.document_id,
+                    node_id = %self.config.actor.node_id,
+                    "Create-receiving node holds no bucket of the governing strategy; falling back to the hashed bucket"
+                );
+                placement_ref_for_target(config, &target, context)
+            }
+        }
+    }
+
+    fn build_record(
+        &self,
+        holder_node_ids: Vec<NodeId>,
+        placement: PlacementRef,
+    ) -> MetadataRegistryRecord {
         let now = Self::current_timestamp_ms();
         MetadataRegistryRecord {
             realm_id: self.config.actor.realm_id,
@@ -152,6 +206,7 @@ impl CreateMetadataDocumentOperation {
             graph_iri: self.graph_iri(),
             public: self.config.public,
             permission_path: self.permission_path(),
+            placement,
             holder_node_ids,
             created_at_ms: now,
             updated_at_ms: now,
@@ -243,8 +298,18 @@ impl CreateMetadataDocumentOperation {
         smallvec![self.graph_validation_effect()]
     }
 
-    fn append_create_event_effect(&mut self) -> Effects {
-        let record = self.build_record(self.holder_node_ids());
+    fn read_realm_config_effect(&mut self) -> Effects {
+        self.state = CreateMetadataDocumentState::ReadRealmConfig;
+        smallvec![read_effect(
+            &DocumentSyncTarget::RealmConfig {
+                realm_id: self.config.actor.realm_id,
+            },
+            None,
+        )]
+    }
+
+    fn append_create_event_effect(&mut self, placement: PlacementRef) -> Effects {
+        let record = self.build_record(self.holder_node_ids(), placement);
         let create_event = self.create_event_record(&record);
         self.create_event = Some(create_event.clone());
         self.record = Some(create_event.record.clone());
@@ -301,7 +366,7 @@ impl Operation for CreateMetadataDocumentOperation {
             CreateMetadataDocumentState::ValidateGraph => match event {
                 Event::Metadata(MetadataEvent::ValidationResult { .. }) => {
                     if self.skip_existing_check {
-                        return self.append_create_event_effect();
+                        return self.read_realm_config_effect();
                     }
                     self.state = CreateMetadataDocumentState::CheckExisting;
                     smallvec![read_registry_by_document_effect(
@@ -318,7 +383,7 @@ impl Operation for CreateMetadataDocumentOperation {
                 match crate::metadata::repository::parse_registry_read(event) {
                     Ok(Some(_)) => self
                         .fail_without_cleanup(CreateMetadataDocumentError::DocumentAlreadyExists),
-                    Ok(None) => self.append_create_event_effect(),
+                    Ok(None) => self.read_realm_config_effect(),
                     Err(crate::metadata::repository::StorageReadError::Storage(error)) => {
                         self.fail_without_cleanup(error.into())
                     }
@@ -327,6 +392,23 @@ impl Operation for CreateMetadataDocumentOperation {
                     }
                 }
             }
+            CreateMetadataDocumentState::ReadRealmConfig => match event {
+                Event::Storage(StorageEvent::ReadResult { value, .. }) => {
+                    let config = match value {
+                        Some(bytes) => match RealmConfigDocument::from_bytes(&bytes) {
+                            Ok(config) => Some(config),
+                            Err(error) => return self.fail_without_cleanup(error.into()),
+                        },
+                        None => None,
+                    };
+                    let placement = self.choose_placement(config.as_ref());
+                    self.append_create_event_effect(placement)
+                }
+                Event::Storage(StorageEvent::Error { error }) => {
+                    self.fail_without_cleanup(error.into())
+                }
+                other => self.unexpected_event("realm config read result", format!("{other:?}")),
+            },
             CreateMetadataDocumentState::AppendCreateEvent => match event {
                 Event::Storage(StorageEvent::BatchWriteResult { .. }) => {
                     let Some(record) = self.record.clone() else {
@@ -385,7 +467,7 @@ mod tests {
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{
         METADATA_DOCUMENT_INDEX_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE,
-        METADATA_PENDING_PROJECTION_KEYSPACE,
+        METADATA_PENDING_PROJECTION_KEYSPACE, REALM_CONFIG_KEYSPACE,
     };
     use aruna_core::metadata::{
         MetadataCreateEventPayload, MetadataCreateEventRecord, MetadataEffect, MetadataError,
@@ -393,9 +475,11 @@ mod tests {
     };
     use aruna_core::operation::Operation;
     use aruna_core::storage_entries::{metadata_event_log_prefix, metadata_pending_projection_key};
-    use aruna_core::structs::{Actor, RealmId};
+    use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
     use aruna_core::types::{GroupId, Key};
     use ulid::Ulid;
+
+    use crate::placement::resolve_shard_holders;
 
     fn actor(realm_id: RealmId, key_byte: u8) -> Actor {
         Actor {
@@ -403,6 +487,41 @@ mod tests {
             user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
             realm_id,
         }
+    }
+
+    // Four servers at the default replication factor: no node holds every
+    // bucket, so a stamped bucket the origin holds is a real assertion.
+    fn realm_config(actor: &Actor) -> RealmConfigDocument {
+        let mut config = RealmConfigDocument::default_for_realm(actor.realm_id, Vec::new());
+        config.seed_default_placement();
+        config.ensure_node(actor.node_id, RealmNodeKind::Server);
+        for seed in 20..23u8 {
+            config.ensure_node(
+                iroh::SecretKey::from_bytes(&[seed; 32]).public(),
+                RealmNodeKind::Server,
+            );
+        }
+        config
+    }
+
+    fn realm_config_read(config: Option<&RealmConfigDocument>, actor: &Actor) -> Event {
+        Event::Storage(StorageEvent::ReadResult {
+            key: actor.realm_id.as_bytes().to_vec().into(),
+            value: config.map(|config| {
+                config
+                    .to_bytes(actor)
+                    .expect("realm config encodes")
+                    .to_vec()
+                    .into()
+            }),
+        })
+    }
+
+    fn assert_realm_config_read(effects: &[Effect]) {
+        let [Effect::Storage(StorageEffect::Read { key_space, .. })] = effects else {
+            panic!("expected realm config read");
+        };
+        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
     }
 
     fn config(actor: Actor, group_id: GroupId, document_id: Ulid) -> CreateMetadataDocumentConfig {
@@ -508,7 +627,36 @@ mod tests {
         let effects = operation.start();
         assert_validation_effect(effects.as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
+        assert_realm_config_read(effects.as_slice());
+        let effects = operation.step(realm_config_read(None, &actor));
         assert_create_event_append(effects.as_slice(), document_id, &actor);
+    }
+
+    #[test]
+    fn stamped_bucket_is_held() {
+        // Topic membership is the holder set, so the origin can only publish a
+        // create onto a bucket it holds: the stamp must land in its held set.
+        let realm_id = RealmId([21u8; 32]);
+        let actor = actor(realm_id, 4);
+        let realm_config = realm_config(&actor);
+        let document_id = Ulid::r#gen();
+        let mut operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
+            actor.clone(),
+            GroupId::r#gen(),
+            document_id,
+        ));
+
+        operation.start();
+        operation.step(validation_result(document_id));
+        operation.step(realm_config_read(Some(&realm_config), &actor));
+
+        let placement = operation
+            .record
+            .as_ref()
+            .expect("create record is built")
+            .placement;
+        assert_ne!(placement, PlacementRef::NIL);
+        assert!(resolve_shard_holders(&realm_config, &placement).contains(&actor.node_id));
     }
 
     #[test]
@@ -528,6 +676,8 @@ mod tests {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
+        assert_realm_config_read(effects.as_slice());
+        let effects = operation.step(realm_config_read(None, &actor));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         assert_eq!(
             operation
@@ -566,6 +716,8 @@ mod tests {
 
         assert_validation_effect(operation.start().as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
+        assert_realm_config_read(effects.as_slice());
+        let effects = operation.step(realm_config_read(None, &actor));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![(METADATA_EVENT_LOG_KEYSPACE.to_string(), create_event_key)],
@@ -620,10 +772,12 @@ mod tests {
 
         assert_validation_effect(operation.start().as_slice(), document_id);
         assert_existing_read(operation.step(validation_result(document_id)).as_slice());
-        let append = operation.step(Event::Storage(StorageEvent::ReadResult {
+        let config_read = operation.step(Event::Storage(StorageEvent::ReadResult {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
+        assert_realm_config_read(config_read.as_slice());
+        let append = operation.step(realm_config_read(None, &actor));
         assert_create_event_append(append.as_slice(), document_id, &actor);
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -12,9 +12,9 @@ use aruna_core::operation::Operation;
 use aruna_core::structs::{Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument};
 use aruna_core::types::{Effects, GroupId};
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
 use thiserror::Error;
-use tracing::warn;
 use ulid::Ulid;
 
 use crate::document_repository::read_effect;
@@ -22,8 +22,7 @@ use crate::driver::{DriverContext, drive};
 use crate::metadata::projector::schedule_pending_metadata_projection_drain;
 use crate::metadata::repository::{read_registry_by_document_effect, write_create_event_effect};
 use crate::placement::{
-    PlacementResolutionContext, choose_origin_bucket, placement_ref_for_target,
-    strategy_for_target, subject_bytes,
+    PlacementResolutionContext, choose_origin_bucket, strategy_for_target, subject_bytes,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -36,7 +35,7 @@ pub struct CreateMetadataDocumentConfig {
     pub payload: CreateMetadataDocumentPayload,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum CreateMetadataDocumentPayload {
     Scaffold {
         name: String,
@@ -97,6 +96,10 @@ pub enum CreateMetadataDocumentError {
     MetadataError(#[from] MetadataError),
     #[error("document already exists")]
     DocumentAlreadyExists,
+    /// The receiving node holds no bucket of the governing strategy, so it can
+    /// never publish this document. The caller forwards the create to a holder.
+    #[error("create-receiving node holds no bucket of the governing strategy")]
+    OriginHoldsNoBucket,
     #[error("missing active transaction")]
     MissingTransaction,
     #[error("topic announcement failed: {0}")]
@@ -125,6 +128,10 @@ impl CreateMetadataDocumentOperation {
         let mut operation = Self::new(config);
         operation.skip_existing_check = true;
         operation
+    }
+
+    pub fn config(&self) -> &CreateMetadataDocumentConfig {
+        &self.config
     }
 
     fn graph_iri(&self) -> String {
@@ -158,9 +165,17 @@ impl CreateMetadataDocumentOperation {
     /// buckets it holds. Stamped at event-append time only: the projector
     /// re-runs on replay, and re-choosing under a changed config would fork the
     /// document across two topics.
-    fn choose_placement(&self, config: Option<&RealmConfigDocument>) -> PlacementRef {
+    ///
+    /// `Err` when a strategy governs the target but the receiving node holds
+    /// none of its buckets: it could never publish this document onto the
+    /// bucket's topic, so the create must be forwarded to a holder rather than
+    /// accepted onto a bucket it cannot replicate.
+    fn choose_placement(
+        &self,
+        config: Option<&RealmConfigDocument>,
+    ) -> Result<PlacementRef, CreateMetadataDocumentError> {
         let Some(config) = config else {
-            return PlacementRef::NIL;
+            return Ok(PlacementRef::NIL);
         };
         let target = self.lifecycle_target();
         let document_path =
@@ -170,24 +185,15 @@ impl CreateMetadataDocumentOperation {
             metadata_path: Some(document_path.as_str()),
         };
         let Some((strategy, _)) = strategy_for_target(config, &target, context) else {
-            return PlacementRef::NIL;
+            return Ok(PlacementRef::NIL);
         };
-        match choose_origin_bucket(
+        choose_origin_bucket(
             config,
             strategy,
             self.config.actor.node_id,
             &subject_bytes(&target),
-        ) {
-            Some(placement) => placement,
-            None => {
-                warn!(
-                    document_id = %self.config.document_id,
-                    node_id = %self.config.actor.node_id,
-                    "Create-receiving node holds no bucket of the governing strategy; falling back to the hashed bucket"
-                );
-                placement_ref_for_target(config, &target, context)
-            }
-        }
+        )
+        .ok_or(CreateMetadataDocumentError::OriginHoldsNoBucket)
     }
 
     fn build_record(
@@ -401,8 +407,10 @@ impl Operation for CreateMetadataDocumentOperation {
                         },
                         None => None,
                     };
-                    let placement = self.choose_placement(config.as_ref());
-                    self.append_create_event_effect(placement)
+                    match self.choose_placement(config.as_ref()) {
+                        Ok(placement) => self.append_create_event_effect(placement),
+                        Err(error) => self.fail_without_cleanup(error),
+                    }
                 }
                 Event::Storage(StorageEvent::Error { error }) => {
                     self.fail_without_cleanup(error.into())

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -3,12 +3,17 @@ use std::sync::Arc;
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::errors::StorageError;
 use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::METADATA_CREATE_ACCEPTANCE_KEYSPACE;
 use aruna_core::metadata::{
     MetadataCreateCrateRequest, MetadataCreateEventPayload, MetadataCreateEventRecord,
     MetadataEffect, MetadataError, MetadataEvent, MetadataGraphPolicy, MetadataRequestDurability,
 };
 use aruna_core::operation::Operation;
+use aruna_core::storage_entries::{
+    metadata_create_acceptance_key, metadata_create_acceptance_write_entry,
+};
 use aruna_core::structs::{
     Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument, shard_for_subject,
 };
@@ -19,7 +24,6 @@ use smallvec::smallvec;
 use thiserror::Error;
 use ulid::Ulid;
 
-use crate::document_repository::read_effect;
 use crate::driver::{DriverContext, drive};
 use crate::metadata::projector::schedule_pending_metadata_projection_drain;
 use crate::metadata::repository::{
@@ -76,6 +80,7 @@ pub struct CreateMetadataDocumentOperation {
     skip_existing_check: bool,
     /// Set when a non-holder forwarded this create; see [`Self::choose_placement`].
     forwarded: bool,
+    conflict_recheck: bool,
     txn_id: Option<TxnId>,
     state: CreateMetadataDocumentState,
     record: Option<MetadataRegistryRecord>,
@@ -89,7 +94,7 @@ enum CreateMetadataDocumentState {
     ValidateGraph,
     CheckExisting,
     StartTransaction,
-    ReadRealmConfig,
+    ReadCreateFence,
     AppendCreateEvent,
     CommitTransaction,
     Finish,
@@ -128,6 +133,7 @@ impl CreateMetadataDocumentOperation {
             config,
             skip_existing_check: false,
             forwarded: false,
+            conflict_recheck: false,
             txn_id: None,
             state: CreateMetadataDocumentState::Init,
             record: None,
@@ -356,15 +362,81 @@ impl CreateMetadataDocumentOperation {
         })]
     }
 
-    fn read_realm_config_effect(&mut self, txn_id: TxnId) -> Effects {
+    fn read_create_fence_effect(&mut self, txn_id: TxnId) -> Effects {
         self.txn_id = Some(txn_id);
-        self.state = CreateMetadataDocumentState::ReadRealmConfig;
-        smallvec![read_effect(
-            &DocumentSyncTarget::RealmConfig {
-                realm_id: self.config.actor.realm_id,
+        self.state = CreateMetadataDocumentState::ReadCreateFence;
+        let realm_target = DocumentSyncTarget::RealmConfig {
+            realm_id: self.config.actor.realm_id,
+        };
+        smallvec![Effect::Storage(StorageEffect::BatchRead {
+            reads: vec![
+                (
+                    METADATA_CREATE_ACCEPTANCE_KEYSPACE.to_string(),
+                    metadata_create_acceptance_key(self.config.document_id),
+                ),
+                (
+                    realm_target.storage_keyspace().to_string(),
+                    realm_target.storage_key(),
+                ),
+            ],
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    fn accepted_identity_matches(&self, event: &MetadataCreateEventRecord) -> bool {
+        event.record.realm_id == self.config.actor.realm_id
+            && event.record.group_id == self.config.group_id
+            && event.record.document_path
+                == MetadataRegistryRecord::normalize_document_path(&self.config.document_path)
+    }
+
+    fn finish_accepted_create(&mut self, event: MetadataCreateEventRecord) -> Effects {
+        let Some(txn_id) = self.txn_id.take() else {
+            return self.fail(CreateMetadataDocumentError::MissingTransaction);
+        };
+        self.record = Some(event.record.clone());
+        self.create_event = Some(event.clone());
+        self.state = CreateMetadataDocumentState::Finish;
+        self.output = Some(Ok(CreateMetadataDocumentResult {
+            record: event.record,
+            event_id: event.event_id,
+        }));
+        smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })]
+    }
+
+    fn apply_create_fence(
+        &mut self,
+        acceptance_value: Option<Value>,
+        realm_config_value: Option<Value>,
+    ) -> Effects {
+        if let Some(bytes) = acceptance_value {
+            let event: MetadataCreateEventRecord = match postcard::from_bytes(&bytes) {
+                Ok(event) => event,
+                Err(error) => {
+                    return self.fail(CreateMetadataDocumentError::ConversionError(error.into()));
+                }
+            };
+            return if self.accepted_identity_matches(&event) {
+                self.finish_accepted_create(event)
+            } else {
+                self.fail(CreateMetadataDocumentError::DocumentAlreadyExists)
+            };
+        }
+        if self.conflict_recheck {
+            return self.fail(StorageError::TransactionConflict.into());
+        }
+
+        let config = match realm_config_value.as_ref() {
+            Some(bytes) => match RealmConfigDocument::from_bytes(bytes) {
+                Ok(config) => Some(config),
+                Err(error) => return self.fail(error.into()),
             },
-            Some(txn_id),
-        )]
+            None => None,
+        };
+        match self.choose_placement(config.as_ref()) {
+            Ok(placement) => self.append_create_event_effect(placement, realm_config_value),
+            Err(error) => self.fail(error),
+        }
     }
 
     fn append_create_event_effect(
@@ -380,7 +452,12 @@ impl CreateMetadataDocumentOperation {
         self.create_event = Some(create_event.clone());
         self.record = Some(create_event.record.clone());
         self.state = CreateMetadataDocumentState::AppendCreateEvent;
-        match metadata_create_event_and_pending_projection_write_entries(&create_event) {
+        let writes = metadata_create_event_and_pending_projection_write_entries(&create_event)
+            .and_then(|mut writes| {
+                writes.push(metadata_create_acceptance_write_entry(&create_event)?);
+                Ok(writes)
+            });
+        match writes {
             Ok(mut writes) => {
                 if let Some(value) = realm_config_value {
                     let target = DocumentSyncTarget::RealmConfig {
@@ -482,28 +559,22 @@ impl Operation for CreateMetadataDocumentOperation {
             }
             CreateMetadataDocumentState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
-                    self.read_realm_config_effect(txn_id)
+                    self.read_create_fence_effect(txn_id)
                 }
                 Event::Storage(StorageEvent::Error { error }) => {
                     self.fail_without_cleanup(error.into())
                 }
                 other => self.unexpected_event("transaction start result", format!("{other:?}")),
             },
-            CreateMetadataDocumentState::ReadRealmConfig => match event {
-                Event::Storage(StorageEvent::ReadResult { value, .. }) => {
-                    let (config, realm_config_value) = match value {
-                        Some(bytes) => match RealmConfigDocument::from_bytes(&bytes) {
-                            Ok(config) => (Some(config), Some(bytes)),
-                            Err(error) => return self.fail_without_cleanup(error.into()),
-                        },
-                        None => (None, None),
+            CreateMetadataDocumentState::ReadCreateFence => match event {
+                Event::Storage(StorageEvent::BatchReadResult { values }) => {
+                    let [(_, acceptance_value), (_, realm_config_value)] = values.as_slice() else {
+                        return self.unexpected_event(
+                            "metadata create fence read",
+                            format!("batch read with {} values", values.len()),
+                        );
                     };
-                    match self.choose_placement(config.as_ref()) {
-                        Ok(placement) => {
-                            self.append_create_event_effect(placement, realm_config_value)
-                        }
-                        Err(error) => self.fail_without_cleanup(error),
-                    }
+                    self.apply_create_fence(acceptance_value.clone(), realm_config_value.clone())
                 }
                 Event::Storage(StorageEvent::Error { error }) => {
                     self.fail_without_cleanup(error.into())
@@ -538,6 +609,15 @@ impl Operation for CreateMetadataDocumentOperation {
                         event_id: create_event.event_id,
                     }));
                     smallvec![]
+                }
+                Event::Storage(StorageEvent::Error {
+                    error: StorageError::TransactionConflict,
+                }) => {
+                    self.txn_id = None;
+                    self.record = None;
+                    self.create_event = None;
+                    self.conflict_recheck = true;
+                    self.start_transaction_effect()
                 }
                 Event::Storage(StorageEvent::Error { error }) => {
                     self.txn_id = None;
@@ -581,15 +661,17 @@ mod tests {
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{
-        METADATA_DOCUMENT_INDEX_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE,
-        METADATA_PENDING_PROJECTION_KEYSPACE, REALM_CONFIG_KEYSPACE,
+        METADATA_CREATE_ACCEPTANCE_KEYSPACE, METADATA_DOCUMENT_INDEX_KEYSPACE,
+        METADATA_EVENT_LOG_KEYSPACE, METADATA_PENDING_PROJECTION_KEYSPACE, REALM_CONFIG_KEYSPACE,
     };
     use aruna_core::metadata::{
         MetadataCreateEventPayload, MetadataCreateEventRecord, MetadataEffect, MetadataError,
         MetadataEvent, MetadataRequestDurability,
     };
     use aruna_core::operation::Operation;
-    use aruna_core::storage_entries::{metadata_event_log_prefix, metadata_pending_projection_key};
+    use aruna_core::storage_entries::{
+        metadata_create_acceptance_key, metadata_event_log_prefix, metadata_pending_projection_key,
+    };
     use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
     use aruna_core::types::{Effects, GroupId, Key};
     use ulid::Ulid;
@@ -619,23 +701,32 @@ mod tests {
         config
     }
 
-    fn realm_config_read(config: Option<&RealmConfigDocument>, actor: &Actor) -> Event {
-        Event::Storage(StorageEvent::ReadResult {
-            key: actor.realm_id.as_bytes().to_vec().into(),
-            value: config.map(|config| {
-                config
-                    .to_bytes(actor)
-                    .expect("realm config encodes")
-                    .to_vec()
-                    .into()
-            }),
+    fn realm_config_read(
+        config: Option<&RealmConfigDocument>,
+        actor: &Actor,
+        document_id: Ulid,
+    ) -> Event {
+        Event::Storage(StorageEvent::BatchReadResult {
+            values: vec![
+                (metadata_create_acceptance_key(document_id), None),
+                (
+                    actor.realm_id.as_bytes().to_vec().into(),
+                    config.map(|config| {
+                        config
+                            .to_bytes(actor)
+                            .expect("realm config encodes")
+                            .to_vec()
+                            .into()
+                    }),
+                ),
+            ],
         })
     }
 
     fn assert_realm_config_read(effects: &[Effect]) {
         let [
-            Effect::Storage(StorageEffect::Read {
-                key_space,
+            Effect::Storage(StorageEffect::BatchRead {
+                reads,
                 txn_id: Some(_),
                 ..
             }),
@@ -643,7 +734,9 @@ mod tests {
         else {
             panic!("expected realm config read");
         };
-        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
+        assert_eq!(reads.len(), 2);
+        assert_eq!(reads[0].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
+        assert_eq!(reads[1].0, REALM_CONFIG_KEYSPACE);
     }
 
     fn begin_transaction(
@@ -680,8 +773,8 @@ mod tests {
         let txn_id = Ulid::from_bytes([32; 16]);
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         let [
-            Effect::Storage(StorageEffect::Read {
-                key_space,
+            Effect::Storage(StorageEffect::BatchRead {
+                reads,
                 txn_id: Some(read_txn),
                 ..
             }),
@@ -689,10 +782,12 @@ mod tests {
         else {
             panic!("expected transactional realm config read");
         };
-        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
+        assert_eq!(reads.len(), 2);
+        assert_eq!(reads[0].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
+        assert_eq!(reads[1].0, REALM_CONFIG_KEYSPACE);
         assert_eq!(*read_txn, txn_id);
 
-        let effects = operation.step(realm_config_read(Some(&realm_config), &actor));
+        let effects = operation.step(realm_config_read(Some(&realm_config), &actor, document_id));
         let [
             Effect::Storage(StorageEffect::BatchWrite {
                 writes,
@@ -715,6 +810,65 @@ mod tests {
             writes
                 .iter()
                 .any(|(key_space, _, _)| key_space == METADATA_PENDING_PROJECTION_KEYSPACE)
+        );
+        assert!(
+            writes
+                .iter()
+                .any(|(key_space, _, _)| key_space == METADATA_CREATE_ACCEPTANCE_KEYSPACE)
+        );
+
+        let mut winner: MetadataCreateEventRecord = writes
+            .iter()
+            .find(|(key_space, _, _)| key_space == METADATA_CREATE_ACCEPTANCE_KEYSPACE)
+            .and_then(|(_, _, value)| postcard::from_bytes(value.as_ref()).ok())
+            .expect("create acceptance decodes");
+        winner.event_id = Ulid::from_bytes([33; 16]);
+        winner.record.last_event_id = winner.event_id;
+
+        let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
+            entries: Vec::new(),
+        }));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::CommitTransaction { txn_id: committed })]
+                if *committed == txn_id
+        ));
+        let effects = operation.step(Event::Storage(StorageEvent::Error {
+            error: aruna_core::errors::StorageError::TransactionConflict,
+        }));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::StartTransaction {
+                read: false
+            })]
+        ));
+
+        let retry_txn = Ulid::from_bytes([34; 16]);
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted {
+            txn_id: retry_txn,
+        }));
+        assert_realm_config_read(effects.as_slice());
+        let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
+            values: vec![
+                (
+                    metadata_create_acceptance_key(document_id),
+                    Some(postcard::to_allocvec(&winner).unwrap().into()),
+                ),
+                (actor.realm_id.as_bytes().to_vec().into(), None),
+            ],
+        }));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::AbortTransaction { txn_id: aborted })]
+                if *aborted == retry_txn
+        ));
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize().expect("winner is replayed"),
+            super::CreateMetadataDocumentResult {
+                record: winner.record,
+                event_id: winner.event_id,
+            }
         );
     }
 
@@ -772,7 +926,7 @@ mod tests {
             panic!("expected metadata create event append");
         };
         assert!(txn_id.is_some());
-        assert_eq!(writes.len(), 2);
+        assert_eq!(writes.len(), 3);
         let (_, key, value) = writes
             .iter()
             .find(|(key_space, _, _)| key_space == METADATA_EVENT_LOG_KEYSPACE)
@@ -789,9 +943,18 @@ mod tests {
         assert_eq!(event.user_id, actor.user_id);
         assert_eq!(event.node_id, actor.node_id);
         assert!(matches!(
-            event.payload,
+            &event.payload,
             MetadataCreateEventPayload::Scaffold { .. }
         ));
+
+        let (_, acceptance_key, acceptance_value) = writes
+            .iter()
+            .find(|(key_space, _, _)| key_space == METADATA_CREATE_ACCEPTANCE_KEYSPACE)
+            .expect("create acceptance write exists");
+        assert_eq!(acceptance_key, &metadata_create_acceptance_key(document_id));
+        let accepted: MetadataCreateEventRecord =
+            postcard::from_bytes(acceptance_value.as_ref()).expect("create acceptance decodes");
+        assert_eq!(accepted, event);
 
         let (_, marker_key, marker_value) = writes
             .iter()
@@ -833,7 +996,7 @@ mod tests {
         let effects = operation.step(validation_result(document_id));
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_realm_config_read(effects.as_slice());
-        let effects = operation.step(realm_config_read(None, &actor));
+        let effects = operation.step(realm_config_read(None, &actor, document_id));
         assert_create_event_append(effects.as_slice(), document_id, &actor);
     }
 
@@ -854,7 +1017,7 @@ mod tests {
         operation.start();
         let effects = operation.step(validation_result(document_id));
         begin_transaction(&mut operation, effects.as_slice());
-        operation.step(realm_config_read(Some(&realm_config), &actor));
+        operation.step(realm_config_read(Some(&realm_config), &actor, document_id));
 
         let placement = operation
             .record
@@ -884,7 +1047,7 @@ mod tests {
         }));
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_realm_config_read(effects.as_slice());
-        let effects = operation.step(realm_config_read(None, &actor));
+        let effects = operation.step(realm_config_read(None, &actor, document_id));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         assert_eq!(
             operation
@@ -925,7 +1088,7 @@ mod tests {
         let effects = operation.step(validation_result(document_id));
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_realm_config_read(effects.as_slice());
-        let effects = operation.step(realm_config_read(None, &actor));
+        let effects = operation.step(realm_config_read(None, &actor, document_id));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![(METADATA_EVENT_LOG_KEYSPACE.to_string(), create_event_key)],
@@ -986,7 +1149,7 @@ mod tests {
         }));
         let config_read = begin_transaction(&mut operation, config_read.as_slice());
         assert_realm_config_read(config_read.as_slice());
-        let append = operation.step(realm_config_read(None, &actor));
+        let append = operation.step(realm_config_read(None, &actor, document_id));
         assert_create_event_append(append.as_slice(), document_id, &actor);
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -9,7 +9,9 @@ use aruna_core::metadata::{
     MetadataEffect, MetadataError, MetadataEvent, MetadataGraphPolicy, MetadataRequestDurability,
 };
 use aruna_core::operation::Operation;
-use aruna_core::structs::{Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument};
+use aruna_core::structs::{
+    Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument, shard_for_subject,
+};
 use aruna_core::types::{Effects, GroupId};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -22,7 +24,8 @@ use crate::driver::{DriverContext, drive};
 use crate::metadata::projector::schedule_pending_metadata_projection_drain;
 use crate::metadata::repository::{read_registry_by_document_effect, write_create_event_effect};
 use crate::placement::{
-    PlacementResolutionContext, choose_origin_bucket, strategy_for_target, subject_bytes,
+    PlacementResolutionContext, choose_origin_bucket, holds_placement, strategy_for_target,
+    subject_bytes,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -69,6 +72,8 @@ pub struct CreateMetadataDocumentResult {
 pub struct CreateMetadataDocumentOperation {
     config: CreateMetadataDocumentConfig,
     skip_existing_check: bool,
+    /// Set when a non-holder forwarded this create; see [`Self::choose_placement`].
+    forwarded: bool,
     state: CreateMetadataDocumentState,
     record: Option<MetadataRegistryRecord>,
     create_event: Option<MetadataCreateEventRecord>,
@@ -117,6 +122,7 @@ impl CreateMetadataDocumentOperation {
         Self {
             config,
             skip_existing_check: false,
+            forwarded: false,
             state: CreateMetadataDocumentState::Init,
             record: None,
             create_event: None,
@@ -127,6 +133,15 @@ impl CreateMetadataDocumentOperation {
     pub fn new_for_generated_document_id(config: CreateMetadataDocumentConfig) -> Self {
         let mut operation = Self::new(config);
         operation.skip_existing_check = true;
+        operation
+    }
+
+    /// A create a non-holder forwarded here. The document's bucket is its blind
+    /// hash rather than this node's pick, so every holder the forwarder may try
+    /// stamps the same bucket.
+    pub fn new_forwarded(config: CreateMetadataDocumentConfig) -> Self {
+        let mut operation = Self::new(config);
+        operation.forwarded = true;
         operation
     }
 
@@ -161,15 +176,21 @@ impl CreateMetadataDocumentOperation {
         }
     }
 
-    /// The document's bucket, chosen once here by the receiving node from the
-    /// buckets it holds. Stamped at event-append time only: the projector
-    /// re-runs on replay, and re-choosing under a changed config would fork the
-    /// document across two topics.
+    /// The document's bucket, chosen once here by the receiving node. Stamped at
+    /// event-append time only: the projector re-runs on replay, and re-choosing
+    /// under a changed config would fork the document across two topics.
     ///
-    /// `Err` when a strategy governs the target but the receiving node holds
-    /// none of its buckets: it could never publish this document onto the
-    /// bucket's topic, so the create must be forwarded to a holder rather than
-    /// accepted onto a bucket it cannot replicate.
+    /// A locally-originated create picks the best-ranked of the buckets this node
+    /// already holds, so the origin can always publish onto the bucket it stamps.
+    /// A *forwarded* create instead takes the document's blind-hashed bucket: the
+    /// forwarder only ever offers the create to holders of that one bucket, so
+    /// every candidate holder stamps the same bucket and a retry after a timed-out
+    /// response can never fork the document onto a second topic.
+    ///
+    /// `Err` when a strategy governs the target but this node holds no usable
+    /// bucket for it: it could never publish the document onto the bucket's
+    /// topic, so the create must go to a holder rather than be accepted onto a
+    /// bucket it cannot replicate.
     fn choose_placement(
         &self,
         config: Option<&RealmConfigDocument>,
@@ -187,6 +208,17 @@ impl CreateMetadataDocumentOperation {
         let Some((strategy, _)) = strategy_for_target(config, &target, context) else {
             return Ok(PlacementRef::NIL);
         };
+        if self.forwarded {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard: shard_for_subject(&subject_bytes(&target), strategy.shard_count),
+            };
+            if !holds_placement(config, &placement, self.config.actor.node_id) {
+                return Err(CreateMetadataDocumentError::OriginHoldsNoBucket);
+            }
+            return Ok(placement);
+        }
         choose_origin_bucket(
             config,
             strategy,

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -24,8 +24,8 @@ use crate::driver::{DriverContext, drive};
 use crate::metadata::projector::schedule_pending_metadata_projection_drain;
 use crate::metadata::repository::{read_registry_by_document_effect, write_create_event_effect};
 use crate::placement::{
-    PlacementResolutionContext, choose_origin_bucket, holds_placement, strategy_for_target,
-    subject_bytes,
+    PlacementResolutionContext, choose_origin_bucket, holds_placement, meta_bucket_subject,
+    strategy_for_target, subject_bytes,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -219,11 +219,18 @@ impl CreateMetadataDocumentOperation {
             }
             return Ok(placement);
         }
+        // Bucket-choice subject is the canonical `(realm_id, group_id, path)`
+        // tuple (spec 6.3.6), never the document id: the id must not steer the
+        // bucket it embeds.
         choose_origin_bucket(
             config,
             strategy,
             self.config.actor.node_id,
-            &subject_bytes(&target),
+            &meta_bucket_subject(
+                self.config.actor.realm_id,
+                self.config.group_id,
+                &document_path,
+            ),
         )
         .ok_or(CreateMetadataDocumentError::OriginHoldsNoBucket)
     }

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
-use aruna_core::effects::Effect;
+use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::metadata::{
     MetadataCreateCrateRequest, MetadataCreateEventPayload, MetadataCreateEventRecord,
@@ -12,7 +12,7 @@ use aruna_core::operation::Operation;
 use aruna_core::structs::{
     Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument, shard_for_subject,
 };
-use aruna_core::types::{Effects, GroupId};
+use aruna_core::types::{Effects, GroupId, TxnId, Value};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
@@ -22,7 +22,9 @@ use ulid::Ulid;
 use crate::document_repository::read_effect;
 use crate::driver::{DriverContext, drive};
 use crate::metadata::projector::schedule_pending_metadata_projection_drain;
-use crate::metadata::repository::{read_registry_by_document_effect, write_create_event_effect};
+use crate::metadata::repository::{
+    metadata_create_event_and_pending_projection_write_entries, read_registry_by_document_effect,
+};
 use crate::placement::{
     PlacementResolutionContext, choose_origin_bucket, holds_placement, meta_bucket_subject,
     strategy_for_target, subject_bytes,
@@ -74,6 +76,7 @@ pub struct CreateMetadataDocumentOperation {
     skip_existing_check: bool,
     /// Set when a non-holder forwarded this create; see [`Self::choose_placement`].
     forwarded: bool,
+    txn_id: Option<TxnId>,
     state: CreateMetadataDocumentState,
     record: Option<MetadataRegistryRecord>,
     create_event: Option<MetadataCreateEventRecord>,
@@ -85,8 +88,10 @@ enum CreateMetadataDocumentState {
     Init,
     ValidateGraph,
     CheckExisting,
+    StartTransaction,
     ReadRealmConfig,
     AppendCreateEvent,
+    CommitTransaction,
     Finish,
     Error,
 }
@@ -123,6 +128,7 @@ impl CreateMetadataDocumentOperation {
             config,
             skip_existing_check: false,
             forwarded: false,
+            txn_id: None,
             state: CreateMetadataDocumentState::Init,
             record: None,
             create_event: None,
@@ -343,38 +349,75 @@ impl CreateMetadataDocumentOperation {
         smallvec![self.graph_validation_effect()]
     }
 
-    fn read_realm_config_effect(&mut self) -> Effects {
+    fn start_transaction_effect(&mut self) -> Effects {
+        self.state = CreateMetadataDocumentState::StartTransaction;
+        smallvec![Effect::Storage(StorageEffect::StartTransaction {
+            read: false,
+        })]
+    }
+
+    fn read_realm_config_effect(&mut self, txn_id: TxnId) -> Effects {
+        self.txn_id = Some(txn_id);
         self.state = CreateMetadataDocumentState::ReadRealmConfig;
         smallvec![read_effect(
             &DocumentSyncTarget::RealmConfig {
                 realm_id: self.config.actor.realm_id,
             },
-            None,
+            Some(txn_id),
         )]
     }
 
-    fn append_create_event_effect(&mut self, placement: PlacementRef) -> Effects {
+    fn append_create_event_effect(
+        &mut self,
+        placement: PlacementRef,
+        realm_config_value: Option<Value>,
+    ) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.fail(CreateMetadataDocumentError::MissingTransaction);
+        };
         let record = self.build_record(self.holder_node_ids(), placement);
         let create_event = self.create_event_record(&record);
         self.create_event = Some(create_event.clone());
         self.record = Some(create_event.record.clone());
         self.state = CreateMetadataDocumentState::AppendCreateEvent;
-        match write_create_event_effect(&create_event) {
-            Ok(effect) => smallvec![effect],
+        match metadata_create_event_and_pending_projection_write_entries(&create_event) {
+            Ok(mut writes) => {
+                if let Some(value) = realm_config_value {
+                    let target = DocumentSyncTarget::RealmConfig {
+                        realm_id: self.config.actor.realm_id,
+                    };
+                    writes.push((
+                        target.storage_keyspace().to_string(),
+                        target.storage_key(),
+                        value,
+                    ));
+                }
+                smallvec![Effect::Storage(StorageEffect::BatchWrite {
+                    writes,
+                    txn_id: Some(txn_id),
+                })]
+            }
             Err(error) => self.fail(CreateMetadataDocumentError::ConversionError(error)),
         }
     }
 
+    fn commit_transaction_effect(&mut self) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.fail(CreateMetadataDocumentError::MissingTransaction);
+        };
+        self.state = CreateMetadataDocumentState::CommitTransaction;
+        smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
+    }
+
     fn fail(&mut self, error: CreateMetadataDocumentError) -> Effects {
+        let cleanup = self.abort();
         self.state = CreateMetadataDocumentState::Error;
         self.output = Some(Err(error));
-        smallvec![]
+        cleanup
     }
 
     fn fail_without_cleanup(&mut self, error: CreateMetadataDocumentError) -> Effects {
-        self.state = CreateMetadataDocumentState::Error;
-        self.output = Some(Err(error));
-        smallvec![]
+        self.fail(error)
     }
 
     fn unexpected_event(&mut self, expected: &'static str, got: String) -> Effects {
@@ -411,7 +454,7 @@ impl Operation for CreateMetadataDocumentOperation {
             CreateMetadataDocumentState::ValidateGraph => match event {
                 Event::Metadata(MetadataEvent::ValidationResult { .. }) => {
                     if self.skip_existing_check {
-                        return self.read_realm_config_effect();
+                        return self.start_transaction_effect();
                     }
                     self.state = CreateMetadataDocumentState::CheckExisting;
                     smallvec![read_registry_by_document_effect(
@@ -428,7 +471,7 @@ impl Operation for CreateMetadataDocumentOperation {
                 match crate::metadata::repository::parse_registry_read(event) {
                     Ok(Some(_)) => self
                         .fail_without_cleanup(CreateMetadataDocumentError::DocumentAlreadyExists),
-                    Ok(None) => self.read_realm_config_effect(),
+                    Ok(None) => self.start_transaction_effect(),
                     Err(crate::metadata::repository::StorageReadError::Storage(error)) => {
                         self.fail_without_cleanup(error.into())
                     }
@@ -437,17 +480,28 @@ impl Operation for CreateMetadataDocumentOperation {
                     }
                 }
             }
+            CreateMetadataDocumentState::StartTransaction => match event {
+                Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
+                    self.read_realm_config_effect(txn_id)
+                }
+                Event::Storage(StorageEvent::Error { error }) => {
+                    self.fail_without_cleanup(error.into())
+                }
+                other => self.unexpected_event("transaction start result", format!("{other:?}")),
+            },
             CreateMetadataDocumentState::ReadRealmConfig => match event {
                 Event::Storage(StorageEvent::ReadResult { value, .. }) => {
-                    let config = match value {
+                    let (config, realm_config_value) = match value {
                         Some(bytes) => match RealmConfigDocument::from_bytes(&bytes) {
-                            Ok(config) => Some(config),
+                            Ok(config) => (Some(config), Some(bytes)),
                             Err(error) => return self.fail_without_cleanup(error.into()),
                         },
-                        None => None,
+                        None => (None, None),
                     };
                     match self.choose_placement(config.as_ref()) {
-                        Ok(placement) => self.append_create_event_effect(placement),
+                        Ok(placement) => {
+                            self.append_create_event_effect(placement, realm_config_value)
+                        }
                         Err(error) => self.fail_without_cleanup(error),
                     }
                 }
@@ -458,6 +512,18 @@ impl Operation for CreateMetadataDocumentOperation {
             },
             CreateMetadataDocumentState::AppendCreateEvent => match event {
                 Event::Storage(StorageEvent::BatchWriteResult { .. }) => {
+                    self.commit_transaction_effect()
+                }
+                Event::Storage(StorageEvent::Error { error }) => {
+                    self.fail_without_cleanup(error.into())
+                }
+                other => {
+                    self.unexpected_event("metadata create event append", format!("{other:?}"))
+                }
+            },
+            CreateMetadataDocumentState::CommitTransaction => match event {
+                Event::Storage(StorageEvent::TransactionCommitted { .. }) => {
+                    self.txn_id = None;
                     let Some(record) = self.record.clone() else {
                         return self
                             .fail_without_cleanup(CreateMetadataDocumentError::MissingTransaction);
@@ -474,11 +540,10 @@ impl Operation for CreateMetadataDocumentOperation {
                     smallvec![]
                 }
                 Event::Storage(StorageEvent::Error { error }) => {
+                    self.txn_id = None;
                     self.fail_without_cleanup(error.into())
                 }
-                other => {
-                    self.unexpected_event("metadata create event append", format!("{other:?}"))
-                }
+                other => self.unexpected_event("transaction commit result", format!("{other:?}")),
             },
             CreateMetadataDocumentState::Finish
             | CreateMetadataDocumentState::Error
@@ -499,7 +564,10 @@ impl Operation for CreateMetadataDocumentOperation {
     }
 
     fn abort(&mut self) -> Effects {
-        smallvec![]
+        match self.txn_id.take() {
+            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
+            None => smallvec![],
+        }
     }
 }
 
@@ -523,7 +591,7 @@ mod tests {
     use aruna_core::operation::Operation;
     use aruna_core::storage_entries::{metadata_event_log_prefix, metadata_pending_projection_key};
     use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
-    use aruna_core::types::{GroupId, Key};
+    use aruna_core::types::{Effects, GroupId, Key};
     use ulid::Ulid;
 
     use crate::placement::resolve_shard_holders;
@@ -565,10 +633,89 @@ mod tests {
     }
 
     fn assert_realm_config_read(effects: &[Effect]) {
-        let [Effect::Storage(StorageEffect::Read { key_space, .. })] = effects else {
+        let [
+            Effect::Storage(StorageEffect::Read {
+                key_space,
+                txn_id: Some(_),
+                ..
+            }),
+        ] = effects
+        else {
             panic!("expected realm config read");
         };
         assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
+    }
+
+    fn begin_transaction(
+        operation: &mut CreateMetadataDocumentOperation,
+        effects: &[Effect],
+    ) -> Effects {
+        let [Effect::Storage(StorageEffect::StartTransaction { read: false })] = effects else {
+            panic!("expected create transaction start");
+        };
+        operation.step(Event::Storage(StorageEvent::TransactionStarted {
+            txn_id: Ulid::from_bytes([30; 16]),
+        }))
+    }
+
+    #[test]
+    fn create_conflict_fence() {
+        let realm_id = RealmId([31u8; 32]);
+        let actor = actor(realm_id, 9);
+        let document_id = Ulid::from_bytes([31; 16]);
+        let realm_config = realm_config(&actor);
+        let mut operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
+            actor.clone(),
+            GroupId::r#gen(),
+            document_id,
+        ));
+
+        operation.start();
+        let effects = operation.step(validation_result(document_id));
+        let [Effect::Storage(StorageEffect::StartTransaction { read: false })] = effects.as_slice()
+        else {
+            panic!("expected create transaction start");
+        };
+
+        let txn_id = Ulid::from_bytes([32; 16]);
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
+        let [
+            Effect::Storage(StorageEffect::Read {
+                key_space,
+                txn_id: Some(read_txn),
+                ..
+            }),
+        ] = effects.as_slice()
+        else {
+            panic!("expected transactional realm config read");
+        };
+        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
+        assert_eq!(*read_txn, txn_id);
+
+        let effects = operation.step(realm_config_read(Some(&realm_config), &actor));
+        let [
+            Effect::Storage(StorageEffect::BatchWrite {
+                writes,
+                txn_id: Some(write_txn),
+            }),
+        ] = effects.as_slice()
+        else {
+            panic!("expected transactional create append");
+        };
+        assert_eq!(*write_txn, txn_id);
+        assert!(writes.iter().any(|(key_space, key, _)| {
+            key_space == REALM_CONFIG_KEYSPACE && key.as_ref() == actor.realm_id.as_bytes()
+        }));
+        assert!(
+            writes
+                .iter()
+                .any(|(key_space, _, _)| key_space == METADATA_EVENT_LOG_KEYSPACE)
+        );
+        assert!(
+            writes
+                .iter()
+                .any(|(key_space, _, _)| key_space == METADATA_PENDING_PROJECTION_KEYSPACE)
+        );
     }
 
     fn config(actor: Actor, group_id: GroupId, document_id: Ulid) -> CreateMetadataDocumentConfig {
@@ -624,7 +771,7 @@ mod tests {
         let [Effect::Storage(StorageEffect::BatchWrite { writes, txn_id })] = effects else {
             panic!("expected metadata create event append");
         };
-        assert_eq!(txn_id, &None);
+        assert!(txn_id.is_some());
         assert_eq!(writes.len(), 2);
         let (_, key, value) = writes
             .iter()
@@ -659,6 +806,16 @@ mod tests {
         key.clone()
     }
 
+    fn commit_create(operation: &mut CreateMetadataDocumentOperation, effects: &[Effect]) {
+        let [Effect::Storage(StorageEffect::CommitTransaction { txn_id })] = effects else {
+            panic!("expected create transaction commit");
+        };
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionCommitted {
+            txn_id: *txn_id,
+        }));
+        assert!(effects.is_empty());
+    }
+
     #[test]
     fn generated_document_id_validates_then_appends_without_existing_read() {
         let realm_id = RealmId([11u8; 32]);
@@ -674,6 +831,7 @@ mod tests {
         let effects = operation.start();
         assert_validation_effect(effects.as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
+        let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_realm_config_read(effects.as_slice());
         let effects = operation.step(realm_config_read(None, &actor));
         assert_create_event_append(effects.as_slice(), document_id, &actor);
@@ -694,7 +852,8 @@ mod tests {
         ));
 
         operation.start();
-        operation.step(validation_result(document_id));
+        let effects = operation.step(validation_result(document_id));
+        begin_transaction(&mut operation, effects.as_slice());
         operation.step(realm_config_read(Some(&realm_config), &actor));
 
         let placement = operation
@@ -723,6 +882,7 @@ mod tests {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
+        let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_realm_config_read(effects.as_slice());
         let effects = operation.step(realm_config_read(None, &actor));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
@@ -737,7 +897,7 @@ mod tests {
         let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![(METADATA_EVENT_LOG_KEYSPACE.to_string(), create_event_key)],
         }));
-        assert!(effects.is_empty());
+        commit_create(&mut operation, effects.as_slice());
         assert!(operation.is_complete());
         assert_eq!(
             operation
@@ -763,6 +923,7 @@ mod tests {
 
         assert_validation_effect(operation.start().as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
+        let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_realm_config_read(effects.as_slice());
         let effects = operation.step(realm_config_read(None, &actor));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
@@ -770,7 +931,7 @@ mod tests {
             entries: vec![(METADATA_EVENT_LOG_KEYSPACE.to_string(), create_event_key)],
         }));
 
-        assert!(effects.is_empty());
+        commit_create(&mut operation, effects.as_slice());
         assert!(operation.is_complete());
         assert_eq!(
             operation
@@ -823,6 +984,7 @@ mod tests {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
+        let config_read = begin_transaction(&mut operation, config_read.as_slice());
         assert_realm_config_read(config_read.as_slice());
         let append = operation.step(realm_config_read(None, &actor));
         assert_create_event_append(append.as_slice(), document_id, &actor);
@@ -830,7 +992,10 @@ mod tests {
         let effects = operation.step(Event::Storage(StorageEvent::Error {
             error: aruna_core::errors::StorageError::WriteError,
         }));
-        assert!(effects.is_empty());
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::AbortTransaction { .. })]
+        ));
         assert!(operation.is_complete());
         assert_eq!(
             operation.finalize(),

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -704,7 +704,7 @@ mod test {
             config_doc.default_strategy_id,
             Some(seeded_strategies[0].strategy_id)
         );
-        assert_eq!(seeded_bindings.len(), 2);
+        assert_eq!(seeded_bindings.len(), 4);
         assert_eq!(
             config_state.materialized_realm_config_default_strategy(),
             Some(seeded_default_strategy_id)
@@ -719,14 +719,15 @@ mod test {
             config_state
                 .materialized_realm_config_strategy_bindings()
                 .len(),
-            2
+            4
         );
 
         let outbox_records = write_values(writes, DOCUMENT_SYNC_OUTBOX_KEYSPACE)
             .into_iter()
             .map(|value| postcard::from_bytes::<DocumentSyncOutboxRecord>(value.as_ref()).unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(outbox_records.len(), 12);
+        // Two more than the strategies alone: the group and user class bindings.
+        assert_eq!(outbox_records.len(), 14);
         assert!(outbox_records.iter().any(|record| {
             record.target == DocumentSyncTarget::RealmAuthorization { realm_id }
                 && matches!(
@@ -825,6 +826,18 @@ mod test {
                 ),
                 (
                     11,
+                    AdminDocumentOperation::RealmConfigStrategyBindingSet {
+                        binding: seeded_bindings[2].clone(),
+                    },
+                ),
+                (
+                    12,
+                    AdminDocumentOperation::RealmConfigStrategyBindingSet {
+                        binding: seeded_bindings[3].clone(),
+                    },
+                ),
+                (
+                    13,
                     AdminDocumentOperation::RealmConfigNodePlacementSet {
                         entry: NodePlacementEntry {
                             node_id: actor.node_id,

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -880,9 +880,13 @@ mod test {
             .filter(|binding| binding.strategy_id == everywhere.strategy_id)
             .map(|binding| binding.scope.clone())
             .collect::<Vec<_>>();
-        assert_eq!(config_doc.strategy_bindings.len(), 2);
+        assert_eq!(config_doc.strategy_bindings.len(), 4);
         assert!(bound_scopes.contains(&BindingScope::Class(DocumentClass::MetadataRegistry)));
         assert!(bound_scopes.contains(&BindingScope::Class(DocumentClass::Admin)));
+        // Group (which covers group authorization documents) and user documents
+        // must reach every node: the permission check reads them locally.
+        assert!(bound_scopes.contains(&BindingScope::Class(DocumentClass::Group)));
+        assert!(bound_scopes.contains(&BindingScope::Class(DocumentClass::User)));
     }
 
     #[test]

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -22,6 +22,7 @@ use ulid::Ulid;
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::placement::placement_ref_for_target;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CreateRealmConfig {
@@ -224,6 +225,9 @@ impl CreateRealmOperation {
 
         let realm_auth_target = DocumentSyncTarget::RealmAuthorization { realm_id };
         let realm_config_target = DocumentSyncTarget::RealmConfig { realm_id };
+        let realm_auth_placement = placement_ref_for_target(config_doc, &realm_auth_target, None);
+        let realm_config_placement =
+            placement_ref_for_target(config_doc, &realm_config_target, None);
         let realm_auth_record = new_outbox_record_with_id(
             realm_role_event.event_id,
             self.config.actor.node_id,
@@ -232,6 +236,7 @@ impl CreateRealmOperation {
             DocumentSyncOutboxEvent::AdminOperation {
                 event: Box::new(realm_role_event),
             },
+            realm_auth_placement,
             true,
         );
         let mut writes = vec![
@@ -248,6 +253,7 @@ impl CreateRealmOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event),
                 },
+                realm_config_placement,
                 true,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -225,9 +225,10 @@ impl CreateRealmOperation {
 
         let realm_auth_target = DocumentSyncTarget::RealmAuthorization { realm_id };
         let realm_config_target = DocumentSyncTarget::RealmConfig { realm_id };
-        let realm_auth_placement = placement_ref_for_target(config_doc, &realm_auth_target, None);
+        let realm_auth_placement =
+            placement_ref_for_target(config_doc, &realm_auth_target, Default::default());
         let realm_config_placement =
-            placement_ref_for_target(config_doc, &realm_config_target, None);
+            placement_ref_for_target(config_doc, &realm_config_target, Default::default());
         let realm_auth_record = new_outbox_record_with_id(
             realm_role_event.event_id,
             self.config.actor.node_id,

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -37,7 +37,6 @@ use crate::metadata::repository::{
     write_document_lifecycle_with_revision_effect, write_graph_lifecycle_effect,
 };
 use crate::placement::{PlacementResolutionContext, placement_ref_for_target};
-use crate::sync_placement::delete_placement_effect_with_txn;
 
 #[derive(Debug, PartialEq)]
 pub struct DeleteMetadataDocumentOperation {
@@ -68,7 +67,6 @@ enum DeleteMetadataDocumentState {
     DeleteRegistry,
     DeleteDocumentIndex,
     DeleteHolders,
-    DeletePlacementInventory,
     WriteAudit,
     WriteDocumentLifecycleOutbox,
     WriteGraphLifecycleOutbox,
@@ -189,7 +187,7 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
-            self.placement_ref,
+            self.document_lifecycle_placement_ref,
             true,
         ))
     }
@@ -238,7 +236,7 @@ impl DeleteMetadataDocumentOperation {
             DocumentSyncOutboxEvent::Upsert { bytes, change },
             // First (and only) write to the per-graph lifecycle topic, so the
             // deleting holder originates and may mint its genesis.
-            self.placement_ref,
+            self.graph_lifecycle_placement_ref,
             true,
         );
         Ok(smallvec![
@@ -279,7 +277,7 @@ impl DeleteMetadataDocumentOperation {
             // Registry delete rides the document's own topic and shares the delete
             // publish batch with the tombstones above; keep it consistent so the
             // batch is not blocked mid-flight.
-            self.placement_ref,
+            self.registry_placement_ref,
             true,
         );
         Ok(smallvec![
@@ -524,26 +522,6 @@ impl Operation for DeleteMetadataDocumentOperation {
                     let Some(record) = self.record.as_ref() else {
                         return self.fail(DeleteMetadataDocumentError::DocumentNotFound);
                     };
-                    self.state = DeleteMetadataDocumentState::DeletePlacementInventory;
-                    smallvec![delete_placement_effect_with_txn(
-                        record.realm_id,
-                        &DocumentSyncTarget::MetadataDocumentLifecycle {
-                            document_id: record.document_id,
-                        },
-                        Some(txn_id),
-                    )]
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("holders delete result", format!("{other:?}")),
-            },
-            DeleteMetadataDocumentState::DeletePlacementInventory => match event {
-                Event::Storage(StorageEvent::DeleteResult { .. }) => {
-                    let Some(txn_id) = self.txn_id else {
-                        return self.fail(DeleteMetadataDocumentError::MissingTransaction);
-                    };
-                    let Some(record) = self.record.as_ref() else {
-                        return self.fail(DeleteMetadataDocumentError::DocumentNotFound);
-                    };
                     self.state = DeleteMetadataDocumentState::WriteAudit;
                     match write_audit_effect(
                         &self.audit_record(record),
@@ -557,9 +535,7 @@ impl Operation for DeleteMetadataDocumentOperation {
                     }
                 }
                 Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => {
-                    self.unexpected_event("placement inventory delete result", format!("{other:?}"))
-                }
+                other => self.unexpected_event("holders delete result", format!("{other:?}")),
             },
             DeleteMetadataDocumentState::WriteAudit => match event {
                 Event::Storage(StorageEvent::WriteResult { .. }) => {
@@ -866,6 +842,7 @@ mod tests {
                 replica_count: Some(1),
                 distinct_locations: false,
                 affinity: Vec::new(),
+                shard_count: 64,
             })
             .collect();
         config.default_strategy_id = Some(strategy_ids[0]);
@@ -904,19 +881,37 @@ mod tests {
             value: Some(postcard::to_allocvec(&config).unwrap().into()),
         }));
 
-        let expected = |strategy_id| PlacementRef {
+        let expected = |strategy_id, target: &DocumentSyncTarget| PlacementRef {
             strategy_id,
             epoch: 0,
+            shard: aruna_core::structs::shard_for_subject(
+                &crate::placement::subject_bytes(target),
+                64,
+            ),
         };
         assert_eq!(
             operation.document_lifecycle_placement_ref,
-            expected(strategy_ids[0])
+            expected(
+                strategy_ids[0],
+                &DocumentSyncTarget::MetadataDocumentLifecycle {
+                    document_id: record.document_id,
+                },
+            )
         );
         assert_eq!(
             operation.graph_lifecycle_placement_ref,
-            expected(strategy_ids[1])
+            expected(strategy_ids[1], &graph_target)
         );
-        assert_eq!(operation.registry_placement_ref, expected(strategy_ids[2]));
+        assert_eq!(
+            operation.registry_placement_ref,
+            expected(
+                strategy_ids[2],
+                &DocumentSyncTarget::MetadataRegistry {
+                    group_id: record.group_id,
+                    document_id: record.document_id,
+                },
+            )
+        );
 
         let document_outbox = operation
             .document_lifecycle_outbox_record(&record)
@@ -951,9 +946,29 @@ mod tests {
         else {
             panic!("expected registry delete");
         };
-        assert_eq!(document_change.placement, expected(strategy_ids[0]));
-        assert_eq!(graph_change.placement, expected(strategy_ids[1]));
-        assert_eq!(registry_change.placement, expected(strategy_ids[2]));
+        assert_eq!(
+            document_change.placement,
+            expected(
+                strategy_ids[0],
+                &DocumentSyncTarget::MetadataDocumentLifecycle {
+                    document_id: record.document_id,
+                },
+            )
+        );
+        assert_eq!(
+            graph_change.placement,
+            expected(strategy_ids[1], &graph_target)
+        );
+        assert_eq!(
+            registry_change.placement,
+            expected(
+                strategy_ids[2],
+                &DocumentSyncTarget::MetadataRegistry {
+                    group_id: record.group_id,
+                    document_id: record.document_id,
+                },
+            )
+        );
     }
 
     #[test]

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -1,3 +1,4 @@
+use aruna_core::NodeId;
 use aruna_core::document::{
     DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncOutboxEvent, DocumentSyncOutboxRecord,
     DocumentSyncRevision, DocumentSyncTarget,
@@ -36,7 +37,7 @@ use crate::metadata::repository::{
     parse_registry_read, read_registry_effect, write_audit_effect,
     write_document_lifecycle_with_revision_effect, write_graph_lifecycle_effect,
 };
-use crate::placement::{PlacementResolutionContext, placement_ref_for_target};
+use crate::placement::resolve_shard_holders;
 
 #[derive(Debug, PartialEq)]
 pub struct DeleteMetadataDocumentOperation {
@@ -50,6 +51,7 @@ pub struct DeleteMetadataDocumentOperation {
     document_lifecycle_placement_ref: PlacementRef,
     graph_lifecycle_placement_ref: PlacementRef,
     registry_placement_ref: PlacementRef,
+    holder_peers: Vec<NodeId>,
     txn_id: Option<Ulid>,
     state: DeleteMetadataDocumentState,
     output: Option<Result<(), DeleteMetadataDocumentError>>,
@@ -115,9 +117,20 @@ impl DeleteMetadataDocumentOperation {
             document_lifecycle_placement_ref: PlacementRef::NIL,
             graph_lifecycle_placement_ref: PlacementRef::NIL,
             registry_placement_ref: PlacementRef::NIL,
+            holder_peers: Vec::new(),
             txn_id: None,
             state: DeleteMetadataDocumentState::Init,
             output: None,
+        }
+    }
+
+    /// Live holders of the document's bucket; the event-time stamp on the
+    /// record is only the fallback for a realm without a readable config.
+    fn peers(&self, record: &MetadataRegistryRecord) -> Vec<NodeId> {
+        if self.holder_peers.is_empty() {
+            record.holder_node_ids.clone()
+        } else {
+            self.holder_peers.clone()
         }
     }
 
@@ -185,7 +198,7 @@ impl DeleteMetadataDocumentOperation {
             DocumentSyncTarget::MetadataDocumentLifecycle {
                 document_id: record.document_id,
             },
-            record.holder_node_ids.clone(),
+            self.peers(record),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
             self.document_lifecycle_placement_ref,
             true,
@@ -232,7 +245,7 @@ impl DeleteMetadataDocumentOperation {
             DocumentSyncTarget::MetadataGraphLifecycle {
                 graph_iri: lifecycle_record.graph_iri.clone(),
             },
-            record.holder_node_ids.clone(),
+            self.peers(record),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
             // First (and only) write to the per-graph lifecycle topic, so the
             // deleting holder originates and may mint its genesis.
@@ -272,7 +285,7 @@ impl DeleteMetadataDocumentOperation {
                 group_id: record.group_id,
                 document_id: record.document_id,
             },
-            record.holder_node_ids.clone(),
+            self.peers(record),
             DocumentSyncOutboxEvent::Delete { change },
             // Registry delete rides the document's own topic and shares the delete
             // publish batch with the tombstones above; keep it consistent so the
@@ -359,42 +372,21 @@ impl Operation for DeleteMetadataDocumentOperation {
                         return self.fail(DeleteMetadataDocumentError::DocumentNotFound);
                     };
                     if let Some(bytes) = value {
-                        match RealmConfigDocument::from_bytes(&bytes) {
-                            Ok(config) => {
-                                let context = PlacementResolutionContext {
-                                    group_id: Some(record.group_id),
-                                    metadata_path: Some(record.document_path.as_str()),
-                                };
-                                let document_lifecycle_target =
-                                    DocumentSyncTarget::MetadataDocumentLifecycle {
-                                        document_id: record.document_id,
-                                    };
-                                self.document_lifecycle_placement_ref = placement_ref_for_target(
-                                    &config,
-                                    &document_lifecycle_target,
-                                    context,
-                                );
-                                let graph_lifecycle_target =
-                                    DocumentSyncTarget::MetadataGraphLifecycle {
-                                        graph_iri: record.graph_iri.clone(),
-                                    };
-                                self.graph_lifecycle_placement_ref = placement_ref_for_target(
-                                    &config,
-                                    &graph_lifecycle_target,
-                                    context,
-                                );
-                                let registry_target = DocumentSyncTarget::MetadataRegistry {
-                                    group_id: record.group_id,
-                                    document_id: record.document_id,
-                                };
-                                self.registry_placement_ref =
-                                    placement_ref_for_target(&config, &registry_target, context);
-                            }
+                        let config = match RealmConfigDocument::from_bytes(&bytes) {
+                            Ok(config) => config,
                             Err(error) => {
                                 return self
                                     .fail(DeleteMetadataDocumentError::ConversionError(error));
                             }
-                        }
+                        };
+                        // Every record of the document rides the bucket its
+                        // create stamped, so a tombstone lands on the topic the
+                        // document itself lives on. Peers are that bucket's live
+                        // holders, not the event-time stamp.
+                        self.holder_peers = resolve_shard_holders(&config, &record.placement);
+                        self.document_lifecycle_placement_ref = record.placement;
+                        self.graph_lifecycle_placement_ref = record.placement;
+                        self.registry_placement_ref = record.placement;
                     }
                     self.state = DeleteMetadataDocumentState::StartTransaction;
                     smallvec![Effect::Storage(StorageEffect::StartTransaction {
@@ -739,9 +731,7 @@ mod tests {
         METADATA_GRAPH_PRUNE_JOB_KEYSPACE,
     };
     use aruna_core::storage_entries::document_sync_revision_key;
-    use aruna_core::structs::{
-        BindingScope, DocumentClass, PlacementOverride, PlacementStrategy, RealmId, StrategyBinding,
-    };
+    use aruna_core::structs::{PlacementStrategy, RealmId, RealmNodeKind};
 
     fn actor() -> aruna_core::structs::Actor {
         let realm_id = RealmId::from_bytes([7u8; 32]);
@@ -822,47 +812,32 @@ mod tests {
         assert_eq!(event.deleted_after_event_id, record.last_event_id);
     }
 
+    // Every record of a document rides the bucket its create stamped, so all
+    // three tombstones land on the topic the document itself lives on.
     #[test]
-    fn delete_resolves_each_target_placement_reference_independently() {
+    fn delete_rides_stored_bucket() {
         let actor = actor();
-        let record = record(&actor);
-        let graph_target = DocumentSyncTarget::MetadataGraphLifecycle {
-            graph_iri: record.graph_iri.clone(),
-        };
-        let strategy_ids = [
-            Ulid::from_bytes([1; 16]),
-            Ulid::from_bytes([2; 16]),
-            Ulid::from_bytes([3; 16]),
-        ];
+        let mut record = record(&actor);
         let mut config = RealmConfigDocument::new(record.realm_id, Vec::new(), 3);
-        config.strategies = strategy_ids
-            .into_iter()
-            .map(|strategy_id| PlacementStrategy {
-                strategy_id,
-                name: strategy_id.to_string(),
-                replica_count: Some(1),
-                distinct_locations: false,
-                affinity: Vec::new(),
-                shard_count: 64,
-            })
-            .collect();
-        config.default_strategy_id = Some(strategy_ids[0]);
-        config.strategy_bindings = vec![
-            StrategyBinding {
-                scope: BindingScope::Class(DocumentClass::Metadata),
-                strategy_id: strategy_ids[0],
-            },
-            StrategyBinding {
-                scope: BindingScope::Class(DocumentClass::MetadataRegistry),
-                strategy_id: strategy_ids[2],
-            },
-        ];
-        config.placement_overrides = vec![PlacementOverride {
-            subject: crate::placement::subject_bytes(&graph_target),
-            pinned: Vec::new(),
-            excluded: Vec::new(),
-            strategy_id: Some(strategy_ids[1]),
-        }];
+        let strategy = PlacementStrategy {
+            strategy_id: Ulid::from_bytes([1; 16]),
+            name: "default".to_string(),
+            replica_count: Some(1),
+            distinct_locations: false,
+            affinity: Vec::new(),
+            shard_count: 64,
+        };
+        config.default_strategy_id = Some(strategy.strategy_id);
+        config.strategies = vec![strategy.clone()];
+        config.ensure_node(actor.node_id, RealmNodeKind::Server);
+        record.placement = crate::placement::choose_origin_bucket(
+            &config,
+            &strategy,
+            actor.node_id,
+            &record.document_id.to_bytes(),
+        )
+        .expect("origin holds a bucket");
+
         let mut operation = DeleteMetadataDocumentOperation::new(
             actor.clone(),
             record.group_id,
@@ -876,43 +851,14 @@ mod tests {
             ),
             value: Some(postcard::to_allocvec(&record).unwrap().into()),
         }));
-
         let _ = operation.step(Event::Storage(StorageEvent::ReadResult {
             key: ByteView::from(*record.realm_id.as_bytes()),
             value: Some(postcard::to_allocvec(&config).unwrap().into()),
         }));
 
-        let expected = |strategy_id, target: &DocumentSyncTarget| PlacementRef {
-            strategy_id,
-            epoch: 0,
-            shard: aruna_core::structs::shard_for_subject(
-                &crate::placement::subject_bytes(target),
-                64,
-            ),
-        };
-        assert_eq!(
-            operation.document_lifecycle_placement_ref,
-            expected(
-                strategy_ids[0],
-                &DocumentSyncTarget::MetadataDocumentLifecycle {
-                    document_id: record.document_id,
-                },
-            )
-        );
-        assert_eq!(
-            operation.graph_lifecycle_placement_ref,
-            expected(strategy_ids[1], &graph_target)
-        );
-        assert_eq!(
-            operation.registry_placement_ref,
-            expected(
-                strategy_ids[2],
-                &DocumentSyncTarget::MetadataRegistry {
-                    group_id: record.group_id,
-                    document_id: record.document_id,
-                },
-            )
-        );
+        assert_eq!(operation.document_lifecycle_placement_ref, record.placement);
+        assert_eq!(operation.graph_lifecycle_placement_ref, record.placement);
+        assert_eq!(operation.registry_placement_ref, record.placement);
 
         let document_outbox = operation
             .document_lifecycle_outbox_record(&record)
@@ -947,29 +893,10 @@ mod tests {
         else {
             panic!("expected registry delete");
         };
-        assert_eq!(
-            document_change.placement,
-            expected(
-                strategy_ids[0],
-                &DocumentSyncTarget::MetadataDocumentLifecycle {
-                    document_id: record.document_id,
-                },
-            )
-        );
-        assert_eq!(
-            graph_change.placement,
-            expected(strategy_ids[1], &graph_target)
-        );
-        assert_eq!(
-            registry_change.placement,
-            expected(
-                strategy_ids[2],
-                &DocumentSyncTarget::MetadataRegistry {
-                    group_id: record.group_id,
-                    document_id: record.document_id,
-                },
-            )
-        );
+        assert_eq!(document_change.placement, record.placement);
+        assert_eq!(graph_change.placement, record.placement);
+        assert_eq!(registry_change.placement, record.placement);
+        assert_eq!(document_outbox.peers, vec![actor.node_id]);
     }
 
     #[test]

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -862,7 +862,11 @@ mod tests {
 
         assert_eq!(operation.document_lifecycle_placement_ref, record.placement);
         assert_eq!(operation.graph_lifecycle_placement_ref, record.placement);
-        assert_eq!(operation.registry_placement_ref, record.placement);
+        // The registry tombstone follows the registry row, which rides the
+        // everywhere-bound registry class rather than the document's capped bucket.
+        let registry_ref = registry_placement(&config, &record);
+        assert_eq!(operation.registry_placement_ref, registry_ref);
+        assert_ne!(registry_ref, record.placement);
 
         let document_outbox = operation
             .document_lifecycle_outbox_record(&record)
@@ -899,7 +903,7 @@ mod tests {
         };
         assert_eq!(document_change.placement, record.placement);
         assert_eq!(graph_change.placement, record.placement);
-        assert_eq!(registry_change.placement, record.placement);
+        assert_eq!(registry_change.placement, registry_ref);
         assert_eq!(document_outbox.peers, vec![actor.node_id]);
     }
 

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -189,6 +189,7 @@ impl DeleteMetadataDocumentOperation {
             },
             record.holder_node_ids.clone(),
             DocumentSyncOutboxEvent::Upsert { bytes, change },
+            self.placement_ref,
             true,
         ))
     }
@@ -237,6 +238,7 @@ impl DeleteMetadataDocumentOperation {
             DocumentSyncOutboxEvent::Upsert { bytes, change },
             // First (and only) write to the per-graph lifecycle topic, so the
             // deleting holder originates and may mint its genesis.
+            self.placement_ref,
             true,
         );
         Ok(smallvec![
@@ -277,6 +279,7 @@ impl DeleteMetadataDocumentOperation {
             // Registry delete rides the document's own topic and shares the delete
             // publish batch with the tombstones above; keep it consistent so the
             // batch is not blocked mid-flight.
+            self.placement_ref,
             true,
         );
         Ok(smallvec![

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -770,6 +770,7 @@ mod tests {
                 document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![actor.node_id],
             created_at_ms: 1,
             updated_at_ms: 2,

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -37,7 +37,7 @@ use crate::metadata::repository::{
     parse_registry_read, read_registry_effect, write_audit_effect,
     write_document_lifecycle_with_revision_effect, write_graph_lifecycle_effect,
 };
-use crate::placement::resolve_shard_holders;
+use crate::placement::{registry_placement, resolve_shard_holders};
 
 #[derive(Debug, PartialEq)]
 pub struct DeleteMetadataDocumentOperation {
@@ -52,6 +52,7 @@ pub struct DeleteMetadataDocumentOperation {
     graph_lifecycle_placement_ref: PlacementRef,
     registry_placement_ref: PlacementRef,
     holder_peers: Vec<NodeId>,
+    registry_peers: Vec<NodeId>,
     txn_id: Option<Ulid>,
     state: DeleteMetadataDocumentState,
     output: Option<Result<(), DeleteMetadataDocumentError>>,
@@ -118,6 +119,7 @@ impl DeleteMetadataDocumentOperation {
             graph_lifecycle_placement_ref: PlacementRef::NIL,
             registry_placement_ref: PlacementRef::NIL,
             holder_peers: Vec::new(),
+            registry_peers: Vec::new(),
             txn_id: None,
             state: DeleteMetadataDocumentState::Init,
             output: None,
@@ -285,11 +287,8 @@ impl DeleteMetadataDocumentOperation {
                 group_id: record.group_id,
                 document_id: record.document_id,
             },
-            self.peers(record),
+            self.registry_peers.clone(),
             DocumentSyncOutboxEvent::Delete { change },
-            // Registry delete rides the document's own topic and shares the delete
-            // publish batch with the tombstones above; keep it consistent so the
-            // batch is not blocked mid-flight.
             self.registry_placement_ref,
             true,
         );
@@ -386,7 +385,12 @@ impl Operation for DeleteMetadataDocumentOperation {
                         self.holder_peers = resolve_shard_holders(&config, &record.placement);
                         self.document_lifecycle_placement_ref = record.placement;
                         self.graph_lifecycle_placement_ref = record.placement;
-                        self.registry_placement_ref = record.placement;
+                        // The registry row rides the registry class's own topic,
+                        // not the document's capped bucket, so its tombstone must
+                        // go where the row went: to every node that has one.
+                        self.registry_placement_ref = registry_placement(&config, record);
+                        self.registry_peers =
+                            resolve_shard_holders(&config, &self.registry_placement_ref);
                     }
                     self.state = DeleteMetadataDocumentState::StartTransaction;
                     smallvec![Effect::Storage(StorageEffect::StartTransaction {

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -96,14 +96,6 @@ pub fn write_outbox_effect(record: &DocumentSyncOutboxRecord) -> Result<Effect, 
     write_outbox_effect_with_txn(record, None)
 }
 
-pub fn delete_outbox_effect(record: &DocumentSyncOutboxRecord) -> Effect {
-    Effect::Storage(StorageEffect::Delete {
-        key_space: DOCUMENT_SYNC_OUTBOX_KEYSPACE.to_string(),
-        key: outbox_key(record),
-        txn_id: None,
-    })
-}
-
 pub fn outbox_write_entry(
     record: &DocumentSyncOutboxRecord,
 ) -> Result<(String, ByteView, ByteView), postcard::Error> {

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -341,11 +341,11 @@ mod tests {
         }
     }
 
-    fn placement(bucket: u32) -> aruna_core::structs::PlacementRef {
+    fn placement(shard: u32) -> aruna_core::structs::PlacementRef {
         aruna_core::structs::PlacementRef {
             strategy_id: Ulid::from_parts(42, 1),
             epoch: 0,
-            bucket,
+            shard,
         }
     }
 
@@ -691,7 +691,7 @@ mod tests {
             aruna_core::structs::PlacementRef::NIL,
             false,
         );
-        let bucketed = new_outbox_record_with_id(
+        let sharded = new_outbox_record_with_id(
             outbox_id,
             node(1),
             target,
@@ -701,7 +701,7 @@ mod tests {
             false,
         );
         // The FIFO key layout must not depend on the placement field.
-        assert_ne!(nil.placement, bucketed.placement);
-        assert_eq!(outbox_key(&nil), outbox_key(&bucketed));
+        assert_ne!(nil.placement, sharded.placement);
+        assert_eq!(outbox_key(&nil), outbox_key(&sharded));
     }
 }

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -5,6 +5,7 @@ use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncOutboxRecord, Do
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::DOCUMENT_SYNC_OUTBOX_KEYSPACE;
+use aruna_core::structs::PlacementRef;
 use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
 use aruna_core::types::{Key, TxnId};
 use aruna_core::util::unix_timestamp_secs;
@@ -47,26 +48,45 @@ pub fn new_outbox_record(
     target: DocumentSyncTarget,
     peers: Vec<NodeId>,
     event: DocumentSyncOutboxEvent,
+    admin_placement: PlacementRef,
     allow_genesis: bool,
 ) -> DocumentSyncOutboxRecord {
-    new_outbox_record_with_id(Ulid::r#gen(), node_id, target, peers, event, allow_genesis)
+    new_outbox_record_with_id(
+        Ulid::r#gen(),
+        node_id,
+        target,
+        peers,
+        event,
+        admin_placement,
+        allow_genesis,
+    )
 }
 
+/// `admin_placement` is only consulted for `AdminOperation` records (which carry
+/// no envelope change); `Upsert`/`Delete` always take their ref from the event's
+/// change so the record and its envelope can never diverge.
 pub fn new_outbox_record_with_id(
     outbox_id: Ulid,
     node_id: NodeId,
     target: DocumentSyncTarget,
     mut peers: Vec<NodeId>,
     event: DocumentSyncOutboxEvent,
+    admin_placement: PlacementRef,
     allow_genesis: bool,
 ) -> DocumentSyncOutboxRecord {
     crate::sync_placement::sort_node_ids(&mut peers);
+    let placement = match &event {
+        DocumentSyncOutboxEvent::Upsert { change, .. }
+        | DocumentSyncOutboxEvent::Delete { change } => change.placement,
+        DocumentSyncOutboxEvent::AdminOperation { .. } => admin_placement,
+    };
     DocumentSyncOutboxRecord {
         outbox_id,
         node_id,
         target,
         peers,
         event,
+        placement,
         updated_at: unix_timestamp_secs(),
         allow_genesis,
     }
@@ -321,6 +341,14 @@ mod tests {
         }
     }
 
+    fn placement(bucket: u32) -> aruna_core::structs::PlacementRef {
+        aruna_core::structs::PlacementRef {
+            strategy_id: Ulid::from_parts(42, 1),
+            epoch: 0,
+            bucket,
+        }
+    }
+
     fn change() -> DocumentSyncChange {
         DocumentSyncChange {
             base: None,
@@ -331,7 +359,7 @@ mod tests {
                 updated_at_ms: 9,
             },
             kind: DocumentSyncChangeKind::Upsert,
-            placement: aruna_core::structs::PlacementRef::NIL,
+            placement: placement(5),
         }
     }
 
@@ -456,6 +484,7 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         write_raw_outbox_record(&storage, corrupt_key.clone(), vec![1, 2, 3]).await;
@@ -505,6 +534,7 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         let bytes = postcard::to_allocvec(&record).expect("record serializes");
@@ -525,6 +555,7 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             true,
         );
         let bytes = postcard::to_allocvec(&record).expect("record serializes");
@@ -533,6 +564,9 @@ mod tests {
 
         assert_eq!(decoded, record);
         assert!(decoded.allow_genesis);
+        // Upsert mirrors the envelope change's ref, never the admin fallback.
+        assert_eq!(decoded.placement, change().placement);
+        assert_ne!(decoded.placement, aruna_core::structs::PlacementRef::NIL);
     }
 
     #[test]
@@ -544,6 +578,7 @@ mod tests {
             DocumentSyncOutboxEvent::Delete {
                 change: delete_change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         let bytes = postcard::to_allocvec(&record).expect("record serializes");
@@ -551,6 +586,7 @@ mod tests {
             postcard::from_bytes(&bytes).expect("record decodes");
 
         assert_eq!(decoded, record);
+        assert_eq!(decoded.placement, delete_change().placement);
     }
 
     #[test]
@@ -559,8 +595,22 @@ mod tests {
             bytes: vec![1],
             change: change(),
         };
-        let left = new_outbox_record(node(1), target(), vec![node(2)], event.clone(), false);
-        let right = new_outbox_record(node(1), target(), vec![node(2)], event, false);
+        let left = new_outbox_record(
+            node(1),
+            target(),
+            vec![node(2)],
+            event.clone(),
+            aruna_core::structs::PlacementRef::NIL,
+            false,
+        );
+        let right = new_outbox_record(
+            node(1),
+            target(),
+            vec![node(2)],
+            event,
+            aruna_core::structs::PlacementRef::NIL,
+            false,
+        );
         let prefix = outbox_prefix(&left.event);
 
         assert_ne!(outbox_key(&left), outbox_key(&right));
@@ -574,7 +624,14 @@ mod tests {
             bytes: vec![1],
             change: change(),
         };
-        let mut older = new_outbox_record(node(1), target(), vec![node(2)], event.clone(), false);
+        let mut older = new_outbox_record(
+            node(1),
+            target(),
+            vec![node(2)],
+            event.clone(),
+            aruna_core::structs::PlacementRef::NIL,
+            false,
+        );
         older.outbox_id = Ulid::from_parts(1, 0);
         let mut newer = new_outbox_record(
             node(1),
@@ -583,6 +640,7 @@ mod tests {
             },
             vec![node(2)],
             event,
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         newer.outbox_id = Ulid::from_parts(2, 0);
@@ -599,6 +657,7 @@ mod tests {
             target.clone(),
             Vec::new(),
             user_admin_event(user_id, 1),
+            placement(9),
             false,
         );
         earlier.outbox_id = Ulid::from_parts(2, 2);
@@ -607,10 +666,42 @@ mod tests {
             target,
             Vec::new(),
             user_admin_event(user_id, 2),
+            placement(9),
             false,
         );
         later.outbox_id = Ulid::from_parts(1, 1);
 
         assert!(outbox_key(&earlier) < outbox_key(&later));
+        // AdminOperation records take the supplied ref (no envelope change).
+        assert_eq!(earlier.placement, placement(9));
+    }
+
+    #[test]
+    fn outbox_key_is_byte_identical_regardless_of_placement() {
+        let user_id = UserId::local(Ulid::from_parts(7, 1), RealmId::from_bytes([3; 32]));
+        let event = user_admin_event(user_id, 1);
+        let outbox_id = Ulid::from_parts(5, 5);
+        let target = DocumentSyncTarget::User { user_id };
+        let nil = new_outbox_record_with_id(
+            outbox_id,
+            node(1),
+            target.clone(),
+            Vec::new(),
+            event.clone(),
+            aruna_core::structs::PlacementRef::NIL,
+            false,
+        );
+        let bucketed = new_outbox_record_with_id(
+            outbox_id,
+            node(1),
+            target,
+            Vec::new(),
+            event,
+            placement(17),
+            false,
+        );
+        // The FIFO key layout must not depend on the placement field.
+        assert_ne!(nil.placement, bucketed.placement);
+        assert_eq!(outbox_key(&nil), outbox_key(&bucketed));
     }
 }

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -40,6 +40,12 @@ pub fn outbox_key(record: &DocumentSyncOutboxRecord) -> Key {
         bytes.extend_from_slice(&event.origin_seq.to_be_bytes());
     }
     bytes.extend_from_slice(&record.outbox_id.to_bytes());
+    // One event can enqueue several publishes under its own id — a metadata
+    // create emits both the document's lifecycle event and its registry row, each
+    // onto a different topic. Without the target in the key the second would
+    // silently overwrite the first and that publish would simply never happen.
+    // Ordering is untouched: the id still compares first, so this only breaks ties.
+    bytes.extend_from_slice(record.target.storage_key().as_ref());
     ByteView::from(bytes)
 }
 

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -125,48 +125,6 @@ pub fn write_outbox_effect_with_txn(
     }))
 }
 
-fn decode_outbox_record(bytes: &[u8]) -> Result<DocumentSyncOutboxRecord, postcard::Error> {
-    match postcard::from_bytes::<DocumentSyncOutboxRecord>(bytes) {
-        Ok(record) => Ok(record),
-        Err(_) => postcard::from_bytes::<LegacyDocumentSyncOutboxRecord>(bytes).map(Into::into),
-    }
-}
-
-/// Pre-`allow_genesis` mirror of [`DocumentSyncOutboxRecord`], used only to
-/// decode outbox rows persisted before that field existed. Keep field order
-/// identical to the historical layout.
-#[derive(serde::Deserialize)]
-struct LegacyDocumentSyncOutboxRecord {
-    outbox_id: Ulid,
-    node_id: NodeId,
-    target: DocumentSyncTarget,
-    peers: Vec<NodeId>,
-    event: DocumentSyncOutboxEvent,
-    updated_at: u64,
-}
-
-impl From<LegacyDocumentSyncOutboxRecord> for DocumentSyncOutboxRecord {
-    fn from(legacy: LegacyDocumentSyncOutboxRecord) -> Self {
-        let placement = match &legacy.event {
-            DocumentSyncOutboxEvent::Upsert { change, .. }
-            | DocumentSyncOutboxEvent::Delete { change } => change.placement,
-            DocumentSyncOutboxEvent::AdminOperation { .. } => PlacementRef::NIL,
-        };
-        Self {
-            outbox_id: legacy.outbox_id,
-            node_id: legacy.node_id,
-            target: legacy.target,
-            peers: legacy.peers,
-            event: legacy.event,
-            placement,
-            updated_at: legacy.updated_at,
-            // Before `allow_genesis` existed, outbox publishes could mint missing
-            // sync topic genesis. Preserve that behavior for already-queued work.
-            allow_genesis: true,
-        }
-    }
-}
-
 pub fn schedule_outbox_drain_effect() -> Effect {
     Effect::Task(TaskEffect::ResetTimer {
         key: TaskKey::DrainDocumentSyncOutbox,
@@ -187,7 +145,10 @@ pub async fn read_outbox_record(
         .await
     {
         Event::Storage(StorageEvent::ReadResult { value, .. }) => value
-            .map(|bytes| decode_outbox_record(&bytes).map_err(|error| error.to_string()))
+            .map(|bytes| {
+                postcard::from_bytes::<DocumentSyncOutboxRecord>(&bytes)
+                    .map_err(|error| error.to_string())
+            })
             .transpose(),
         Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
         other => Err(format!("unexpected storage event: {other:?}")),
@@ -220,7 +181,7 @@ pub async fn read_outbox_records(
             let has_more = values.len() > limit;
             let mut records = Vec::with_capacity(values.len().min(limit));
             for (key, value) in values.into_iter().take(limit) {
-                match decode_outbox_record(&value) {
+                match postcard::from_bytes::<DocumentSyncOutboxRecord>(&value) {
                     Ok(record) => records.push((key.to_vec(), record)),
                     Err(error) => {
                         let key = key.to_vec();
@@ -388,70 +349,6 @@ mod tests {
             Event::Storage(StorageEvent::WriteResult { .. }) => {}
             other => panic!("unexpected outbox write event: {other:?}"),
         }
-    }
-
-    fn legacy_pre_allow_genesis_bytes(record: &DocumentSyncOutboxRecord) -> Vec<u8> {
-        #[derive(serde::Serialize)]
-        struct LegacyRecord {
-            outbox_id: Ulid,
-            node_id: NodeId,
-            target: DocumentSyncTarget,
-            peers: Vec<NodeId>,
-            event: DocumentSyncOutboxEvent,
-            updated_at: u64,
-        }
-
-        postcard::to_allocvec(&LegacyRecord {
-            outbox_id: record.outbox_id,
-            node_id: record.node_id,
-            target: record.target.clone(),
-            peers: record.peers.clone(),
-            event: record.event.clone(),
-            updated_at: record.updated_at,
-        })
-        .expect("legacy record serializes")
-    }
-
-    #[tokio::test]
-    async fn legacy_pre_allow_genesis_outbox_record_is_preserved() {
-        let dir = tempdir().expect("temp dir");
-        let storage =
-            FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
-        let mut legacy = new_outbox_record(
-            node(1),
-            target(),
-            vec![node(2)],
-            DocumentSyncOutboxEvent::Upsert {
-                bytes: vec![4, 5],
-                change: change(),
-            },
-            PlacementRef::NIL,
-            false,
-        );
-        legacy.outbox_id = Ulid::from_parts(3, 4);
-        legacy.updated_at = 42;
-        let key = outbox_key(&legacy).to_vec();
-        write_raw_outbox_record(
-            &storage,
-            key.clone(),
-            legacy_pre_allow_genesis_bytes(&legacy),
-        )
-        .await;
-
-        let mut expected = legacy;
-        expected.allow_genesis = true;
-        let batch = read_outbox_records(&storage, &[], None, OUTBOX_DRAIN_BATCH_SIZE)
-            .await
-            .expect("outbox read succeeds");
-
-        assert_eq!(batch.records, vec![(key.clone(), expected.clone())]);
-        assert!(!batch.has_more);
-        assert_eq!(
-            read_outbox_record(&storage, &key)
-                .await
-                .expect("legacy record was preserved"),
-            Some(expected)
-        );
     }
 
     #[tokio::test]

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use aruna_core::NodeId;
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncOutboxRecord, DocumentSyncTarget};
-use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::DOCUMENT_SYNC_OUTBOX_KEYSPACE;
 use aruna_core::structs::PlacementRef;
@@ -198,6 +198,7 @@ pub struct OutboxReadBatch {
 pub async fn read_outbox_records(
     storage: &StorageHandle,
     prefix: &[u8],
+    start_after: Option<Vec<u8>>,
     limit: usize,
 ) -> Result<OutboxReadBatch, String> {
     let read_limit = limit.saturating_add(1);
@@ -205,7 +206,7 @@ pub async fn read_outbox_records(
         .send_storage_effect(StorageEffect::Iter {
             key_space: DOCUMENT_SYNC_OUTBOX_KEYSPACE.to_string(),
             prefix: Some(ByteView::from(prefix.to_vec())),
-            start: None,
+            start: start_after.map(|key| IterStart::After(ByteView::from(key))),
             limit: read_limit,
             txn_id: None,
         })
@@ -456,7 +457,7 @@ mod tests {
         let corrupt_key = b"000-corrupt-outbox".to_vec();
         write_raw_outbox_record(&storage, corrupt_key.clone(), vec![1, 2, 3]).await;
 
-        let batch = read_outbox_records(&storage, &[], OUTBOX_DRAIN_BATCH_SIZE)
+        let batch = read_outbox_records(&storage, &[], None, OUTBOX_DRAIN_BATCH_SIZE)
             .await
             .expect("outbox read succeeds");
 
@@ -496,7 +497,7 @@ mod tests {
             other => panic!("unexpected valid outbox write event: {other:?}"),
         }
 
-        let batch = read_outbox_records(&storage, &[], OUTBOX_DRAIN_BATCH_SIZE)
+        let batch = read_outbox_records(&storage, &[], None, OUTBOX_DRAIN_BATCH_SIZE)
             .await
             .expect("outbox read succeeds");
 

--- a/operations/src/document_sync_outbox.rs
+++ b/operations/src/document_sync_outbox.rs
@@ -149,12 +149,18 @@ struct LegacyDocumentSyncOutboxRecord {
 
 impl From<LegacyDocumentSyncOutboxRecord> for DocumentSyncOutboxRecord {
     fn from(legacy: LegacyDocumentSyncOutboxRecord) -> Self {
+        let placement = match &legacy.event {
+            DocumentSyncOutboxEvent::Upsert { change, .. }
+            | DocumentSyncOutboxEvent::Delete { change } => change.placement,
+            DocumentSyncOutboxEvent::AdminOperation { .. } => PlacementRef::NIL,
+        };
         Self {
             outbox_id: legacy.outbox_id,
             node_id: legacy.node_id,
             target: legacy.target,
             peers: legacy.peers,
             event: legacy.event,
+            placement,
             updated_at: legacy.updated_at,
             // Before `allow_genesis` existed, outbox publishes could mint missing
             // sync topic genesis. Preserve that behavior for already-queued work.
@@ -421,6 +427,7 @@ mod tests {
                 bytes: vec![4, 5],
                 change: change(),
             },
+            PlacementRef::NIL,
             false,
         );
         legacy.outbox_id = Ulid::from_parts(3, 4);
@@ -435,7 +442,7 @@ mod tests {
 
         let mut expected = legacy;
         expected.allow_genesis = true;
-        let batch = read_outbox_records(&storage, &[], OUTBOX_DRAIN_BATCH_SIZE)
+        let batch = read_outbox_records(&storage, &[], None, OUTBOX_DRAIN_BATCH_SIZE)
             .await
             .expect("outbox read succeeds");
 

--- a/operations/src/ensure_realm_config.rs
+++ b/operations/src/ensure_realm_config.rs
@@ -773,7 +773,7 @@ mod tests {
             replica_count: Some(3),
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         };
         let binding = StrategyBinding {
             scope: BindingScope::Class(DocumentClass::MetadataRegistry),

--- a/operations/src/ensure_realm_config.rs
+++ b/operations/src/ensure_realm_config.rs
@@ -770,6 +770,7 @@ mod tests {
             replica_count: Some(3),
             distinct_locations: false,
             affinity: Vec::new(),
+            bucket_count: 64,
         };
         let binding = StrategyBinding {
             scope: BindingScope::Class(DocumentClass::MetadataRegistry),

--- a/operations/src/ensure_realm_config.rs
+++ b/operations/src/ensure_realm_config.rs
@@ -28,6 +28,7 @@ use ulid::Ulid;
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::placement::placement_ref_for_target;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct EnsureRealmConfigConfig {
@@ -218,6 +219,7 @@ impl EnsureRealmConfigOperation {
             Some(&reducer_state),
         );
         let document_target = self.document_ref();
+        let placement = placement_ref_for_target(&document, &document_target, None);
         let mut writes = vec![
             (
                 document_target.storage_keyspace().to_string(),
@@ -234,6 +236,7 @@ impl EnsureRealmConfigOperation {
             DocumentSyncOutboxEvent::AdminOperation {
                 event: Box::new(admin_event),
             },
+            placement,
             false,
         );
         writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/ensure_realm_config.rs
+++ b/operations/src/ensure_realm_config.rs
@@ -219,7 +219,7 @@ impl EnsureRealmConfigOperation {
             Some(&reducer_state),
         );
         let document_target = self.document_ref();
-        let placement = placement_ref_for_target(&document, &document_target, None);
+        let placement = placement_ref_for_target(&document, &document_target, Default::default());
         let mut writes = vec![
             (
                 document_target.storage_keyspace().to_string(),

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -13,7 +13,7 @@ use crate::metadata::projector::{
 };
 use crate::metadata::prune_queue::process_metadata_graph_tombstones;
 use crate::notifications::watch::interest::refresh_watch_interest_for_targets;
-use crate::process_placements::process_bucket_placements;
+use crate::process_placements::process_shard_placements;
 use crate::replication::incoming_version_replication::IncomingVersionReplicationOperation;
 use crate::replication::protocol::VersionReplicationMessage;
 use crate::usage_stats::refresh_realm_usage_summary_for_targets;
@@ -169,7 +169,7 @@ async fn reconcile_inbound_document_sync_topics(
         .iter()
         .any(|target| matches!(target, DocumentSyncTarget::RealmConfig { .. }));
     if realm_config_changed {
-        process_bucket_placements(context, *net_handle.realm_id(), net_handle.node_id()).await;
+        process_shard_placements(context, *net_handle.realm_id(), net_handle.node_id()).await;
     }
     refresh_realm_usage_summary_for_targets(context, net_handle.node_id(), &targets.targets).await;
     refresh_watch_interest_for_targets(context, &targets.targets).await;

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -299,7 +299,10 @@ impl InboundEventHandler for OperationsInboundHandler {
                         warn!(node_id = %node_id, "Dropping inbound metadata stream without metadata handle");
                         return;
                     };
-                    if let Err(err) = metadata_handle.handle_inbound_stream(stream, node_id).await {
+                    if let Err(err) = metadata_handle
+                        .handle_inbound_stream(&self.context, stream, node_id)
+                        .await
+                    {
                         error!(error = ?err, "Failed to process inbound metadata stream");
                     }
                 }

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -311,6 +311,14 @@ impl InboundEventHandler for OperationsInboundHandler {
                     )
                     .await;
                 }
+                Alpn::Shard => {
+                    crate::shard::incoming::handle_shard_stream(
+                        self.context.as_ref(),
+                        stream,
+                        node_id,
+                    )
+                    .await;
+                }
                 Alpn::Dht => {
                     warn!(
                         node_id = %node_id,

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -369,6 +369,7 @@ async fn reemit_evicted_documents(
             document.target,
             Vec::new(),
             document.event,
+            aruna_core::structs::PlacementRef::NIL,
             document.allow_genesis,
         );
         let effect = match write_outbox_effect(&record) {

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -13,7 +13,7 @@ use crate::metadata::projector::{
 };
 use crate::metadata::prune_queue::process_metadata_graph_tombstones;
 use crate::notifications::watch::interest::refresh_watch_interest_for_targets;
-use crate::process_placements::{PlacementConfig, ProcessPlacementsOperation};
+use crate::process_placements::process_bucket_placements;
 use crate::replication::incoming_version_replication::IncomingVersionReplicationOperation;
 use crate::replication::protocol::VersionReplicationMessage;
 use crate::usage_stats::refresh_realm_usage_summary_for_targets;
@@ -169,14 +169,7 @@ async fn reconcile_inbound_document_sync_topics(
         .iter()
         .any(|target| matches!(target, DocumentSyncTarget::RealmConfig { .. }));
     if realm_config_changed {
-        let operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id: *net_handle.realm_id(),
-            local_node_id: net_handle.node_id(),
-            retry_after: crate::sync_placement::SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        if let Err(error) = drive(operation, context.as_ref()).await {
-            error!(error = ?error, "Failed to process pending placements after document sync reconciliation");
-        }
+        process_bucket_placements(context, *net_handle.realm_id(), net_handle.node_id()).await;
     }
     refresh_realm_usage_summary_for_targets(context, net_handle.node_id(), &targets.targets).await;
     refresh_watch_interest_for_targets(context, &targets.targets).await;
@@ -369,7 +362,7 @@ async fn reemit_evicted_documents(
             document.target,
             Vec::new(),
             document.event,
-            aruna_core::structs::PlacementRef::NIL,
+            document.placement,
             document.allow_genesis,
         );
         let effect = match write_outbox_effect(&record) {

--- a/operations/src/lib.rs
+++ b/operations/src/lib.rs
@@ -58,6 +58,7 @@ pub mod reserve_onboarding_secret;
 pub mod s3;
 pub mod search_users;
 pub mod set_realm_quota;
+pub mod shard;
 pub mod staging;
 pub mod startup;
 pub mod status;

--- a/operations/src/list_metadata_documents.rs
+++ b/operations/src/list_metadata_documents.rs
@@ -171,7 +171,7 @@ mod tests {
     use aruna_core::handle::Handle;
     use aruna_core::keyspaces::METADATA_INDEX_KEYSPACE;
     use aruna_core::metadata::MetadataGraphLifecycleRecord;
-    use aruna_core::structs::{MetadataRegistryRecord, RealmId};
+    use aruna_core::structs::{MetadataRegistryRecord, PlacementRef, RealmId};
     use aruna_storage::FjallStorage;
     use byteview::ByteView;
     use tempfile::tempdir;
@@ -202,6 +202,7 @@ mod tests {
                     &format!("docs/{idx}"),
                     document_id,
                 ),
+                placement: PlacementRef::NIL,
                 holder_node_ids: Vec::new(),
                 created_at_ms: now,
                 updated_at_ms: now,
@@ -365,6 +366,7 @@ mod tests {
                 path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: Vec::new(),
             created_at_ms: 0,
             updated_at_ms: 0,

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -1338,6 +1338,7 @@ pub fn query_form(query: &str) -> Option<MetadataQueryForm> {
 mod tests {
     use super::*;
 
+    use aruna_core::structs::PlacementRef;
     use std::collections::BTreeMap;
 
     #[test]
@@ -1435,6 +1436,7 @@ mod tests {
             graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
             public: true,
             permission_path: "/metadata/query-targets".to_string(),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![remote_node_id, local_node_id, remote_node_id],
             created_at_ms: 0,
             updated_at_ms: 0,

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -19,7 +19,9 @@ use aruna_core::metadata::{
 use aruna_core::storage_entries::{
     metadata_event_log_key, metadata_graph_lifecycle_key, metadata_pending_projection_target,
 };
-use aruna_core::structs::{AuthContext, MetadataRegistryRecord, Permission, RealmId};
+use aruna_core::structs::{
+    AuthContext, MetadataRegistryRecord, Permission, RealmConfigDocument, RealmId,
+};
 use aruna_core::telemetry::record_elapsed_ms;
 use aruna_core::types::GroupId;
 use futures_util::StreamExt;
@@ -35,10 +37,12 @@ use crate::driver::{DriverContext, drive};
 use crate::get_metadata_document::{
     is_metadata_record_materialized_for_graph_read, load_metadata_record_by_document,
 };
+use crate::get_realm_config::GetRealmConfigOperation;
 use crate::get_realm_nodes::GetRealmNodesOperation;
 use crate::list_groups::ListGroupOperation;
 use crate::list_metadata_documents::ListMetadataDocumentsOperation;
 use crate::metadata::repository::{LIST_METADATA_PAGE_SIZE, StorageReadError};
+use crate::placement::resolve_shard_holders;
 
 const DEFAULT_LIST_METADATA_LIMIT: usize = 50;
 const MAX_LIST_METADATA_LIMIT: usize = 1_000;
@@ -332,6 +336,7 @@ pub async fn query_metadata_document(
     let record = load_record_by_document(context, request.document_id).await?;
     ensure_record_readable(context, realm_id, request.auth.as_ref(), &record).await?;
     ensure_record_materialized_for_graph_read(context, &record).await?;
+    let config = load_realm_config(context, realm_id).await;
 
     query_metadata(
         context,
@@ -343,7 +348,11 @@ pub async fn query_metadata_document(
             graph_iris: Some(vec![record.graph_iri.clone()]),
             query: request.query,
             mode: request.mode,
-            target_nodes: Some(document_replica_query_nodes(&record, local_node_id)),
+            target_nodes: Some(document_replica_query_nodes(
+                config.as_ref(),
+                &record,
+                local_node_id,
+            )),
         },
     )
     .await
@@ -396,6 +405,19 @@ pub async fn search_metadata(
     )
     .await?;
     Ok(MetadataSearchExecution { hits, fanout_stats })
+}
+
+pub async fn load_realm_config(
+    context: &DriverContext,
+    realm_id: RealmId,
+) -> Option<RealmConfigDocument> {
+    match drive(GetRealmConfigOperation::new(realm_id), context).await {
+        Ok(config) => Some(config),
+        Err(error) => {
+            warn!(error = %error, "realm config unavailable; querying the local replica only");
+            None
+        }
+    }
 }
 
 pub async fn load_metadata_realm_nodes(
@@ -815,11 +837,18 @@ fn ensure_supported_query_form(query: &str) -> Result<(), MetadataApiError> {
     }
 }
 
+/// Nodes a document query fans out to: the live holders of the bucket the
+/// document was created into, not the holder set stamped at event time (which a
+/// rebalance leaves stale).
 pub fn document_replica_query_nodes(
+    config: Option<&RealmConfigDocument>,
     record: &MetadataRegistryRecord,
     local_node_id: NodeId,
 ) -> Vec<NodeId> {
-    let nodes = deduplicate_fanout_nodes(record.holder_node_ids.clone());
+    let holders = config
+        .map(|config| resolve_shard_holders(config, &record.placement))
+        .unwrap_or_default();
+    let nodes = deduplicate_fanout_nodes(holders);
     if nodes.is_empty() {
         vec![local_node_id]
     } else {
@@ -1338,7 +1367,6 @@ pub fn query_form(query: &str) -> Option<MetadataQueryForm> {
 mod tests {
     use super::*;
 
-    use aruna_core::structs::PlacementRef;
     use std::collections::BTreeMap;
 
     #[test]
@@ -1423,35 +1451,52 @@ mod tests {
         assert_eq!(query_form("CONSTRUCT WHERE { ?s ?p ?o }"), None);
     }
 
+    // Fan-out follows the live holders of the stored bucket; the event-time
+    // holder stamp on the record is ignored, and no config means local only.
     #[test]
-    fn document_replica_query_nodes_use_deduplicated_replicas() {
+    fn query_fans_out_to_holders() {
         let local_node_id = iroh::SecretKey::from_bytes(&[21u8; 32]).public();
         let remote_node_id = iroh::SecretKey::from_bytes(&[22u8; 32]).public();
+        let stale_node_id = iroh::SecretKey::from_bytes(&[23u8; 32]).public();
+        let realm_id = RealmId([3u8; 32]);
         let document_id = Ulid::r#gen();
+        let mut config = RealmConfigDocument::new(realm_id, Vec::new(), 2);
+        config.seed_default_placement();
+        config.ensure_node(local_node_id, aruna_core::structs::RealmNodeKind::Server);
+        config.ensure_node(remote_node_id, aruna_core::structs::RealmNodeKind::Server);
+        let strategy = config
+            .strategy(&config.default_strategy_id.expect("default strategy"))
+            .expect("default strategy resolves");
+        let placement = crate::placement::choose_origin_bucket(
+            &config,
+            strategy,
+            local_node_id,
+            &document_id.to_bytes(),
+        )
+        .expect("origin holds a bucket");
+
         let record = MetadataRegistryRecord {
-            realm_id: RealmId([3u8; 32]),
+            realm_id,
             group_id: Ulid::r#gen(),
             document_id,
             document_path: "datasets/query-targets".to_string(),
             graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
             public: true,
             permission_path: "/metadata/query-targets".to_string(),
-            placement: PlacementRef::NIL,
-            holder_node_ids: vec![remote_node_id, local_node_id, remote_node_id],
+            placement,
+            holder_node_ids: vec![stale_node_id],
             created_at_ms: 0,
             updated_at_ms: 0,
             last_event_id: Ulid::nil(),
         };
 
-        assert_eq!(
-            document_replica_query_nodes(&record, local_node_id),
-            vec![remote_node_id, local_node_id]
-        );
+        let nodes = document_replica_query_nodes(Some(&config), &record, local_node_id);
+        assert_eq!(nodes.len(), 2);
+        assert!(nodes.contains(&local_node_id) && nodes.contains(&remote_node_id));
+        assert!(!nodes.contains(&stale_node_id));
 
-        let mut empty_replicas = record;
-        empty_replicas.holder_node_ids.clear();
         assert_eq!(
-            document_replica_query_nodes(&empty_replicas, local_node_id),
+            document_replica_query_nodes(None, &record, local_node_id),
             vec![local_node_id]
         );
     }

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
+use aruna_core::metadata::MetadataError;
 use aruna_core::structs::{
     Actor, AuthContext, MetadataRegistryRecord, Permission, PlacementRef, RealmConfigDocument,
     RealmId,
@@ -176,6 +177,9 @@ pub async fn update_metadata_document_routed(
     .await?;
     match response {
         MetadataTransportMessage::ForwardedRecord { record } => Ok(*record),
+        MetadataTransportMessage::ForwardedUpdateInvalidInput { message } => Err(
+            UpdateMetadataDocumentError::MetadataError(MetadataError::InvalidInput(message)).into(),
+        ),
         other => Err(unexpected_response(other)),
     }
 }
@@ -340,6 +344,9 @@ pub(crate) async fn apply_forwarded_write(
                 Ok(record) => MetadataTransportMessage::ForwardedRecord {
                     record: Box::new(record),
                 },
+                Err(UpdateMetadataDocumentError::MetadataError(MetadataError::InvalidInput(
+                    message,
+                ))) => MetadataTransportMessage::ForwardedUpdateInvalidInput { message },
                 Err(error) => reject(format!("forwarded metadata update failed: {error}")),
             }
         }

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -21,6 +21,7 @@ use crate::delete_metadata_document::{
 };
 use crate::driver::{DriverContext, drive};
 use crate::get_metadata_document::load_metadata_record_by_document;
+use crate::metadata::handle::MetadataRequestDelivery;
 use crate::metadata::protocol::{MetadataAuthToken, MetadataTransportMessage};
 use crate::placement::{
     PlacementResolutionContext, holds_placement, plan_target_placement, resolve_shard_holders,
@@ -548,6 +549,11 @@ async fn forward_to_holders(
             Ok(response) => return Ok(response),
             Err(error) => {
                 warn!(holder = %holder, error = %error, "Failed to forward a metadata write to holder");
+                if retry_disposition(&message, error.delivery()) == RetryDisposition::Stop {
+                    return Err(MetadataWriteError::Undeliverable(format!(
+                        "forward to holder `{holder}` may have applied the metadata write before failing; refusing to replay it: {error}"
+                    )));
+                }
                 failures.push(format!("{holder}: {error}"));
             }
         }
@@ -564,6 +570,27 @@ async fn forward_to_holders(
         "Metadata write reached a non-holder and no holder accepted the forward"
     );
     Err(MetadataWriteError::Undeliverable(detail))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RetryDisposition {
+    TryNext,
+    Stop,
+}
+
+fn retry_disposition(
+    message: &MetadataTransportMessage,
+    delivery: MetadataRequestDelivery,
+) -> RetryDisposition {
+    match delivery {
+        MetadataRequestDelivery::DefinitelyNotSent => RetryDisposition::TryNext,
+        MetadataRequestDelivery::PossiblySent => match message {
+            MetadataTransportMessage::ForwardCreateDocument { .. } => RetryDisposition::TryNext,
+            MetadataTransportMessage::ForwardUpdateDocument { .. }
+            | MetadataTransportMessage::ForwardDeleteDocument { .. } => RetryDisposition::Stop,
+            _ => RetryDisposition::Stop,
+        },
+    }
 }
 
 fn unexpected_response(response: MetadataTransportMessage) -> MetadataWriteError {
@@ -679,6 +706,49 @@ mod tests {
         assert_eq!(
             write_route(None, &PlacementRef::NIL, node(1)),
             MetadataWriteRoute::Local
+        );
+    }
+
+    #[test]
+    fn ambiguous_mutations_stop() {
+        let update = MetadataTransportMessage::ForwardUpdateDocument {
+            auth_token: None,
+            document_id: Ulid::nil(),
+            public: None,
+            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
+                jsonld: "{}".to_string(),
+            },
+        };
+        let delete = MetadataTransportMessage::ForwardDeleteDocument {
+            auth_token: None,
+            document_id: Ulid::nil(),
+        };
+        let create = MetadataTransportMessage::ForwardCreateDocument {
+            auth_token: None,
+            group_id: Ulid::nil(),
+            document_id: Ulid::nil(),
+            document_path: "datasets/forwarded".to_string(),
+            public: false,
+            payload: crate::create_metadata_document::CreateMetadataDocumentPayload::RoCrate {
+                jsonld: "{}".to_string(),
+            },
+        };
+
+        assert_eq!(
+            retry_disposition(&update, MetadataRequestDelivery::PossiblySent),
+            RetryDisposition::Stop
+        );
+        assert_eq!(
+            retry_disposition(&delete, MetadataRequestDelivery::PossiblySent),
+            RetryDisposition::Stop
+        );
+        assert_eq!(
+            retry_disposition(&update, MetadataRequestDelivery::DefinitelyNotSent),
+            RetryDisposition::TryNext
+        );
+        assert_eq!(
+            retry_disposition(&create, MetadataRequestDelivery::PossiblySent),
+            RetryDisposition::TryNext
         );
     }
 }

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use aruna_core::NodeId;
-use aruna_core::document::DocumentSyncTarget;
+use aruna_core::document::{DocumentSyncOutboxRecord, DocumentSyncTarget};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
 use aruna_core::structs::{
     Actor, AuthContext, MetadataRegistryRecord, Permission, PlacementRef, RealmConfigDocument,
     RealmId,
@@ -18,6 +20,7 @@ use crate::create_metadata_document::{
 use crate::delete_metadata_document::{
     DeleteMetadataDocumentError, DeleteMetadataDocumentOperation, delete_metadata_document,
 };
+use crate::document_sync_outbox::{schedule_outbox_drain_effect, write_outbox_effect};
 use crate::driver::{DriverContext, drive};
 use crate::get_metadata_document::load_metadata_record_by_document;
 use crate::metadata::protocol::{MetadataAuthToken, MetadataTransportMessage};
@@ -91,10 +94,12 @@ pub async fn resolve_write_route(
     write_route(config.as_ref(), placement, net_handle.node_id())
 }
 
-/// Creates locally when the origin holds a bucket of the governing strategy,
-/// and forwards to a holder when it holds none (a User-kind node, or one
-/// filtered out by affinity/`weight = 0`/`full`/`draining`). The receiving
-/// holder chooses the bucket from the buckets *it* holds.
+/// Creates locally when the origin holds a bucket of the governing strategy, and
+/// forwards to a holder when it holds none (a User-kind node, or one filtered out
+/// by affinity/`weight = 0`/`full`/`draining`). A forwarded create is offered to
+/// the holders of the document's blind-hashed bucket, each of which stamps that
+/// same bucket, so retrying the next holder after a lost response cannot fork the
+/// document onto a second topic.
 pub async fn create_metadata_document_routed(
     operation: CreateMetadataDocumentOperation,
     context: Arc<DriverContext>,
@@ -211,13 +216,27 @@ pub async fn delete_metadata_document_routed(
 ///
 /// The forwarded bearer token is re-validated and the same permission checks the
 /// origin's HTTP handler runs are re-run here: forwarding is a routing hop, not
-/// an internal trust bypass. The forwarding peer must additionally be a
-/// sync-eligible node of this realm, as on every other inbound path.
+/// an internal trust bypass.
+///
+/// The peer gate is realm membership (`authorize_remote_peer` confirms the peer
+/// is a configured node of the token's realm), deliberately *not*
+/// sync-eligibility. User-kind nodes are never sync-eligible and therefore hold
+/// no bucket at all, which makes them precisely the nodes that must forward every
+/// write; gating the forward on sync-eligibility would reject exactly the case it
+/// exists to serve. This grants nothing: a forward can do nothing the peer could
+/// not do by calling this node's HTTP API directly, under the same token and the
+/// same permission check. Sync-eligibility keeps guarding who may *hold* and sync
+/// documents — that is a separate question from who may ask a holder to write.
 pub(crate) async fn apply_forwarded_write(
     context: &Arc<DriverContext>,
     peer: NodeId,
     message: MetadataTransportMessage,
 ) -> MetadataTransportMessage {
+    // A relayed outbox record carries an already-authorized change rather than a
+    // caller request, so it gates on realm membership and holdership alone.
+    if let MetadataTransportMessage::ForwardOutboxRecord { record } = message {
+        return apply_forwarded_outbox_record(context, peer, *record).await;
+    }
     let Some(net_handle) = context.net_handle.as_ref() else {
         return reject("forwarded metadata write needs a net handle");
     };
@@ -225,15 +244,6 @@ pub(crate) async fn apply_forwarded_write(
     let Some(config) = load_realm_config(context, realm_id).await else {
         return reject(format!("realm `{realm_id}` config unavailable"));
     };
-    match config.sync_eligible_node_ids() {
-        Ok(eligible) if eligible.contains(&peer) => {}
-        Ok(_) => {
-            return reject(format!(
-                "metadata peer `{peer}` is not a sync-eligible node in realm `{realm_id}`"
-            ));
-        }
-        Err(error) => return reject(error.to_string()),
-    }
 
     let auth = match authorize_forwarded_caller(context, peer, realm_id, &message).await {
         Ok(auth) => auth,
@@ -256,22 +266,49 @@ pub(crate) async fn apply_forwarded_write(
             if let Err(error) = authorize_write(context, auth.clone(), path).await {
                 return reject(error);
             }
-            let operation = CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
-                actor: Actor {
-                    node_id: net_handle.node_id(),
-                    user_id: auth.user_id,
-                    realm_id,
-                },
-                group_id,
-                document_id,
-                document_path,
-                public,
-                payload,
-            });
+            // Idempotent on the document's identity, never on its bucket: a
+            // forward whose response was lost is retried, possibly against a
+            // different holder, and a second create under the same document id
+            // would fork one document into two. Replay the record instead.
+            match existing_record(context, document_id).await {
+                Ok(Some(record)) => {
+                    return MetadataTransportMessage::ForwardedRecord {
+                        record: Box::new(record),
+                    };
+                }
+                Ok(None) => {}
+                Err(error) => return reject(error),
+            }
+            let operation =
+                CreateMetadataDocumentOperation::new_forwarded(CreateMetadataDocumentConfig {
+                    actor: Actor {
+                        node_id: net_handle.node_id(),
+                        user_id: auth.user_id,
+                        realm_id,
+                    },
+                    group_id,
+                    document_id,
+                    document_path,
+                    public,
+                    payload,
+                });
             match create_metadata_document(operation, context.clone()).await {
                 Ok(created) => MetadataTransportMessage::ForwardedRecord {
                     record: Box::new(created.record),
                 },
+                // Lost the race against a concurrent delivery of the same
+                // forward: the winner's record is the answer, not an error.
+                Err(CreateMetadataDocumentError::DocumentAlreadyExists) => {
+                    match existing_record(context, document_id).await {
+                        Ok(Some(record)) => MetadataTransportMessage::ForwardedRecord {
+                            record: Box::new(record),
+                        },
+                        Ok(None) => reject(format!(
+                            "forwarded metadata create for `{document_id}` raced a delete"
+                        )),
+                        Err(error) => reject(error),
+                    }
+                }
                 Err(error) => reject(format!("forwarded metadata create failed: {error}")),
             }
         }
@@ -341,6 +378,107 @@ pub(crate) async fn apply_forwarded_write(
     }
 }
 
+/// Relays a queued sync publish this node can never make to a holder of its
+/// bucket, which publishes it instead.
+///
+/// A record reaches here only when the local node holds none of the record's
+/// bucket: it may neither mint that bucket's topic genesis nor join the topic, so
+/// no amount of retrying would ever drain it. Deleting it would be silent data
+/// loss — the caller already has its 200 — and there is no replay source for an
+/// admin-operation outbox record. The two ways in are a User-kind node (never
+/// sync-eligible, so it holds no bucket at all) and a rebalance race, where the
+/// node held the bucket when it accepted the write and lost it before the topic
+/// arrived.
+pub(crate) async fn forward_outbox_record(
+    context: &Arc<DriverContext>,
+    record: &DocumentSyncOutboxRecord,
+) -> Result<(), MetadataWriteError> {
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        return Err(MetadataWriteError::Undeliverable(
+            "no net handle to forward an outbox record with".to_string(),
+        ));
+    };
+    let realm_id = *net_handle.realm_id();
+    let Some(config) = load_realm_config(context, realm_id).await else {
+        return Err(MetadataWriteError::Undeliverable(format!(
+            "realm `{realm_id}` config unavailable"
+        )));
+    };
+    let holders = resolve_shard_holders(&config, &record.placement);
+    forward_to_holders(
+        context,
+        &holders,
+        MetadataTransportMessage::ForwardOutboxRecord {
+            record: Box::new(record.clone()),
+        },
+    )
+    .await
+    .and_then(|response| match response {
+        MetadataTransportMessage::ForwardedOutboxRecord => Ok(()),
+        other => Err(unexpected_response(other)),
+    })
+}
+
+/// Publishes a relayed outbox record on the emitter's behalf.
+///
+/// The peer is a configured node of this realm and the record's bucket is one
+/// this node holds, so the record is queued into the local outbox verbatim and
+/// drains onto the bucket's topic like any locally-emitted record. Verbatim
+/// matters for admin operations: they are ordered by `(origin_node_id,
+/// origin_seq)` on every receiver, so re-stamping the relay as the origin would
+/// break that ordering and drop the emitter's earlier operations as stale.
+async fn apply_forwarded_outbox_record(
+    context: &Arc<DriverContext>,
+    peer: NodeId,
+    record: DocumentSyncOutboxRecord,
+) -> MetadataTransportMessage {
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        return reject("relayed outbox record needs a net handle");
+    };
+    let realm_id = *net_handle.realm_id();
+    let Some(config) = load_realm_config(context, realm_id).await else {
+        return reject(format!("realm `{realm_id}` config unavailable"));
+    };
+    let Some(metadata_handle) = context.metadata_handle.as_ref() else {
+        return reject("relayed outbox record needs a metadata handle");
+    };
+    match metadata_handle.authorize_remote_peer(peer, None).await {
+        Ok(_) => {}
+        Err(error) => return reject(error.to_string()),
+    }
+    if !holds_placement(&config, &record.placement, net_handle.node_id()) {
+        return reject(format!(
+            "node holds none of bucket {}/{} of the relayed outbox record",
+            record.placement.strategy_id, record.placement.shard
+        ));
+    }
+
+    let effect = match write_outbox_effect(&record) {
+        Ok(effect) => effect,
+        Err(error) => return reject(format!("relayed outbox record is malformed: {error}")),
+    };
+    match context.storage_handle.send_effect(effect).await {
+        Event::Storage(StorageEvent::WriteResult { .. }) => {}
+        other => return reject(format!("relayed outbox record write failed: {other:?}")),
+    }
+    if let Some(task_handle) = context.task_handle.as_ref() {
+        task_handle
+            .send_effect(schedule_outbox_drain_effect())
+            .await;
+    }
+    MetadataTransportMessage::ForwardedOutboxRecord
+}
+
+/// The document's registry record, whatever this node's holdership of it.
+async fn existing_record(
+    context: &Arc<DriverContext>,
+    document_id: Ulid,
+) -> Result<Option<MetadataRegistryRecord>, String> {
+    load_metadata_record_by_document(context.as_ref(), document_id)
+        .await
+        .map_err(|error| format!("metadata registry read failed: {error:?}"))
+}
+
 /// The document as this node holds it. A forward is never chained: a node that
 /// is not a holder rejects, so the origin tries the next holder in rank order.
 async fn held_record(
@@ -349,11 +487,9 @@ async fn held_record(
     local_node_id: NodeId,
     document_id: Ulid,
 ) -> Result<MetadataRegistryRecord, String> {
-    let record = match load_metadata_record_by_document(context.as_ref(), document_id).await {
-        Ok(Some(record)) => record,
-        Ok(None) => return Err(format!("metadata document `{document_id}` not found")),
-        Err(error) => return Err(format!("metadata registry read failed: {error:?}")),
-    };
+    let record = existing_record(context, document_id)
+        .await?
+        .ok_or_else(|| format!("metadata document `{document_id}` not found"))?;
     match write_route(Some(config), &record.placement, local_node_id) {
         MetadataWriteRoute::Local => Ok(record),
         MetadataWriteRoute::Forward(_) => Err(format!(
@@ -415,9 +551,10 @@ async fn authorize_write(
     }
 }
 
-/// Holders of the document's hashed bucket, used only to pick where to forward a
-/// create the origin cannot place. The receiving holder re-chooses the bucket
-/// from its own held set, so this never becomes the stored placement.
+/// Holders of the document's blind-hashed bucket: the candidates for a create the
+/// origin cannot place. Every candidate holds that one bucket, and a forwarded
+/// create stamps exactly it (see `CreateMetadataDocumentOperation::new_forwarded`),
+/// so which candidate answers cannot change where the document lands.
 async fn create_forward_holders(
     context: &Arc<DriverContext>,
     config: &CreateMetadataDocumentConfig,
@@ -566,7 +703,11 @@ mod tests {
     #[test]
     fn user_node_writes_forward() {
         // A User-kind node is never sync-eligible, so it holds no bucket at all:
-        // locality is unattainable for it and every write must be forwarded.
+        // locality is unattainable for it and every write must be forwarded. The
+        // receiving half — a holder accepting that forward from a User peer, and
+        // applying it under the caller's token — is
+        // `metadata_forwarding::user_node_forwards_create`, which needs a real
+        // node and a real token and so cannot live here.
         let (mut config, placement) = config_and_placement();
         config.ensure_node(node(9), RealmNodeKind::User);
 

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -260,7 +260,9 @@ pub(crate) async fn apply_forwarded_write(
             payload,
             ..
         } => {
-            if MetadataRegistryRecord::normalize_document_path(&document_path).is_empty() {
+            let normalized_document_path =
+                MetadataRegistryRecord::normalize_document_path(&document_path);
+            if normalized_document_path.is_empty() {
                 return reject("forwarded metadata create has an empty document path");
             }
             let path = format!("/{realm_id}/g/{group_id}/meta/**");
@@ -273,9 +275,12 @@ pub(crate) async fn apply_forwarded_write(
             // would fork one document into two. Replay the record instead.
             match existing_record(context, document_id).await {
                 Ok(Some(record)) => {
-                    return MetadataTransportMessage::ForwardedRecord {
-                        record: Box::new(record),
-                    };
+                    return forwarded_create_replay(
+                        record,
+                        realm_id,
+                        group_id,
+                        &normalized_document_path,
+                    );
                 }
                 Ok(None) => {}
                 Err(error) => return reject(error),
@@ -301,9 +306,12 @@ pub(crate) async fn apply_forwarded_write(
                 // forward: the winner's record is the answer, not an error.
                 Err(CreateMetadataDocumentError::DocumentAlreadyExists) => {
                     match existing_record(context, document_id).await {
-                        Ok(Some(record)) => MetadataTransportMessage::ForwardedRecord {
-                            record: Box::new(record),
-                        },
+                        Ok(Some(record)) => forwarded_create_replay(
+                            record,
+                            realm_id,
+                            group_id,
+                            &normalized_document_path,
+                        ),
                         Ok(None) => reject(format!(
                             "forwarded metadata create for `{document_id}` raced a delete"
                         )),
@@ -379,6 +387,24 @@ pub(crate) async fn apply_forwarded_write(
             "unexpected forwarded metadata message: {}",
             super::handle::transport_message_kind(&other)
         )),
+    }
+}
+
+fn forwarded_create_replay(
+    record: MetadataRegistryRecord,
+    realm_id: RealmId,
+    group_id: Ulid,
+    normalized_document_path: &str,
+) -> MetadataTransportMessage {
+    if record.realm_id == realm_id
+        && record.group_id == group_id
+        && record.document_path == normalized_document_path
+    {
+        MetadataTransportMessage::ForwardedRecord {
+            record: Box::new(record),
+        }
+    } else {
+        reject("forwarded metadata create collides with an existing document")
     }
 }
 

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -423,10 +423,15 @@ pub(crate) async fn forward_outbox_record(
 ///
 /// The peer is a configured node of this realm and the record's bucket is one
 /// this node holds, so the record is queued into the local outbox verbatim and
-/// drains onto the bucket's topic like any locally-emitted record. Verbatim
-/// matters for admin operations: they are ordered by `(origin_node_id,
-/// origin_seq)` on every receiver, so re-stamping the relay as the origin would
-/// break that ordering and drop the emitter's earlier operations as stale.
+/// drains onto the bucket's topic like any locally-emitted record.
+///
+/// Document upserts and deletes only: an admin operation cannot be relayed at
+/// all. Receivers authenticate an admin event by requiring its signed publisher
+/// on the topic to *be* its `origin_node_id` (`validate_replicated_admin_event`),
+/// and a relay is by construction a different node signing for another origin, so
+/// every receiver would reject it. Accepting one here would report success while
+/// the operation was silently dropped realm-wide — worse than refusing it, which
+/// leaves the record in the emitter's outbox, retried and loud.
 async fn apply_forwarded_outbox_record(
     context: &Arc<DriverContext>,
     peer: NodeId,
@@ -445,6 +450,14 @@ async fn apply_forwarded_outbox_record(
     match metadata_handle.authorize_remote_peer(peer, None).await {
         Ok(_) => {}
         Err(error) => return reject(error.to_string()),
+    }
+    if matches!(
+        record.event,
+        aruna_core::document::DocumentSyncOutboxEvent::AdminOperation { .. }
+    ) {
+        return reject(
+            "an admin operation cannot be relayed: receivers require its signed publisher to be its origin node",
+        );
     }
     if !holds_placement(&config, &record.placement, net_handle.node_id()) {
         return reject(format!(

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -1,0 +1,593 @@
+use std::sync::Arc;
+
+use aruna_core::NodeId;
+use aruna_core::document::DocumentSyncTarget;
+use aruna_core::structs::{
+    Actor, AuthContext, MetadataRegistryRecord, Permission, PlacementRef, RealmConfigDocument,
+    RealmId,
+};
+use thiserror::Error;
+use tracing::{error, warn};
+use ulid::Ulid;
+
+use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
+use crate::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentError, CreateMetadataDocumentOperation,
+    CreateMetadataDocumentResult, create_metadata_document,
+};
+use crate::delete_metadata_document::{
+    DeleteMetadataDocumentError, DeleteMetadataDocumentOperation, delete_metadata_document,
+};
+use crate::driver::{DriverContext, drive};
+use crate::get_metadata_document::load_metadata_record_by_document;
+use crate::metadata::protocol::{MetadataAuthToken, MetadataTransportMessage};
+use crate::placement::{PlacementResolutionContext, plan_target_placement, resolve_shard_holders};
+use crate::process_placements::load_realm_config;
+use crate::update_metadata_document::{
+    UpdateMetadataDocumentConfig, UpdateMetadataDocumentError, UpdateMetadataDocumentMutation,
+    UpdateMetadataDocumentOperation, update_metadata_document,
+};
+
+/// Where a metadata write must be applied.
+///
+/// Topic membership is the bucket's holder set, so a non-holder can neither
+/// publish the write nor join the topic to try: the mutation goes to a holder
+/// instead. Membership is never widened to admit the origin — that would grow
+/// every bucket toward every node and dissolve sharding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetadataWriteRoute {
+    Local,
+    /// Holders of the document's bucket in rank order (rank-0 first).
+    Forward(Vec<NodeId>),
+}
+
+#[derive(Debug, Error)]
+pub enum MetadataWriteError {
+    #[error(transparent)]
+    Create(#[from] CreateMetadataDocumentError),
+    #[error(transparent)]
+    Update(#[from] UpdateMetadataDocumentError),
+    #[error(transparent)]
+    Delete(#[from] DeleteMetadataDocumentError),
+    /// The write reached a node that cannot publish it and no holder accepted
+    /// the forward. Loud by construction: never accepted, never deferred into an
+    /// outbox that can only drain to a topic this node may not join.
+    #[error("metadata write is undeliverable: {0}")]
+    Undeliverable(String),
+}
+
+/// Route for a write against `placement`, from the local node's point of view.
+///
+/// An empty holder set means no strategy governs the bucket (early bootstrap,
+/// [`PlacementRef::NIL`]): there is nowhere to forward to and no sharding to
+/// respect, so the local node stays the authority.
+pub fn write_route(
+    config: Option<&RealmConfigDocument>,
+    placement: &PlacementRef,
+    local_node_id: NodeId,
+) -> MetadataWriteRoute {
+    let Some(config) = config else {
+        return MetadataWriteRoute::Local;
+    };
+    let holders = resolve_shard_holders(config, placement);
+    if holders.is_empty() || holders.contains(&local_node_id) {
+        return MetadataWriteRoute::Local;
+    }
+    MetadataWriteRoute::Forward(holders)
+}
+
+/// Route resolved against the live realm config. The presence of a local
+/// registry record is deliberately not consulted: after a rebalance a node keeps
+/// a stale copy of a document it no longer holds, and that copy is not authority.
+pub async fn resolve_write_route(
+    context: &Arc<DriverContext>,
+    placement: &PlacementRef,
+) -> MetadataWriteRoute {
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        return MetadataWriteRoute::Local;
+    };
+    let config = load_realm_config(context, *net_handle.realm_id()).await;
+    write_route(config.as_ref(), placement, net_handle.node_id())
+}
+
+/// Creates locally when the origin holds a bucket of the governing strategy,
+/// and forwards to a holder when it holds none (a User-kind node, or one
+/// filtered out by affinity/`weight = 0`/`full`/`draining`). The receiving
+/// holder chooses the bucket from the buckets *it* holds.
+pub async fn create_metadata_document_routed(
+    operation: CreateMetadataDocumentOperation,
+    context: Arc<DriverContext>,
+    auth_token: Option<MetadataAuthToken>,
+) -> Result<CreateMetadataDocumentResult, MetadataWriteError> {
+    let config = operation.config().clone();
+    match create_metadata_document(operation, context.clone()).await {
+        Err(CreateMetadataDocumentError::OriginHoldsNoBucket) => {}
+        Ok(created) => return Ok(created),
+        Err(error) => return Err(error.into()),
+    }
+
+    let holders = create_forward_holders(&context, &config).await;
+    let response = forward_to_holders(
+        &context,
+        &holders,
+        MetadataTransportMessage::ForwardCreateDocument {
+            auth_token,
+            group_id: config.group_id,
+            document_id: config.document_id,
+            document_path: config.document_path.clone(),
+            public: config.public,
+            payload: config.payload.clone(),
+        },
+    )
+    .await?;
+    match response {
+        MetadataTransportMessage::ForwardedRecord { record } => Ok(CreateMetadataDocumentResult {
+            event_id: record.last_event_id,
+            record: *record,
+        }),
+        other => Err(unexpected_response(other)),
+    }
+}
+
+pub async fn update_metadata_document_routed(
+    context: &Arc<DriverContext>,
+    actor: Actor,
+    record: &MetadataRegistryRecord,
+    public: Option<bool>,
+    mutation: UpdateMetadataDocumentMutation,
+    auth_token: Option<MetadataAuthToken>,
+) -> Result<MetadataRegistryRecord, MetadataWriteError> {
+    let holders = match resolve_write_route(context, &record.placement).await {
+        MetadataWriteRoute::Local => {
+            return update_metadata_document(
+                UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
+                    actor,
+                    group_id: record.group_id,
+                    document_id: record.document_id,
+                    public: public.unwrap_or(record.public),
+                    mutation,
+                }),
+                context.as_ref(),
+            )
+            .await
+            .map_err(Into::into);
+        }
+        MetadataWriteRoute::Forward(holders) => holders,
+    };
+
+    let response = forward_to_holders(
+        context,
+        &holders,
+        MetadataTransportMessage::ForwardUpdateDocument {
+            auth_token,
+            document_id: record.document_id,
+            public,
+            mutation,
+        },
+    )
+    .await?;
+    match response {
+        MetadataTransportMessage::ForwardedRecord { record } => Ok(*record),
+        other => Err(unexpected_response(other)),
+    }
+}
+
+pub async fn delete_metadata_document_routed(
+    context: &Arc<DriverContext>,
+    actor: Actor,
+    record: &MetadataRegistryRecord,
+    auth_token: Option<MetadataAuthToken>,
+) -> Result<(), MetadataWriteError> {
+    let holders = match resolve_write_route(context, &record.placement).await {
+        MetadataWriteRoute::Local => {
+            return delete_metadata_document(
+                DeleteMetadataDocumentOperation::new(actor, record.group_id, record.document_id),
+                context.as_ref(),
+                record.document_id,
+            )
+            .await
+            .map_err(Into::into);
+        }
+        MetadataWriteRoute::Forward(holders) => holders,
+    };
+
+    let response = forward_to_holders(
+        context,
+        &holders,
+        MetadataTransportMessage::ForwardDeleteDocument {
+            auth_token,
+            document_id: record.document_id,
+        },
+    )
+    .await?;
+    match response {
+        MetadataTransportMessage::ForwardedDelete => Ok(()),
+        other => Err(unexpected_response(other)),
+    }
+}
+
+/// Applies a write forwarded by a non-holder, under the caller's authority.
+///
+/// The forwarded bearer token is re-validated and the same permission checks the
+/// origin's HTTP handler runs are re-run here: forwarding is a routing hop, not
+/// an internal trust bypass. The forwarding peer must additionally be a
+/// sync-eligible node of this realm, as on every other inbound path.
+pub(crate) async fn apply_forwarded_write(
+    context: &Arc<DriverContext>,
+    peer: NodeId,
+    message: MetadataTransportMessage,
+) -> MetadataTransportMessage {
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        return reject("forwarded metadata write needs a net handle");
+    };
+    let realm_id = *net_handle.realm_id();
+    let Some(config) = load_realm_config(context, realm_id).await else {
+        return reject(format!("realm `{realm_id}` config unavailable"));
+    };
+    match config.sync_eligible_node_ids() {
+        Ok(eligible) if eligible.contains(&peer) => {}
+        Ok(_) => {
+            return reject(format!(
+                "metadata peer `{peer}` is not a sync-eligible node in realm `{realm_id}`"
+            ));
+        }
+        Err(error) => return reject(error.to_string()),
+    }
+
+    let auth = match authorize_forwarded_caller(context, peer, realm_id, &message).await {
+        Ok(auth) => auth,
+        Err(error) => return reject(error),
+    };
+
+    match message {
+        MetadataTransportMessage::ForwardCreateDocument {
+            group_id,
+            document_id,
+            document_path,
+            public,
+            payload,
+            ..
+        } => {
+            if MetadataRegistryRecord::normalize_document_path(&document_path).is_empty() {
+                return reject("forwarded metadata create has an empty document path");
+            }
+            let path = format!("/{realm_id}/g/{group_id}/meta/**");
+            if let Err(error) = authorize_write(context, auth.clone(), path).await {
+                return reject(error);
+            }
+            let operation = CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+                actor: Actor {
+                    node_id: net_handle.node_id(),
+                    user_id: auth.user_id,
+                    realm_id,
+                },
+                group_id,
+                document_id,
+                document_path,
+                public,
+                payload,
+            });
+            match create_metadata_document(operation, context.clone()).await {
+                Ok(created) => MetadataTransportMessage::ForwardedRecord {
+                    record: Box::new(created.record),
+                },
+                Err(error) => reject(format!("forwarded metadata create failed: {error}")),
+            }
+        }
+        MetadataTransportMessage::ForwardUpdateDocument {
+            document_id,
+            public,
+            mutation,
+            ..
+        } => {
+            let record =
+                match held_record(context, &config, net_handle.node_id(), document_id).await {
+                    Ok(record) => record,
+                    Err(error) => return reject(error),
+                };
+            if let Err(error) =
+                authorize_write(context, auth.clone(), record.permission_path.clone()).await
+            {
+                return reject(error);
+            }
+            let operation = UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
+                actor: Actor {
+                    node_id: net_handle.node_id(),
+                    user_id: auth.user_id,
+                    realm_id,
+                },
+                group_id: record.group_id,
+                document_id,
+                public: public.unwrap_or(record.public),
+                mutation,
+            });
+            match update_metadata_document(operation, context.as_ref()).await {
+                Ok(record) => MetadataTransportMessage::ForwardedRecord {
+                    record: Box::new(record),
+                },
+                Err(error) => reject(format!("forwarded metadata update failed: {error}")),
+            }
+        }
+        MetadataTransportMessage::ForwardDeleteDocument { document_id, .. } => {
+            let record =
+                match held_record(context, &config, net_handle.node_id(), document_id).await {
+                    Ok(record) => record,
+                    Err(error) => return reject(error),
+                };
+            if let Err(error) =
+                authorize_write(context, auth.clone(), record.permission_path.clone()).await
+            {
+                return reject(error);
+            }
+            let operation = DeleteMetadataDocumentOperation::new(
+                Actor {
+                    node_id: net_handle.node_id(),
+                    user_id: auth.user_id,
+                    realm_id,
+                },
+                record.group_id,
+                document_id,
+            );
+            match delete_metadata_document(operation, context.as_ref(), document_id).await {
+                Ok(()) => MetadataTransportMessage::ForwardedDelete,
+                Err(error) => reject(format!("forwarded metadata delete failed: {error}")),
+            }
+        }
+        other => reject(format!(
+            "unexpected forwarded metadata message: {}",
+            super::handle::transport_message_kind(&other)
+        )),
+    }
+}
+
+/// The document as this node holds it. A forward is never chained: a node that
+/// is not a holder rejects, so the origin tries the next holder in rank order.
+async fn held_record(
+    context: &Arc<DriverContext>,
+    config: &RealmConfigDocument,
+    local_node_id: NodeId,
+    document_id: Ulid,
+) -> Result<MetadataRegistryRecord, String> {
+    let record = match load_metadata_record_by_document(context.as_ref(), document_id).await {
+        Ok(Some(record)) => record,
+        Ok(None) => return Err(format!("metadata document `{document_id}` not found")),
+        Err(error) => return Err(format!("metadata registry read failed: {error:?}")),
+    };
+    match write_route(Some(config), &record.placement, local_node_id) {
+        MetadataWriteRoute::Local => Ok(record),
+        MetadataWriteRoute::Forward(_) => Err(format!(
+            "node does not hold bucket {}/{} of metadata document `{document_id}`",
+            record.placement.strategy_id, record.placement.shard
+        )),
+    }
+}
+
+async fn authorize_forwarded_caller(
+    context: &Arc<DriverContext>,
+    peer: NodeId,
+    realm_id: RealmId,
+    message: &MetadataTransportMessage,
+) -> Result<AuthContext, String> {
+    let Some(metadata_handle) = context.metadata_handle.as_ref() else {
+        return Err("forwarded metadata write needs a metadata handle".to_string());
+    };
+    let auth_token = match message {
+        MetadataTransportMessage::ForwardCreateDocument { auth_token, .. }
+        | MetadataTransportMessage::ForwardUpdateDocument { auth_token, .. }
+        | MetadataTransportMessage::ForwardDeleteDocument { auth_token, .. } => auth_token.clone(),
+        _ => None,
+    };
+    let auth = metadata_handle
+        .authorize_remote_peer(peer, auth_token)
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "forwarded metadata write needs an authenticated caller".to_string())?;
+    if auth.realm_id != realm_id {
+        return Err(format!(
+            "forwarded metadata write carries a token for realm `{}`, not `{realm_id}`",
+            auth.realm_id
+        ));
+    }
+    Ok(auth)
+}
+
+async fn authorize_write(
+    context: &Arc<DriverContext>,
+    auth_context: AuthContext,
+    path: String,
+) -> Result<(), String> {
+    match drive(
+        CheckPermissionsOperation::new(CheckPermissionsConfig {
+            auth_context,
+            path: path.clone(),
+            required_permission: Permission::WRITE,
+        }),
+        context.as_ref(),
+    )
+    .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(format!(
+            "forwarded metadata write is not permitted on `{path}`"
+        )),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+/// Holders of the document's hashed bucket, used only to pick where to forward a
+/// create the origin cannot place. The receiving holder re-chooses the bucket
+/// from its own held set, so this never becomes the stored placement.
+async fn create_forward_holders(
+    context: &Arc<DriverContext>,
+    config: &CreateMetadataDocumentConfig,
+) -> Vec<NodeId> {
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        return Vec::new();
+    };
+    let Some(realm_config) = load_realm_config(context, *net_handle.realm_id()).await else {
+        return Vec::new();
+    };
+    let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+        document_id: config.document_id,
+    };
+    let document_path = MetadataRegistryRecord::normalize_document_path(&config.document_path);
+    plan_target_placement(
+        &realm_config,
+        &target,
+        PlacementResolutionContext {
+            group_id: Some(config.group_id),
+            metadata_path: Some(document_path.as_str()),
+        },
+    )
+    .map(|plan| plan.holders)
+    .unwrap_or_default()
+}
+
+async fn forward_to_holders(
+    context: &Arc<DriverContext>,
+    holders: &[NodeId],
+    message: MetadataTransportMessage,
+) -> Result<MetadataTransportMessage, MetadataWriteError> {
+    let Some(metadata_handle) = context.metadata_handle.as_ref() else {
+        return Err(MetadataWriteError::Undeliverable(
+            "no metadata handle to forward with".to_string(),
+        ));
+    };
+    let local_node_id = context.net_handle.as_ref().map(|net| net.node_id());
+
+    let mut failures: Vec<String> = Vec::new();
+    for holder in holders
+        .iter()
+        .filter(|holder| Some(**holder) != local_node_id)
+    {
+        match metadata_handle
+            .request_forwarded_write(*holder, message.clone())
+            .await
+        {
+            Ok(MetadataTransportMessage::Reject(error)) => {
+                warn!(holder = %holder, error = %error, "Holder rejected a forwarded metadata write");
+                failures.push(format!("{holder}: {error}"));
+            }
+            Ok(response) => return Ok(response),
+            Err(error) => {
+                warn!(holder = %holder, error = %error, "Failed to forward a metadata write to holder");
+                failures.push(format!("{holder}: {error}"));
+            }
+        }
+    }
+
+    let detail = if failures.is_empty() {
+        "the document's bucket has no reachable holder".to_string()
+    } else {
+        failures.join("; ")
+    };
+    error!(
+        holders = holders.len(),
+        detail = %detail,
+        "Metadata write reached a non-holder and no holder accepted the forward"
+    );
+    Err(MetadataWriteError::Undeliverable(detail))
+}
+
+fn unexpected_response(response: MetadataTransportMessage) -> MetadataWriteError {
+    MetadataWriteError::Undeliverable(format!(
+        "unexpected forwarded metadata response: {}",
+        super::handle::transport_message_kind(&response)
+    ))
+}
+
+fn reject(error: impl Into<String>) -> MetadataTransportMessage {
+    MetadataTransportMessage::Reject(error.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_core::structs::{PlacementStrategy, RealmNodeKind};
+
+    fn node(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    fn config_and_placement() -> (RealmConfigDocument, PlacementRef) {
+        let mut config = RealmConfigDocument::new(RealmId::from_bytes([7u8; 32]), Vec::new(), 3);
+        let strategy = PlacementStrategy {
+            strategy_id: Ulid::from_bytes([4u8; 16]),
+            name: "default".to_string(),
+            replica_count: Some(2),
+            distinct_locations: false,
+            affinity: Vec::new(),
+            shard_count: 64,
+        };
+        config.default_strategy_id = Some(strategy.strategy_id);
+        config.strategies = vec![strategy.clone()];
+        for seed in 1..=4u8 {
+            config.ensure_node(node(seed), RealmNodeKind::Server);
+        }
+        (
+            config,
+            PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard: 9,
+            },
+        )
+    }
+
+    #[test]
+    fn holder_writes_stay_local() {
+        let (config, placement) = config_and_placement();
+        let holders = resolve_shard_holders(&config, &placement);
+
+        assert_eq!(
+            write_route(Some(&config), &placement, holders[0]),
+            MetadataWriteRoute::Local
+        );
+    }
+
+    #[test]
+    fn non_holder_writes_forward() {
+        // Rank order is the holder set's own: rank-0 is tried first, the rest on
+        // failure. Replica 2 of 4 servers guarantees a non-holder exists.
+        let (config, placement) = config_and_placement();
+        let holders = resolve_shard_holders(&config, &placement);
+        let outsider = (1..=4u8)
+            .map(node)
+            .find(|candidate| !holders.contains(candidate))
+            .expect("a replica-capped bucket leaves a non-holder");
+
+        assert_eq!(
+            write_route(Some(&config), &placement, outsider),
+            MetadataWriteRoute::Forward(holders)
+        );
+    }
+
+    #[test]
+    fn user_node_writes_forward() {
+        // A User-kind node is never sync-eligible, so it holds no bucket at all:
+        // locality is unattainable for it and every write must be forwarded.
+        let (mut config, placement) = config_and_placement();
+        config.ensure_node(node(9), RealmNodeKind::User);
+
+        assert!(matches!(
+            write_route(Some(&config), &placement, node(9)),
+            MetadataWriteRoute::Forward(_)
+        ));
+    }
+
+    #[test]
+    fn unplaced_writes_stay_local() {
+        // No strategy governs a NIL ref (early bootstrap): nowhere to forward to,
+        // and no sharding to respect.
+        let (config, _) = config_and_placement();
+
+        assert_eq!(
+            write_route(Some(&config), &PlacementRef::NIL, node(1)),
+            MetadataWriteRoute::Local
+        );
+        assert_eq!(
+            write_route(None, &PlacementRef::NIL, node(1)),
+            MetadataWriteRoute::Local
+        );
+    }
+}

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -60,16 +60,21 @@ pub enum MetadataWriteError {
 
 /// Route for a write against `placement`, from the local node's point of view.
 ///
-/// An empty holder set means no strategy governs the bucket (early bootstrap,
-/// [`PlacementRef::NIL`]): there is nowhere to forward to and no sharding to
-/// respect, so the local node stays the authority.
+/// [`PlacementRef::NIL`] has no governing strategy (early bootstrap), so the
+/// local node stays the authority even without readable config. A non-NIL
+/// placement needs config to establish authority; when config is unavailable,
+/// an empty forward route fails closed as undeliverable.
 pub fn write_route(
     config: Option<&RealmConfigDocument>,
     placement: &PlacementRef,
     local_node_id: NodeId,
 ) -> MetadataWriteRoute {
     let Some(config) = config else {
-        return MetadataWriteRoute::Local;
+        return if *placement == PlacementRef::NIL {
+            MetadataWriteRoute::Local
+        } else {
+            MetadataWriteRoute::Forward(Vec::new())
+        };
     };
     if holds_placement(config, placement, local_node_id) {
         return MetadataWriteRoute::Local;
@@ -616,6 +621,16 @@ mod tests {
             write_route(Some(&config), &placement, node(9)),
             MetadataWriteRoute::Forward(_)
         ));
+    }
+
+    #[test]
+    fn missing_config_forwards() {
+        let (_, placement) = config_and_placement();
+
+        assert_eq!(
+            write_route(None, &placement, node(1)),
+            MetadataWriteRoute::Forward(Vec::new())
+        );
     }
 
     #[test]

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -21,7 +21,9 @@ use crate::delete_metadata_document::{
 use crate::driver::{DriverContext, drive};
 use crate::get_metadata_document::load_metadata_record_by_document;
 use crate::metadata::protocol::{MetadataAuthToken, MetadataTransportMessage};
-use crate::placement::{PlacementResolutionContext, plan_target_placement, resolve_shard_holders};
+use crate::placement::{
+    PlacementResolutionContext, holds_placement, plan_target_placement, resolve_shard_holders,
+};
 use crate::process_placements::load_realm_config;
 use crate::update_metadata_document::{
     UpdateMetadataDocumentConfig, UpdateMetadataDocumentError, UpdateMetadataDocumentMutation,
@@ -69,11 +71,10 @@ pub fn write_route(
     let Some(config) = config else {
         return MetadataWriteRoute::Local;
     };
-    let holders = resolve_shard_holders(config, placement);
-    if holders.is_empty() || holders.contains(&local_node_id) {
+    if holds_placement(config, placement, local_node_id) {
         return MetadataWriteRoute::Local;
     }
-    MetadataWriteRoute::Forward(holders)
+    MetadataWriteRoute::Forward(resolve_shard_holders(config, placement))
 }
 
 /// Route resolved against the live realm config. The presence of a local

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncOutboxRecord, DocumentSyncTarget};
-use aruna_core::events::{Event, StorageEvent};
-use aruna_core::handle::Handle;
+use aruna_core::document::DocumentSyncTarget;
 use aruna_core::structs::{
     Actor, AuthContext, MetadataRegistryRecord, Permission, PlacementRef, RealmConfigDocument,
     RealmId,
@@ -20,7 +18,6 @@ use crate::create_metadata_document::{
 use crate::delete_metadata_document::{
     DeleteMetadataDocumentError, DeleteMetadataDocumentOperation, delete_metadata_document,
 };
-use crate::document_sync_outbox::{schedule_outbox_drain_effect, write_outbox_effect};
 use crate::driver::{DriverContext, drive};
 use crate::get_metadata_document::load_metadata_record_by_document;
 use crate::metadata::protocol::{MetadataAuthToken, MetadataTransportMessage};
@@ -232,11 +229,6 @@ pub(crate) async fn apply_forwarded_write(
     peer: NodeId,
     message: MetadataTransportMessage,
 ) -> MetadataTransportMessage {
-    // A relayed outbox record carries an already-authorized change rather than a
-    // caller request, so it gates on realm membership and holdership alone.
-    if let MetadataTransportMessage::ForwardOutboxRecord { record } = message {
-        return apply_forwarded_outbox_record(context, peer, *record).await;
-    }
     let Some(net_handle) = context.net_handle.as_ref() else {
         return reject("forwarded metadata write needs a net handle");
     };
@@ -376,110 +368,6 @@ pub(crate) async fn apply_forwarded_write(
             super::handle::transport_message_kind(&other)
         )),
     }
-}
-
-/// Relays a queued sync publish this node can never make to a holder of its
-/// bucket, which publishes it instead.
-///
-/// A record reaches here only when the local node holds none of the record's
-/// bucket: it may neither mint that bucket's topic genesis nor join the topic, so
-/// no amount of retrying would ever drain it. Deleting it would be silent data
-/// loss — the caller already has its 200 — and there is no replay source for an
-/// admin-operation outbox record. The two ways in are a User-kind node (never
-/// sync-eligible, so it holds no bucket at all) and a rebalance race, where the
-/// node held the bucket when it accepted the write and lost it before the topic
-/// arrived.
-pub(crate) async fn forward_outbox_record(
-    context: &Arc<DriverContext>,
-    record: &DocumentSyncOutboxRecord,
-) -> Result<(), MetadataWriteError> {
-    let Some(net_handle) = context.net_handle.as_ref() else {
-        return Err(MetadataWriteError::Undeliverable(
-            "no net handle to forward an outbox record with".to_string(),
-        ));
-    };
-    let realm_id = *net_handle.realm_id();
-    let Some(config) = load_realm_config(context, realm_id).await else {
-        return Err(MetadataWriteError::Undeliverable(format!(
-            "realm `{realm_id}` config unavailable"
-        )));
-    };
-    let holders = resolve_shard_holders(&config, &record.placement);
-    forward_to_holders(
-        context,
-        &holders,
-        MetadataTransportMessage::ForwardOutboxRecord {
-            record: Box::new(record.clone()),
-        },
-    )
-    .await
-    .and_then(|response| match response {
-        MetadataTransportMessage::ForwardedOutboxRecord => Ok(()),
-        other => Err(unexpected_response(other)),
-    })
-}
-
-/// Publishes a relayed outbox record on the emitter's behalf.
-///
-/// The peer is a configured node of this realm and the record's bucket is one
-/// this node holds, so the record is queued into the local outbox verbatim and
-/// drains onto the bucket's topic like any locally-emitted record.
-///
-/// Document upserts and deletes only: an admin operation cannot be relayed at
-/// all. Receivers authenticate an admin event by requiring its signed publisher
-/// on the topic to *be* its `origin_node_id` (`validate_replicated_admin_event`),
-/// and a relay is by construction a different node signing for another origin, so
-/// every receiver would reject it. Accepting one here would report success while
-/// the operation was silently dropped realm-wide — worse than refusing it, which
-/// leaves the record in the emitter's outbox, retried and loud.
-async fn apply_forwarded_outbox_record(
-    context: &Arc<DriverContext>,
-    peer: NodeId,
-    record: DocumentSyncOutboxRecord,
-) -> MetadataTransportMessage {
-    let Some(net_handle) = context.net_handle.as_ref() else {
-        return reject("relayed outbox record needs a net handle");
-    };
-    let realm_id = *net_handle.realm_id();
-    let Some(config) = load_realm_config(context, realm_id).await else {
-        return reject(format!("realm `{realm_id}` config unavailable"));
-    };
-    let Some(metadata_handle) = context.metadata_handle.as_ref() else {
-        return reject("relayed outbox record needs a metadata handle");
-    };
-    match metadata_handle.authorize_remote_peer(peer, None).await {
-        Ok(_) => {}
-        Err(error) => return reject(error.to_string()),
-    }
-    if matches!(
-        record.event,
-        aruna_core::document::DocumentSyncOutboxEvent::AdminOperation { .. }
-    ) {
-        return reject(
-            "an admin operation cannot be relayed: receivers require its signed publisher to be its origin node",
-        );
-    }
-    if !holds_placement(&config, &record.placement, net_handle.node_id()) {
-        return reject(format!(
-            "node holds none of bucket {}/{} of the relayed outbox record",
-            record.placement.strategy_id, record.placement.shard
-        ));
-    }
-
-    let effect = match write_outbox_effect(&record) {
-        Ok(effect) => effect,
-        Err(error) => return reject(format!("relayed outbox record is malformed: {error}")),
-    };
-    match context.storage_handle.send_effect(effect).await {
-        Event::Storage(StorageEvent::WriteResult { .. }) => {}
-        other => return reject(format!("relayed outbox record write failed: {other:?}")),
-    }
-    if let Some(task_handle) = context.task_handle.as_ref() {
-        task_handle
-            .send_effect(schedule_outbox_drain_effect())
-            .await;
-    }
-    MetadataTransportMessage::ForwardedOutboxRecord
 }
 
 /// The document's registry record, whatever this node's holdership of it.

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -941,6 +941,7 @@ impl MetadataHandle {
     )]
     pub async fn handle_inbound_stream(
         &self,
+        context: &Arc<DriverContext>,
         mut stream: BiStream,
         peer: NodeId,
     ) -> Result<(), MetadataError> {
@@ -949,7 +950,7 @@ impl MetadataHandle {
         let message = read_transport_message(&mut stream).await?;
         let span = Span::current();
         record_elapsed_ms(&span, "read_ms", read_started);
-        span.record("request", metadata_transport_message_kind(&message));
+        span.record("request", transport_message_kind(&message));
 
         let process_started = Instant::now();
         let response = match message {
@@ -1004,8 +1005,15 @@ impl MetadataHandle {
                 },
                 Err(error) => MetadataTransportMessage::Reject(error.to_string()),
             },
+            forward @ (MetadataTransportMessage::ForwardCreateDocument { .. }
+            | MetadataTransportMessage::ForwardUpdateDocument { .. }
+            | MetadataTransportMessage::ForwardDeleteDocument { .. }) => {
+                super::forward::apply_forwarded_write(context, peer, forward).await
+            }
             MetadataTransportMessage::QueryResults { .. }
             | MetadataTransportMessage::SearchResults { .. }
+            | MetadataTransportMessage::ForwardedRecord { .. }
+            | MetadataTransportMessage::ForwardedDelete
             | MetadataTransportMessage::Reject(_) => {
                 MetadataTransportMessage::Reject("unexpected metadata control message".to_string())
             }
@@ -1021,8 +1029,50 @@ impl MetadataHandle {
         record_elapsed_ms(&span, "write_ms", write_started);
         close_stream(&mut stream).await;
         record_elapsed_ms(&span, "elapsed_ms", total_started);
-        span.record("response", metadata_transport_message_kind(&response));
+        span.record("response", transport_message_kind(&response));
         Ok(())
+    }
+
+    /// Validates a forwarded caller's bearer token and confirms the forwarding
+    /// peer belongs to the token's realm, exactly as the query/search paths do.
+    pub(crate) async fn authorize_remote_peer(
+        &self,
+        peer: NodeId,
+        auth_token: Option<MetadataAuthToken>,
+    ) -> Result<Option<AuthContext>, MetadataError> {
+        authorize_remote_metadata_peer(
+            &self.inner.auth_validation,
+            &self.inner.storage_handle,
+            peer,
+            self.inner.net_handle.as_ref().map(|net| *net.realm_id()),
+            auth_token,
+        )
+        .await
+    }
+
+    #[tracing::instrument(
+        name = "metadata.forward.remote",
+        level = "debug",
+        skip(self, message),
+        fields(
+            peer = ?node_id,
+            request = transport_message_kind(&message),
+            elapsed_ms = field::Empty,
+        )
+    )]
+    pub(crate) async fn request_forwarded_write(
+        &self,
+        node_id: NodeId,
+        message: MetadataTransportMessage,
+    ) -> Result<MetadataTransportMessage, MetadataError> {
+        let started = Instant::now();
+        let span = Span::current();
+        let result = send_remote_metadata_request(&self.inner, &span, node_id, message).await;
+        record_elapsed_ms(&span, "elapsed_ms", started);
+        if let Err(error) = &result {
+            record_error(&span, &error.to_string());
+        }
+        result
     }
 
     #[tracing::instrument(
@@ -3112,12 +3162,17 @@ fn record_metadata_query_result_counts(span: &Span, results: &MetadataQueryResul
     }
 }
 
-fn metadata_transport_message_kind(message: &MetadataTransportMessage) -> &'static str {
+pub(crate) fn transport_message_kind(message: &MetadataTransportMessage) -> &'static str {
     match message {
         MetadataTransportMessage::QueryGraphs { .. } => "query_graphs",
         MetadataTransportMessage::QueryResults { .. } => "query_results",
         MetadataTransportMessage::SearchGraphs { .. } => "search_graphs",
         MetadataTransportMessage::SearchResults { .. } => "search_results",
+        MetadataTransportMessage::ForwardCreateDocument { .. } => "forward_create_document",
+        MetadataTransportMessage::ForwardUpdateDocument { .. } => "forward_update_document",
+        MetadataTransportMessage::ForwardDeleteDocument { .. } => "forward_delete_document",
+        MetadataTransportMessage::ForwardedRecord { .. } => "forwarded_record",
+        MetadataTransportMessage::ForwardedDelete => "forwarded_delete",
         MetadataTransportMessage::Reject(_) => "reject",
     }
 }
@@ -4132,7 +4187,7 @@ async fn refresh_lifecycle_visibility_for_records(
     skip(net_handle, message),
     fields(
         peer = ?node_id,
-        request = metadata_transport_message_kind(&message),
+        request = transport_message_kind(&message),
         response = field::Empty,
         open_stream_ms = field::Empty,
         write_ms = field::Empty,
@@ -4176,7 +4231,7 @@ async fn send_request(
     close_stream(&mut stream).await;
     record_elapsed_ms(&span, "close_ms", close_started);
     record_elapsed_ms(&span, "elapsed_ms", total_started);
-    span.record("response", metadata_transport_message_kind(&response));
+    span.record("response", transport_message_kind(&response));
     Ok(response)
 }
 

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -45,7 +45,10 @@ use tokio::time::{sleep, timeout};
 use tracing::{Instrument, Span, debug_span, field, warn};
 use ulid::Ulid;
 
-use super::protocol::{MetadataAuthToken, MetadataTransportMessage, read_message, write_message};
+use super::protocol::{
+    MetadataAuthToken, MetadataTransportMessage, encode_message, read_message,
+    write_encoded_message, write_message,
+};
 use super::repository::{REGISTRY_FILL_PAGE_SIZE, iter_all_registry_effect, parse_registry_iter};
 use crate::auth::{
     ArunaBearerTokenError, ArunaBearerTokenValidationState, IssuerKeyCache,
@@ -68,6 +71,48 @@ const METADATA_VISIBILITY_CACHE_TTL: Duration = Duration::from_secs(30);
 #[derive(Clone)]
 pub struct MetadataHandle {
     inner: Arc<MetadataInner>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MetadataRequestDelivery {
+    DefinitelyNotSent,
+    PossiblySent,
+}
+
+#[derive(Debug)]
+pub(crate) struct MetadataRequestError {
+    delivery: MetadataRequestDelivery,
+    error: MetadataError,
+}
+
+impl MetadataRequestError {
+    fn definitely_not_sent(error: MetadataError) -> Self {
+        Self {
+            delivery: MetadataRequestDelivery::DefinitelyNotSent,
+            error,
+        }
+    }
+
+    fn possibly_sent(error: MetadataError) -> Self {
+        Self {
+            delivery: MetadataRequestDelivery::PossiblySent,
+            error,
+        }
+    }
+
+    pub(crate) fn delivery(&self) -> MetadataRequestDelivery {
+        self.delivery
+    }
+
+    fn into_metadata_error(self) -> MetadataError {
+        self.error
+    }
+}
+
+impl std::fmt::Display for MetadataRequestError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(formatter)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1065,7 +1110,7 @@ impl MetadataHandle {
         &self,
         node_id: NodeId,
         message: MetadataTransportMessage,
-    ) -> Result<MetadataTransportMessage, MetadataError> {
+    ) -> Result<MetadataTransportMessage, MetadataRequestError> {
         let started = Instant::now();
         let span = Span::current();
         let result = send_remote_metadata_request(&self.inner, &span, node_id, message).await;
@@ -1215,7 +1260,8 @@ impl MetadataHandle {
                 sparql,
             },
         )
-        .await?
+        .await
+        .map_err(MetadataRequestError::into_metadata_error)?
         {
             MetadataTransportMessage::QueryResults { results } => Ok(results),
             MetadataTransportMessage::Reject(error) => Err(MetadataError::Backend(error)),
@@ -1269,7 +1315,8 @@ impl MetadataHandle {
                 limit,
             },
         )
-        .await?
+        .await
+        .map_err(MetadataRequestError::into_metadata_error)?
         {
             MetadataTransportMessage::SearchResults { hits } => Ok(hits),
             MetadataTransportMessage::Reject(error) => Err(MetadataError::Backend(error)),
@@ -1378,10 +1425,12 @@ async fn send_remote_metadata_request(
     span: &Span,
     node_id: NodeId,
     message: MetadataTransportMessage,
-) -> Result<MetadataTransportMessage, MetadataError> {
+) -> Result<MetadataTransportMessage, MetadataRequestError> {
     let Some(net_handle) = inner.net_handle.clone() else {
         record_error(span, "metadata net handle missing");
-        return Err(MetadataError::HandleMissing);
+        return Err(MetadataRequestError::definitely_not_sent(
+            MetadataError::HandleMissing,
+        ));
     };
 
     send_request(&net_handle, node_id, message).await
@@ -4205,30 +4254,40 @@ async fn send_request(
     net_handle: &NetHandle,
     node_id: NodeId,
     message: MetadataTransportMessage,
-) -> Result<MetadataTransportMessage, MetadataError> {
+) -> Result<MetadataTransportMessage, MetadataRequestError> {
     let span = Span::current();
     let total_started = Instant::now();
+
+    let bytes = encode_message(&message)
+        .map_err(MetadataError::Backend)
+        .map_err(MetadataRequestError::definitely_not_sent)?;
 
     let open_started = Instant::now();
     let mut stream = net_handle
         .open_stream(node_id, Alpn::Metadata)
         .await
-        .map_err(|error| MetadataError::Backend(error.to_string()))?;
+        .map_err(|error| MetadataError::Backend(error.to_string()))
+        .map_err(MetadataRequestError::definitely_not_sent)?;
     record_elapsed_ms(&span, "open_stream_ms", open_started);
 
     let write_started = Instant::now();
-    write_transport_message(&mut stream, &message).await?;
+    write_encoded_transport_message(&mut stream, &bytes)
+        .await
+        .map_err(MetadataRequestError::possibly_sent)?;
     record_elapsed_ms(&span, "write_ms", write_started);
 
     let finish_started = Instant::now();
     stream
         .0
         .finish()
-        .map_err(|error| MetadataError::Backend(error.to_string()))?;
+        .map_err(|error| MetadataError::Backend(error.to_string()))
+        .map_err(MetadataRequestError::possibly_sent)?;
     record_elapsed_ms(&span, "finish_ms", finish_started);
 
     let read_started = Instant::now();
-    let response = read_transport_message(&mut stream).await?;
+    let response = read_transport_message(&mut stream)
+        .await
+        .map_err(MetadataRequestError::possibly_sent)?;
     record_elapsed_ms(&span, "read_ms", read_started);
 
     let close_started = Instant::now();
@@ -4245,6 +4304,17 @@ async fn write_transport_message(
 ) -> Result<(), MetadataError> {
     let result: Result<Result<(), String>, tokio::time::error::Elapsed> =
         timeout(METADATA_IO_TIMEOUT, write_message(stream, message)).await;
+    result
+        .map_err(|_| MetadataError::Backend("timed out writing metadata message".to_string()))?
+        .map_err(MetadataError::Backend)
+}
+
+async fn write_encoded_transport_message(
+    stream: &mut BiStream,
+    bytes: &[u8],
+) -> Result<(), MetadataError> {
+    let result: Result<Result<(), String>, tokio::time::error::Elapsed> =
+        timeout(METADATA_IO_TIMEOUT, write_encoded_message(stream, bytes)).await;
     result
         .map_err(|_| MetadataError::Backend("timed out writing metadata message".to_string()))?
         .map_err(MetadataError::Backend)

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -1007,12 +1007,14 @@ impl MetadataHandle {
             },
             forward @ (MetadataTransportMessage::ForwardCreateDocument { .. }
             | MetadataTransportMessage::ForwardUpdateDocument { .. }
-            | MetadataTransportMessage::ForwardDeleteDocument { .. }) => {
+            | MetadataTransportMessage::ForwardDeleteDocument { .. }
+            | MetadataTransportMessage::ForwardOutboxRecord { .. }) => {
                 super::forward::apply_forwarded_write(context, peer, forward).await
             }
             MetadataTransportMessage::QueryResults { .. }
             | MetadataTransportMessage::SearchResults { .. }
             | MetadataTransportMessage::ForwardedRecord { .. }
+            | MetadataTransportMessage::ForwardedOutboxRecord
             | MetadataTransportMessage::ForwardedDelete
             | MetadataTransportMessage::Reject(_) => {
                 MetadataTransportMessage::Reject("unexpected metadata control message".to_string())
@@ -3171,6 +3173,8 @@ pub(crate) fn transport_message_kind(message: &MetadataTransportMessage) -> &'st
         MetadataTransportMessage::ForwardCreateDocument { .. } => "forward_create_document",
         MetadataTransportMessage::ForwardUpdateDocument { .. } => "forward_update_document",
         MetadataTransportMessage::ForwardDeleteDocument { .. } => "forward_delete_document",
+        MetadataTransportMessage::ForwardOutboxRecord { .. } => "forward_outbox_record",
+        MetadataTransportMessage::ForwardedOutboxRecord => "forwarded_outbox_record",
         MetadataTransportMessage::ForwardedRecord { .. } => "forwarded_record",
         MetadataTransportMessage::ForwardedDelete => "forwarded_delete",
         MetadataTransportMessage::Reject(_) => "reject",

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -4223,7 +4223,7 @@ mod tests {
     use aruna_core::auth::{TOKEN_REVOCATION_LIST_KEY, TRUSTED_REALMS_LIST_KEY, bearer_token_hash};
     use aruna_core::keyspaces::{API_STATE_KEYSPACE, REALM_CONFIG_KEYSPACE};
     use aruna_core::structs::{
-        PathRestriction, RealmConfigDocument, RealmId, RealmNodeKind, TokenClaims,
+        PathRestriction, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind, TokenClaims,
     };
     use aruna_storage::{FjallStorage, StorageHandle};
     use byteview::ByteView;
@@ -4645,6 +4645,7 @@ mod tests {
             graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
             public: true,
             permission_path: format!("/metadata/{document_path}"),
+            placement: PlacementRef::NIL,
             holder_node_ids: Vec::new(),
             created_at_ms: 0,
             updated_at_ms: 0,

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -1014,6 +1014,7 @@ impl MetadataHandle {
             | MetadataTransportMessage::SearchResults { .. }
             | MetadataTransportMessage::ForwardedRecord { .. }
             | MetadataTransportMessage::ForwardedDelete
+            | MetadataTransportMessage::ForwardedUpdateInvalidInput { .. }
             | MetadataTransportMessage::Reject(_) => {
                 MetadataTransportMessage::Reject("unexpected metadata control message".to_string())
             }
@@ -3174,6 +3175,9 @@ pub(crate) fn transport_message_kind(message: &MetadataTransportMessage) -> &'st
         MetadataTransportMessage::ForwardedRecord { .. } => "forwarded_record",
         MetadataTransportMessage::ForwardedDelete => "forwarded_delete",
         MetadataTransportMessage::Reject(_) => "reject",
+        MetadataTransportMessage::ForwardedUpdateInvalidInput { .. } => {
+            "forwarded_update_invalid_input"
+        }
     }
 }
 

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -1007,14 +1007,12 @@ impl MetadataHandle {
             },
             forward @ (MetadataTransportMessage::ForwardCreateDocument { .. }
             | MetadataTransportMessage::ForwardUpdateDocument { .. }
-            | MetadataTransportMessage::ForwardDeleteDocument { .. }
-            | MetadataTransportMessage::ForwardOutboxRecord { .. }) => {
+            | MetadataTransportMessage::ForwardDeleteDocument { .. }) => {
                 super::forward::apply_forwarded_write(context, peer, forward).await
             }
             MetadataTransportMessage::QueryResults { .. }
             | MetadataTransportMessage::SearchResults { .. }
             | MetadataTransportMessage::ForwardedRecord { .. }
-            | MetadataTransportMessage::ForwardedOutboxRecord
             | MetadataTransportMessage::ForwardedDelete
             | MetadataTransportMessage::Reject(_) => {
                 MetadataTransportMessage::Reject("unexpected metadata control message".to_string())
@@ -3173,8 +3171,6 @@ pub(crate) fn transport_message_kind(message: &MetadataTransportMessage) -> &'st
         MetadataTransportMessage::ForwardCreateDocument { .. } => "forward_create_document",
         MetadataTransportMessage::ForwardUpdateDocument { .. } => "forward_update_document",
         MetadataTransportMessage::ForwardDeleteDocument { .. } => "forward_delete_document",
-        MetadataTransportMessage::ForwardOutboxRecord { .. } => "forward_outbox_record",
-        MetadataTransportMessage::ForwardedOutboxRecord => "forwarded_outbox_record",
         MetadataTransportMessage::ForwardedRecord { .. } => "forwarded_record",
         MetadataTransportMessage::ForwardedDelete => "forwarded_delete",
         MetadataTransportMessage::Reject(_) => "reject",

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -2000,7 +2000,7 @@ mod tests {
     use super::*;
     use aruna_core::NodeId;
     use aruna_core::storage_entries::metadata_create_event_write_entry;
-    use aruna_core::structs::{MetadataRegistryRecord, RealmId};
+    use aruna_core::structs::{MetadataRegistryRecord, PlacementRef, RealmId};
     use aruna_storage::{FjallStorage, StorageHandle};
     use std::collections::BTreeSet;
     use std::thread;
@@ -2027,6 +2027,7 @@ mod tests {
                 &document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![node(1)],
             created_at_ms: 1,
             updated_at_ms: 1,

--- a/operations/src/metadata/mod.rs
+++ b/operations/src/metadata/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod forward;
 mod handle;
 pub mod materialization_queue;
 pub mod projector;

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -891,6 +891,7 @@ pub fn create_event_outbox_record(
                 .expect("metadata document lifecycle event serializes"),
             change,
         },
+        placement,
         updated_at: event.occurred_at_ms / 1_000,
         allow_genesis,
     }

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -793,8 +793,10 @@ async fn read_realm_config(
 /// bound "everywhere", so this row reaches every node and gives each one the
 /// `document_id -> placement -> holders` mapping the routing layer runs on.
 ///
-/// `None` without a readable realm config: there is no strategy to resolve, and a
-/// NIL-placed shard record would derive a NIL topic.
+/// `None` without a readable realm config (no strategy to resolve, and a
+/// NIL-placed shard record would derive a NIL topic) and `None` when the registry
+/// bucket has no holder at all: the realm has no eligible node, so there is nobody
+/// to publish to, and replay re-plans the row once there is.
 pub fn registry_outbox_record(
     event: &MetadataCreateEventRecord,
     realm_config: Option<&RealmConfigDocument>,
@@ -811,6 +813,9 @@ pub fn registry_outbox_record(
         document_id: record.document_id,
     };
     let peers = resolve_shard_holders(config, &placement);
+    if peers.is_empty() {
+        return None;
+    }
     let change = DocumentSyncChange {
         base: None,
         current: DocumentSyncRevision {
@@ -1344,34 +1349,53 @@ mod tests {
 
         let expected_holders = resolve_shard_holders(&config, &event.record.placement);
 
-        let outbox = match storage
+        // Two publishes, on two topics: the lifecycle event onto the document's
+        // own capped bucket, the registry row onto the everywhere-bound registry
+        // class. They share the event id, so they must not share an outbox key.
+        let records = match storage
             .send_storage_effect(StorageEffect::Iter {
                 key_space: aruna_core::keyspaces::DOCUMENT_SYNC_OUTBOX_KEYSPACE.to_string(),
                 prefix: None,
                 start: None,
-                limit: 2,
+                limit: 4,
                 txn_id: None,
             })
             .await
         {
-            Event::Storage(StorageEvent::IterResult { values, .. }) => {
-                assert_eq!(
-                    values.len(),
-                    1,
-                    "origin projection writes one outbox record"
-                );
-                postcard::from_bytes::<DocumentSyncOutboxRecord>(values[0].1.as_ref())
-                    .expect("outbox record decodes")
-            }
+            Event::Storage(StorageEvent::IterResult { values, .. }) => values
+                .iter()
+                .map(|(_, value)| {
+                    postcard::from_bytes::<DocumentSyncOutboxRecord>(value.as_ref())
+                        .expect("outbox record decodes")
+                })
+                .collect::<Vec<_>>(),
             other => panic!("expected outbox iter result, got {other:?}"),
         };
+        assert_eq!(records.len(), 2);
 
+        let outbox = records
+            .iter()
+            .find(|record| {
+                matches!(
+                    record.target,
+                    DocumentSyncTarget::MetadataDocumentLifecycle { .. }
+                )
+            })
+            .expect("origin projection writes a lifecycle outbox record");
         assert_eq!(outbox.placement, event.record.placement);
         assert_eq!(outbox.peers, expected_holders);
         let DocumentSyncOutboxEvent::Upsert { change, .. } = &outbox.event else {
             panic!("expected lifecycle upsert outbox event");
         };
         assert_eq!(change.placement, event.record.placement);
+
+        let registry = records
+            .iter()
+            .find(|record| matches!(record.target, DocumentSyncTarget::MetadataRegistry { .. }))
+            .expect("origin projection writes a registry outbox record");
+        let registry_ref = registry_placement(&config, &event.record);
+        assert_eq!(registry.placement, registry_ref);
+        assert_ne!(registry_ref, event.record.placement);
     }
 
     // A locally authored event with no eligible holders must not enqueue an

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -45,9 +45,7 @@ use crate::metadata::repository::{
     create_records_and_outbox_write_entries,
     create_records_outbox_and_materialization_write_entries, read_registry_by_document_effect,
 };
-use crate::placement::{
-    PlacementResolutionContext, placement_ref_for_target, plan_target_placement,
-};
+use crate::placement::resolve_shard_holders;
 use crate::sync_placement::sort_node_ids;
 use crate::task_persistence::persist_task_effect;
 
@@ -743,16 +741,11 @@ fn expand_create_event_holders(
         return Ok(event);
     };
 
-    let target = DocumentSyncTarget::MetadataDocumentLifecycle {
-        document_id: event.record.document_id,
-    };
-    let context = PlacementResolutionContext {
-        group_id: Some(event.record.group_id),
-        metadata_path: Some(event.record.document_path.as_str()),
-    };
+    // Holders are derived from the bucket the create stamped, never re-chosen:
+    // this runs again on replay, and a config change between runs would move the
+    // document to a different topic.
     event.record.holder_node_ids = realm_config
-        .and_then(|config| plan_target_placement(config, &target, context))
-        .map(|plan| plan.holders)
+        .map(|config| resolve_shard_holders(config, &event.record.placement))
         .unwrap_or_default();
     Ok(event)
 }
@@ -789,26 +782,19 @@ pub fn create_event_outbox_record(
     let target = DocumentSyncTarget::MetadataDocumentLifecycle {
         document_id: event.record.document_id,
     };
-    // The origin knows the governing strategy: stamp the real reference so the
-    // metadata create/lifecycle envelope carries it (else the nil fallback).
-    let placement = realm_config
-        .map(|config| {
-            placement_ref_for_target(
-                config,
-                &target,
-                PlacementResolutionContext {
-                    group_id: Some(event.record.group_id),
-                    metadata_path: Some(event.record.document_path.as_str()),
-                },
-            )
-        })
-        .unwrap_or(aruna_core::structs::PlacementRef::NIL);
+    // The bucket is the one the create stamped; peers are its live holders, so a
+    // publish after a rebalance targets the current holder set and not the
+    // event-time one.
+    let placement = event.record.placement;
+    let peers = realm_config
+        .map(|config| resolve_shard_holders(config, &placement))
+        .unwrap_or_default();
     let change = metadata_document_lifecycle_revision_change(&lifecycle, event.node_id, placement);
     DocumentSyncOutboxRecord {
         outbox_id: event.event_id,
         node_id: event.node_id,
         target,
-        peers: event.record.holder_node_ids.clone(),
+        peers,
         event: DocumentSyncOutboxEvent::Upsert {
             bytes: postcard::to_allocvec(&lifecycle)
                 .expect("metadata document lifecycle event serializes"),
@@ -1034,6 +1020,31 @@ mod tests {
         }
     }
 
+    // Stands in for the create operation: stamps the bucket its origin would
+    // have chosen from the buckets it holds.
+    fn stamped(
+        mut event: MetadataCreateEventRecord,
+        config: &RealmConfigDocument,
+    ) -> MetadataCreateEventRecord {
+        let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: event.record.document_id,
+        };
+        let context = crate::placement::PlacementResolutionContext {
+            group_id: Some(event.record.group_id),
+            metadata_path: Some(event.record.document_path.as_str()),
+        };
+        let (strategy, _) = crate::placement::strategy_for_target(config, &target, context)
+            .expect("strategy resolves");
+        event.record.placement = crate::placement::choose_origin_bucket(
+            config,
+            strategy,
+            event.node_id,
+            &crate::placement::subject_bytes(&target),
+        )
+        .expect("origin holds a bucket");
+        event
+    }
+
     fn realm_config(realm_id: RealmId, nodes: &[NodeId]) -> RealmConfigDocument {
         let mut config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
         config.seed_default_placement();
@@ -1219,24 +1230,31 @@ mod tests {
         event.node_id = node(1);
         event.record.holder_node_ids = vec![node(1)];
         let config = realm_config(event.record.realm_id, &[node(1), node(2), node(3), node(4)]);
+        let event = stamped(event, &config);
 
         let expanded =
             expand_create_event_holders(event.clone(), Some(event.node_id), Some(&config))
                 .expect("holders expand");
 
+        assert_eq!(
+            expanded.record.holder_node_ids,
+            resolve_shard_holders(&config, &event.record.placement)
+        );
         assert_eq!(expanded.record.holder_node_ids.len(), 3);
+        assert!(expanded.record.holder_node_ids.contains(&event.node_id));
         assert_eq!(expanded.record.last_event_id, event.event_id);
     }
 
-    // The origin's outbox record must carry the placement resolved with the
-    // full group + document-path context, not the bare default strategy.
+    // The origin's outbox record rides the bucket stored on the record, and its
+    // peers are that bucket's live holders.
     #[tokio::test]
-    async fn contextual_placement_stamped() {
+    async fn outbox_rides_stored_bucket() {
         let dir = tempdir().expect("temp dir");
         let storage =
             FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
         let event = create_event();
         let config = realm_config(event.record.realm_id, &[event.node_id, node(2), node(3)]);
+        let event = stamped(event, &config);
         write_entries(
             &storage,
             vec![(
@@ -1258,18 +1276,7 @@ mod tests {
             .await
             .expect("projection succeeds");
 
-        let target = DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: event.record.document_id,
-        };
-        let expected = plan_target_placement(
-            &config,
-            &target,
-            PlacementResolutionContext {
-                group_id: Some(event.record.group_id),
-                metadata_path: Some(event.record.document_path.as_str()),
-            },
-        )
-        .expect("placement resolves");
+        let expected_holders = resolve_shard_holders(&config, &event.record.placement);
 
         let outbox = match storage
             .send_storage_effect(StorageEffect::Iter {
@@ -1293,12 +1300,12 @@ mod tests {
             other => panic!("expected outbox iter result, got {other:?}"),
         };
 
-        assert_eq!(outbox.placement, expected.placement);
-        assert_eq!(outbox.peers, expected.holders);
+        assert_eq!(outbox.placement, event.record.placement);
+        assert_eq!(outbox.peers, expected_holders);
         let DocumentSyncOutboxEvent::Upsert { change, .. } = &outbox.event else {
             panic!("expected lifecycle upsert outbox event");
         };
-        assert_eq!(change.placement, expected.placement);
+        assert_eq!(change.placement, event.record.placement);
     }
 
     // A locally authored event with no eligible holders must not enqueue an
@@ -1389,22 +1396,11 @@ mod tests {
             config.ensure_node(candidate, RealmNodeKind::Server);
         }
 
+        let event = stamped(event, &config);
         let expanded =
             expand_create_event_holders(event.clone(), Some(event.node_id), Some(&config))
                 .expect("holders resolve");
-        let target = DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: event.record.document_id,
-        };
-        let expected = plan_target_placement(
-            &config,
-            &target,
-            PlacementResolutionContext {
-                group_id: Some(event.record.group_id),
-                metadata_path: Some(event.record.document_path.as_str()),
-            },
-        )
-        .expect("strategy resolves")
-        .holders;
+        let expected = resolve_shard_holders(&config, &event.record.placement);
 
         assert_eq!(config.metadata_replication.default_replication_factor, 4);
         assert_eq!(expanded.record.holder_node_ids, expected);
@@ -1422,6 +1418,15 @@ mod tests {
         config.ensure_node(node(2), RealmNodeKind::Server);
         config.ensure_node(node(3), RealmNodeKind::Server);
         config.ensure_node(node(4), RealmNodeKind::Server);
+        // A user node holds no bucket, so its create fell back to the hashed
+        // one (stage 1); it still never becomes a holder of it.
+        event.record.placement = crate::placement::placement_ref_for_target(
+            &config,
+            &DocumentSyncTarget::MetadataDocumentLifecycle {
+                document_id: event.record.document_id,
+            },
+            Default::default(),
+        );
 
         let expanded = expand_create_event_holders(event, Some(node(1)), Some(&config))
             .expect("holders expand");
@@ -1466,7 +1471,9 @@ mod tests {
 
         assert!(outbox.allow_genesis);
         assert_eq!(outbox.outbox_id, event.event_id);
-        assert_eq!(outbox.peers, event.record.holder_node_ids);
+        // Without a realm config the holders are unresolvable here; the outbox
+        // drain resolves them from the bucket before publishing.
+        assert!(outbox.peers.is_empty());
         assert_eq!(
             outbox.target,
             DocumentSyncTarget::MetadataDocumentLifecycle {
@@ -1495,6 +1502,7 @@ mod tests {
     fn create_and_update_stamp_equal_placement_refs() {
         let create = create_event();
         let config = realm_config(create.record.realm_id, &[node(1), node(2)]);
+        let create = stamped(create, &config);
 
         // An update of the same document reuses its id and path; only the event
         // identity/timestamps advance.

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -968,7 +968,9 @@ mod tests {
     use aruna_core::storage_entries::{
         metadata_create_event_write_entry, metadata_pending_projection_key,
     };
-    use aruna_core::structs::{PlacementStrategy, RealmConfigDocument, RealmId, RealmNodeKind};
+    use aruna_core::structs::{
+        PlacementRef, PlacementStrategy, RealmConfigDocument, RealmId, RealmNodeKind,
+    };
     use aruna_core::types::UserId;
     use aruna_storage::{FjallStorage, StorageHandle};
     use aruna_tasks::{InboundTaskHandler, TaskHandle};
@@ -1011,6 +1013,7 @@ mod tests {
                 document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![node(2)],
             created_at_ms: 1_000,
             updated_at_ms: 1_000,
@@ -1528,6 +1531,7 @@ mod tests {
                 graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
                 public: false,
                 permission_path: String::new(),
+                placement: PlacementRef::NIL,
                 holder_node_ids: Vec::new(),
                 created_at_ms: updated_at_ms,
                 updated_at_ms,

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -812,7 +812,7 @@ pub fn registry_outbox_record(
         group_id: record.group_id,
         document_id: record.document_id,
     };
-    let mut peers = resolve_shard_holders(config, &placement);
+    let peers = resolve_shard_holders(config, &placement);
     if peers.is_empty() {
         return None;
     }
@@ -827,7 +827,6 @@ pub fn registry_outbox_record(
         kind: DocumentSyncChangeKind::Upsert,
         placement,
     };
-    sort_node_ids(&mut peers);
     Some(DocumentSyncOutboxRecord {
         outbox_id: event.event_id,
         node_id: event.node_id,
@@ -858,11 +857,10 @@ pub fn create_event_outbox_record(
     // publish after a rebalance targets the current holder set and not the
     // event-time one.
     let placement = event.record.placement;
-    let mut peers = realm_config
+    let peers = realm_config
         .map(|config| resolve_shard_holders(config, &placement))
         .unwrap_or_default();
     let change = metadata_document_lifecycle_revision_change(&lifecycle, event.node_id, placement);
-    sort_node_ids(&mut peers);
     DocumentSyncOutboxRecord {
         outbox_id: event.event_id,
         node_id: event.node_id,

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -16,7 +16,6 @@ use aruna_core::metadata::{
     MetadataGraphLifecycleRecord, MetadataMaterializationStatusRecord,
 };
 use aruna_core::storage_entries::{
-    document_placement_delete_entry, document_placement_write_entry,
     metadata_document_lifecycle_revision_change, metadata_document_lifecycle_write_entry,
     metadata_event_log_key, metadata_graph_lifecycle_key, metadata_materialization_status_key,
     metadata_pending_projection_delete_entry, metadata_pending_projection_key,
@@ -49,9 +48,7 @@ use crate::metadata::repository::{
 use crate::placement::{
     PlacementResolutionContext, placement_ref_for_target, plan_target_placement,
 };
-use crate::sync_placement::{
-    new_placement_with_context, placement_satisfied, schedule_placement_retry_effect, sort_node_ids,
-};
+use crate::sync_placement::sort_node_ids;
 use crate::task_persistence::persist_task_effect;
 
 const REPLAY_PAGE_SIZE: usize = 1_024;
@@ -403,7 +400,6 @@ pub async fn project_metadata_create_events(
     let mut outboxes = Vec::new();
     let mut pending_projection_delete_targets = BTreeSet::new();
     let mut pending_projection_retry_targets = BTreeSet::new();
-    let mut placement_retries = BTreeSet::new();
     let mut needs_materialization_drain = false;
     let mut projected = 0usize;
     let mut projected_records = Vec::new();
@@ -444,12 +440,6 @@ pub async fn project_metadata_create_events(
             repair_deletes.extend(metadata_registry_delete_entries(
                 stale_record.group_id,
                 stale_record.document_id,
-            ));
-            repair_deletes.push(document_placement_delete_entry(
-                stale_record.realm_id,
-                &DocumentSyncTarget::MetadataDocumentLifecycle {
-                    document_id: stale_record.document_id,
-                },
             ));
             repaired_records.push(stale_record.clone());
             registry_cache.insert(document_id, None);
@@ -521,34 +511,6 @@ pub async fn project_metadata_create_events(
         } else {
             None
         };
-        let lifecycle_placement = if local_node_id == Some(event.node_id) {
-            let target = DocumentSyncTarget::MetadataDocumentLifecycle {
-                document_id: event.record.document_id,
-            };
-            let context = PlacementResolutionContext {
-                group_id: Some(event.record.group_id),
-                metadata_path: Some(event.record.document_path.as_str()),
-            };
-            let plan = realm_configs
-                .get(&event.record.realm_id)
-                .and_then(|config| config.as_ref())
-                .and_then(|config| plan_target_placement(config, &target, context));
-            let (desired_count, holders, placement) = plan
-                .map(|plan| (plan.desired_count, plan.holders, plan.placement))
-                .unwrap_or((1, Vec::new(), aruna_core::structs::PlacementRef::NIL));
-            Some(new_placement_with_context(
-                event.record.realm_id,
-                target,
-                event.node_id,
-                Some(event.record.group_id),
-                Some(event.record.document_path.clone()),
-                desired_count,
-                holders,
-                placement,
-            ))
-        } else {
-            None
-        };
         let audit = audit_record(&event);
         if needs_materialization {
             let now = aruna_core::util::unix_timestamp_millis();
@@ -574,15 +536,6 @@ pub async fn project_metadata_create_events(
         }
         if let Some(outbox) = outbox {
             outboxes.push(outbox);
-        }
-        if let Some(placement) = lifecycle_placement {
-            if !placement_satisfied(
-                placement.selected_holders.len(),
-                placement.desired_holder_count,
-            ) {
-                placement_retries.insert((placement.realm_id, placement.origin_node_id));
-            }
-            writes.push(document_placement_write_entry(&placement)?);
         }
         if local_node_id == Some(event.node_id) {
             writes.push(metadata_document_lifecycle_write_entry(
@@ -647,7 +600,6 @@ pub async fn project_metadata_create_events(
     if needs_materialization_drain {
         schedule_materialization_drain(context).await?;
     }
-    schedule_placement_retries(context, placement_retries).await?;
     write_pending_projection_markers(context, &pending_projection_retry_targets).await?;
     delete_pending_projection_markers(context, pending_projection_delete_targets).await?;
 
@@ -658,35 +610,6 @@ pub async fn project_metadata_create_events(
     }
 
     Ok(projected)
-}
-
-async fn schedule_placement_retries(
-    context: &DriverContext,
-    retries: BTreeSet<(RealmId, NodeId)>,
-) -> Result<(), MetadataProjectionError> {
-    for (realm_id, node_id) in retries {
-        let Effect::Task(effect) = schedule_placement_retry_effect(realm_id, node_id) else {
-            unreachable!("placement retry helper must return a task effect");
-        };
-        persist_task_effect(&context.storage_handle, &effect)
-            .await
-            .map_err(MetadataProjectionError::UnexpectedEvent)?;
-        let Some(task_handle) = context.task_handle.as_ref() else {
-            continue;
-        };
-        match task_handle.send_effect(Effect::Task(effect)).await {
-            Event::Task(TaskEvent::TimerScheduled { .. }) => {}
-            Event::Task(TaskEvent::Error { message, .. }) => {
-                return Err(MetadataProjectionError::UnexpectedEvent(message));
-            }
-            other => {
-                return Err(MetadataProjectionError::UnexpectedEvent(format!(
-                    "{other:?}"
-                )));
-            }
-        }
-    }
-    Ok(())
 }
 
 async fn write_pending_projection_markers(
@@ -1302,8 +1225,10 @@ mod tests {
         assert_eq!(expanded.record.last_event_id, event.event_id);
     }
 
+    // The origin's outbox record must carry the placement resolved with the
+    // full group + document-path context, not the bare default strategy.
     #[tokio::test]
-    async fn local_projection_persists_exact_contextual_placement_inventory() {
+    async fn contextual_placement_stamped() {
         let dir = tempdir().expect("temp dir");
         let storage =
             FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
@@ -1333,20 +1258,6 @@ mod tests {
         let target = DocumentSyncTarget::MetadataDocumentLifecycle {
             document_id: event.record.document_id,
         };
-        let value = match storage
-            .send_storage_effect(StorageEffect::Read {
-                key_space: aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE.to_string(),
-                key: crate::sync_placement::placement_key(event.record.realm_id, &target),
-                txn_id: None,
-            })
-            .await
-        {
-            Event::Storage(StorageEvent::ReadResult {
-                value: Some(value), ..
-            }) => value,
-            other => panic!("expected placement inventory, got {other:?}"),
-        };
-        let placement = crate::sync_placement::decode_placement(&value).expect("placement decodes");
         let expected = plan_target_placement(
             &config,
             &target,
@@ -1356,21 +1267,41 @@ mod tests {
             },
         )
         .expect("placement resolves");
-        let mut expected_holders = expected.holders;
-        sort_node_ids(&mut expected_holders);
 
-        assert_eq!(placement.group_id, Some(event.record.group_id));
-        assert_eq!(
-            placement.metadata_path.as_deref(),
-            Some(event.record.document_path.as_str())
-        );
-        assert_eq!(placement.desired_holder_count, expected.desired_count);
-        assert_eq!(placement.selected_holders, expected_holders);
-        assert_eq!(placement.placement, expected.placement);
+        let outbox = match storage
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: aruna_core::keyspaces::DOCUMENT_SYNC_OUTBOX_KEYSPACE.to_string(),
+                prefix: None,
+                start: None,
+                limit: 2,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult { values, .. }) => {
+                assert_eq!(
+                    values.len(),
+                    1,
+                    "origin projection writes one outbox record"
+                );
+                postcard::from_bytes::<DocumentSyncOutboxRecord>(values[0].1.as_ref())
+                    .expect("outbox record decodes")
+            }
+            other => panic!("expected outbox iter result, got {other:?}"),
+        };
+
+        assert_eq!(outbox.placement, expected.placement);
+        assert_eq!(outbox.peers, expected.holders);
+        let DocumentSyncOutboxEvent::Upsert { change, .. } = &outbox.event else {
+            panic!("expected lifecycle upsert outbox event");
+        };
+        assert_eq!(change.placement, expected.placement);
     }
 
+    // A locally authored event with no eligible holders must not enqueue an
+    // outbox publish; replay re-plans it once eligible holders exist.
     #[tokio::test]
-    async fn local_projection_with_no_eligible_holders_keeps_placement_pending_without_outbox() {
+    async fn holderless_projection_defers() {
         let dir = tempdir().expect("temp dir");
         let storage =
             FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
@@ -1414,23 +1345,6 @@ mod tests {
         let target = DocumentSyncTarget::MetadataDocumentLifecycle {
             document_id: event.record.document_id,
         };
-        let placement = storage
-            .send_storage_effect(StorageEffect::Read {
-                key_space: aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE.to_string(),
-                key: crate::sync_placement::placement_key(event.record.realm_id, &target),
-                txn_id: None,
-            })
-            .await;
-        let Event::Storage(StorageEvent::ReadResult {
-            value: Some(value), ..
-        }) = placement
-        else {
-            panic!("expected pending placement inventory, got {placement:?}");
-        };
-        let placement = crate::sync_placement::decode_placement(&value).expect("placement decodes");
-        assert_eq!(placement.desired_holder_count, 3);
-        assert!(placement.selected_holders.is_empty());
-
         let lifecycle = storage
             .send_effect(crate::document_repository::read_effect(&target, None))
             .await;
@@ -1464,6 +1378,7 @@ mod tests {
             replica_count: Some(2),
             distinct_locations: false,
             affinity: Vec::new(),
+            shard_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
         config.strategies = vec![strategy];

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -812,7 +812,7 @@ pub fn registry_outbox_record(
         group_id: record.group_id,
         document_id: record.document_id,
     };
-    let peers = resolve_shard_holders(config, &placement);
+    let mut peers = resolve_shard_holders(config, &placement);
     if peers.is_empty() {
         return None;
     }
@@ -827,6 +827,7 @@ pub fn registry_outbox_record(
         kind: DocumentSyncChangeKind::Upsert,
         placement,
     };
+    sort_node_ids(&mut peers);
     Some(DocumentSyncOutboxRecord {
         outbox_id: event.event_id,
         node_id: event.node_id,
@@ -857,10 +858,11 @@ pub fn create_event_outbox_record(
     // publish after a rebalance targets the current holder set and not the
     // event-time one.
     let placement = event.record.placement;
-    let peers = realm_config
+    let mut peers = realm_config
         .map(|config| resolve_shard_holders(config, &placement))
         .unwrap_or_default();
     let change = metadata_document_lifecycle_revision_change(&lifecycle, event.node_id, placement);
+    sort_node_ids(&mut peers);
     DocumentSyncOutboxRecord {
         outbox_id: event.event_id,
         node_id: event.node_id,

--- a/operations/src/metadata/projector.rs
+++ b/operations/src/metadata/projector.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncOutboxRecord, DocumentSyncTarget};
+use aruna_core::document::{
+    DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncOutboxEvent, DocumentSyncOutboxRecord,
+    DocumentSyncRevision, DocumentSyncTarget,
+};
 use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
@@ -22,7 +25,7 @@ use aruna_core::storage_entries::{
     metadata_pending_projection_target, metadata_registry_delete_entries,
 };
 use aruna_core::structs::{
-    MetadataAuditRecord, MetadataRegistryRecord, RealmConfigDocument, RealmId,
+    MetadataAuditRecord, MetadataRegistryRecord, PlacementRef, RealmConfigDocument, RealmId,
 };
 use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
 use aruna_core::types::Key;
@@ -45,7 +48,7 @@ use crate::metadata::repository::{
     create_records_and_outbox_write_entries,
     create_records_outbox_and_materialization_write_entries, read_registry_by_document_effect,
 };
-use crate::placement::resolve_shard_holders;
+use crate::placement::{registry_placement, resolve_shard_holders};
 use crate::sync_placement::sort_node_ids;
 use crate::task_persistence::persist_task_effect;
 
@@ -493,22 +496,22 @@ pub async fn project_metadata_create_events(
             continue;
         }
 
-        let outbox = if local_node_id == Some(event.node_id)
-            && (!registry_exists || needs_materialization || holders_changed)
-            && !event.record.holder_node_ids.is_empty()
-        {
+        let realm_config = realm_configs
+            .get(&event.record.realm_id)
+            .and_then(|config| config.as_ref());
+        let authored_here = local_node_id == Some(event.node_id)
+            && (!registry_exists || needs_materialization || holders_changed);
+        let outbox = if authored_here && !event.record.holder_node_ids.is_empty() {
             // The local node authored this create event, so it originates the
             // document's lifecycle sync topic and may mint its genesis.
-            Some(create_event_outbox_record(
-                &event,
-                realm_configs
-                    .get(&event.record.realm_id)
-                    .and_then(|config| config.as_ref()),
-                true,
-            ))
+            Some(create_event_outbox_record(&event, realm_config, true))
         } else {
             None
         };
+        // The registry row rides its own everywhere-bound topic, so it goes out
+        // even when the document's own bucket has no holders to publish to.
+        let registry_outbox =
+            authored_here.then(|| registry_outbox_record(&event, realm_config, true));
         let audit = audit_record(&event);
         if needs_materialization {
             let now = aruna_core::util::unix_timestamp_millis();
@@ -534,6 +537,13 @@ pub async fn project_metadata_create_events(
         }
         if let Some(outbox) = outbox {
             outboxes.push(outbox);
+        }
+        if let Some(registry_outbox) = registry_outbox.flatten() {
+            writes.push(
+                crate::document_sync_outbox::outbox_write_entry(&registry_outbox)
+                    .map_err(ConversionError::from)?,
+            );
+            outboxes.push(registry_outbox);
         }
         if local_node_id == Some(event.node_id) {
             writes.push(metadata_document_lifecycle_write_entry(
@@ -769,6 +779,62 @@ async fn read_realm_config(
             "{other:?}"
         ))),
     }
+}
+
+/// The document's registry row, published on the registry class's own topic
+/// rather than the document's bucket topic.
+///
+/// The bucket is replica-capped, so on a realm larger than the replication factor
+/// most nodes never see the document's bucket topic at all — and every registry
+/// row a node has today arrives as a side effect of that topic's lifecycle
+/// events. Those nodes would therefore never learn the document exists: a GET
+/// through them 404s forever, and update/delete could not even load the record
+/// they need in order to decide to forward it to a holder. The registry class is
+/// bound "everywhere", so this row reaches every node and gives each one the
+/// `document_id -> placement -> holders` mapping the routing layer runs on.
+///
+/// `None` without a readable realm config: there is no strategy to resolve, and a
+/// NIL-placed shard record would derive a NIL topic.
+pub fn registry_outbox_record(
+    event: &MetadataCreateEventRecord,
+    realm_config: Option<&RealmConfigDocument>,
+    allow_genesis: bool,
+) -> Option<DocumentSyncOutboxRecord> {
+    let record = &event.record;
+    let config = realm_config?;
+    let placement = registry_placement(config, record);
+    if placement == PlacementRef::NIL {
+        return None;
+    }
+    let target = DocumentSyncTarget::MetadataRegistry {
+        group_id: record.group_id,
+        document_id: record.document_id,
+    };
+    let peers = resolve_shard_holders(config, &placement);
+    let change = DocumentSyncChange {
+        base: None,
+        current: DocumentSyncRevision {
+            generation: record.updated_at_ms,
+            event_id: event.event_id,
+            actor: event.node_id,
+            updated_at_ms: record.updated_at_ms,
+        },
+        kind: DocumentSyncChangeKind::Upsert,
+        placement,
+    };
+    Some(DocumentSyncOutboxRecord {
+        outbox_id: event.event_id,
+        node_id: event.node_id,
+        target,
+        peers,
+        event: DocumentSyncOutboxEvent::Upsert {
+            bytes: postcard::to_allocvec(record).expect("metadata registry record serializes"),
+            change,
+        },
+        placement,
+        updated_at: event.occurred_at_ms / 1_000,
+        allow_genesis,
+    })
 }
 
 pub fn create_event_outbox_record(

--- a/operations/src/metadata/protocol.rs
+++ b/operations/src/metadata/protocol.rs
@@ -129,11 +129,23 @@ pub async fn write_message(
     stream: &mut BiStream,
     message: &MetadataTransportMessage,
 ) -> Result<(), String> {
+    let bytes = encode_message(message)?;
+    write_encoded_message(stream, &bytes).await
+}
+
+pub(crate) fn encode_message(message: &MetadataTransportMessage) -> Result<Vec<u8>, String> {
     let bytes = postcard::to_allocvec(message).map_err(|err| err.to_string())?;
     if bytes.len() > MAX_MESSAGE_SIZE {
         return Err("metadata message exceeds maximum size".to_string());
     }
 
+    Ok(bytes)
+}
+
+pub(crate) async fn write_encoded_message(
+    stream: &mut BiStream,
+    bytes: &[u8],
+) -> Result<(), String> {
     stream
         .0
         .write_all(&(bytes.len() as u32).to_be_bytes())

--- a/operations/src/metadata/protocol.rs
+++ b/operations/src/metadata/protocol.rs
@@ -1,8 +1,14 @@
 use aruna_core::metadata::{MetadataQueryResults, MetadataSearchHit};
+use aruna_core::structs::MetadataRegistryRecord;
+use aruna_core::types::GroupId;
 use aruna_net::streams::BiStream;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 use tokio::io::AsyncWriteExt;
+use ulid::Ulid;
+
+use crate::create_metadata_document::CreateMetadataDocumentPayload;
+use crate::update_metadata_document::UpdateMetadataDocumentMutation;
 
 const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 pub const MAX_METADATA_BEARER_TOKEN_LEN: usize = 4096;
@@ -83,6 +89,34 @@ pub enum MetadataTransportMessage {
     SearchResults {
         hits: Vec<MetadataSearchHit>,
     },
+    /// A metadata write that arrived at a node holding none of the document's
+    /// bucket, forwarded to a holder. The payloads mirror the HTTP handlers'
+    /// deconstructed request; `auth_token` carries the caller's authority so the
+    /// holder re-runs the same permission checks the origin would have run.
+    ForwardCreateDocument {
+        auth_token: Option<MetadataAuthToken>,
+        group_id: GroupId,
+        document_id: Ulid,
+        document_path: String,
+        public: bool,
+        payload: CreateMetadataDocumentPayload,
+    },
+    ForwardUpdateDocument {
+        auth_token: Option<MetadataAuthToken>,
+        document_id: Ulid,
+        /// `None` leaves the holder's current visibility untouched: the origin's
+        /// record copy may be stale, so only an explicit request value travels.
+        public: Option<bool>,
+        mutation: UpdateMetadataDocumentMutation,
+    },
+    ForwardDeleteDocument {
+        auth_token: Option<MetadataAuthToken>,
+        document_id: Ulid,
+    },
+    ForwardedRecord {
+        record: Box<MetadataRegistryRecord>,
+    },
+    ForwardedDelete,
     Reject(String),
 }
 
@@ -147,6 +181,58 @@ mod tests {
             query: "dataset".to_string(),
             limit: 10,
         });
+    }
+
+    #[test]
+    fn forwarded_writes_carry_authority() {
+        // The holder applies a forwarded write under the caller's own token, so
+        // every forward variant must carry one: a tokenless forward would be an
+        // unauthenticated internal write path.
+        assert_has_auth_token_field(MetadataTransportMessage::ForwardCreateDocument {
+            auth_token: Some(MetadataAuthToken::bearer("create-token").unwrap()),
+            group_id: Ulid::nil(),
+            document_id: Ulid::nil(),
+            document_path: "datasets/forwarded".to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::RoCrate {
+                jsonld: "{}".to_string(),
+            },
+        });
+        assert_has_auth_token_field(MetadataTransportMessage::ForwardUpdateDocument {
+            auth_token: Some(MetadataAuthToken::bearer("update-token").unwrap()),
+            document_id: Ulid::nil(),
+            public: None,
+            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
+                jsonld: "{}".to_string(),
+            },
+        });
+        assert_has_auth_token_field(MetadataTransportMessage::ForwardDeleteDocument {
+            auth_token: Some(MetadataAuthToken::bearer("delete-token").unwrap()),
+            document_id: Ulid::nil(),
+        });
+    }
+
+    #[test]
+    fn forwarded_create_round_trips() {
+        let message = MetadataTransportMessage::ForwardCreateDocument {
+            auth_token: Some(MetadataAuthToken::bearer("create-token").unwrap()),
+            group_id: Ulid::from_bytes([3u8; 16]),
+            document_id: Ulid::from_bytes([4u8; 16]),
+            document_path: "datasets/forwarded".to_string(),
+            public: false,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Forwarded".to_string(),
+                description: "Placed by a holder".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        };
+        let bytes = postcard::to_allocvec(&message).unwrap();
+
+        assert_eq!(
+            postcard::from_bytes::<MetadataTransportMessage>(&bytes).unwrap(),
+            message
+        );
     }
 
     #[test]

--- a/operations/src/metadata/protocol.rs
+++ b/operations/src/metadata/protocol.rs
@@ -1,4 +1,3 @@
-use aruna_core::document::DocumentSyncOutboxRecord;
 use aruna_core::metadata::{MetadataQueryResults, MetadataSearchHit};
 use aruna_core::structs::MetadataRegistryRecord;
 use aruna_core::types::GroupId;
@@ -114,16 +113,6 @@ pub enum MetadataTransportMessage {
         auth_token: Option<MetadataAuthToken>,
         document_id: Ulid,
     },
-    /// A queued sync publish whose bucket the emitting node holds none of, so it
-    /// can neither mint nor join that bucket's topic and could never publish the
-    /// record itself. Relayed to a holder, which publishes it on the emitter's
-    /// behalf rather than letting the write be dropped. Carries no `auth_token`:
-    /// the payload is an already-authorized local change, and the holder gates on
-    /// the peer being a configured node of the realm.
-    ForwardOutboxRecord {
-        record: Box<DocumentSyncOutboxRecord>,
-    },
-    ForwardedOutboxRecord,
     ForwardedRecord {
         record: Box<MetadataRegistryRecord>,
     },

--- a/operations/src/metadata/protocol.rs
+++ b/operations/src/metadata/protocol.rs
@@ -153,7 +153,7 @@ pub(crate) async fn write_encoded_message(
         .map_err(|err| err.to_string())?;
     stream
         .0
-        .write_all(&bytes)
+        .write_all(bytes)
         .await
         .map_err(|err| err.to_string())?;
     stream.0.flush().await.map_err(|err| err.to_string())?;

--- a/operations/src/metadata/protocol.rs
+++ b/operations/src/metadata/protocol.rs
@@ -1,3 +1,4 @@
+use aruna_core::document::DocumentSyncOutboxRecord;
 use aruna_core::metadata::{MetadataQueryResults, MetadataSearchHit};
 use aruna_core::structs::MetadataRegistryRecord;
 use aruna_core::types::GroupId;
@@ -113,6 +114,16 @@ pub enum MetadataTransportMessage {
         auth_token: Option<MetadataAuthToken>,
         document_id: Ulid,
     },
+    /// A queued sync publish whose bucket the emitting node holds none of, so it
+    /// can neither mint nor join that bucket's topic and could never publish the
+    /// record itself. Relayed to a holder, which publishes it on the emitter's
+    /// behalf rather than letting the write be dropped. Carries no `auth_token`:
+    /// the payload is an already-authorized local change, and the holder gates on
+    /// the peer being a configured node of the realm.
+    ForwardOutboxRecord {
+        record: Box<DocumentSyncOutboxRecord>,
+    },
+    ForwardedOutboxRecord,
     ForwardedRecord {
         record: Box<MetadataRegistryRecord>,
     },

--- a/operations/src/metadata/protocol.rs
+++ b/operations/src/metadata/protocol.rs
@@ -118,6 +118,11 @@ pub enum MetadataTransportMessage {
     },
     ForwardedDelete,
     Reject(String),
+    /// A permanent update validation failure. Appended after `Reject` so the
+    /// postcard discriminants of existing control messages remain stable.
+    ForwardedUpdateInvalidInput {
+        message: String,
+    },
 }
 
 pub async fn write_message(
@@ -232,6 +237,14 @@ mod tests {
         assert_eq!(
             postcard::from_bytes::<MetadataTransportMessage>(&bytes).unwrap(),
             message
+        );
+    }
+
+    #[test]
+    fn legacy_reject_stable() {
+        assert_eq!(
+            postcard::to_allocvec(&MetadataTransportMessage::Reject(String::new())).unwrap(),
+            vec![9, 0]
         );
     }
 

--- a/operations/src/metadata/prune_queue.rs
+++ b/operations/src/metadata/prune_queue.rs
@@ -832,6 +832,7 @@ mod tests {
         metadata_graph_lifecycle_write_entry, metadata_registry_write_entries,
     };
     use aruna_core::structs::MetadataRegistryRecord;
+    use aruna_core::structs::PlacementRef;
     use aruna_core::structs::RealmId;
     use aruna_storage::FjallStorage;
     use aruna_tasks::TaskHandle;
@@ -865,6 +866,7 @@ mod tests {
                 path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: Vec::new(),
             created_at_ms: 1,
             updated_at_ms: 1,

--- a/operations/src/metadata/repository.rs
+++ b/operations/src/metadata/repository.rs
@@ -14,12 +14,13 @@ use aruna_core::metadata::{
 };
 pub use aruna_core::storage_entries::{
     metadata_create_event_and_pending_projection_write_entries, metadata_create_event_write_entry,
-    metadata_document_key, metadata_document_lifecycle_revision_write_entry,
-    metadata_document_lifecycle_write_entry, metadata_graph_lifecycle_key,
-    metadata_graph_lifecycle_write_entry, metadata_materialization_document_job_write_entry,
-    metadata_materialization_job_key, metadata_materialization_job_write_entry,
-    metadata_materialization_status_key, metadata_materialization_status_write_entry,
-    metadata_registry_key, metadata_registry_prefix,
+    metadata_document_key, metadata_document_lifecycle_manifest_write_entry,
+    metadata_document_lifecycle_revision_write_entry, metadata_document_lifecycle_write_entry,
+    metadata_graph_lifecycle_key, metadata_graph_lifecycle_write_entry,
+    metadata_materialization_document_job_write_entry, metadata_materialization_job_key,
+    metadata_materialization_job_write_entry, metadata_materialization_status_key,
+    metadata_materialization_status_write_entry, metadata_registry_key, metadata_registry_prefix,
+    shard_manifest_write_entry,
 };
 use aruna_core::structs::{MetadataAuditRecord, MetadataRegistryRecord};
 use aruna_core::types::{Effects, GroupId, Key, TxnId};
@@ -184,11 +185,17 @@ pub fn write_document_lifecycle_with_revision_effect(
     placement: aruna_core::structs::PlacementRef,
     txn_id: Option<TxnId>,
 ) -> Result<Effect, ConversionError> {
+    let mut writes = vec![
+        metadata_document_lifecycle_write_entry(record)?,
+        metadata_document_lifecycle_revision_write_entry(record, delete_actor, placement)?,
+    ];
+    if let Some(manifest) =
+        metadata_document_lifecycle_manifest_write_entry(record, delete_actor, placement)?
+    {
+        writes.push(manifest);
+    }
     Ok(Effect::Storage(StorageEffect::BatchWrite {
-        writes: vec![
-            metadata_document_lifecycle_write_entry(record)?,
-            metadata_document_lifecycle_revision_write_entry(record, delete_actor, placement)?,
-        ],
+        writes,
         txn_id,
     }))
 }
@@ -291,6 +298,9 @@ pub fn create_records_and_outbox_write_entries(
         if let Some(revision) = document_lifecycle_revision_from_outbox(outbox)? {
             writes.push(revision);
         }
+        if let Some(manifest) = document_lifecycle_manifest_from_outbox(outbox)? {
+            writes.push(manifest);
+        }
     }
 
     Ok(writes)
@@ -299,6 +309,36 @@ pub fn create_records_and_outbox_write_entries(
 fn document_lifecycle_revision_from_outbox(
     outbox: &DocumentSyncOutboxRecord,
 ) -> Result<Option<(String, ByteView, ByteView)>, ConversionError> {
+    let Some((lifecycle, change)) = outbox_document_lifecycle_upsert(outbox)? else {
+        return Ok(None);
+    };
+    // Mirror the outbox envelope's placement into the revision sidecar so the
+    // same document carries the same reference locally and on the wire.
+    Ok(Some(metadata_document_lifecycle_revision_write_entry(
+        &lifecycle,
+        outbox.node_id,
+        change.placement,
+    )?))
+}
+
+fn document_lifecycle_manifest_from_outbox(
+    outbox: &DocumentSyncOutboxRecord,
+) -> Result<Option<(String, ByteView, ByteView)>, ConversionError> {
+    let Some((_, change)) = outbox_document_lifecycle_upsert(outbox)? else {
+        return Ok(None);
+    };
+    shard_manifest_write_entry(&outbox.target, &change)
+}
+
+fn outbox_document_lifecycle_upsert(
+    outbox: &DocumentSyncOutboxRecord,
+) -> Result<
+    Option<(
+        MetadataDocumentLifecycleRecord,
+        aruna_core::document::DocumentSyncChange,
+    )>,
+    ConversionError,
+> {
     if !matches!(
         &outbox.target,
         DocumentSyncTarget::MetadataDocumentLifecycle { .. }
@@ -309,13 +349,7 @@ fn document_lifecycle_revision_from_outbox(
         return Ok(None);
     };
     let lifecycle: MetadataDocumentLifecycleRecord = postcard::from_bytes(bytes)?;
-    // Mirror the outbox envelope's placement into the revision sidecar so the
-    // same document carries the same reference locally and on the wire.
-    Ok(Some(metadata_document_lifecycle_revision_write_entry(
-        &lifecycle,
-        outbox.node_id,
-        change.placement,
-    )?))
+    Ok(Some((lifecycle, *change)))
 }
 
 pub fn write_create_records_outbox_and_materialization_effect(

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -211,6 +211,12 @@ pub enum MutateRealmPlacementError {
     RealmConfigNotFound,
     #[error("invalid placement mutation: {0}")]
     InvalidInput(String),
+    #[error(
+        "disjoint holder transition for strategy {strategy_id} shard {shard}: at least one current holder must remain until new holders verify"
+    )]
+    DisjointHolderTransition { strategy_id: Ulid, shard: u32 },
+    #[error("placement leaves strategy {strategy_id} shard {shard} with no eligible holders")]
+    EmptyShardHolders { strategy_id: Ulid, shard: u32 },
     #[error("placement strategy {strategy_id} is currently referenced")]
     StrategyReferenced { strategy_id: Ulid },
     #[error("missing active transaction")]
@@ -301,7 +307,23 @@ impl MutateRealmPlacementOperation {
             .unwrap_or_else(|| AdminDocumentReducerState::new(target));
         let admin_event = reducer_state
             .apply_operation(&self.config.actor, self.config.mutation.admin_operation())?;
+        let pre_document = document.clone();
         overlay_realm_config_placement_reducer_materialization(&mut document, &reducer_state);
+
+        if let Some(placement) =
+            crate::placement::first_disjoint_shard_transition(&pre_document, &document)
+        {
+            return Err(MutateRealmPlacementError::DisjointHolderTransition {
+                strategy_id: placement.strategy_id,
+                shard: placement.shard,
+            });
+        }
+        if let Some(placement) = crate::placement::first_empty_referenced_shard(&document) {
+            return Err(MutateRealmPlacementError::EmptyShardHolders {
+                strategy_id: placement.strategy_id,
+                shard: placement.shard,
+            });
+        }
 
         let stale_conflict_deletes = stale_admin_document_conflict_delete_entries(
             previous_reducer_state.as_ref(),
@@ -700,7 +722,8 @@ mod tests {
         metadata_create_event_and_pending_projection_write_entries, metadata_registry_write_entries,
     };
     use aruna_core::structs::{
-        DEFAULT_NODE_WEIGHT, DocumentClass, MetadataRegistryRecord, PlacementRef, RealmId,
+        AffinityEffect, AffinityRule, DEFAULT_NODE_WEIGHT, DEFAULT_SHARD_COUNT, DocumentClass,
+        LabelMatch, MetadataRegistryRecord, PlacementRef, RealmId, RealmNodeKind,
     };
     use aruna_core::task::{TaskEffect, TaskKey};
     use aruna_core::types::UserId;
@@ -1173,6 +1196,132 @@ mod tests {
                 },
                 after,
             })] if *scheduled_realm == realm_id && *node_id == actor.node_id && after.is_zero()
+        ));
+    }
+
+    async fn seed_placement_config(
+        context: &DriverContext,
+        actor: &Actor,
+        nodes: &[aruna_core::NodeId],
+        replica: Option<u32>,
+    ) -> RealmConfigDocument {
+        let mut document = RealmConfigDocument::new(actor.realm_id, Vec::new(), 3);
+        document.seed_default_placement();
+        let default_id = document.default_strategy_id.unwrap();
+        for strategy in document.strategies.iter_mut() {
+            if strategy.strategy_id == default_id {
+                strategy.replica_count = replica;
+            }
+        }
+        for node_id in nodes {
+            document.ensure_node(*node_id, RealmNodeKind::Server);
+        }
+        let target = DocumentSyncTarget::RealmConfig {
+            realm_id: actor.realm_id,
+        };
+        let event = context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: target.storage_keyspace().to_string(),
+                key: target.storage_key(),
+                value: document.to_bytes(actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+        document
+    }
+
+    fn draining_entry(node_id: aruna_core::NodeId) -> NodePlacementEntry {
+        NodePlacementEntry {
+            node_id,
+            location: String::new(),
+            weight: DEFAULT_NODE_WEIGHT,
+            full: false,
+            draining: true,
+            labels: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn disjoint_transition_rejected() {
+        let directory = tempdir().unwrap();
+        let context = context(directory.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([21; 32]);
+        let actor = actor(realm_id);
+        // Single-replica: every shard has one holder, so draining a node moves its
+        // shards to a disjoint holder.
+        seed_placement_config(&context, &actor, &[node(1), node(2)], Some(1)).await;
+
+        assert!(matches!(
+            mutate(
+                &context,
+                &actor,
+                RealmPlacementMutation::UpsertNode(draining_entry(node(1)))
+            )
+            .await,
+            Err(MutateRealmPlacementError::DisjointHolderTransition { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn overlapping_transition_allowed() {
+        let directory = tempdir().unwrap();
+        let context = context(directory.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([22; 32]);
+        let actor = actor(realm_id);
+        // Replica two with two nodes: every shard holds both, so draining one
+        // leaves the other as an overlapping holder.
+        seed_placement_config(&context, &actor, &[node(1), node(2)], Some(2)).await;
+
+        let result = mutate(
+            &context,
+            &actor,
+            RealmPlacementMutation::UpsertNode(draining_entry(node(1))),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "overlap-preserving change rejected: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_holder_config_rejected() {
+        let directory = tempdir().unwrap();
+        let context = context(directory.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([23; 32]);
+        let actor = actor(realm_id);
+        let document = seed_placement_config(&context, &actor, &[node(1), node(2)], Some(2)).await;
+        let default_id = document.default_strategy_id.unwrap();
+        // Refilter the referenced default strategy onto a label no node carries:
+        // its shards resolve to zero holders while both nodes stay usable.
+        let filtered = PlacementStrategy {
+            strategy_id: default_id,
+            name: "default".to_string(),
+            replica_count: Some(2),
+            distinct_locations: false,
+            affinity: vec![AffinityRule {
+                matcher: LabelMatch {
+                    key: "tier".to_string(),
+                    value: "hot".to_string(),
+                },
+                effect: AffinityEffect::Filter,
+            }],
+            shard_count: DEFAULT_SHARD_COUNT,
+        };
+
+        assert!(matches!(
+            mutate(
+                &context,
+                &actor,
+                RealmPlacementMutation::UpsertStrategy(filtered)
+            )
+            .await,
+            Err(MutateRealmPlacementError::EmptyShardHolders { .. })
         ));
     }
 

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -5,18 +5,23 @@ use aruna_core::admin_document_reducer::{
 };
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
-use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
-use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
+use aruna_core::keyspaces::{
+    ADMIN_DOCUMENT_STATE_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE, METADATA_INDEX_KEYSPACE,
+    METADATA_PENDING_PROJECTION_KEYSPACE,
+};
+use aruna_core::metadata::MetadataCreateEventRecord;
 use aruna_core::operation::Operation;
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
-    admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
+    admin_document_reducer_state_write_entry, metadata_pending_projection_target,
+    stale_admin_document_conflict_delete_entries,
 };
 use aruna_core::structs::{
-    Actor, BindingScope, NodePlacementEntry, PlacementOverride, PlacementStrategy,
-    RealmConfigDocument, StrategyBinding,
+    Actor, BindingScope, MetadataRegistryRecord, NodePlacementEntry, PlacementOverride,
+    PlacementRef, PlacementStrategy, RealmConfigDocument, StrategyBinding,
 };
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, KeySpace, TxnId, Value};
@@ -30,6 +35,8 @@ use crate::document_sync_outbox::{
 };
 use crate::placement::placement_ref_for_target;
 use crate::sync_placement::schedule_placement_revalidation_effect;
+
+const STRATEGY_REFERENCE_SCAN_PAGE_SIZE: usize = 8_192;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RealmPlacementMutation {
@@ -155,10 +162,27 @@ pub struct MutateRealmPlacementOperation {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+struct StrategyRemovalCheck {
+    document_value: Value,
+    reducer_state_value: Option<Value>,
+    strategy_id: Ulid,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 enum MutateRealmPlacementState {
     Init,
     StartTransaction,
     ReadCurrent,
+    ReadRegistryReferences {
+        check: StrategyRemovalCheck,
+    },
+    ReadPendingReferences {
+        check: StrategyRemovalCheck,
+    },
+    ReadPendingEvents {
+        check: StrategyRemovalCheck,
+        next_start_after: Option<Key>,
+    },
     WriteDocumentAndAdminState {
         document: RealmConfigDocument,
         stale_conflict_deletes: Vec<(KeySpace, Key)>,
@@ -318,6 +342,85 @@ impl MutateRealmPlacementOperation {
         })])
     }
 
+    fn emit_reference_check_or_write(
+        &mut self,
+        document_value: Option<Value>,
+        reducer_state_value: Option<Value>,
+    ) -> Result<Effects, MutateRealmPlacementError> {
+        let Some(document_value) = document_value else {
+            return Err(MutateRealmPlacementError::RealmConfigNotFound);
+        };
+        let document = RealmConfigDocument::from_bytes(&document_value)?;
+        self.config.mutation.validate(&document)?;
+        let strategy_id = match &self.config.mutation {
+            RealmPlacementMutation::RemoveStrategy(strategy_id) => *strategy_id,
+            _ => {
+                return self.emit_write_document_and_admin_state(
+                    Some(document_value),
+                    reducer_state_value,
+                );
+            }
+        };
+        let check = StrategyRemovalCheck {
+            document_value,
+            reducer_state_value,
+            strategy_id,
+        };
+        Ok(self.emit_registry_reference_scan(check, None))
+    }
+
+    fn emit_registry_reference_scan(
+        &mut self,
+        check: StrategyRemovalCheck,
+        start_after: Option<Key>,
+    ) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.fail(MutateRealmPlacementError::MissingTransaction);
+        };
+        self.state = MutateRealmPlacementState::ReadRegistryReferences { check };
+        smallvec![Effect::Storage(StorageEffect::Iter {
+            key_space: METADATA_INDEX_KEYSPACE.to_string(),
+            prefix: None,
+            start: start_after.map(IterStart::After),
+            limit: STRATEGY_REFERENCE_SCAN_PAGE_SIZE,
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    fn emit_pending_reference_scan(
+        &mut self,
+        check: StrategyRemovalCheck,
+        start_after: Option<Key>,
+    ) -> Effects {
+        let Some(txn_id) = self.txn_id else {
+            return self.fail(MutateRealmPlacementError::MissingTransaction);
+        };
+        self.state = MutateRealmPlacementState::ReadPendingReferences { check };
+        smallvec![Effect::Storage(StorageEffect::Iter {
+            key_space: METADATA_PENDING_PROJECTION_KEYSPACE.to_string(),
+            prefix: None,
+            start: start_after.map(IterStart::After),
+            limit: STRATEGY_REFERENCE_SCAN_PAGE_SIZE,
+            txn_id: Some(txn_id),
+        })]
+    }
+
+    fn reference_matches(&self, record: &MetadataRegistryRecord, strategy_id: Ulid) -> bool {
+        record.realm_id == self.config.actor.realm_id
+            && record.placement != PlacementRef::NIL
+            && record.placement.strategy_id == strategy_id
+    }
+
+    fn emit_write_after_reference_check(&mut self, check: StrategyRemovalCheck) -> Effects {
+        match self.emit_write_document_and_admin_state(
+            Some(check.document_value),
+            check.reducer_state_value,
+        ) {
+            Ok(effects) => effects,
+            Err(error) => self.fail(error),
+        }
+    }
+
     fn emit_commit_transaction(&mut self, document: RealmConfigDocument) -> Effects {
         let Some(txn_id) = self.txn_id else {
             return self.fail(MutateRealmPlacementError::MissingTransaction);
@@ -371,7 +474,7 @@ impl Operation for MutateRealmPlacementOperation {
                             format!("{values:?}"),
                         );
                     };
-                    match self.emit_write_document_and_admin_state(
+                    match self.emit_reference_check_or_write(
                         document_value.clone(),
                         reducer_state_value.clone(),
                     ) {
@@ -381,6 +484,108 @@ impl Operation for MutateRealmPlacementOperation {
                 }
                 Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
                 other => self.unexpected_event("storage batch read result", format!("{other:?}")),
+            },
+            MutateRealmPlacementState::ReadRegistryReferences { check } => match event {
+                Event::Storage(StorageEvent::IterResult {
+                    values,
+                    next_start_after,
+                }) => {
+                    for (_, value) in values {
+                        let record: MetadataRegistryRecord = match postcard::from_bytes(&value) {
+                            Ok(record) => record,
+                            Err(error) => return self.fail(ConversionError::from(error).into()),
+                        };
+                        if self.reference_matches(&record, check.strategy_id) {
+                            return self.fail(MutateRealmPlacementError::StrategyReferenced {
+                                strategy_id: check.strategy_id,
+                            });
+                        }
+                    }
+                    match next_start_after {
+                        Some(start_after) => {
+                            self.emit_registry_reference_scan(check, Some(start_after))
+                        }
+                        None => self.emit_pending_reference_scan(check, None),
+                    }
+                }
+                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
+                other => {
+                    self.unexpected_event("metadata registry scan result", format!("{other:?}"))
+                }
+            },
+            MutateRealmPlacementState::ReadPendingReferences { check } => match event {
+                Event::Storage(StorageEvent::IterResult {
+                    values,
+                    next_start_after,
+                }) => {
+                    if values.is_empty() {
+                        return match next_start_after {
+                            Some(start_after) => {
+                                self.emit_pending_reference_scan(check, Some(start_after))
+                            }
+                            None => self.emit_write_after_reference_check(check),
+                        };
+                    }
+                    let Some(txn_id) = self.txn_id else {
+                        return self.fail(MutateRealmPlacementError::MissingTransaction);
+                    };
+                    self.state = MutateRealmPlacementState::ReadPendingEvents {
+                        check,
+                        next_start_after,
+                    };
+                    smallvec![Effect::Storage(StorageEffect::BatchRead {
+                        reads: values
+                            .into_iter()
+                            .map(|(key, _)| (METADATA_EVENT_LOG_KEYSPACE.to_string(), key))
+                            .collect(),
+                        txn_id: Some(txn_id),
+                    })]
+                }
+                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
+                other => {
+                    self.unexpected_event("pending projection scan result", format!("{other:?}"))
+                }
+            },
+            MutateRealmPlacementState::ReadPendingEvents {
+                check,
+                next_start_after,
+            } => match event {
+                Event::Storage(StorageEvent::BatchReadResult { values }) => {
+                    for (key, value) in values {
+                        let Some(value) = value else {
+                            return self.fail(MutateRealmPlacementError::StrategyReferenced {
+                                strategy_id: check.strategy_id,
+                            });
+                        };
+                        let event: MetadataCreateEventRecord = match postcard::from_bytes(&value) {
+                            Ok(event) => event,
+                            Err(_) => {
+                                return self.fail(MutateRealmPlacementError::StrategyReferenced {
+                                    strategy_id: check.strategy_id,
+                                });
+                            }
+                        };
+                        let valid_target = metadata_pending_projection_target(key.as_ref())
+                            .is_some_and(|(document_id, event_id)| {
+                                event.record.document_id == document_id
+                                    && event.event_id == event_id
+                            });
+                        if !valid_target || self.reference_matches(&event.record, check.strategy_id)
+                        {
+                            return self.fail(MutateRealmPlacementError::StrategyReferenced {
+                                strategy_id: check.strategy_id,
+                            });
+                        }
+                    }
+                    match next_start_after {
+                        Some(start_after) => {
+                            self.emit_pending_reference_scan(check, Some(start_after))
+                        }
+                        None => self.emit_write_after_reference_check(check),
+                    }
+                }
+                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
+                other => self.unexpected_event("pending create event reads", format!("{other:?}")),
             },
             MutateRealmPlacementState::WriteDocumentAndAdminState {
                 document,
@@ -490,7 +695,13 @@ mod tests {
 
     use aruna_core::document::DocumentSyncTarget;
     use aruna_core::events::StorageEvent;
-    use aruna_core::structs::{DEFAULT_NODE_WEIGHT, DocumentClass, RealmId};
+    use aruna_core::metadata::{MetadataCreateEventPayload, MetadataCreateEventRecord};
+    use aruna_core::storage_entries::{
+        metadata_create_event_and_pending_projection_write_entries, metadata_registry_write_entries,
+    };
+    use aruna_core::structs::{
+        DEFAULT_NODE_WEIGHT, DocumentClass, MetadataRegistryRecord, PlacementRef, RealmId,
+    };
     use aruna_core::task::{TaskEffect, TaskKey};
     use aruna_core::types::UserId;
     use tempfile::tempdir;
@@ -567,6 +778,59 @@ mod tests {
             affinity: Vec::new(),
             shard_count: 64,
         }
+    }
+
+    fn create_event(
+        actor: &Actor,
+        strategy_id: Ulid,
+        document_seed: u8,
+    ) -> MetadataCreateEventRecord {
+        let document_id = Ulid::from_bytes([document_seed; 16]);
+        let event_id = Ulid::from_bytes([document_seed.wrapping_add(1); 16]);
+        MetadataCreateEventRecord {
+            event_id,
+            record: MetadataRegistryRecord {
+                realm_id: actor.realm_id,
+                group_id: Ulid::from_bytes([document_seed.wrapping_add(2); 16]),
+                document_id,
+                document_path: "datasets/referenced".to_string(),
+                graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+                public: true,
+                permission_path: "/referenced".to_string(),
+                placement: PlacementRef {
+                    strategy_id,
+                    epoch: 0,
+                    shard: 1,
+                },
+                holder_node_ids: vec![actor.node_id],
+                created_at_ms: 1,
+                updated_at_ms: 1,
+                last_event_id: event_id,
+            },
+            user_id: actor.user_id,
+            node_id: actor.node_id,
+            payload: MetadataCreateEventPayload::Scaffold {
+                name: "Referenced".to_string(),
+                description: "Strategy reference".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+            occurred_at_ms: 1,
+        }
+    }
+
+    async fn write_entries(context: &DriverContext, writes: Vec<(String, Key, Value)>) {
+        let event = context
+            .storage_handle
+            .send_storage_effect(StorageEffect::BatchWrite {
+                writes,
+                txn_id: None,
+            })
+            .await;
+        assert!(matches!(
+            event,
+            Event::Storage(StorageEvent::BatchWriteResult { .. })
+        ));
     }
 
     #[tokio::test]
@@ -789,6 +1053,72 @@ mod tests {
         let actor = actor(realm_id);
         let document = seed_config(&context, &actor).await;
         let strategy_id = document.default_strategy_id.unwrap();
+
+        assert_eq!(
+            mutate(
+                &context,
+                &actor,
+                RealmPlacementMutation::RemoveStrategy(strategy_id)
+            )
+            .await,
+            Err(MutateRealmPlacementError::StrategyReferenced { strategy_id })
+        );
+    }
+
+    #[tokio::test]
+    async fn materialized_reference_blocks() {
+        let directory = tempdir().unwrap();
+        let context = context(directory.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([14; 32]);
+        let actor = actor(realm_id);
+        seed_config(&context, &actor).await;
+        let strategy_id = Ulid::from_bytes([14; 16]);
+        mutate(
+            &context,
+            &actor,
+            RealmPlacementMutation::UpsertStrategy(strategy(strategy_id)),
+        )
+        .await
+        .unwrap();
+        let event = create_event(&actor, strategy_id, 31);
+        write_entries(
+            &context,
+            metadata_registry_write_entries(&event.record).unwrap(),
+        )
+        .await;
+
+        assert_eq!(
+            mutate(
+                &context,
+                &actor,
+                RealmPlacementMutation::RemoveStrategy(strategy_id)
+            )
+            .await,
+            Err(MutateRealmPlacementError::StrategyReferenced { strategy_id })
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_reference_blocks() {
+        let directory = tempdir().unwrap();
+        let context = context(directory.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([15; 32]);
+        let actor = actor(realm_id);
+        seed_config(&context, &actor).await;
+        let strategy_id = Ulid::from_bytes([15; 16]);
+        mutate(
+            &context,
+            &actor,
+            RealmPlacementMutation::UpsertStrategy(strategy(strategy_id)),
+        )
+        .await
+        .unwrap();
+        let event = create_event(&actor, strategy_id, 41);
+        write_entries(
+            &context,
+            metadata_create_event_and_pending_projection_write_entries(&event).unwrap(),
+        )
+        .await;
 
         assert_eq!(
             mutate(

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -28,6 +28,7 @@ use ulid::Ulid;
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::placement::placement_ref_for_target;
 use crate::sync_placement::schedule_placement_revalidation_effect;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -283,6 +284,7 @@ impl MutateRealmPlacementOperation {
             Some(&reducer_state),
         );
         let document_target = self.document_ref();
+        let placement = placement_ref_for_target(&document, &document_target, Default::default());
         let mut writes = vec![
             (
                 document_target.storage_keyspace().to_string(),
@@ -299,6 +301,7 @@ impl MutateRealmPlacementOperation {
             DocumentSyncOutboxEvent::AdminOperation {
                 event: Box::new(admin_event),
             },
+            placement,
             false,
         );
         writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -565,6 +565,7 @@ mod tests {
             replica_count: Some(2),
             distinct_locations: true,
             affinity: Vec::new(),
+            shard_count: 64,
         }
     }
 
@@ -868,6 +869,7 @@ mod tests {
             name: "affinity".to_string(),
             replica_count: None,
             distinct_locations: false,
+            shard_count: 64,
             affinity: vec![aruna_core::structs::AffinityRule {
                 matcher: aruna_core::structs::LabelMatch {
                     key: "tier".to_string(),

--- a/operations/src/notifications/placement.rs
+++ b/operations/src/notifications/placement.rs
@@ -1,7 +1,7 @@
 use aruna_core::NodeId;
 use aruna_core::errors::ConversionError;
 use aruna_core::structs::{
-    DEFAULT_BUCKET_COUNT, PlacementStrategy, RealmConfigDocument, WatchSubscription,
+    DEFAULT_SHARD_COUNT, PlacementStrategy, RealmConfigDocument, WatchSubscription,
 };
 use aruna_core::types::UserId;
 use ulid::Ulid;
@@ -26,7 +26,7 @@ fn inbox_strategy() -> PlacementStrategy {
         replica_count: Some(1),
         distinct_locations: false,
         affinity: Vec::new(),
-        bucket_count: DEFAULT_BUCKET_COUNT,
+        shard_count: DEFAULT_SHARD_COUNT,
     }
 }
 

--- a/operations/src/notifications/placement.rs
+++ b/operations/src/notifications/placement.rs
@@ -36,7 +36,7 @@ pub fn resolve_inbox_holder(
 ) -> Result<Option<NodeId>, ConversionError> {
     let view = build_view(realm_config);
     let subject = inbox_topic_id(user_id);
-    Ok(resolve_holders(&view, &inbox_strategy(), &subject, 0, None)
+    Ok(resolve_holders(&view, &inbox_strategy(), &subject, None)
         .into_iter()
         .next())
 }

--- a/operations/src/notifications/placement.rs
+++ b/operations/src/notifications/placement.rs
@@ -1,6 +1,8 @@
 use aruna_core::NodeId;
 use aruna_core::errors::ConversionError;
-use aruna_core::structs::{PlacementStrategy, RealmConfigDocument, WatchSubscription};
+use aruna_core::structs::{
+    DEFAULT_BUCKET_COUNT, PlacementStrategy, RealmConfigDocument, WatchSubscription,
+};
 use aruna_core::types::UserId;
 use ulid::Ulid;
 
@@ -24,6 +26,7 @@ fn inbox_strategy() -> PlacementStrategy {
         replica_count: Some(1),
         distinct_locations: false,
         affinity: Vec::new(),
+        bucket_count: DEFAULT_BUCKET_COUNT,
     }
 }
 

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -463,6 +463,7 @@ fn watch_upsert_replication(
                 .map_err(|error| WatchSubscriptionError::Storage(error.to_string()))?,
             change: revision,
         },
+        PlacementRef::NIL,
         false,
     );
     Ok(WatchReplication { revision, outbox })
@@ -492,6 +493,7 @@ fn watch_delete_replication(
         watch_subscription_target(owner, watch_id),
         Vec::new(),
         DocumentSyncOutboxEvent::Delete { change: revision },
+        PlacementRef::NIL,
         false,
     );
     WatchReplication { revision, outbox }

--- a/operations/src/placement/distribution.rs
+++ b/operations/src/placement/distribution.rs
@@ -58,7 +58,7 @@ fn replica_one() -> PlacementStrategy {
         replica_count: Some(1),
         distinct_locations: false,
         affinity: Vec::new(),
-        bucket_count: 64,
+        shard_count: 64,
     }
 }
 

--- a/operations/src/placement/distribution.rs
+++ b/operations/src/placement/distribution.rs
@@ -58,6 +58,7 @@ fn replica_one() -> PlacementStrategy {
         replica_count: Some(1),
         distinct_locations: false,
         affinity: Vec::new(),
+        bucket_count: 64,
     }
 }
 

--- a/operations/src/placement/distribution.rs
+++ b/operations/src/placement/distribution.rs
@@ -63,7 +63,7 @@ fn replica_one() -> PlacementStrategy {
 }
 
 fn top_holder(view: &PlacementView, strategy: &PlacementStrategy, counter: u64) -> NodeId {
-    resolve_holders(view, strategy, &subject(counter), 0, None)[0]
+    resolve_holders(view, strategy, &subject(counter), None)[0]
 }
 
 fn share_of(view: &PlacementView, strategy: &PlacementStrategy, seed: u8) -> f64 {

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -6,7 +6,7 @@ pub mod selector;
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
 use aruna_core::structs::{
-    PlacementOverride, PlacementRef, PlacementStrategy, RealmConfigDocument, bucket_for_subject,
+    PlacementOverride, PlacementRef, PlacementStrategy, RealmConfigDocument, shard_for_subject,
 };
 
 pub use resolver::{
@@ -14,28 +14,28 @@ pub use resolver::{
     resolve_holders, strategy_for_target, subject_bytes,
 };
 
-/// Canonical rendezvous subject for a bucket's holder resolution:
-/// `strategy_id(16) ‖ epoch(8, little-endian) ‖ bucket(4, big-endian)`. Every
-/// document hashing into the bucket resolves the same holder set from this, so
-/// one sync topic per bucket has one authoritative holder set (unlike stage 1,
+/// Canonical rendezvous subject for a shard's holder resolution:
+/// `strategy_id(16) ‖ epoch(8, little-endian) ‖ shard(4, big-endian)`. Every
+/// document hashing into the shard resolves the same holder set from this, so
+/// one sync topic per shard has one authoritative holder set (unlike stage 1,
 /// where the rendezvous subject was the individual document).
-pub fn bucket_subject_bytes(placement: &PlacementRef) -> Vec<u8> {
+pub fn shard_subject_bytes(placement: &PlacementRef) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(28);
     bytes.extend_from_slice(&placement.strategy_id.to_bytes());
     bytes.extend_from_slice(&placement.epoch.to_le_bytes());
-    bytes.extend_from_slice(&placement.bucket.to_be_bytes());
+    bytes.extend_from_slice(&placement.shard.to_be_bytes());
     bytes
 }
 
-/// Holder pin/exclude override for a bucket: matched on the bucket subject, not
-/// a document subject, because one bucket topic has exactly one holder set.
+/// Holder pin/exclude override for a shard: matched on the shard subject, not
+/// a document subject, because one shard topic has exactly one holder set.
 /// Per-document overrides still steer strategy selection (see
 /// [`strategy_for_target`]); their pin/exclude lists are inert for holders.
-fn bucket_override<'a>(
+fn shard_override<'a>(
     config: &'a RealmConfigDocument,
     placement: &PlacementRef,
 ) -> Option<&'a PlacementOverride> {
-    let subject = bucket_subject_bytes(placement);
+    let subject = shard_subject_bytes(placement);
     config
         .placement_overrides
         .iter()
@@ -57,14 +57,14 @@ pub fn placement_ref_for_target(
         Some((strategy, _)) => PlacementRef {
             strategy_id: strategy.strategy_id,
             epoch: 0,
-            bucket: bucket_for_subject(&subject_bytes(target), strategy.bucket_count),
+            shard: shard_for_subject(&subject_bytes(target), strategy.shard_count),
         },
         None => PlacementRef::NIL,
     }
 }
 
-/// Placement plan for a document `target`: its bucket's rank-ordered holder set
-/// (the same set every document in the bucket resolves), the nominal replica
+/// Placement plan for a document `target`: its shard's rank-ordered holder set
+/// (the same set every document in the shard resolves), the nominal replica
 /// target the pending machinery tops up toward, and the envelope reference.
 /// `None` when no strategy governs the target.
 pub struct TargetPlacementPlan {
@@ -82,9 +82,9 @@ pub fn plan_target_placement(
     let placement = PlacementRef {
         strategy_id: strategy.strategy_id,
         epoch: 0,
-        bucket: bucket_for_subject(&subject_bytes(target), strategy.bucket_count),
+        shard: shard_for_subject(&subject_bytes(target), strategy.shard_count),
     };
-    let holders = resolve_bucket_holders_with(config, strategy, &placement);
+    let holders = resolve_shard_holders_with(config, strategy, &placement);
     let desired_count = match strategy.replica_count {
         Some(count) => count as usize,
         None => holders.len(),
@@ -96,9 +96,9 @@ pub fn plan_target_placement(
     })
 }
 
-/// Full eligible-node ranking for the bucket that `target` hashes into
+/// Full eligible-node ranking for the shard that `target` hashes into
 /// (ignoring the strategy's replica cap) so callers can top up beyond
-/// `replica_count`. Rank order is the bucket's, not the individual document's.
+/// `replica_count`. Rank order is the shard's, not the individual document's.
 pub fn rank_eligible_holders(
     config: &RealmConfigDocument,
     target: &DocumentSyncTarget,
@@ -110,7 +110,7 @@ pub fn rank_eligible_holders(
     let placement = PlacementRef {
         strategy_id: strategy.strategy_id,
         epoch: 0,
-        bucket: bucket_for_subject(&subject_bytes(target), strategy.bucket_count),
+        shard: shard_for_subject(&subject_bytes(target), strategy.shard_count),
     };
     let mut uncapped = strategy.clone();
     uncapped.replica_count = None;
@@ -118,28 +118,28 @@ pub fn rank_eligible_holders(
     resolve_holders(
         &view,
         &uncapped,
-        &bucket_subject_bytes(&placement),
+        &shard_subject_bytes(&placement),
         placement.epoch,
-        bucket_override(config, &placement),
+        shard_override(config, &placement),
     )
 }
 
-/// Rank-ordered holders of a specific bucket (capped by the strategy's
+/// Rank-ordered holders of a specific shard (capped by the strategy's
 /// `replica_count`, or all eligible for an everywhere strategy). Used by the
 /// placement reconciler and the startup restore to enumerate the co-holders of
-/// each bucket the local node is responsible for. Returns `Vec::new()` when the
+/// each shard the local node is responsible for. Returns `Vec::new()` when the
 /// referenced strategy is unknown.
-pub fn resolve_bucket_holders(
+pub fn resolve_shard_holders(
     config: &RealmConfigDocument,
     placement: &PlacementRef,
 ) -> Vec<NodeId> {
     let Some(strategy) = config.strategy(&placement.strategy_id) else {
         return Vec::new();
     };
-    resolve_bucket_holders_with(config, strategy, placement)
+    resolve_shard_holders_with(config, strategy, placement)
 }
 
-fn resolve_bucket_holders_with(
+fn resolve_shard_holders_with(
     config: &RealmConfigDocument,
     strategy: &PlacementStrategy,
     placement: &PlacementRef,
@@ -148,9 +148,9 @@ fn resolve_bucket_holders_with(
     resolve_holders(
         &view,
         strategy,
-        &bucket_subject_bytes(placement),
+        &shard_subject_bytes(placement),
         placement.epoch,
-        bucket_override(config, placement),
+        shard_override(config, placement),
     )
 }
 
@@ -172,7 +172,7 @@ mod tests {
             replica_count: Some(2),
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
         config.strategies = vec![strategy.clone()];
@@ -184,35 +184,35 @@ mod tests {
             PlacementRef {
                 strategy_id: strategy.strategy_id,
                 epoch: 0,
-                bucket: 7,
+                shard: 7,
             },
         )
     }
 
     #[test]
-    fn bucket_subject_override_pins_and_excludes_holders() {
+    fn shard_subject_override_pins_and_excludes_holders() {
         let (mut config, placement) = config_and_placement();
-        let baseline = resolve_bucket_holders(&config, &placement);
+        let baseline = resolve_shard_holders(&config, &placement);
         assert_eq!(baseline.len(), 2);
 
         let pinned = *baseline.last().unwrap();
         let excluded = baseline[0];
         config.placement_overrides = vec![PlacementOverride {
-            subject: bucket_subject_bytes(&placement),
+            subject: shard_subject_bytes(&placement),
             pinned: vec![pinned],
             excluded: vec![excluded],
             strategy_id: None,
         }];
 
-        let overridden = resolve_bucket_holders(&config, &placement);
+        let overridden = resolve_shard_holders(&config, &placement);
         assert_eq!(overridden[0], pinned);
         assert!(!overridden.contains(&excluded));
     }
 
     #[test]
-    fn document_subject_override_does_not_touch_bucket_holders() {
+    fn document_subject_override_does_not_touch_shard_holders() {
         let (mut config, placement) = config_and_placement();
-        let baseline = resolve_bucket_holders(&config, &placement);
+        let baseline = resolve_shard_holders(&config, &placement);
 
         // Same pin/exclude, but keyed by a document subject: holder resolution
         // ignores it (strategy selection is its only remaining effect).
@@ -223,6 +223,6 @@ mod tests {
             strategy_id: None,
         }];
 
-        assert_eq!(resolve_bucket_holders(&config, &placement), baseline);
+        assert_eq!(resolve_shard_holders(&config, &placement), baseline);
     }
 }

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -5,12 +5,42 @@ pub mod selector;
 
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
-use aruna_core::structs::{PlacementRef, RealmConfigDocument, bucket_for_subject};
+use aruna_core::structs::{
+    PlacementOverride, PlacementRef, PlacementStrategy, RealmConfigDocument, bucket_for_subject,
+};
 
 pub use resolver::{
     PlacementResolutionContext, PlacementView, ResolvedNode, build_view, document_class,
     resolve_holders, strategy_for_target, subject_bytes,
 };
+
+/// Canonical rendezvous subject for a bucket's holder resolution:
+/// `strategy_id(16) ‖ epoch(8, little-endian) ‖ bucket(4, big-endian)`. Every
+/// document hashing into the bucket resolves the same holder set from this, so
+/// one sync topic per bucket has one authoritative holder set (unlike stage 1,
+/// where the rendezvous subject was the individual document).
+pub fn bucket_subject_bytes(placement: &PlacementRef) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(28);
+    bytes.extend_from_slice(&placement.strategy_id.to_bytes());
+    bytes.extend_from_slice(&placement.epoch.to_le_bytes());
+    bytes.extend_from_slice(&placement.bucket.to_be_bytes());
+    bytes
+}
+
+/// Holder pin/exclude override for a bucket: matched on the bucket subject, not
+/// a document subject, because one bucket topic has exactly one holder set.
+/// Per-document overrides still steer strategy selection (see
+/// [`strategy_for_target`]); their pin/exclude lists are inert for holders.
+fn bucket_override<'a>(
+    config: &'a RealmConfigDocument,
+    placement: &PlacementRef,
+) -> Option<&'a PlacementOverride> {
+    let subject = bucket_subject_bytes(placement);
+    config
+        .placement_overrides
+        .iter()
+        .find(|over| over.subject == subject)
+}
 
 /// Placement reference stamped into a change's sync envelope for `target`.
 ///
@@ -33,11 +63,10 @@ pub fn placement_ref_for_target(
     }
 }
 
-/// Placement plan for a whole-document sync `target`: the currently achievable
-/// rank-ordered holder set, the nominal replica target the pending machinery
-/// tops up toward (`replica_count`, or all eligible for the everywhere
-/// strategy), and the envelope reference. `None` when no strategy governs the
-/// target.
+/// Placement plan for a document `target`: its bucket's rank-ordered holder set
+/// (the same set every document in the bucket resolves), the nominal replica
+/// target the pending machinery tops up toward, and the envelope reference.
+/// `None` when no strategy governs the target.
 pub struct TargetPlacementPlan {
     pub holders: Vec<NodeId>,
     pub desired_count: usize,
@@ -49,10 +78,13 @@ pub fn plan_target_placement(
     target: &DocumentSyncTarget,
     context: PlacementResolutionContext<'_>,
 ) -> Option<TargetPlacementPlan> {
-    let (strategy, override_) = strategy_for_target(config, target, context)?;
-    let subject = subject_bytes(target);
-    let view = build_view(config);
-    let holders = resolve_holders(&view, strategy, &subject, 0, override_);
+    let (strategy, _override) = strategy_for_target(config, target, context)?;
+    let placement = PlacementRef {
+        strategy_id: strategy.strategy_id,
+        epoch: 0,
+        bucket: bucket_for_subject(&subject_bytes(target), strategy.bucket_count),
+    };
+    let holders = resolve_bucket_holders_with(config, strategy, &placement);
     let desired_count = match strategy.replica_count {
         Some(count) => count as usize,
         None => holders.len(),
@@ -60,53 +92,137 @@ pub fn plan_target_placement(
     Some(TargetPlacementPlan {
         holders,
         desired_count,
-        placement: PlacementRef {
-            strategy_id: strategy.strategy_id,
-            epoch: 0,
-            bucket: bucket_for_subject(&subject, strategy.bucket_count),
-        },
+        placement,
     })
 }
 
-/// Full eligible-node ranking for `target` (ignoring the strategy's replica
-/// cap) so callers can top up beyond `replica_count`. Preserves affinity and
-/// `distinct_locations` eligibility from the resolved strategy.
+/// Full eligible-node ranking for the bucket that `target` hashes into
+/// (ignoring the strategy's replica cap) so callers can top up beyond
+/// `replica_count`. Rank order is the bucket's, not the individual document's.
 pub fn rank_eligible_holders(
     config: &RealmConfigDocument,
     target: &DocumentSyncTarget,
     context: PlacementResolutionContext<'_>,
 ) -> Vec<NodeId> {
-    rank_eligible_holders_excluding(config, target, context, &[])
-}
-
-pub fn rank_eligible_holders_excluding(
-    config: &RealmConfigDocument,
-    target: &DocumentSyncTarget,
-    context: PlacementResolutionContext<'_>,
-    excluded: &[NodeId],
-) -> Vec<NodeId> {
-    let Some((strategy, override_)) = strategy_for_target(config, target, context) else {
+    let Some((strategy, _override)) = strategy_for_target(config, target, context) else {
         return Vec::new();
+    };
+    let placement = PlacementRef {
+        strategy_id: strategy.strategy_id,
+        epoch: 0,
+        bucket: bucket_for_subject(&subject_bytes(target), strategy.bucket_count),
     };
     let mut uncapped = strategy.clone();
     uncapped.replica_count = None;
-    let mut effective_override = override_.cloned();
-    if !excluded.is_empty() {
-        let override_ =
-            effective_override.get_or_insert_with(|| aruna_core::structs::PlacementOverride {
-                subject: subject_bytes(target),
-                pinned: Vec::new(),
-                excluded: Vec::new(),
-                strategy_id: None,
-            });
-        override_.excluded.extend_from_slice(excluded);
-    }
     let view = build_view(config);
     resolve_holders(
         &view,
         &uncapped,
-        &subject_bytes(target),
-        0,
-        effective_override.as_ref().or(override_),
+        &bucket_subject_bytes(&placement),
+        placement.epoch,
+        bucket_override(config, &placement),
     )
+}
+
+/// Rank-ordered holders of a specific bucket (capped by the strategy's
+/// `replica_count`, or all eligible for an everywhere strategy). Used by the
+/// placement reconciler and the startup restore to enumerate the co-holders of
+/// each bucket the local node is responsible for. Returns `Vec::new()` when the
+/// referenced strategy is unknown.
+pub fn resolve_bucket_holders(
+    config: &RealmConfigDocument,
+    placement: &PlacementRef,
+) -> Vec<NodeId> {
+    let Some(strategy) = config.strategy(&placement.strategy_id) else {
+        return Vec::new();
+    };
+    resolve_bucket_holders_with(config, strategy, placement)
+}
+
+fn resolve_bucket_holders_with(
+    config: &RealmConfigDocument,
+    strategy: &PlacementStrategy,
+    placement: &PlacementRef,
+) -> Vec<NodeId> {
+    let view = build_view(config);
+    resolve_holders(
+        &view,
+        strategy,
+        &bucket_subject_bytes(placement),
+        placement.epoch,
+        bucket_override(config, placement),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_core::structs::{RealmId, RealmNodeKind};
+    use ulid::Ulid;
+
+    fn node(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    fn config_and_placement() -> (RealmConfigDocument, PlacementRef) {
+        let mut config = RealmConfigDocument::new(RealmId::from_bytes([3u8; 32]), Vec::new(), 3);
+        let strategy = PlacementStrategy {
+            strategy_id: Ulid::from_bytes([5u8; 16]),
+            name: "default".to_string(),
+            replica_count: Some(2),
+            distinct_locations: false,
+            affinity: Vec::new(),
+            bucket_count: 64,
+        };
+        config.default_strategy_id = Some(strategy.strategy_id);
+        config.strategies = vec![strategy.clone()];
+        for seed in 1..=4u8 {
+            config.ensure_node(node(seed), RealmNodeKind::Server);
+        }
+        (
+            config,
+            PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                bucket: 7,
+            },
+        )
+    }
+
+    #[test]
+    fn bucket_subject_override_pins_and_excludes_holders() {
+        let (mut config, placement) = config_and_placement();
+        let baseline = resolve_bucket_holders(&config, &placement);
+        assert_eq!(baseline.len(), 2);
+
+        let pinned = *baseline.last().unwrap();
+        let excluded = baseline[0];
+        config.placement_overrides = vec![PlacementOverride {
+            subject: bucket_subject_bytes(&placement),
+            pinned: vec![pinned],
+            excluded: vec![excluded],
+            strategy_id: None,
+        }];
+
+        let overridden = resolve_bucket_holders(&config, &placement);
+        assert_eq!(overridden[0], pinned);
+        assert!(!overridden.contains(&excluded));
+    }
+
+    #[test]
+    fn document_subject_override_does_not_touch_bucket_holders() {
+        let (mut config, placement) = config_and_placement();
+        let baseline = resolve_bucket_holders(&config, &placement);
+
+        // Same pin/exclude, but keyed by a document subject: holder resolution
+        // ignores it (strategy selection is its only remaining effect).
+        config.placement_overrides = vec![PlacementOverride {
+            subject: Ulid::from_bytes([9u8; 16]).to_bytes().to_vec(),
+            pinned: vec![*baseline.last().unwrap()],
+            excluded: vec![baseline[0]],
+            strategy_id: None,
+        }];
+
+        assert_eq!(resolve_bucket_holders(&config, &placement), baseline);
+    }
 }

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -9,6 +9,8 @@ use aruna_core::structs::{
     PlacementOverride, PlacementRef, PlacementStrategy, RealmConfigDocument, shard_for_subject,
 };
 
+use crate::placement::selector::{ROLE_SHARD, rank_weighted};
+
 pub use resolver::{
     PlacementResolutionContext, PlacementView, ResolvedNode, build_view, document_class,
     resolve_holders, strategy_for_target, subject_bytes,
@@ -139,6 +141,47 @@ pub fn resolve_shard_holders(
     resolve_shard_holders_with(config, strategy, placement)
 }
 
+/// Buckets of `strategy` that `node_id` is a holder of. Empty when the node is
+/// not sync-eligible, is unknown to the config, or is filtered out everywhere.
+pub fn held_buckets(
+    config: &RealmConfigDocument,
+    strategy: &PlacementStrategy,
+    node_id: NodeId,
+) -> Vec<u32> {
+    (0..strategy.shard_count)
+        .filter(|shard| {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard: *shard,
+            };
+            resolve_shard_holders_with(config, strategy, &placement).contains(&node_id)
+        })
+        .collect()
+}
+
+/// Bucket the create-receiving node picks for `subject`: the best-ranked of the
+/// buckets it already holds, so the origin is always a holder of the bucket it
+/// stamps and can always publish onto that bucket's topic. Weighted rendezvous
+/// on the subject spreads one node's documents across all its held buckets.
+/// `None` when the origin holds no bucket of the strategy.
+pub fn choose_origin_bucket(
+    config: &RealmConfigDocument,
+    strategy: &PlacementStrategy,
+    origin: NodeId,
+    subject: &[u8],
+) -> Option<PlacementRef> {
+    let held = held_buckets(config, strategy, origin);
+    let candidates: Vec<([u8; 4], u64)> =
+        held.iter().map(|shard| (shard.to_be_bytes(), 1)).collect();
+    let best = *rank_weighted(ROLE_SHARD, 0, subject, &candidates).first()?;
+    Some(PlacementRef {
+        strategy_id: strategy.strategy_id,
+        epoch: 0,
+        shard: held[best],
+    })
+}
+
 fn resolve_shard_holders_with(
     config: &RealmConfigDocument,
     strategy: &PlacementStrategy,
@@ -187,6 +230,85 @@ mod tests {
                 shard: 7,
             },
         )
+    }
+
+    fn strategy_of(config: &RealmConfigDocument) -> &PlacementStrategy {
+        config
+            .strategy(&config.default_strategy_id.expect("default strategy"))
+            .expect("default strategy resolves")
+    }
+
+    fn subject(seed: u64) -> [u8; 32] {
+        *blake3::hash(&seed.to_le_bytes()).as_bytes()
+    }
+
+    #[test]
+    fn origin_bucket_is_deterministic() {
+        let (config, _) = config_and_placement();
+        let strategy = strategy_of(&config);
+        let first = choose_origin_bucket(&config, strategy, node(1), &subject(1));
+        let second = choose_origin_bucket(&config, strategy, node(1), &subject(1));
+        assert_eq!(first, second);
+        assert_eq!(
+            first.expect("origin holds buckets").strategy_id,
+            strategy.strategy_id
+        );
+    }
+
+    #[test]
+    fn origin_holds_chosen_bucket() {
+        let (config, _) = config_and_placement();
+        let strategy = strategy_of(&config);
+        // Replica 2 of 4 nodes: no node holds every bucket, so a blind hash
+        // would land outside the origin's held set for some subjects.
+        let held = held_buckets(&config, strategy, node(1));
+        assert!(!held.is_empty() && held.len() < strategy.shard_count as usize);
+        for seed in 0..256u64 {
+            let placement = choose_origin_bucket(&config, strategy, node(1), &subject(seed))
+                .expect("origin holds buckets");
+            assert!(held.contains(&placement.shard));
+            assert!(resolve_shard_holders(&config, &placement).contains(&node(1)));
+        }
+    }
+
+    #[test]
+    fn origin_buckets_spread() {
+        let (config, _) = config_and_placement();
+        let strategy = strategy_of(&config);
+        let held = held_buckets(&config, strategy, node(1));
+        let chosen: std::collections::HashSet<u32> = (0..1_000u64)
+            .filter_map(|seed| choose_origin_bucket(&config, strategy, node(1), &subject(seed)))
+            .map(|placement| placement.shard)
+            .collect();
+        assert!(
+            chosen.len() * 2 > held.len(),
+            "chosen {} of {} held buckets",
+            chosen.len(),
+            held.len()
+        );
+    }
+
+    #[test]
+    fn unknown_origin_holds_nothing() {
+        let (config, _) = config_and_placement();
+        let strategy = strategy_of(&config);
+        assert!(held_buckets(&config, strategy, node(9)).is_empty());
+        assert_eq!(
+            choose_origin_bucket(&config, strategy, node(9), &subject(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn user_origin_holds_nothing() {
+        let (mut config, _) = config_and_placement();
+        config.ensure_node(node(5), RealmNodeKind::User);
+        let strategy = strategy_of(&config);
+        assert!(held_buckets(&config, strategy, node(5)).is_empty());
+        assert_eq!(
+            choose_origin_bucket(&config, strategy, node(5), &subject(1)),
+            None
+        );
     }
 
     #[test]

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -141,6 +141,22 @@ pub fn resolve_shard_holders(
     resolve_shard_holders_with(config, strategy, placement)
 }
 
+/// Whether `node_id` holds `placement`, and may therefore publish onto its
+/// topic. An empty holder set means no strategy governs the bucket (early
+/// bootstrap, [`PlacementRef::NIL`]): nobody shards it, so it is nobody's to
+/// withhold and the local node counts as a holder.
+///
+/// The presence of a local copy of a document is never evidence of holdership:
+/// a rebalance leaves a stale copy behind on a node that is no longer a holder.
+pub fn holds_placement(
+    config: &RealmConfigDocument,
+    placement: &PlacementRef,
+    node_id: NodeId,
+) -> bool {
+    let holders = resolve_shard_holders(config, placement);
+    holders.is_empty() || holders.contains(&node_id)
+}
+
 /// Buckets of `strategy` that `node_id` is a holder of. Empty when the node is
 /// not sync-eligible, is unknown to the config, or is filtered out everywhere.
 pub fn held_buckets(

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -167,6 +167,86 @@ pub fn resolve_shard_holders(
     resolve_shard_holders_with(config, strategy, placement)
 }
 
+/// First `(strategy, shard)` whose holder set is non-empty both before and after
+/// a config change yet shares no holder: a disjoint transition that would strand
+/// the shard's history and let a new holder mint a rival genesis. Interim
+/// [BR-025] guard until the staged handoff protocol (#264) lands; at least one
+/// current holder must remain until the new holders have verified.
+pub fn first_disjoint_shard_transition(
+    pre: &RealmConfigDocument,
+    post: &RealmConfigDocument,
+) -> Option<PlacementRef> {
+    let pre_view = build_view(pre);
+    let post_view = build_view(post);
+    for strategy in &post.strategies {
+        let Some(pre_strategy) = pre.strategy(&strategy.strategy_id) else {
+            continue;
+        };
+        for shard in 0..strategy.shard_count {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard,
+            };
+            let pre_holders =
+                resolve_shard_holders_from_view(pre, &pre_view, pre_strategy, &placement);
+            if pre_holders.is_empty() {
+                continue;
+            }
+            let post_holders =
+                resolve_shard_holders_from_view(post, &post_view, strategy, &placement);
+            if post_holders.is_empty() {
+                continue;
+            }
+            if !pre_holders.iter().any(|node| post_holders.contains(node)) {
+                return Some(placement);
+            }
+        }
+    }
+    None
+}
+
+/// First shard of a referenced strategy that resolves to zero holders while the
+/// realm still has usable capacity: a filter, affinity, or override that leaves
+/// documents routed to it with nowhere to live. Bootstrap, full drain, and
+/// all-full realms have no usable node and are not flagged (fail-early for a
+/// genuine misconfiguration, not for an empty realm).
+pub fn first_empty_referenced_shard(config: &RealmConfigDocument) -> Option<PlacementRef> {
+    let view = build_view(config);
+    let has_capacity = view.nodes.iter().any(|node| {
+        node.kind.is_sync_eligible() && !node.full && !node.draining && node.weight > 0
+    });
+    if !has_capacity {
+        return None;
+    }
+    for strategy in &config.strategies {
+        let id = strategy.strategy_id;
+        let referenced = config.default_strategy_id == Some(id)
+            || config
+                .strategy_bindings
+                .iter()
+                .any(|binding| binding.strategy_id == id)
+            || config
+                .placement_overrides
+                .iter()
+                .any(|record| record.strategy_id == Some(id));
+        if !referenced {
+            continue;
+        }
+        for shard in 0..strategy.shard_count {
+            let placement = PlacementRef {
+                strategy_id: id,
+                epoch: 0,
+                shard,
+            };
+            if resolve_shard_holders_from_view(config, &view, strategy, &placement).is_empty() {
+                return Some(placement);
+            }
+        }
+    }
+    None
+}
+
 /// Whether `node_id` holds `placement`, and may therefore publish onto its
 /// topic. [`PlacementRef::NIL`] means no strategy governs the bucket during
 /// early bootstrap: nobody shards it, so it is nobody's to withhold and the

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -6,7 +6,8 @@ pub mod selector;
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
 use aruna_core::structs::{
-    PlacementOverride, PlacementRef, PlacementStrategy, RealmConfigDocument, shard_for_subject,
+    DocumentClass, PlacementOverride, PlacementRef, PlacementStrategy, RealmConfigDocument,
+    shard_for_subject,
 };
 
 use crate::placement::selector::{ROLE_SHARD, rank_weighted};
@@ -67,27 +68,28 @@ pub fn placement_ref_for_target(
 
 /// Bucket the document's registry row rides.
 ///
-/// Resolved for the registry target itself, not for the document's own bucket:
-/// the registry class is bound "everywhere" so every node carries the row, while
-/// the document's bucket is replica-capped and reaches only its holders. The
-/// document path is deliberately not passed — a path-prefix binding steers where
-/// the *document* lives, and letting it cap the registry row too would put the
-/// row back out of reach of the nodes that need it to route.
+/// Resolved directly from the registry class, not from the document's general
+/// precedence chain: the registry class is bound "everywhere" so every node
+/// carries the row, while the document's bucket is replica-capped and reaches
+/// only its holders. Document overrides and group/path bindings steer where the
+/// *document* lives and must not cap the registry row too.
 pub fn registry_placement(
     config: &RealmConfigDocument,
     record: &aruna_core::structs::MetadataRegistryRecord,
 ) -> PlacementRef {
-    placement_ref_for_target(
-        config,
-        &DocumentSyncTarget::MetadataRegistry {
-            group_id: record.group_id,
-            document_id: record.document_id,
-        },
-        PlacementResolutionContext {
-            group_id: Some(record.group_id),
-            metadata_path: None,
-        },
-    )
+    let Some(strategy) = resolver::strategy_for_class(config, DocumentClass::MetadataRegistry)
+    else {
+        return PlacementRef::NIL;
+    };
+    let target = DocumentSyncTarget::MetadataRegistry {
+        group_id: record.group_id,
+        document_id: record.document_id,
+    };
+    PlacementRef {
+        strategy_id: strategy.strategy_id,
+        epoch: 0,
+        shard: shard_for_subject(&subject_bytes(&target), strategy.shard_count),
+    }
 }
 
 /// Placement plan for a document `target`: its shard's rank-ordered holder set
@@ -239,7 +241,9 @@ fn resolve_shard_holders_with(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aruna_core::structs::{RealmId, RealmNodeKind};
+    use aruna_core::structs::{
+        BindingScope, MetadataRegistryRecord, RealmId, RealmNodeKind, StrategyBinding,
+    };
     use ulid::Ulid;
 
     fn node(seed: u8) -> NodeId {
@@ -279,6 +283,79 @@ mod tests {
 
     fn subject(seed: u64) -> [u8; 32] {
         *blake3::hash(&seed.to_le_bytes()).as_bytes()
+    }
+
+    #[test]
+    fn registry_uses_class() {
+        let (mut config, _) = config_and_placement();
+        let group_id = Ulid::from_bytes([6u8; 16]);
+        let document_id = Ulid::from_bytes([7u8; 16]);
+        let general_strategy_id = config.default_strategy_id.unwrap();
+        let class_strategy = PlacementStrategy {
+            strategy_id: Ulid::from_bytes([8u8; 16]),
+            name: "registry".to_string(),
+            replica_count: None,
+            distinct_locations: false,
+            affinity: Vec::new(),
+            shard_count: 16,
+        };
+        config.strategies.push(class_strategy.clone());
+        config.strategy_bindings = vec![
+            StrategyBinding {
+                scope: BindingScope::Group(group_id),
+                strategy_id: general_strategy_id,
+            },
+            StrategyBinding {
+                scope: BindingScope::Class(DocumentClass::MetadataRegistry),
+                strategy_id: class_strategy.strategy_id,
+            },
+        ];
+        config.placement_overrides = vec![PlacementOverride {
+            subject: document_id.to_bytes().to_vec(),
+            pinned: Vec::new(),
+            excluded: Vec::new(),
+            strategy_id: Some(general_strategy_id),
+        }];
+        let record = MetadataRegistryRecord {
+            realm_id: RealmId::from_bytes([3u8; 32]),
+            group_id,
+            document_id,
+            document_path: "datasets/example".to_string(),
+            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+            public: false,
+            permission_path: String::new(),
+            placement: PlacementRef::NIL,
+            holder_node_ids: Vec::new(),
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            last_event_id: Ulid::from_bytes([9u8; 16]),
+        };
+
+        let placement = registry_placement(&config, &record);
+        assert_eq!(placement.strategy_id, class_strategy.strategy_id);
+        assert_eq!(
+            placement.shard,
+            shard_for_subject(&document_id.to_bytes(), class_strategy.shard_count)
+        );
+
+        config.strategy_bindings[1].strategy_id = Ulid::from_bytes([99u8; 16]);
+        assert_eq!(registry_placement(&config, &record), PlacementRef::NIL);
+
+        config.strategy_bindings.truncate(1);
+        let fallback = registry_placement(&config, &record);
+        assert_eq!(fallback.strategy_id, config.default_strategy_id.unwrap());
+
+        config.default_strategy_id = Some(Ulid::from_bytes([99u8; 16]));
+        assert_eq!(registry_placement(&config, &record), PlacementRef::NIL);
+
+        config.default_strategy_id = None;
+        assert_eq!(
+            registry_placement(&config, &record).strategy_id,
+            config.strategies[0].strategy_id
+        );
+
+        config.strategies.clear();
+        assert_eq!(registry_placement(&config, &record), PlacementRef::NIL);
     }
 
     #[test]

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -13,18 +13,18 @@ use crate::placement::selector::{ROLE_SHARD, rank_weighted};
 
 pub use resolver::{
     PlacementResolutionContext, PlacementView, ResolvedNode, build_view, document_class,
-    resolve_holders, strategy_for_target, subject_bytes,
+    meta_bucket_subject, resolve_holders, strategy_for_target, subject_bytes,
 };
 
 /// Canonical rendezvous subject for a shard's holder resolution:
-/// `strategy_id(16) ‖ epoch(8, little-endian) ‖ shard(4, big-endian)`. Every
-/// document hashing into the shard resolves the same holder set from this, so
-/// one sync topic per shard has one authoritative holder set (unlike stage 1,
-/// where the rendezvous subject was the individual document).
+/// `strategy_id(16) ‖ shard(4, big-endian)`. The epoch is deliberately excluded
+/// (spec 6.3.1): the holder set is a pure function of the bucket, so a rebalance
+/// stays a map change and never a per-document rewrite. Every document hashing
+/// into the shard resolves the same holder set from this, so one sync topic per
+/// shard has one authoritative holder set.
 pub fn shard_subject_bytes(placement: &PlacementRef) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(28);
+    let mut bytes = Vec::with_capacity(20);
     bytes.extend_from_slice(&placement.strategy_id.to_bytes());
-    bytes.extend_from_slice(&placement.epoch.to_le_bytes());
     bytes.extend_from_slice(&placement.shard.to_be_bytes());
     bytes
 }
@@ -146,7 +146,6 @@ pub fn rank_eligible_holders(
         &view,
         &uncapped,
         &shard_subject_bytes(&placement),
-        placement.epoch,
         shard_override(config, &placement),
     )
 }
@@ -215,7 +214,7 @@ pub fn choose_origin_bucket(
     let held = held_buckets(config, strategy, origin);
     let candidates: Vec<([u8; 4], u64)> =
         held.iter().map(|shard| (shard.to_be_bytes(), 1)).collect();
-    let best = *rank_weighted(ROLE_SHARD, 0, subject, &candidates).first()?;
+    let best = *rank_weighted(ROLE_SHARD, subject, &candidates).first()?;
     Some(PlacementRef {
         strategy_id: strategy.strategy_id,
         epoch: 0,
@@ -233,7 +232,6 @@ fn resolve_shard_holders_with(
         &view,
         strategy,
         &shard_subject_bytes(placement),
-        placement.epoch,
         shard_override(config, placement),
     )
 }

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -5,7 +5,7 @@ pub mod selector;
 
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
-use aruna_core::structs::{PlacementRef, RealmConfigDocument};
+use aruna_core::structs::{PlacementRef, RealmConfigDocument, bucket_for_subject};
 
 pub use resolver::{
     PlacementResolutionContext, PlacementView, ResolvedNode, build_view, document_class,
@@ -27,6 +27,7 @@ pub fn placement_ref_for_target(
         Some((strategy, _)) => PlacementRef {
             strategy_id: strategy.strategy_id,
             epoch: 0,
+            bucket: bucket_for_subject(&subject_bytes(target), strategy.bucket_count),
         },
         None => PlacementRef::NIL,
     }
@@ -49,8 +50,9 @@ pub fn plan_target_placement(
     context: PlacementResolutionContext<'_>,
 ) -> Option<TargetPlacementPlan> {
     let (strategy, override_) = strategy_for_target(config, target, context)?;
+    let subject = subject_bytes(target);
     let view = build_view(config);
-    let holders = resolve_holders(&view, strategy, &subject_bytes(target), 0, override_);
+    let holders = resolve_holders(&view, strategy, &subject, 0, override_);
     let desired_count = match strategy.replica_count {
         Some(count) => count as usize,
         None => holders.len(),
@@ -61,6 +63,7 @@ pub fn plan_target_placement(
         placement: PlacementRef {
             strategy_id: strategy.strategy_id,
             epoch: 0,
+            bucket: bucket_for_subject(&subject, strategy.bucket_count),
         },
     })
 }

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -190,6 +190,7 @@ pub fn held_buckets(
     strategy: &PlacementStrategy,
     node_id: NodeId,
 ) -> Vec<u32> {
+    let view = build_view(config);
     (0..strategy.shard_count)
         .filter(|shard| {
             let placement = PlacementRef {
@@ -197,7 +198,7 @@ pub fn held_buckets(
                 epoch: 0,
                 shard: *shard,
             };
-            resolve_shard_holders_with(config, strategy, &placement).contains(&node_id)
+            resolve_shard_holders_from_view(config, &view, strategy, &placement).contains(&node_id)
         })
         .collect()
 }
@@ -230,8 +231,17 @@ fn resolve_shard_holders_with(
     placement: &PlacementRef,
 ) -> Vec<NodeId> {
     let view = build_view(config);
+    resolve_shard_holders_from_view(config, &view, strategy, placement)
+}
+
+fn resolve_shard_holders_from_view(
+    config: &RealmConfigDocument,
+    view: &PlacementView,
+    strategy: &PlacementStrategy,
+    placement: &PlacementRef,
+) -> Vec<NodeId> {
     resolve_holders(
-        &view,
+        view,
         strategy,
         &shard_subject_bytes(placement),
         shard_override(config, placement),

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -65,6 +65,31 @@ pub fn placement_ref_for_target(
     }
 }
 
+/// Bucket the document's registry row rides.
+///
+/// Resolved for the registry target itself, not for the document's own bucket:
+/// the registry class is bound "everywhere" so every node carries the row, while
+/// the document's bucket is replica-capped and reaches only its holders. The
+/// document path is deliberately not passed — a path-prefix binding steers where
+/// the *document* lives, and letting it cap the registry row too would put the
+/// row back out of reach of the nodes that need it to route.
+pub fn registry_placement(
+    config: &RealmConfigDocument,
+    record: &aruna_core::structs::MetadataRegistryRecord,
+) -> PlacementRef {
+    placement_ref_for_target(
+        config,
+        &DocumentSyncTarget::MetadataRegistry {
+            group_id: record.group_id,
+            document_id: record.document_id,
+        },
+        PlacementResolutionContext {
+            group_id: Some(record.group_id),
+            metadata_path: None,
+        },
+    )
+}
+
 /// Placement plan for a document `target`: its shard's rank-ordered holder set
 /// (the same set every document in the shard resolves), the nominal replica
 /// target the pending machinery tops up toward, and the envelope reference.

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -168,9 +168,9 @@ pub fn resolve_shard_holders(
 }
 
 /// Whether `node_id` holds `placement`, and may therefore publish onto its
-/// topic. An empty holder set means no strategy governs the bucket (early
-/// bootstrap, [`PlacementRef::NIL`]): nobody shards it, so it is nobody's to
-/// withhold and the local node counts as a holder.
+/// topic. [`PlacementRef::NIL`] means no strategy governs the bucket during
+/// early bootstrap: nobody shards it, so it is nobody's to withhold and the
+/// local node counts as a holder.
 ///
 /// The presence of a local copy of a document is never evidence of holdership:
 /// a rebalance leaves a stale copy behind on a node that is no longer a holder.
@@ -180,7 +180,7 @@ pub fn holds_placement(
     node_id: NodeId,
 ) -> bool {
     let holders = resolve_shard_holders(config, placement);
-    holders.is_empty() || holders.contains(&node_id)
+    *placement == PlacementRef::NIL || holders.contains(&node_id)
 }
 
 /// Buckets of `strategy` that `node_id` is a holder of. Empty when the node is
@@ -423,6 +423,24 @@ mod tests {
             choose_origin_bucket(&config, strategy, node(9), &subject(1)),
             None
         );
+    }
+
+    #[test]
+    fn empty_holders_rejected() {
+        let (mut config, placement) = config_and_placement();
+        assert!(holds_placement(&config, &placement, node(1)));
+
+        config.nodes.clear();
+        assert!(resolve_shard_holders(&config, &placement).is_empty());
+        assert!(!holds_placement(&config, &placement, node(1)));
+
+        let dangling = PlacementRef {
+            strategy_id: Ulid::from_bytes([99u8; 16]),
+            ..placement
+        };
+        assert!(resolve_shard_holders(&config, &dangling).is_empty());
+        assert!(!holds_placement(&config, &dangling, node(1)));
+        assert!(holds_placement(&config, &PlacementRef::NIL, node(1)));
     }
 
     #[test]

--- a/operations/src/placement/resolver.rs
+++ b/operations/src/placement/resolver.rs
@@ -462,7 +462,7 @@ mod tests {
             replica_count,
             distinct_locations,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         }
     }
 
@@ -505,7 +505,7 @@ mod tests {
             replica_count: Some(3),
             distinct_locations: true,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         }
     }
 
@@ -1116,8 +1116,8 @@ mod tests {
     }
 
     #[test]
-    fn all_document_variants_share_one_bucket() {
-        use aruna_core::structs::bucket_for_subject;
+    fn all_document_variants_share_one_shard() {
+        use aruna_core::structs::shard_for_subject;
 
         let document_id = sid(4);
         let variants = [
@@ -1131,9 +1131,9 @@ mod tests {
             },
             DocumentSyncTarget::MetadataDocumentLifecycle { document_id },
         ];
-        let expected = bucket_for_subject(&subject_bytes(&variants[0]), 64);
+        let expected = shard_for_subject(&subject_bytes(&variants[0]), 64);
         for target in &variants {
-            assert_eq!(bucket_for_subject(&subject_bytes(target), 64), expected);
+            assert_eq!(shard_for_subject(&subject_bytes(target), 64), expected);
         }
     }
 

--- a/operations/src/placement/resolver.rs
+++ b/operations/src/placement/resolver.rs
@@ -9,7 +9,7 @@ use aruna_core::document::DocumentSyncTarget;
 use aruna_core::structs::{
     AffinityEffect, BindingScope, DEFAULT_LOCATION, DEFAULT_NODE_WEIGHT, DocumentClass,
     KIND_LABEL_KEY, LabelMatch, MetadataRegistryRecord, PlacementOverride, PlacementStrategy,
-    RealmConfigDocument, RealmNodeKind,
+    RealmConfigDocument, RealmId, RealmNodeKind,
 };
 use aruna_core::types::GroupId;
 
@@ -89,7 +89,6 @@ pub fn resolve_holders(
     view: &PlacementView,
     strategy: &PlacementStrategy,
     subject: &[u8],
-    epoch: u64,
     override_: Option<&PlacementOverride>,
 ) -> Vec<NodeId> {
     let target = strategy.replica_count.map(|count| count as usize);
@@ -127,7 +126,7 @@ pub fn resolve_holders(
         }
     }
 
-    let ranked = ranked_locations(view, strategy, subject, epoch);
+    let ranked = ranked_locations(view, strategy, subject);
     'outer: for location in &ranked {
         if reached(&result) {
             break;
@@ -138,7 +137,7 @@ pub fn resolve_holders(
         if strategy.distinct_locations && seen_locations.contains(location.name) {
             continue;
         }
-        for node_index in ranked_nodes(view, &location.members, strategy, subject, epoch) {
+        for node_index in ranked_nodes(view, &location.members, strategy, subject) {
             let node = &view.nodes[node_index];
             if used_nodes.contains(&node.node_id) {
                 continue;
@@ -223,6 +222,19 @@ pub fn subject_bytes(target: &DocumentSyncTarget) -> Vec<u8> {
     }
 }
 
+/// Canonical bucket-choice subject for a Meta Resource (spec 6.3.6): the byte
+/// serialization of `(realm_id, group_id, normalized_canonical_path)`. It is
+/// known before the MetaResourceId is generated, so bucket choice never
+/// substitutes the id and becomes circular. The fixed-width `realm_id ‖ group_id`
+/// prefix keeps the trailing path unambiguous.
+pub fn meta_bucket_subject(realm_id: RealmId, group_id: GroupId, normalized_path: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(32 + 16 + normalized_path.len());
+    bytes.extend_from_slice(realm_id.as_bytes());
+    bytes.extend_from_slice(&group_id.to_bytes());
+    bytes.extend_from_slice(normalized_path.as_bytes());
+    bytes
+}
+
 struct RankedLocation<'a> {
     name: &'a str,
     w_loc: u64,
@@ -233,7 +245,6 @@ fn ranked_locations<'a>(
     view: &'a PlacementView,
     strategy: &PlacementStrategy,
     subject: &[u8],
-    epoch: u64,
 ) -> Vec<RankedLocation<'a>> {
     let mut groups: BTreeMap<&'a str, (u64, Vec<usize>)> = BTreeMap::new();
     for (index, node) in view.nodes.iter().enumerate() {
@@ -260,7 +271,7 @@ fn ranked_locations<'a>(
         .iter()
         .map(|location| (location.name.as_bytes(), location.w_loc))
         .collect();
-    let order = rank_weighted(ROLE_LOCATION, epoch, subject, &candidates);
+    let order = rank_weighted(ROLE_LOCATION, subject, &candidates);
 
     let mut slots: Vec<Option<RankedLocation<'a>>> = locations.into_iter().map(Some).collect();
     order
@@ -274,7 +285,6 @@ fn ranked_nodes(
     members: &[usize],
     strategy: &PlacementStrategy,
     subject: &[u8],
-    epoch: u64,
 ) -> Vec<usize> {
     let candidates: Vec<([u8; 32], u64)> = members
         .iter()
@@ -283,7 +293,7 @@ fn ranked_nodes(
             (*node.node_id.as_bytes(), effective_weight(node, strategy))
         })
         .collect();
-    rank_weighted(ROLE_NODE, epoch, subject, &candidates)
+    rank_weighted(ROLE_NODE, subject, &candidates)
         .into_iter()
         .map(|position| members[position])
         .collect()
@@ -585,7 +595,7 @@ mod tests {
         let mut strategy = strategy(None, false);
         strategy.affinity = vec![filter_rule("tier", "hot")];
 
-        let holders = resolve_holders(&view, &strategy, b"subject", 0, None);
+        let holders = resolve_holders(&view, &strategy, b"subject", None);
         assert_eq!(holders, vec![labeled]);
     }
 
@@ -603,14 +613,14 @@ mod tests {
         };
         let strategy = strategy(Some(3), true);
 
-        let first = resolve_holders(&view, &strategy, b"subject", 0, None);
-        let second = resolve_holders(&view, &strategy, b"subject", 0, None);
+        let first = resolve_holders(&view, &strategy, b"subject", None);
+        let second = resolve_holders(&view, &strategy, b"subject", None);
         assert_eq!(first, second);
 
         let mut reversed = nodes;
         reversed.reverse();
         let reversed_view = PlacementView { nodes: reversed };
-        let third = resolve_holders(&reversed_view, &strategy, b"subject", 0, None);
+        let third = resolve_holders(&reversed_view, &strategy, b"subject", None);
         assert_eq!(first, third);
     }
 
@@ -627,7 +637,7 @@ mod tests {
         let view = PlacementView { nodes };
         let strategy = strategy(Some(3), true);
 
-        let holders = resolve_holders(&view, &strategy, b"subject", 0, None);
+        let holders = resolve_holders(&view, &strategy, b"subject", None);
         assert_eq!(holders.len(), 3);
         let locations: HashSet<&str> = holders
             .iter()
@@ -645,10 +655,10 @@ mod tests {
             nodes: nodes.clone(),
         };
 
-        let full_order = resolve_holders(&view, &strategy(None, false), b"subject", 0, None);
+        let full_order = resolve_holders(&view, &strategy(None, false), b"subject", None);
         assert_eq!(full_order.len(), 5);
 
-        let baseline = resolve_holders(&view, &strategy(Some(3), false), b"subject", 0, None);
+        let baseline = resolve_holders(&view, &strategy(Some(3), false), b"subject", None);
         assert_eq!(baseline, full_order[..3].to_vec());
 
         let mut mutated = nodes;
@@ -658,13 +668,7 @@ mod tests {
             }
         }
         let mutated_view = PlacementView { nodes: mutated };
-        let after = resolve_holders(
-            &mutated_view,
-            &strategy(Some(3), false),
-            b"subject",
-            0,
-            None,
-        );
+        let after = resolve_holders(&mutated_view, &strategy(Some(3), false), b"subject", None);
         // Only the rejected node changes: the next candidate slots in, order held.
         assert_eq!(after, full_order[1..4].to_vec());
     }
@@ -677,7 +681,7 @@ mod tests {
             resolved(3, RealmNodeKind::Server, "x", 100),
         ];
         let view = PlacementView { nodes };
-        let holders = resolve_holders(&view, &strategy(None, false), b"subject", 0, None);
+        let holders = resolve_holders(&view, &strategy(None, false), b"subject", None);
         assert_eq!(holders, vec![node_id(3)]);
     }
 
@@ -692,7 +696,7 @@ mod tests {
         let mut strategy = strategy(None, false);
         strategy.affinity = vec![multiply_rule("tier", "cold", 0)];
 
-        let holders = resolve_holders(&view, &strategy, b"subject", 0, None);
+        let holders = resolve_holders(&view, &strategy, b"subject", None);
         assert_eq!(holders, vec![node_id(2)]);
     }
 
@@ -721,7 +725,7 @@ mod tests {
         let mut strategy = strategy(None, false);
         strategy.affinity = vec![filter_rule("tier", "hot"), filter_rule("region", "eu")];
 
-        let holders = resolve_holders(&view, &strategy, b"subject", 0, None);
+        let holders = resolve_holders(&view, &strategy, b"subject", None);
         assert_eq!(holders, vec![node_id(1)]);
     }
 
@@ -739,7 +743,7 @@ mod tests {
         let mut strategy = strategy(Some(1), false);
         strategy.affinity = vec![filter_rule("tier", "hot")];
 
-        let weights: BTreeMap<String, u64> = ranked_locations(&view, &strategy, b"subject", 0)
+        let weights: BTreeMap<String, u64> = ranked_locations(&view, &strategy, b"subject")
             .into_iter()
             .map(|location| (location.name.to_string(), location.w_loc))
             .collect();
@@ -778,7 +782,6 @@ mod tests {
             &view,
             &strategy(Some(2), true),
             b"subject",
-            0,
             Some(&override_),
         );
         assert_eq!(holders, vec![node_id(6), node_id(1)]);
@@ -800,13 +803,7 @@ mod tests {
             strategy_id: None,
         };
 
-        let holders = resolve_holders(
-            &view,
-            &strategy(None, false),
-            b"subject",
-            0,
-            Some(&override_),
-        );
+        let holders = resolve_holders(&view, &strategy(None, false), b"subject", Some(&override_));
         assert!(!holders.contains(&node_id(1)));
         assert_eq!(holders, vec![node_id(2)]);
     }
@@ -825,7 +822,7 @@ mod tests {
             ],
         };
 
-        let holders = resolve_holders(&view, &strategy(None, false), b"subject", 0, None);
+        let holders = resolve_holders(&view, &strategy(None, false), b"subject", None);
         let selected: HashSet<NodeId> = holders.iter().copied().collect();
         assert_eq!(holders.len(), 3);
         assert_eq!(
@@ -1006,9 +1003,7 @@ mod tests {
             strategy_for_target(&config, &target, PlacementResolutionContext::default())
                 .expect("repaired placement remains resolvable");
         assert_eq!(strategy.strategy_id, live);
-        assert!(
-            !resolve_holders(&build_view(&config), strategy, &subject, 0, override_).is_empty()
-        );
+        assert!(!resolve_holders(&build_view(&config), strategy, &subject, override_).is_empty());
     }
 
     #[test]
@@ -1113,6 +1108,20 @@ mod tests {
             document_id: sid(7),
         };
         assert_ne!(subject_bytes(&other), expected);
+    }
+
+    #[test]
+    fn meta_bucket_subject_vector() {
+        // Portable 6.3.6 vector: fixed-width realm_id ‖ group_id, then the path.
+        let subject = meta_bucket_subject(
+            RealmId::from_bytes([1u8; 32]),
+            Ulid::from_bytes([2u8; 16]),
+            "datasets/x",
+        );
+        let mut expected = vec![1u8; 32];
+        expected.extend_from_slice(&[2u8; 16]);
+        expected.extend_from_slice(b"datasets/x");
+        assert_eq!(subject, expected);
     }
 
     #[test]
@@ -1244,11 +1253,11 @@ mod tests {
             };
 
             let strategy = strategy(None, false);
-            let baseline: Vec<String> = ranked_locations(&build(false), &strategy, b"subject", 0)
+            let baseline: Vec<String> = ranked_locations(&build(false), &strategy, b"subject")
                 .iter()
                 .map(|location| location.name.to_string())
                 .collect();
-            let flipped: Vec<String> = ranked_locations(&build(true), &strategy, b"subject", 0)
+            let flipped: Vec<String> = ranked_locations(&build(true), &strategy, b"subject")
                 .iter()
                 .map(|location| location.name.to_string())
                 .collect();
@@ -1281,7 +1290,7 @@ mod tests {
 
             // W_loc counts only sync-eligible node weights; User weights never
             // contribute to a location's rendezvous weight.
-            for location in ranked_locations(&view, &strategy, b"subject", 0) {
+            for location in ranked_locations(&view, &strategy, b"subject") {
                 let expected: u64 = nodes
                     .iter()
                     .filter(|node| {

--- a/operations/src/placement/resolver.rs
+++ b/operations/src/placement/resolver.rs
@@ -184,6 +184,19 @@ pub fn strategy_for_target<'a>(
     Some((strategy, override_))
 }
 
+/// Resolves a class binding without subject, path, or group precedence.
+pub(super) fn strategy_for_class(
+    config: &RealmConfigDocument,
+    class: DocumentClass,
+) -> Option<&PlacementStrategy> {
+    let strategy = match resolve_class_strategy(config, class) {
+        Ok(Some(strategy)) => strategy,
+        Ok(None) => config.strategies.first()?,
+        Err(()) => return None,
+    };
+    Some(strategy)
+}
+
 /// Coarse document class used for class-scoped strategy bindings.
 pub fn document_class(target: &DocumentSyncTarget) -> DocumentClass {
     match target {
@@ -395,6 +408,22 @@ fn resolve_strategy<'a>(
     {
         return Ok(Some(strategy));
     }
+    if let Some(strategy) = binding_strategy(config, &BindingScope::Class(class))? {
+        return Ok(Some(strategy));
+    }
+    if let Some(strategy) = binding_strategy(config, &BindingScope::Realm)? {
+        return Ok(Some(strategy));
+    }
+    if let Some(id) = config.default_strategy_id {
+        return config.strategy(&id).map(Some).ok_or(());
+    }
+    Ok(None)
+}
+
+fn resolve_class_strategy(
+    config: &RealmConfigDocument,
+    class: DocumentClass,
+) -> Result<Option<&PlacementStrategy>, ()> {
     if let Some(strategy) = binding_strategy(config, &BindingScope::Class(class))? {
         return Ok(Some(strategy));
     }

--- a/operations/src/placement/resolver.rs
+++ b/operations/src/placement/resolver.rs
@@ -462,6 +462,7 @@ mod tests {
             replica_count,
             distinct_locations,
             affinity: Vec::new(),
+            bucket_count: 64,
         }
     }
 
@@ -504,6 +505,7 @@ mod tests {
             replica_count: Some(3),
             distinct_locations: true,
             affinity: Vec::new(),
+            bucket_count: 64,
         }
     }
 
@@ -1111,6 +1113,28 @@ mod tests {
             document_id: sid(7),
         };
         assert_ne!(subject_bytes(&other), expected);
+    }
+
+    #[test]
+    fn all_document_variants_share_one_bucket() {
+        use aruna_core::structs::bucket_for_subject;
+
+        let document_id = sid(4);
+        let variants = [
+            DocumentSyncTarget::MetadataRegistry {
+                group_id: sid(5),
+                document_id,
+            },
+            DocumentSyncTarget::MetadataCreateEvent {
+                document_id,
+                event_id: sid(6),
+            },
+            DocumentSyncTarget::MetadataDocumentLifecycle { document_id },
+        ];
+        let expected = bucket_for_subject(&subject_bytes(&variants[0]), 64);
+        for target in &variants {
+            assert_eq!(bucket_for_subject(&subject_bytes(target), 64), expected);
+        }
     }
 
     #[test]

--- a/operations/src/placement/selector.rs
+++ b/operations/src/placement/selector.rs
@@ -8,12 +8,13 @@ pub const ROLE_LOCATION: u8 = b'L';
 pub const ROLE_NODE: u8 = b'N';
 pub const ROLE_SHARD: u8 = b'S';
 
-/// Rendezvous hash of `(role, epoch, subject, id)`, forced nonzero via `| 1`.
-pub fn selector_hash(role: u8, epoch: u64, subject: &[u8], id: &[u8]) -> u64 {
+/// Rendezvous hash of `(role, subject, id)`, forced nonzero via `| 1`. The seed
+/// excludes the epoch: the selector is a pure function of the bucket alone
+/// (spec 6.3.1), so a rebalance never rewrites it.
+pub fn selector_hash(role: u8, subject: &[u8], id: &[u8]) -> u64 {
     let mut hasher = blake3::Hasher::new();
     hasher.update(PLACEMENT_DOMAIN);
     hasher.update(&[role]);
-    hasher.update(&epoch.to_le_bytes());
     hasher.update(subject);
     hasher.update(id);
     let digest = hasher.finalize();
@@ -51,13 +52,12 @@ pub fn neg_log2_q48(h: u64) -> u64 {
 /// so zero-weight candidates (never a numerator advantage) sort after all positive ones.
 pub fn rank_weighted<I: AsRef<[u8]>>(
     role: u8,
-    epoch: u64,
     subject: &[u8],
     candidates: &[(I, u64)],
 ) -> Vec<usize> {
     let scores: Vec<u64> = candidates
         .iter()
-        .map(|(id, _)| neg_log2_q48(selector_hash(role, epoch, subject, id.as_ref())))
+        .map(|(id, _)| neg_log2_q48(selector_hash(role, subject, id.as_ref())))
         .collect();
     let mut order: Vec<usize> = (0..candidates.len()).collect();
     order.sort_unstable_by(|&i, &j| {
@@ -132,8 +132,8 @@ mod tests {
         let weights = [100u64, 100, 100, 300, 50, 200];
         let candidates: Vec<([u8; 32], u64)> =
             ids.iter().zip(weights).map(|(id, w)| (*id, w)).collect();
-        let order = rank_weighted(ROLE_NODE, 0, b"golden-subject", &candidates);
-        assert_eq!(order, vec![2, 5, 3, 1, 4, 0]);
+        let order = rank_weighted(ROLE_NODE, b"golden-subject", &candidates);
+        assert_eq!(order, vec![0, 5, 3, 4, 2, 1]);
     }
 
     #[test]
@@ -145,7 +145,7 @@ mod tests {
         let mut heavy_wins = 0u32;
         for counter in 0..total {
             let subject = blake3::hash(&counter.to_le_bytes());
-            let order = rank_weighted(ROLE_NODE, 0, subject.as_bytes(), &candidates);
+            let order = rank_weighted(ROLE_NODE, subject.as_bytes(), &candidates);
             if order[0] == 1 {
                 heavy_wins += 1;
             }
@@ -165,8 +165,8 @@ mod tests {
 
         #[test]
         fn rank_is_permutation_and_deterministic(candidates in candidate_strategy()) {
-            let first = rank_weighted(ROLE_NODE, 0, b"subject", &candidates);
-            let second = rank_weighted(ROLE_NODE, 0, b"subject", &candidates);
+            let first = rank_weighted(ROLE_NODE, b"subject", &candidates);
+            let second = rank_weighted(ROLE_NODE, b"subject", &candidates);
             prop_assert_eq!(&first, &second);
             let mut sorted = first;
             sorted.sort_unstable();
@@ -178,7 +178,7 @@ mod tests {
             candidates in candidate_strategy(),
             keys in prop::collection::vec(any::<u64>(), 0..12),
         ) {
-            let base_ids = ids_of(&rank_weighted(ROLE_NODE, 7, b"subject", &candidates), &candidates);
+            let base_ids = ids_of(&rank_weighted(ROLE_NODE, b"subject", &candidates), &candidates);
             let mut paired: Vec<(u64, ([u8; 6], u64))> = candidates
                 .iter()
                 .enumerate()
@@ -186,7 +186,7 @@ mod tests {
                 .collect();
             paired.sort_by_key(|(k, _)| *k);
             let permuted: Vec<([u8; 6], u64)> = paired.into_iter().map(|(_, c)| c).collect();
-            let permuted_ids = ids_of(&rank_weighted(ROLE_NODE, 7, b"subject", &permuted), &permuted);
+            let permuted_ids = ids_of(&rank_weighted(ROLE_NODE, b"subject", &permuted), &permuted);
             prop_assert_eq!(base_ids, permuted_ids);
         }
 
@@ -195,10 +195,10 @@ mod tests {
             candidates in candidate_strategy(),
             k in 1u64..1_048_576,
         ) {
-            let base = ids_of(&rank_weighted(ROLE_NODE, 0, b"s", &candidates), &candidates);
+            let base = ids_of(&rank_weighted(ROLE_NODE, b"s", &candidates), &candidates);
             let scaled: Vec<([u8; 6], u64)> =
                 candidates.iter().map(|(id, w)| (*id, w * k)).collect();
-            let scaled_rank = ids_of(&rank_weighted(ROLE_NODE, 0, b"s", &scaled), &scaled);
+            let scaled_rank = ids_of(&rank_weighted(ROLE_NODE, b"s", &scaled), &scaled);
             prop_assert_eq!(base, scaled_rank);
         }
 
@@ -208,7 +208,7 @@ mod tests {
             let mut candidates = candidates;
             candidates[0].1 = 0;
             candidates[1].1 = candidates[1].1.max(1);
-            let order = rank_weighted(ROLE_NODE, 0, b"s", &candidates);
+            let order = rank_weighted(ROLE_NODE, b"s", &candidates);
             let mut seen_zero = false;
             for &i in &order {
                 if candidates[i].1 == 0 {
@@ -225,12 +225,12 @@ mod tests {
             victim in any::<u64>(),
         ) {
             prop_assume!(candidates.len() >= 2);
-            let full = ids_of(&rank_weighted(ROLE_NODE, 3, b"s", &candidates), &candidates);
+            let full = ids_of(&rank_weighted(ROLE_NODE, b"s", &candidates), &candidates);
             let idx = (victim % candidates.len() as u64) as usize;
             let removed_id = candidates[idx].0;
             let mut reduced = candidates.clone();
             reduced.remove(idx);
-            let reduced_ids = ids_of(&rank_weighted(ROLE_NODE, 3, b"s", &reduced), &reduced);
+            let reduced_ids = ids_of(&rank_weighted(ROLE_NODE, b"s", &reduced), &reduced);
             let expected: Vec<[u8; 6]> = full.into_iter().filter(|id| *id != removed_id).collect();
             prop_assert_eq!(reduced_ids, expected);
         }

--- a/operations/src/placement/selector.rs
+++ b/operations/src/placement/selector.rs
@@ -6,6 +6,7 @@
 pub const PLACEMENT_DOMAIN: &[u8] = b"aruna-placement-rendezvous-v3";
 pub const ROLE_LOCATION: u8 = b'L';
 pub const ROLE_NODE: u8 = b'N';
+pub const ROLE_SHARD: u8 = b'S';
 
 /// Rendezvous hash of `(role, epoch, subject, id)`, forced nonzero via `| 1`.
 pub fn selector_hash(role: u8, epoch: u64, subject: &[u8], id: &[u8]) -> u64 {

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -36,13 +36,21 @@ const PENDING_PLACEMENT_PAGE_SIZE: usize = 256;
 /// Returns whether any genesis was withheld (a co-holder was unreachable or
 /// refused a probe) or a held topic could not be pulled, so the caller can
 /// schedule a placement retry.
+#[derive(Clone, Copy, Debug, Default)]
+struct HeldTopicOutcome {
+    /// A rank-0 genesis was withheld (co-holder unreachable or refusing).
+    withheld: bool,
+    /// A held topic could not be pulled from any co-holder yet.
+    pull_pending: bool,
+}
+
 async fn ensure_held_shard_topics(
     context: &Arc<DriverContext>,
     net_handle: &aruna_net::NetHandle,
     config: &RealmConfigDocument,
     realm_id: RealmId,
     local_node_id: NodeId,
-) -> bool {
+) -> HeldTopicOutcome {
     let mut rank0_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     let mut member_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     for strategy in &config.strategies {
@@ -73,7 +81,7 @@ async fn ensure_held_shard_topics(
                 .push(shard_topic_id(realm_id, &placement));
         }
     }
-    let mut withheld = false;
+    let mut outcome = HeldTopicOutcome::default();
     for (co_holders, topics) in rank0_groups {
         debug!(
             event = "placement.genesis.ensure",
@@ -81,7 +89,7 @@ async fn ensure_held_shard_topics(
             co_holders = co_holders.len(),
             "Ensuring rank-0 shard topic geneses"
         );
-        withheld |=
+        outcome.withheld |=
             ensure_rank0_shard_group(context, net_handle, local_node_id, co_holders, topics).await;
     }
     // Non-rank-0 held shards. A topic not known locally is pulled from a
@@ -122,7 +130,7 @@ async fn ensure_held_shard_topics(
                 } else {
                     // No co-holder served a genesis (unreachable, or rank-0 has
                     // not created it yet); retry rather than stay passive.
-                    withheld = true;
+                    outcome.pull_pending = true;
                 }
             }
         }
@@ -131,10 +139,10 @@ async fn ensure_held_shard_topics(
         }
         if let Err(error) = net_handle.allow_document_sync_peers(&known, co_holders) {
             debug!(error = %error, "Could not complete held shard topic membership");
-            withheld = true;
+            outcome.withheld = true;
         }
     }
-    withheld
+    outcome
 }
 
 /// Ensures the shard topics of one rank-0 co-holder group, creating a fresh
@@ -274,8 +282,9 @@ pub async fn process_shard_placements(
     // A withheld genesis or an unpulled held topic leaves no placement record,
     // so it alone must still arm the retry below (otherwise writes defer at 1s
     // forever).
-    let mut retry_needed =
+    let held =
         ensure_held_shard_topics(context, net_handle, &config, realm_id, local_node_id).await;
+    let mut retry_needed = held.withheld || held.pull_pending;
 
     let mut start_after: Option<Key> = None;
     loop {
@@ -406,8 +415,16 @@ pub async fn process_shard_placements(
     }
 
     if retry_needed && let Some(task_handle) = context.task_handle.as_ref() {
+        // A pending pull is join-only and usually one gossip push away, so it
+        // retries on the short cadence; a withheld genesis waits out the full
+        // interval (re-probing a down co-holder is expensive).
+        let after = if held.pull_pending {
+            crate::sync_placement::SHARD_TOPIC_PULL_RETRY_AFTER
+        } else {
+            crate::sync_placement::SYNC_PLACEMENT_RETRY_AFTER
+        };
         let effect =
-            crate::sync_placement::schedule_placement_retry_effect(realm_id, local_node_id);
+            crate::sync_placement::schedule_placement_retry_after(realm_id, local_node_id, after);
         let _ = task_handle.send_effect(effect).await;
         outcome.retry_scheduled = true;
     }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -255,8 +255,15 @@ pub async fn process_shard_placements(
 
             let holders = resolve_shard_holders(&config, &record.placement);
             if !holders.contains(&local_node_id) {
-                // The local node is no longer a holder of this shard.
+                // The local node is no longer a holder of this shard. Drop the
+                // verification marker too so a later re-entry re-verifies.
                 delete_record(context, key.to_vec()).await;
+                crate::shard::verify::delete_shard_verification(
+                    context,
+                    realm_id,
+                    &record.placement,
+                )
+                .await;
                 continue;
             }
             let local_is_rank0 = holders.first() == Some(&local_node_id);

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -30,13 +30,15 @@ const PENDING_PLACEMENT_PAGE_SIZE: usize = 256;
 /// first for a shard whose genesis the previous rank-0 already created), so a
 /// missing topic is first adopted from a co-holder; only what no co-holder
 /// knows either is created fresh.
+/// Returns whether any rank-0 genesis was withheld (a co-holder was unreachable
+/// or refused a probe), so the caller can schedule a placement retry.
 async fn ensure_rank0_shard_topics(
     context: &Arc<DriverContext>,
     net_handle: &aruna_net::NetHandle,
     config: &RealmConfigDocument,
     realm_id: RealmId,
     local_node_id: NodeId,
-) {
+) -> bool {
     let mut rank0_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     let mut member_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     for strategy in &config.strategies {
@@ -67,6 +69,7 @@ async fn ensure_rank0_shard_topics(
                 .push(shard_topic_id(realm_id, &placement));
         }
     }
+    let mut withheld = false;
     for (co_holders, topics) in rank0_groups {
         debug!(
             event = "placement.genesis.ensure",
@@ -74,7 +77,8 @@ async fn ensure_rank0_shard_topics(
             co_holders = co_holders.len(),
             "Ensuring rank-0 shard topic geneses"
         );
-        ensure_rank0_shard_group(context, net_handle, local_node_id, co_holders, topics).await;
+        withheld |=
+            ensure_rank0_shard_group(context, net_handle, local_node_id, co_holders, topics).await;
     }
     // Non-rank-0 held shards: a holder that is already a member (e.g. the
     // previous rank-0 after a config change moved the rank) completes the
@@ -100,6 +104,7 @@ async fn ensure_rank0_shard_topics(
             debug!(error = %error, "Could not complete held shard topic membership");
         }
     }
+    withheld
 }
 
 /// Ensures the shard topics of one rank-0 co-holder group, creating a fresh
@@ -114,13 +119,16 @@ async fn ensure_rank0_shard_topics(
 /// is withheld and left for the next placement pass — either might hold a
 /// genesis, and forking a second one is a permanent split-brain. A sole holder
 /// (no co-holders) creates immediately: no peer can hold a divergent genesis.
+///
+/// Returns whether any genesis was withheld (or an adopt failed to land), so the
+/// caller schedules a placement retry instead of deferring writes forever.
 pub(crate) async fn ensure_rank0_shard_group(
     context: &Arc<DriverContext>,
     net_handle: &aruna_net::NetHandle,
     local_node_id: NodeId,
     co_holders: Vec<NodeId>,
     topics: Vec<::irokle::TopicId>,
-) {
+) -> bool {
     let mut to_ensure: Vec<::irokle::TopicId> = Vec::new();
     let mut missing: Vec<::irokle::TopicId> = Vec::new();
     for topic in topics {
@@ -134,6 +142,7 @@ pub(crate) async fn ensure_rank0_shard_group(
         }
     }
 
+    let mut withheld = false;
     if !missing.is_empty() {
         if co_holders.is_empty() {
             to_ensure.extend(missing);
@@ -147,10 +156,12 @@ pub(crate) async fn ensure_rank0_shard_group(
                     to_adopt.push(topic);
                 } else if probe.unreachable.is_empty() && !probe.unconfirmed.contains(&topic) {
                     to_ensure.push(topic);
+                } else {
+                    // A co-holder was unreachable, or a reached one refused the
+                    // topic (holds it but the prober may not open it yet):
+                    // withhold this genesis rather than fork a second one.
+                    withheld = true;
                 }
-                // Otherwise a co-holder was unreachable, or a reached one refused
-                // the topic (holds it but the prober may not open it yet):
-                // withhold this genesis rather than fork a second one.
             }
             if !to_adopt.is_empty() {
                 let event = net_handle
@@ -159,13 +170,15 @@ pub(crate) async fn ensure_rank0_shard_group(
                 crate::startup::apply_restored_reconcile(context, local_node_id, event).await;
                 // Only ensure membership on topics whose genesis actually landed;
                 // an adopt that failed (co-holder now unreachable) must not fall
-                // through to a fresh create.
+                // through to a fresh create — retry it on the next pass instead.
                 for topic in to_adopt {
                     if net_handle
                         .document_sync_topic_exists(topic)
                         .unwrap_or(false)
                     {
                         to_ensure.push(topic);
+                    } else {
+                        withheld = true;
                     }
                 }
             }
@@ -184,6 +197,15 @@ pub(crate) async fn ensure_rank0_shard_group(
     {
         warn!(error = %error, "Failed to ensure rank-0 shard topics");
     }
+    withheld
+}
+
+/// What a [`process_shard_placements`] pass decided about follow-up work.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PlacementReconcileOutcome {
+    /// A genesis was withheld or a record left incomplete, so a
+    /// [`TaskKey::SyncPlacements`] retry timer was scheduled.
+    pub retry_scheduled: bool,
 }
 
 /// Reconciles the local node's held shard topics with their co-holders.
@@ -199,23 +221,30 @@ pub(crate) async fn ensure_rank0_shard_group(
 /// record the local node no longer holds is dropped; a record whose shard
 /// topic has no genesis locally yet (non-rank-0 holder, genesis in flight) is
 /// kept for retry.
+///
+/// A withheld genesis or an incomplete record schedules a [`TaskKey::SyncPlacements`]
+/// retry so a down/refusing co-holder returning re-runs the reconciler; the
+/// returned [`PlacementReconcileOutcome`] reports whether that retry was armed.
 pub async fn process_shard_placements(
     context: &Arc<DriverContext>,
     realm_id: RealmId,
     local_node_id: NodeId,
-) {
+) -> PlacementReconcileOutcome {
+    let mut outcome = PlacementReconcileOutcome::default();
     let Some(config) = load_realm_config(context, realm_id).await else {
         warn!(%realm_id, "Cannot process shard placements without a realm config");
-        return;
+        return outcome;
     };
     let Some(net_handle) = context.net_handle.as_ref() else {
-        return;
+        return outcome;
     };
 
-    ensure_rank0_shard_topics(context, net_handle, &config, realm_id, local_node_id).await;
+    // A withheld rank-0 genesis leaves no placement record, so it alone must
+    // still arm the retry below (otherwise writes defer at 1s forever).
+    let mut retry_needed =
+        ensure_rank0_shard_topics(context, net_handle, &config, realm_id, local_node_id).await;
 
     let mut start_after: Option<Key> = None;
-    let mut retry_needed = false;
     loop {
         let batch = match context
             .storage_handle
@@ -237,11 +266,11 @@ pub async fn process_shard_placements(
             }
             Event::Storage(StorageEvent::Error { error }) => {
                 warn!(error = %error, "Failed to list pending shard placements");
-                return;
+                return outcome;
             }
             other => {
                 warn!(event = ?other, "Unexpected pending shard placement iter result");
-                return;
+                return outcome;
             }
         };
 
@@ -347,7 +376,9 @@ pub async fn process_shard_placements(
         let effect =
             crate::sync_placement::schedule_placement_retry_effect(realm_id, local_node_id);
         let _ = task_handle.send_effect(effect).await;
+        outcome.retry_scheduled = true;
     }
+    outcome
 }
 
 async fn load_realm_config(

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -20,19 +20,23 @@ use crate::sync_placement::{
 
 const PENDING_PLACEMENT_PAGE_SIZE: usize = 256;
 
-/// Eagerly creates the genesis of every shard topic whose rank-0 holder is the
-/// local node, so genesis creation has exactly one origin per shard (race-free
-/// by rank uniqueness). Every other node is join-only: it receives the genesis
-/// via gossip from the rank-0 holder or bootstraps it during anti-entropy.
-/// Runs on realm-config apply/change and at startup.
+/// Reconciles every shard topic the local node holds, whatever its rank.
+///
+/// Rank-0 is a politeness device for who acts first, never a precondition for
+/// the work happening: the rank-0 holder eagerly creates the genesis (so
+/// creation has exactly one origin per shard, race-free by rank uniqueness),
+/// while every other holder independently pulls the topic from a co-holder and
+/// tops up co-holder membership. A freshly added holder therefore converges on
+/// its own instead of waiting to be pushed to.
 ///
 /// Join-before-create: a config change can move rank-0 (e.g. a new node ranks
 /// first for a shard whose genesis the previous rank-0 already created), so a
 /// missing topic is first adopted from a co-holder; only what no co-holder
 /// knows either is created fresh.
-/// Returns whether any rank-0 genesis was withheld (a co-holder was unreachable
-/// or refused a probe), so the caller can schedule a placement retry.
-async fn ensure_rank0_shard_topics(
+/// Returns whether any genesis was withheld (a co-holder was unreachable or
+/// refused a probe) or a held topic could not be pulled, so the caller can
+/// schedule a placement retry.
+async fn ensure_held_shard_topics(
     context: &Arc<DriverContext>,
     net_handle: &aruna_net::NetHandle,
     config: &RealmConfigDocument,
@@ -80,28 +84,54 @@ async fn ensure_rank0_shard_topics(
         withheld |=
             ensure_rank0_shard_group(context, net_handle, local_node_id, co_holders, topics).await;
     }
-    // Non-rank-0 held shards: a holder that is already a member (e.g. the
-    // previous rank-0 after a config change moved the rank) completes the
-    // membership of freshly added co-holders — a new holder cannot add itself.
-    // Topics not known locally are skipped: their rank-0 creates them with the
-    // full holder set as initial peers.
+    // Non-rank-0 held shards. A topic not known locally is pulled from a
+    // co-holder: `sync_document_topics` is join-only (it adopts an existing
+    // genesis, it can never mint one), so this is safe at any rank and cannot
+    // fork. Without it a freshly added holder would stay passive forever,
+    // depending on an existing member pushing to it — and when the shard's
+    // origin is drained out of the holder set, nobody does.
+    // Topics already known are topped up with the current co-holder set, which
+    // is what admits a freshly added holder on the pushing side.
     for (co_holders, topics) in member_groups {
         if co_holders.is_empty() {
             continue;
         }
-        let known: Vec<::irokle::TopicId> = topics
-            .into_iter()
-            .filter(|topic| {
+        let (mut known, missing): (Vec<::irokle::TopicId>, Vec<::irokle::TopicId>) =
+            topics.into_iter().partition(|topic| {
                 net_handle
                     .document_sync_topic_exists(*topic)
                     .unwrap_or(false)
-            })
-            .collect();
+            });
+        if !missing.is_empty() {
+            debug!(
+                event = "placement.topic.pull",
+                topics = missing.len(),
+                co_holders = co_holders.len(),
+                "Pulling newly held shard topics from co-holders"
+            );
+            let event = net_handle
+                .sync_document_topics(missing.clone(), co_holders.clone())
+                .await;
+            crate::startup::apply_restored_reconcile(context, local_node_id, event).await;
+            for topic in missing {
+                if net_handle
+                    .document_sync_topic_exists(topic)
+                    .unwrap_or(false)
+                {
+                    known.push(topic);
+                } else {
+                    // No co-holder served a genesis (unreachable, or rank-0 has
+                    // not created it yet); retry rather than stay passive.
+                    withheld = true;
+                }
+            }
+        }
         if known.is_empty() {
             continue;
         }
         if let Err(error) = net_handle.allow_document_sync_peers(&known, co_holders) {
             debug!(error = %error, "Could not complete held shard topic membership");
+            withheld = true;
         }
     }
     withheld
@@ -211,8 +241,9 @@ pub struct PlacementReconcileOutcome {
 
 /// Reconciles the local node's held shard topics with their co-holders.
 ///
-/// First creates the genesis of every shard the local node is rank-0 holder
-/// of (see [`ensure_rank0_shard_topics`]). Then iterates the
+/// First reconciles every held shard topic (see [`ensure_held_shard_topics`]):
+/// rank-0 shards get their genesis created, every other held shard is pulled
+/// from a co-holder. Then iterates the
 /// [`SYNC_PLACEMENT_KEYSPACE`] records the write path left behind (one per
 /// shard that was not fully replicated at write time), re-resolves each
 /// shard's holder set from the current realm config, and adds every co-holder
@@ -240,10 +271,11 @@ pub async fn process_shard_placements(
         return outcome;
     };
 
-    // A withheld rank-0 genesis leaves no placement record, so it alone must
-    // still arm the retry below (otherwise writes defer at 1s forever).
+    // A withheld genesis or an unpulled held topic leaves no placement record,
+    // so it alone must still arm the retry below (otherwise writes defer at 1s
+    // forever).
     let mut retry_needed =
-        ensure_rank0_shard_topics(context, net_handle, &config, realm_id, local_node_id).await;
+        ensure_held_shard_topics(context, net_handle, &config, realm_id, local_node_id).await;
 
     let mut start_after: Option<Key> = None;
     loop {

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -258,6 +258,8 @@ pub struct PlacementReconcileOutcome {
     /// Compatibility signal for callers that only need to know whether the
     /// reconciler armed its own retry.
     pub retry_scheduled: bool,
+    /// The retry includes a held topic that could not be pulled yet.
+    pub pull_pending: bool,
     pub status: PlacementReconcileStatus,
 }
 
@@ -266,9 +268,10 @@ impl PlacementReconcileOutcome {
         Self::default()
     }
 
-    fn retry_scheduled() -> Self {
+    fn retry_scheduled(pull_pending: bool) -> Self {
         Self {
             retry_scheduled: true,
+            pull_pending,
             status: PlacementReconcileStatus::RetryScheduled,
         }
     }
@@ -276,6 +279,7 @@ impl PlacementReconcileOutcome {
     fn storage_failure() -> Self {
         Self {
             retry_scheduled: false,
+            pull_pending: false,
             status: PlacementReconcileStatus::StorageFailure,
         }
     }
@@ -471,7 +475,7 @@ pub async fn process_shard_placements(
         let effect =
             crate::sync_placement::schedule_placement_retry_after(realm_id, local_node_id, after);
         let _ = task_handle.send_effect(effect).await;
-        return PlacementReconcileOutcome::retry_scheduled();
+        return PlacementReconcileOutcome::retry_scheduled(held.pull_pending);
     }
     PlacementReconcileOutcome::clean()
 }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -108,8 +108,10 @@ async fn ensure_rank0_shard_topics(
 /// Topics already known locally are ensured (membership top-up only, never a
 /// create). For a missing topic the co-holders are probed: one that a co-holder
 /// already holds is adopted via anti-entropy; one that every reached co-holder
-/// lacks is created fresh; but if any co-holder was unreachable, creation is
-/// withheld and left for the next placement pass — a down co-holder might hold a
+/// positively confirmed unknown (an empty summary) is created fresh; but if any
+/// co-holder was unreachable, or a reached one refused the topic (holds it but
+/// the prober may not open it yet — its summary is silently omitted), creation
+/// is withheld and left for the next placement pass — either might hold a
 /// genesis, and forking a second one is a permanent split-brain. A sole holder
 /// (no co-holders) creates immediately: no peer can hold a divergent genesis.
 pub(crate) async fn ensure_rank0_shard_group(
@@ -143,10 +145,12 @@ pub(crate) async fn ensure_rank0_shard_group(
             for topic in missing {
                 if probe.known_by_co_holder.contains(&topic) {
                     to_adopt.push(topic);
-                } else if probe.unreachable.is_empty() {
+                } else if probe.unreachable.is_empty() && !probe.unconfirmed.contains(&topic) {
                     to_ensure.push(topic);
                 }
-                // Otherwise a co-holder was unreachable: withhold this genesis.
+                // Otherwise a co-holder was unreachable, or a reached one refused
+                // the topic (holds it but the prober may not open it yet):
+                // withhold this genesis rather than fork a second one.
             }
             if !to_adopt.is_empty() {
                 let event = net_handle
@@ -165,10 +169,11 @@ pub(crate) async fn ensure_rank0_shard_group(
                     }
                 }
             }
-            if !probe.unreachable.is_empty() {
+            if !probe.unreachable.is_empty() || !probe.unconfirmed.is_empty() {
                 warn!(
                     unreachable = ?probe.unreachable,
-                    "Withholding shard genesis creation: co-holder(s) unreachable"
+                    unconfirmed = ?probe.unconfirmed,
+                    "Withholding shard genesis creation: co-holder unreachable or topic possibly-existing"
                 );
             }
         }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -1,1294 +1,340 @@
-use aruna_core::NodeId;
-use aruna_core::document::{
-    DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncOutboxEvent, DocumentSyncRevision,
-    DocumentSyncTarget, PendingDocumentPlacement,
-};
-use aruna_core::effects::{Effect, IterStart, StorageEffect};
-use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
-use aruna_core::keyspaces::{
-    DOCUMENT_SYNC_REVISION_KEYSPACE, METADATA_DOCUMENT_INDEX_KEYSPACE, SYNC_PLACEMENT_KEYSPACE,
-};
-use aruna_core::metadata::MetadataDocumentLifecycleRecord;
-use aruna_core::operation::{Operation, boxed_suboperation};
-use aruna_core::storage_entries::{
-    document_placement_write_entry, document_sync_revision_key, document_sync_revision_write_entry,
-    metadata_document_key, metadata_document_lifecycle_revision_change,
-    metadata_document_lifecycle_write_entry, metadata_registry_write_entries,
-};
-use aruna_core::structs::{MetadataRegistryRecord, PlacementRef, RealmConfigDocument, RealmId};
-use aruna_core::task::TaskEvent;
-use aruna_core::types::{Effects, Key, TxnId};
-use smallvec::smallvec;
-use thiserror::Error;
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
-use crate::announce::AnnounceTopicOperation;
-use crate::document_repository::read_effect;
-use crate::document_sync_outbox::{
-    new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
-};
-use crate::placement::{PlacementResolutionContext, plan_target_placement};
+use aruna_core::NodeId;
+use aruna_core::document::{DocumentSyncTarget, bucket_topic_id};
+use aruna_core::effects::{IterStart, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE;
+use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
+use aruna_core::types::Key;
+use byteview::ByteView;
+use tracing::{debug, warn};
+
+use crate::driver::DriverContext;
+use crate::placement::resolve_bucket_holders;
 use crate::sync_placement::{
-    decode_placement, delete_placement_effect, new_placement_with_context, placement_prefix,
-    placement_satisfied, schedule_placement_retry_after, sort_node_ids, write_placement_effect,
+    decode_placement, new_placement, placement_prefix, sort_node_ids, write_placement_effect,
 };
-use std::time::Duration;
-use tracing::warn;
 
 const PENDING_PLACEMENT_PAGE_SIZE: usize = 256;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct PlacementConfig {
-    pub realm_id: RealmId,
-    pub local_node_id: NodeId,
-    /// In-memory backoff duration the driver uses for the retry re-arm; not
-    /// persisted anywhere.
-    pub retry_after: Duration,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct ProcessPlacementsOperation {
-    config: PlacementConfig,
-    state: PlacementState,
-    realm_config: Option<RealmConfigDocument>,
-    records: Vec<PendingDocumentPlacement>,
-    next_start_after: Option<Key>,
-    current: Option<CurrentPlacement>,
-    txn_id: Option<TxnId>,
-    retry_needed: bool,
-    metadata_refresh_queued: bool,
-    rearmed: bool,
-    output: Option<Result<(), PlacementError>>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-enum PlacementState {
-    Init,
-    LoadRealmConfig,
-    ListPending,
-    Publish,
-    StorePlacement,
-    StartMetadataTransaction,
-    ReadMetadataState,
-    WriteMetadataState,
-    CommitMetadataTransaction,
-    ScheduleMetadataRefresh,
-    ScheduleRetry,
-    Finish,
-    Error,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct CurrentPlacement {
-    planned: PendingDocumentPlacement,
-    selected_holders_after_failure: Vec<NodeId>,
-    newly_required_remote_holders: Vec<NodeId>,
-    metadata_holders_changed: bool,
-}
-
-#[derive(Debug, Error, PartialEq)]
-pub enum PlacementError {
-    #[error(transparent)]
-    StorageError(#[from] StorageError),
-    #[error(transparent)]
-    ConversionError(#[from] ConversionError),
-    #[error("pending placement decode failed: {0}")]
-    Decode(String),
-    #[error("realm config document not found")]
-    RealmConfigNotFound,
-    #[error("document sync failed: {0}")]
-    DocumentSync(String),
-    #[error("placement persistence failed: {0}")]
-    Placement(String),
-    #[error("unexpected event in state {state:?}: expected {expected}, got {got}")]
-    UnexpectedEvent {
-        state: String,
-        expected: &'static str,
-        got: String,
-    },
-}
-
-impl ProcessPlacementsOperation {
-    pub fn new(config: PlacementConfig) -> Self {
-        Self {
-            config,
-            state: PlacementState::Init,
-            realm_config: None,
-            records: Vec::new(),
-            next_start_after: None,
-            current: None,
-            txn_id: None,
-            retry_needed: false,
-            metadata_refresh_queued: false,
-            rearmed: false,
-            output: None,
-        }
-    }
-
-    fn fail(&mut self, error: PlacementError) -> Effects {
-        let cleanup = self.abort();
-        self.state = PlacementState::Error;
-        self.output = Some(Err(error));
-        cleanup
-    }
-
-    fn unexpected_event(&mut self, expected: &'static str, got: String) -> Effects {
-        self.fail(PlacementError::UnexpectedEvent {
-            state: format!("{:?}", self.state),
-            expected,
-            got,
-        })
-    }
-
-    fn emit_list_pending(&mut self) -> Effects {
-        self.state = PlacementState::ListPending;
-        smallvec![Effect::Storage(StorageEffect::Iter {
-            key_space: SYNC_PLACEMENT_KEYSPACE.to_string(),
-            prefix: Some(placement_prefix(self.config.realm_id)),
-            start: self.next_start_after.take().map(IterStart::After),
-            limit: PENDING_PLACEMENT_PAGE_SIZE,
-            txn_id: None,
-        })]
-    }
-
-    fn emit_next_record(&mut self) -> Effects {
-        let Some(record) = self.records.pop() else {
-            if self.next_start_after.is_some() {
-                return self.emit_list_pending();
-            }
-            self.state = PlacementState::Finish;
-            self.output = Some(Ok(()));
-            return smallvec![];
-        };
-        if record.realm_id != self.config.realm_id {
-            warn!(
-                record_realm_id = %record.realm_id,
-                config_realm_id = %self.config.realm_id,
-                "Skipping pending placement for a different realm"
-            );
-            return self.emit_next_record();
-        }
-        if record.target.is_admin_document() {
-            // Admin documents never take placements; drain any stale row instead of
-            // retrying it forever. The satisfied-delete path continues the sweep once
-            // the delete result arrives.
-            self.current = None;
-            self.retry_needed = false;
-            self.state = PlacementState::StorePlacement;
-            return smallvec![delete_placement_effect(
-                self.config.realm_id,
-                &record.target
-            )];
-        }
-
-        let context = PlacementResolutionContext {
-            group_id: record.group_id,
-            metadata_path: record.metadata_path.as_deref(),
-        };
-        let mut previously_selected = record.selected_holders.clone();
-        sort_node_ids(&mut previously_selected);
-        let (desired_holder_count, mut planned_holders, placement) = self
-            .realm_config
-            .as_ref()
-            .and_then(|config| plan_target_placement(config, &record.target, context))
-            .map(|plan| (plan.desired_count, plan.holders, plan.placement))
-            .unwrap_or((record.desired_holder_count, Vec::new(), PlacementRef::NIL));
-        sort_node_ids(&mut planned_holders);
-        let is_metadata_lifecycle = matches!(
-            &record.target,
-            DocumentSyncTarget::MetadataDocumentLifecycle { .. }
-        );
-        let metadata_holders_changed =
-            is_metadata_lifecycle && planned_holders != previously_selected;
-
-        let selected_holders_after_failure: Vec<NodeId> = planned_holders
-            .iter()
-            .copied()
-            .filter(|node_id| {
-                previously_selected.contains(node_id)
-                    || (*node_id == self.config.local_node_id && !is_metadata_lifecycle)
-            })
-            .collect();
-        let newly_required_holders: Vec<NodeId> = planned_holders
-            .iter()
-            .copied()
-            .filter(|node_id| !previously_selected.contains(node_id))
-            .collect();
-        let newly_required_remote_holders: Vec<NodeId> = planned_holders
-            .iter()
-            .copied()
-            .filter(|node_id| {
-                *node_id != self.config.local_node_id && !previously_selected.contains(node_id)
-            })
-            .collect();
-        let planned = new_placement_with_context(
-            self.config.realm_id,
-            record.target.clone(),
-            record.origin_node_id,
-            record.group_id,
-            record.metadata_path.clone(),
-            desired_holder_count,
-            planned_holders,
-            placement,
-        );
-        self.current = Some(CurrentPlacement {
-            planned,
-            selected_holders_after_failure,
-            newly_required_remote_holders: newly_required_remote_holders.clone(),
-            metadata_holders_changed,
-        });
-
-        if (newly_required_remote_holders.is_empty() && !is_metadata_lifecycle)
-            || newly_required_holders.is_empty()
-        {
-            return self.emit_placement_update(false);
-        }
-
-        self.state = PlacementState::Publish;
-        // NodeInfo genesis is reserved for the explicit core-document bootstrap;
-        // ordinary documents retain origin-derived genesis on placement retry.
-        let allow_genesis = !matches!(&record.target, DocumentSyncTarget::NodeInfo { .. })
-            && record.origin_node_id == self.config.local_node_id;
-        let announce = if is_metadata_lifecycle {
-            AnnounceTopicOperation::new_for_document_transfer_with_peers_and_placement(
-                record.target.topic_id(),
-                self.config.local_node_id,
-                record.target,
-                newly_required_remote_holders,
-                placement,
-                allow_genesis,
-            )
-        } else {
-            AnnounceTopicOperation::new_for_document_with_peers_and_placement(
-                record.target.topic_id(),
-                self.config.local_node_id,
-                Some(record.target),
-                newly_required_remote_holders,
-                placement,
-                allow_genesis,
-            )
-        };
-        smallvec![Effect::SubOperation(boxed_suboperation(
-            announce,
-            |result| Event::SubOperation(SubOperationEvent::DocumentSyncResult {
-                result: result.map_err(|error| error.to_string()),
-            }),
-        ))]
-    }
-
-    fn emit_placement_update(&mut self, publication_failed: bool) -> Effects {
-        let Some(mut current) = self.current.take() else {
-            return self.emit_next_record();
-        };
-        if publication_failed {
-            current.planned.selected_holders = current.selected_holders_after_failure.clone();
-        }
-
-        self.state = PlacementState::StorePlacement;
-        self.retry_needed = publication_failed
-            || !placement_satisfied(
-                current.planned.selected_holders.len(),
-                current.planned.desired_holder_count,
-            );
-        if current.metadata_holders_changed {
-            self.current = Some(current);
-            self.state = PlacementState::StartMetadataTransaction;
-            return smallvec![Effect::Storage(StorageEffect::StartTransaction {
-                read: false,
-            })];
-        }
-        match write_placement_effect(&current.planned) {
-            Ok(effect) => smallvec![effect],
-            Err(error) => self.fail(PlacementError::Placement(error.to_string())),
-        }
-    }
-
-    fn emit_metadata_placement_update(
-        &mut self,
-        lifecycle: Option<aruna_core::types::Value>,
-        lifecycle_revision: Option<aruna_core::types::Value>,
-        registry: Option<MetadataRegistryRecord>,
-    ) -> Effects {
-        let Some(current) = self.current.take() else {
-            return self.emit_next_record();
-        };
-        let Some(txn_id) = self.txn_id else {
-            return self.fail(PlacementError::Placement(
-                "missing metadata replan transaction".to_string(),
-            ));
-        };
-        let mut writes = Vec::new();
-        if let Some(mut registry) = registry {
-            let DocumentSyncTarget::MetadataDocumentLifecycle { document_id } =
-                &current.planned.target
-            else {
-                unreachable!("metadata holder changes only apply to lifecycle placements");
+/// Eagerly creates the genesis of every bucket topic whose rank-0 holder is the
+/// local node, so genesis creation has exactly one origin per bucket (race-free
+/// by rank uniqueness). Every other node is join-only: it receives the genesis
+/// via gossip from the rank-0 holder or bootstraps it during anti-entropy.
+/// Runs on realm-config apply/change and at startup.
+///
+/// Join-before-create: a config change can move rank-0 (e.g. a new node ranks
+/// first for a bucket whose genesis the previous rank-0 already created), so a
+/// missing topic is first adopted from a co-holder; only what no co-holder
+/// knows either is created fresh.
+async fn ensure_rank0_bucket_topics(
+    context: &Arc<DriverContext>,
+    net_handle: &aruna_net::NetHandle,
+    config: &RealmConfigDocument,
+    realm_id: RealmId,
+    local_node_id: NodeId,
+) {
+    let mut rank0_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+    let mut member_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+    for strategy in &config.strategies {
+        for bucket in 0..strategy.bucket_count {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                bucket,
             };
-            if registry.document_id != *document_id {
-                return self.fail(PlacementError::DocumentSync(format!(
-                    "metadata registry document {} does not match lifecycle placement {document_id}",
-                    registry.document_id
-                )));
+            let holders = resolve_bucket_holders(config, &placement);
+            if !holders.contains(&local_node_id) {
+                continue;
             }
-            registry.holder_node_ids = current.planned.selected_holders.clone();
-            match metadata_registry_write_entries(&registry) {
-                Ok(entries) => writes.extend(entries),
-                Err(error) => return self.fail(error.into()),
-            }
-
-            if let Some(lifecycle) = lifecycle {
-                let mut lifecycle: MetadataDocumentLifecycleRecord =
-                    match postcard::from_bytes(&lifecycle) {
-                        Ok(record) => record,
-                        Err(error) => {
-                            return self.fail(PlacementError::ConversionError(error.into()));
-                        }
-                    };
-                if let MetadataDocumentLifecycleRecord::Upsert { event } = &mut lifecycle {
-                    event.record.holder_node_ids = current.planned.selected_holders.clone();
-                    let previous = match lifecycle_revision {
-                        Some(value) => match postcard::from_bytes::<DocumentSyncChange>(&value) {
-                            Ok(change) => change,
-                            Err(error) => {
-                                return self.fail(PlacementError::ConversionError(error.into()));
-                            }
-                        },
-                        None => metadata_document_lifecycle_revision_change(
-                            &lifecycle,
-                            self.config.local_node_id,
-                            current.planned.placement,
-                        ),
-                    };
-                    if previous.kind != DocumentSyncChangeKind::Delete {
-                        let refresh_id = ulid::Ulid::r#gen();
-                        let now = aruna_core::util::unix_timestamp_millis();
-                        let change = DocumentSyncChange {
-                            base: Some(previous.current),
-                            current: DocumentSyncRevision {
-                                generation: previous.current.generation.saturating_add(1).max(now),
-                                event_id: refresh_id,
-                                actor: self.config.local_node_id,
-                                updated_at_ms: now,
-                            },
-                            kind: DocumentSyncChangeKind::Upsert,
-                            placement: current.planned.placement,
-                        };
-                        let bytes = match postcard::to_allocvec(&lifecycle) {
-                            Ok(bytes) => bytes,
-                            Err(error) => {
-                                return self.fail(PlacementError::ConversionError(error.into()));
-                            }
-                        };
-                        match metadata_document_lifecycle_write_entry(&lifecycle) {
-                            Ok(entry) => writes.push(entry),
-                            Err(error) => return self.fail(error.into()),
-                        }
-                        match document_sync_revision_write_entry(&current.planned.target, &change) {
-                            Ok(entry) => writes.push(entry),
-                            Err(error) => return self.fail(error.into()),
-                        }
-                        let peers: Vec<NodeId> = current
-                            .planned
-                            .selected_holders
-                            .iter()
-                            .copied()
-                            .filter(|node_id| *node_id != self.config.local_node_id)
-                            .collect();
-                        if !peers.is_empty() {
-                            let outbox = new_outbox_record_with_id(
-                                refresh_id,
-                                self.config.local_node_id,
-                                current.planned.target.clone(),
-                                peers,
-                                DocumentSyncOutboxEvent::Upsert { bytes, change },
-                                current.planned.origin_node_id == self.config.local_node_id,
-                            );
-                            match outbox_write_entry(&outbox) {
-                                Ok(entry) => writes.push(entry),
-                                Err(error) => {
-                                    return self
-                                        .fail(PlacementError::ConversionError(error.into()));
-                                }
-                            }
-                            self.metadata_refresh_queued = true;
-                        }
-                    }
-                }
-            }
+            let local_is_rank0 = holders.first() == Some(&local_node_id);
+            let mut co_holders: Vec<NodeId> = holders
+                .into_iter()
+                .filter(|candidate| *candidate != local_node_id)
+                .collect();
+            sort_node_ids(&mut co_holders);
+            let groups = if local_is_rank0 {
+                &mut rank0_groups
+            } else {
+                &mut member_groups
+            };
+            groups
+                .entry(co_holders)
+                .or_default()
+                .push(bucket_topic_id(realm_id, &placement));
         }
-        match document_placement_write_entry(&current.planned) {
-            Ok(entry) => writes.push(entry),
-            Err(error) => return self.fail(error.into()),
+    }
+    for (co_holders, topics) in rank0_groups {
+        let missing: Vec<::irokle::TopicId> = topics
+            .iter()
+            .copied()
+            .filter(|topic| {
+                !net_handle
+                    .document_sync_topic_exists(*topic)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !missing.is_empty() && !co_holders.is_empty() {
+            let event = net_handle
+                .sync_document_topics(missing, co_holders.clone())
+                .await;
+            crate::startup::apply_restored_reconcile(context, local_node_id, event).await;
         }
-        self.state = PlacementState::WriteMetadataState;
-        smallvec![Effect::Storage(StorageEffect::BatchWrite {
-            writes,
-            txn_id: Some(txn_id),
-        })]
+        debug!(
+            event = "placement.genesis.ensure",
+            topics = topics.len(),
+            co_holders = co_holders.len(),
+            "Ensuring rank-0 bucket topic geneses"
+        );
+        if let Err(error) = net_handle.ensure_document_sync_topics(&topics, co_holders) {
+            warn!(error = %error, "Failed to ensure rank-0 bucket topics");
+        }
     }
-
-    fn emit_metadata_state_read(&mut self, txn_id: TxnId) -> Effects {
-        let Some(current) = self.current.as_ref() else {
-            return self.emit_next_record();
-        };
-        let document_id = match &current.planned.target {
-            DocumentSyncTarget::MetadataDocumentLifecycle { document_id } => *document_id,
-            _ => unreachable!("metadata holder changes only apply to lifecycle placements"),
-        };
-        let target = current.planned.target.clone();
-        self.txn_id = Some(txn_id);
-        self.state = PlacementState::ReadMetadataState;
-        smallvec![Effect::Storage(StorageEffect::BatchRead {
-            reads: vec![
-                (target.storage_keyspace().to_string(), target.storage_key()),
-                (
-                    DOCUMENT_SYNC_REVISION_KEYSPACE.to_string(),
-                    document_sync_revision_key(&target),
-                ),
-                (
-                    METADATA_DOCUMENT_INDEX_KEYSPACE.to_string(),
-                    metadata_document_key(document_id),
-                ),
-            ],
-            txn_id: Some(txn_id),
-        })]
-    }
-
-    fn retry_metadata_transaction(&mut self) -> Effects {
-        self.txn_id = None;
-        self.current = None;
-        self.metadata_refresh_queued = false;
-        self.retry_needed = true;
-        self.finish_placement_store()
-    }
-
-    fn finish_placement_store(&mut self) -> Effects {
-        if self.retry_needed {
-            self.rearmed = true;
-            self.state = PlacementState::ScheduleRetry;
-            smallvec![schedule_placement_retry_after(
-                self.config.realm_id,
-                self.config.local_node_id,
-                self.config.retry_after,
-            )]
-        } else {
-            self.emit_next_record()
+    // Non-rank-0 held buckets: a holder that is already a member (e.g. the
+    // previous rank-0 after a config change moved the rank) completes the
+    // membership of freshly added co-holders — a new holder cannot add itself.
+    // Topics not known locally are skipped: their rank-0 creates them with the
+    // full holder set as initial peers.
+    for (co_holders, topics) in member_groups {
+        if co_holders.is_empty() {
+            continue;
+        }
+        let known: Vec<::irokle::TopicId> = topics
+            .into_iter()
+            .filter(|topic| {
+                net_handle
+                    .document_sync_topic_exists(*topic)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if known.is_empty() {
+            continue;
+        }
+        if let Err(error) = net_handle.allow_document_sync_peers(&known, co_holders) {
+            debug!(error = %error, "Could not complete held bucket topic membership");
         }
     }
 }
 
-impl Operation for ProcessPlacementsOperation {
-    /// `true` when this tick re-armed the placement retry timer.
-    type Output = bool;
-    type Error = PlacementError;
+/// Reconciles the local node's held bucket topics with their co-holders.
+///
+/// First creates the genesis of every bucket the local node is rank-0 holder
+/// of (see [`ensure_rank0_bucket_topics`]). Then iterates the
+/// [`SYNC_PLACEMENT_KEYSPACE`] records the write path left behind (one per
+/// bucket that was not fully replicated at write time), re-resolves each
+/// bucket's holder set from the current realm config, and adds every co-holder
+/// as a member of the bucket topic. Membership changes schedule an irokle topic
+/// recheck, so the resync loop then pushes the bucket's events to any freshly
+/// added co-holder. A record whose co-holders are all members is removed; a
+/// record the local node no longer holds is dropped; a record whose bucket
+/// topic has no genesis locally yet (non-rank-0 holder, genesis in flight) is
+/// kept for retry.
+pub async fn process_bucket_placements(
+    context: &Arc<DriverContext>,
+    realm_id: RealmId,
+    local_node_id: NodeId,
+) {
+    let Some(config) = load_realm_config(context, realm_id).await else {
+        warn!(%realm_id, "Cannot process bucket placements without a realm config");
+        return;
+    };
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        return;
+    };
 
-    fn start(&mut self) -> Effects {
-        self.state = PlacementState::LoadRealmConfig;
-        smallvec![read_effect(
-            &DocumentSyncTarget::RealmConfig {
-                realm_id: self.config.realm_id,
-            },
-            None,
-        )]
-    }
+    ensure_rank0_bucket_topics(context, net_handle, &config, realm_id, local_node_id).await;
 
-    fn step(&mut self, event: Event) -> Effects {
-        match self.state {
-            PlacementState::LoadRealmConfig => match event {
-                Event::Storage(StorageEvent::ReadResult { value, .. }) => {
-                    let Some(value) = value else {
-                        return self.fail(PlacementError::RealmConfigNotFound);
-                    };
-                    let config = match RealmConfigDocument::from_bytes(&value) {
-                        Ok(config) => config,
-                        Err(error) => return self.fail(error.into()),
-                    };
-                    self.realm_config = Some(config);
-                    self.emit_list_pending()
+    let mut start_after: Option<Key> = None;
+    let mut retry_needed = false;
+    loop {
+        let batch = match context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: SYNC_PLACEMENT_KEYSPACE.to_string(),
+                prefix: Some(placement_prefix(realm_id)),
+                start: start_after.take().map(IterStart::After),
+                limit: PENDING_PLACEMENT_PAGE_SIZE,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult {
+                values,
+                next_start_after,
+            }) => {
+                start_after = next_start_after;
+                values
+            }
+            Event::Storage(StorageEvent::Error { error }) => {
+                warn!(error = %error, "Failed to list pending bucket placements");
+                return;
+            }
+            other => {
+                warn!(event = ?other, "Unexpected pending bucket placement iter result");
+                return;
+            }
+        };
+
+        for (key, value) in &batch {
+            let record = match decode_placement(value) {
+                Ok(record) => record,
+                Err(error) => {
+                    warn!(error = %error, "Deleting malformed bucket placement record");
+                    delete_record(context, key.to_vec()).await;
+                    continue;
                 }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("realm config read result", format!("{other:?}")),
-            },
-            PlacementState::ListPending => match event {
-                Event::Storage(StorageEvent::IterResult {
-                    values,
-                    next_start_after,
-                }) => {
-                    self.next_start_after = next_start_after;
-                    self.records.clear();
-                    for (_, value) in values.into_iter().rev() {
-                        let record = match decode_placement(&value) {
-                            Ok(record) => record,
-                            Err(error) => {
-                                return self.fail(PlacementError::Decode(error.to_string()));
-                            }
-                        };
-                        self.records.push(record);
+            };
+            if record.realm_id != realm_id {
+                continue;
+            }
+
+            let holders = resolve_bucket_holders(&config, &record.placement);
+            if !holders.contains(&local_node_id) {
+                // The local node is no longer a holder of this bucket.
+                delete_record(context, key.to_vec()).await;
+                continue;
+            }
+            let local_is_rank0 = holders.first() == Some(&local_node_id);
+            let mut co_holders: Vec<NodeId> = holders
+                .into_iter()
+                .filter(|node_id| *node_id != local_node_id)
+                .collect();
+            sort_node_ids(&mut co_holders);
+            if co_holders.is_empty() {
+                delete_record(context, key.to_vec()).await;
+                continue;
+            }
+
+            let topic = bucket_topic_id(realm_id, &record.placement);
+            // Rank-0 may create the genesis; every other holder is join-only
+            // and can only add members to an already-known topic.
+            let membership = if local_is_rank0 {
+                net_handle.ensure_document_sync_topics(&[topic], co_holders.clone())
+            } else {
+                net_handle.allow_document_sync_peers(&[topic], co_holders.clone())
+            };
+            match membership {
+                Ok(()) => {
+                    // Every co-holder is now a member; the resync loop delivers
+                    // the bucket's events. Record satisfied.
+                    delete_record(context, key.to_vec()).await;
+                }
+                Err(error) => {
+                    debug!(error = %error, "Bucket topic membership incomplete; keeping placement record");
+                    let refreshed = new_placement(
+                        realm_id,
+                        record.placement,
+                        local_node_id,
+                        record.selected_peers.clone(),
+                    );
+                    if let Ok(effect) = write_placement_effect(&refreshed) {
+                        let _ = context.storage_handle.send_effect(effect).await;
                     }
-                    self.emit_next_record()
+                    retry_needed = true;
                 }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => {
-                    self.unexpected_event("pending placement iter result", format!("{other:?}"))
-                }
-            },
-            PlacementState::Publish => match event {
-                Event::SubOperation(SubOperationEvent::DocumentSyncResult { result }) => {
-                    match result {
-                        Ok(()) => self.emit_placement_update(false),
-                        Err(error) => {
-                            warn!(error = %error, "Document sync failed; keeping placement pending");
-                            self.emit_placement_update(true)
-                        }
-                    }
-                }
-                other => self.unexpected_event("document sync result", format!("{other:?}")),
-            },
-            PlacementState::StorePlacement => match event {
-                Event::Storage(StorageEvent::WriteResult { .. })
-                | Event::Storage(StorageEvent::BatchWriteResult { .. })
-                | Event::Storage(StorageEvent::DeleteResult { .. }) => {
-                    if self.metadata_refresh_queued {
-                        self.state = PlacementState::ScheduleMetadataRefresh;
-                        smallvec![schedule_outbox_drain_effect()]
-                    } else {
-                        self.finish_placement_store()
-                    }
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("placement storage result", format!("{other:?}")),
-            },
-            PlacementState::StartMetadataTransaction => match event {
-                Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
-                    self.emit_metadata_state_read(txn_id)
-                }
-                Event::Storage(StorageEvent::Error {
-                    error: StorageError::TransactionConflict,
-                }) => self.retry_metadata_transaction(),
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => {
-                    self.unexpected_event("metadata transaction start result", format!("{other:?}"))
-                }
-            },
-            PlacementState::ReadMetadataState => match event {
-                Event::Storage(StorageEvent::BatchReadResult { values }) => {
-                    let [(_, lifecycle), (_, lifecycle_revision), (_, registry)] =
-                        values.as_slice()
-                    else {
-                        return self.unexpected_event(
-                            "metadata lifecycle, revision, and registry read results",
-                            format!("{} batch values", values.len()),
-                        );
-                    };
-                    let registry = match registry {
-                        Some(value) => match postcard::from_bytes(value) {
-                            Ok(record) => Some(record),
-                            Err(error) => {
-                                return self.fail(PlacementError::ConversionError(error.into()));
-                            }
-                        },
-                        None => None,
-                    };
-                    self.emit_metadata_placement_update(
-                        lifecycle.clone(),
-                        lifecycle_revision.clone(),
-                        registry,
-                    )
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => {
-                    self.unexpected_event("metadata state batch read result", format!("{other:?}"))
-                }
-            },
-            PlacementState::WriteMetadataState => match event {
-                Event::Storage(StorageEvent::BatchWriteResult { .. }) => {
-                    let Some(txn_id) = self.txn_id else {
-                        return self.fail(PlacementError::Placement(
-                            "missing metadata replan transaction".to_string(),
-                        ));
-                    };
-                    self.state = PlacementState::CommitMetadataTransaction;
-                    smallvec![Effect::Storage(StorageEffect::CommitTransaction { txn_id })]
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => {
-                    self.unexpected_event("metadata transaction write result", format!("{other:?}"))
-                }
-            },
-            PlacementState::CommitMetadataTransaction => match event {
-                Event::Storage(StorageEvent::TransactionCommitted { .. }) => {
-                    self.txn_id = None;
-                    if self.metadata_refresh_queued {
-                        self.state = PlacementState::ScheduleMetadataRefresh;
-                        smallvec![schedule_outbox_drain_effect()]
-                    } else {
-                        self.finish_placement_store()
-                    }
-                }
-                Event::Storage(StorageEvent::Error {
-                    error: StorageError::TransactionConflict,
-                }) => self.retry_metadata_transaction(),
-                Event::Storage(StorageEvent::Error { error }) => {
-                    self.txn_id = None;
-                    self.fail(error.into())
-                }
-                other => self
-                    .unexpected_event("metadata transaction commit result", format!("{other:?}")),
-            },
-            PlacementState::ScheduleMetadataRefresh => match event {
-                Event::Task(TaskEvent::TimerScheduled { .. }) => {
-                    self.metadata_refresh_queued = false;
-                    self.finish_placement_store()
-                }
-                Event::Task(TaskEvent::Error { message, .. }) => {
-                    warn!(message = %message, "Failed to schedule metadata holder refresh; durable outbox remains retryable");
-                    self.metadata_refresh_queued = false;
-                    self.finish_placement_store()
-                }
-                other => self.unexpected_event(
-                    "metadata holder refresh schedule result",
-                    format!("{other:?}"),
-                ),
-            },
-            PlacementState::ScheduleRetry => match event {
-                Event::Task(TaskEvent::TimerScheduled { .. }) => {
-                    self.retry_needed = false;
-                    self.emit_next_record()
-                }
-                Event::Task(TaskEvent::Error { message, .. }) => {
-                    warn!(message = %message, "Failed to schedule placement retry; pending placement remains durable");
-                    self.retry_needed = false;
-                    self.emit_next_record()
-                }
-                other => self.unexpected_event("task timer schedule result", format!("{other:?}")),
-            },
-            PlacementState::Init | PlacementState::Finish | PlacementState::Error => smallvec![],
+            }
+        }
+
+        if start_after.is_none() {
+            break;
         }
     }
 
-    fn is_complete(&self) -> bool {
-        matches!(self.state, PlacementState::Finish | PlacementState::Error)
+    if retry_needed && let Some(task_handle) = context.task_handle.as_ref() {
+        let effect =
+            crate::sync_placement::schedule_placement_retry_effect(realm_id, local_node_id);
+        let _ = task_handle.send_effect(effect).await;
     }
+}
 
-    fn finalize(self) -> Result<Self::Output, Self::Error> {
-        match self.output {
-            Some(Err(error)) => Err(error),
-            _ => Ok(self.rearmed),
+async fn load_realm_config(
+    context: &Arc<DriverContext>,
+    realm_id: RealmId,
+) -> Option<RealmConfigDocument> {
+    let target = DocumentSyncTarget::RealmConfig { realm_id };
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: target.storage_keyspace().to_string(),
+            key: target.storage_key(),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => {
+            value.and_then(|bytes| RealmConfigDocument::from_bytes(&bytes).ok())
         }
+        _ => None,
     }
+}
 
-    fn abort(&mut self) -> Effects {
-        match self.txn_id.take() {
-            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
-            None => smallvec![],
-        }
-    }
+async fn delete_record(context: &Arc<DriverContext>, key: Vec<u8>) {
+    let _ = context
+        .storage_handle
+        .send_effect(aruna_core::effects::Effect::Storage(
+            StorageEffect::Delete {
+                key_space: SYNC_PLACEMENT_KEYSPACE.to_string(),
+                key: ByteView::from(key),
+                txn_id: None,
+            },
+        ))
+        .await;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sync_placement::{SYNC_PLACEMENT_RETRY_AFTER, new_placement};
-    use aruna_core::structs::{
-        BindingScope, NodePlacementEntry, PlacementStrategy, RealmNodeKind, StrategyBinding,
-    };
-    use std::collections::BTreeMap;
+    use aruna_core::structs::{PlacementRef, PlacementStrategy, RealmNodeKind};
     use ulid::Ulid;
 
     fn node(seed: u8) -> NodeId {
         iroh::SecretKey::from_bytes(&[seed; 32]).public()
     }
 
-    fn group_target(seed: u8) -> DocumentSyncTarget {
-        DocumentSyncTarget::Group {
-            group_id: Ulid::from_bytes([seed; 16]),
-        }
-    }
-
-    fn metadata_target(seed: u8) -> DocumentSyncTarget {
-        DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: Ulid::from_bytes([seed; 16]),
-        }
-    }
-
-    fn config_with(nodes: &[NodeId]) -> RealmConfigDocument {
+    fn config_with(nodes: &[NodeId], replica: Option<u32>) -> (RealmConfigDocument, PlacementRef) {
         let mut config = RealmConfigDocument::new(RealmId::from_bytes([8u8; 32]), Vec::new(), 3);
         let strategy = PlacementStrategy {
             strategy_id: Ulid::from_bytes([9u8; 16]),
             name: "default".to_string(),
-            replica_count: None,
+            replica_count: replica,
             distinct_locations: false,
             affinity: Vec::new(),
             bucket_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
-        config.strategies = vec![strategy];
+        config.strategies = vec![strategy.clone()];
         for node_id in nodes {
             config.ensure_node(*node_id, RealmNodeKind::Server);
         }
-        config
-    }
-
-    fn finish_missing_metadata_state_read(
-        operation: &mut ProcessPlacementsOperation,
-        effects: Effects,
-    ) -> Effects {
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Storage(StorageEffect::StartTransaction {
-                read: false
-            })]
-        ));
-        let txn_id = Ulid::from_bytes([14; 16]);
-        let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Storage(StorageEffect::BatchRead {
-                reads,
-                txn_id: Some(read_txn_id),
-            })] if reads.len() == 3 && *read_txn_id == txn_id
-        ));
-        operation.step(Event::Storage(StorageEvent::BatchReadResult {
-            values: vec![
-                (Key::from(vec![1]), None),
-                (Key::from(vec![2]), None),
-                (Key::from(vec![3]), None),
-            ],
-        }))
-    }
-
-    fn placement_from_batch(effects: &Effects) -> PendingDocumentPlacement {
-        let [Effect::Storage(StorageEffect::BatchWrite { writes, .. })] = effects.as_slice() else {
-            panic!("expected placement batch write, got {effects:?}");
-        };
-        writes
-            .iter()
-            .find(|(key_space, _, _)| key_space == SYNC_PLACEMENT_KEYSPACE)
-            .and_then(|(_, _, value)| decode_placement(value).ok())
-            .expect("placement update is present")
-    }
-
-    #[test]
-    fn task_schedule_error_is_non_blocking_after_placement_write() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(1),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.state = PlacementState::ScheduleRetry;
-        operation.retry_needed = true;
-
-        let effects = operation.step(Event::Task(TaskEvent::Error {
-            key: None,
-            message: "task handle unavailable".to_string(),
-        }));
-
-        assert!(effects.is_empty());
-        assert_eq!(operation.state, PlacementState::Finish);
-        assert_eq!(operation.finalize(), Ok(false));
-    }
-
-    #[test]
-    fn completed_inventory_record_is_rewritten_not_deleted() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let target = metadata_target(4);
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(1),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config_with(&[node(1), node(2), node(3)]));
-        operation.records = vec![new_placement(
-            realm_id,
-            target,
-            node(1),
-            3,
-            vec![node(1), node(2), node(3)],
-            PlacementRef::NIL,
-        )];
-
-        let effects = operation.emit_next_record();
-
-        let [Effect::Storage(StorageEffect::Write { value, .. })] = effects.as_slice() else {
-            panic!("expected retained placement write, got {effects:?}");
-        };
-        let record = decode_placement(value.as_ref()).expect("placement decodes");
-        assert_eq!(record.selected_holders.len(), 3);
-        assert!(!operation.retry_needed);
-    }
-
-    #[test]
-    fn process_placement_may_select_origin_as_holder() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let origin = node(1);
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(9),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config_with(&[origin, node(2)]));
-        operation.records = vec![new_placement(
-            realm_id,
-            metadata_target(5),
-            origin,
-            3,
-            vec![node(2)],
-            PlacementRef::NIL,
-        )];
-
-        let effects = operation.emit_next_record();
-
-        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
-        let current = operation.current.expect("placement is active");
-        assert_eq!(current.planned.origin_node_id, origin);
-        assert!(current.planned.selected_holders.contains(&origin));
-        assert!(current.planned.selected_holders.contains(&node(2)));
-        assert!(current.newly_required_remote_holders.contains(&origin));
-        assert!(!current.newly_required_remote_holders.contains(&node(2)));
-    }
-
-    #[test]
-    fn full_and_draining_holders_are_replaced_in_exact_record() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let target = metadata_target(6);
-        let mut config = config_with(&[node(1), node(2), node(3), node(4)]);
-        config.strategies[0].replica_count = Some(2);
-        config.placement_map = vec![
-            NodePlacementEntry {
-                node_id: node(1),
-                location: String::new(),
-                weight: 100,
-                full: true,
-                draining: false,
-                labels: BTreeMap::new(),
-            },
-            NodePlacementEntry {
-                node_id: node(2),
-                location: String::new(),
-                weight: 100,
-                full: false,
-                draining: true,
-                labels: BTreeMap::new(),
-            },
-        ];
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(9),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config);
-        operation.records = vec![new_placement(
-            realm_id,
-            target,
-            node(1),
-            2,
-            vec![node(1), node(2)],
-            PlacementRef::NIL,
-        )];
-
-        let effects = operation.emit_next_record();
-        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
-        let effects = operation.step(Event::SubOperation(SubOperationEvent::DocumentSyncResult {
-            result: Ok(()),
-        }));
-        let effects = finish_missing_metadata_state_read(&mut operation, effects);
-        let record = placement_from_batch(&effects);
-        assert_eq!(record.desired_holder_count, 2);
-        assert_eq!(record.selected_holders.len(), 2);
-        assert!(record.selected_holders.contains(&node(3)));
-        assert!(record.selected_holders.contains(&node(4)));
-        assert!(!record.selected_holders.contains(&node(1)));
-        assert!(!record.selected_holders.contains(&node(2)));
-        assert!(!operation.retry_needed);
-    }
-
-    #[test]
-    fn metadata_replan_missing_source_and_transaction_conflict_remain_retryable() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let document_id = Ulid::from_bytes([12; 16]);
-        let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-        let mut config = config_with(&[node(1), node(2), node(3)]);
-        config.strategies[0].replica_count = Some(2);
-        config.placement_map = vec![NodePlacementEntry {
-            node_id: node(1),
-            location: String::new(),
-            weight: 100,
-            full: true,
-            draining: false,
-            labels: BTreeMap::new(),
-        }];
-        let group_id = Ulid::from_bytes([11; 16]);
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(9),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config);
-        operation.records = vec![new_placement_with_context(
-            realm_id,
-            target,
-            node(9),
-            Some(group_id),
-            Some("datasets/replan".to_string()),
-            2,
-            vec![node(1), node(2)],
-            PlacementRef::NIL,
-        )];
-
-        let effects = operation.emit_next_record();
-        let Some(Effect::SubOperation(mut transfer)) = effects.into_iter().next() else {
-            panic!("expected required transfer sub-operation");
-        };
-        assert!(matches!(
-            transfer.start().as_slice(),
-            [Effect::Storage(StorageEffect::Read { .. })]
-        ));
-        assert!(
-            transfer
-                .step(Event::Storage(StorageEvent::ReadResult {
-                    key: Key::from(Vec::new()),
-                    value: None,
-                }))
-                .is_empty()
-        );
-        assert!(transfer.is_complete());
-
-        let effects = operation.step(transfer.finalize());
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Storage(StorageEffect::StartTransaction {
-                read: false
-            })]
-        ));
-        let txn_id = Ulid::from_bytes([15; 16]);
-        let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Storage(StorageEffect::BatchRead {
-                reads,
-                txn_id: Some(read_txn_id),
-            })] if reads.len() == 3 && *read_txn_id == txn_id
-        ));
-
-        let registry = MetadataRegistryRecord {
-            realm_id,
-            group_id,
-            document_id,
-            document_path: "datasets/replan".to_string(),
-            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
-            public: false,
-            permission_path: MetadataRegistryRecord::permission_path_for(
-                &realm_id,
-                group_id,
-                "datasets/replan",
-                document_id,
-            ),
-            holder_node_ids: vec![node(1), node(2)],
-            created_at_ms: 1,
-            updated_at_ms: 1,
-            last_event_id: Ulid::from_bytes([10; 16]),
-        };
-        let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
-            values: vec![
-                (Key::from(vec![1]), None),
-                (Key::from(vec![2]), None),
-                (
-                    Key::from(vec![3]),
-                    Some(
-                        postcard::to_allocvec(&registry)
-                            .expect("registry serializes")
-                            .into(),
-                    ),
-                ),
-            ],
-        }));
-        let [
-            Effect::Storage(StorageEffect::BatchWrite {
-                writes,
-                txn_id: Some(write_txn_id),
-            }),
-        ] = effects.as_slice()
-        else {
-            panic!("expected atomic registry and placement update, got {effects:?}");
-        };
-        assert_eq!(*write_txn_id, txn_id);
-        let registry = writes
-            .iter()
-            .find(|(key_space, _, _)| key_space == aruna_core::keyspaces::METADATA_INDEX_KEYSPACE)
-            .and_then(|(_, _, value)| postcard::from_bytes::<MetadataRegistryRecord>(value).ok())
-            .expect("registry update is present");
-        assert_eq!(registry.holder_node_ids, vec![node(2)]);
-        let placement = writes
-            .iter()
-            .find(|(key_space, _, _)| key_space == SYNC_PLACEMENT_KEYSPACE)
-            .and_then(|(_, _, value)| decode_placement(value).ok())
-            .expect("placement update is present");
-        assert_eq!(placement.selected_holders, vec![node(2)]);
-        assert!(operation.retry_needed);
-
-        let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
-            entries: Vec::new(),
-        }));
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Storage(StorageEffect::CommitTransaction { txn_id: commit_txn_id })]
-                if *commit_txn_id == txn_id
-        ));
-        let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::TransactionConflict,
-        }));
-        assert!(matches!(effects.as_slice(), [Effect::Task(_)]));
-        assert!(operation.rearmed);
-        assert!(operation.retry_needed);
-        assert!(operation.txn_id.is_none());
-        assert!(!operation.metadata_refresh_queued);
-    }
-
-    #[test]
-    fn process_placement_does_not_implicitly_count_origin() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let origin = node(1);
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(9),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config_with(&[origin, node(2)]));
-        operation.records = vec![new_placement(
-            realm_id,
-            metadata_target(7),
-            origin,
-            2,
-            Vec::new(),
-            PlacementRef::NIL,
-        )];
-
-        let effects = operation.emit_next_record();
-
-        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
-        let current = operation.current.expect("placement is active");
-        assert_eq!(current.newly_required_remote_holders.len(), 2);
-        assert!(current.newly_required_remote_holders.contains(&origin));
-        assert!(current.newly_required_remote_holders.contains(&node(2)));
-    }
-
-    #[test]
-    fn metadata_binding_and_replica_change_replace_count_ref_and_holders() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let target = metadata_target(8);
-        let path_strategy = PlacementStrategy {
-            strategy_id: Ulid::from_bytes([10; 16]),
-            name: "path".to_string(),
-            replica_count: Some(2),
-            distinct_locations: false,
-            affinity: Vec::new(),
-        };
-        let mut config = config_with(&[node(1), node(2), node(3)]);
-        config.strategies[0].replica_count = Some(1);
-        config.strategies.push(path_strategy.clone());
-        config.strategy_bindings.push(StrategyBinding {
-            scope: BindingScope::MetadataPathPrefix("datasets/special".to_string()),
-            strategy_id: path_strategy.strategy_id,
-        });
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(9),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config);
-        operation.records = vec![new_placement_with_context(
-            realm_id,
-            target,
-            node(1),
-            Some(Ulid::from_bytes([4; 16])),
-            Some("datasets/special/object".to_string()),
-            1,
-            vec![node(1)],
+        (
+            config,
             PlacementRef {
-                strategy_id: Ulid::from_bytes([9; 16]),
+                strategy_id: strategy.strategy_id,
                 epoch: 0,
+                bucket: 3,
             },
-        )];
-
-        let effects = operation.emit_next_record();
-        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
-        let current = operation.current.as_ref().expect("placement is active");
-        assert_eq!(current.planned.desired_holder_count, 2);
-        assert_eq!(current.planned.selected_holders.len(), 2);
-        assert_eq!(
-            current.planned.placement.strategy_id,
-            path_strategy.strategy_id
-        );
-        assert_eq!(
-            current.planned.metadata_path.as_deref(),
-            Some("datasets/special/object")
-        );
-
-        let effects = operation.emit_placement_update(false);
-        let effects = finish_missing_metadata_state_read(&mut operation, effects);
-        let record = placement_from_batch(&effects);
-        assert_eq!(record.desired_holder_count, 2);
-        assert_eq!(record.selected_holders.len(), 2);
-        assert_eq!(record.placement.strategy_id, path_strategy.strategy_id);
+        )
     }
 
     #[test]
-    fn admin_target_placement_is_drained_not_retried() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: node(1),
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.records = vec![new_placement(
-            realm_id,
-            group_target(4),
-            node(1),
-            3,
-            Vec::new(),
-            PlacementRef::NIL,
-        )];
+    fn bucket_holders_are_deterministic_across_node_ordering() {
+        let (config, placement) = config_with(&[node(1), node(2), node(3), node(4)], None);
+        let first = resolve_bucket_holders(&config, &placement);
 
-        let effects = operation.emit_next_record();
+        let (reversed, _) = config_with(&[node(4), node(3), node(2), node(1)], None);
+        let second = resolve_bucket_holders(&reversed, &placement);
 
-        assert!(matches!(
-            effects.as_slice(),
-            [Effect::Storage(StorageEffect::Delete { key_space, .. })]
-                if key_space == SYNC_PLACEMENT_KEYSPACE
-        ));
-        assert!(!operation.retry_needed);
-        assert_eq!(operation.state, PlacementState::StorePlacement);
-        assert!(operation.current.is_none());
-    }
-
-    fn announce_outbox_record(
-        effects: Effects,
-        document_bytes: Vec<u8>,
-    ) -> aruna_core::document::DocumentSyncOutboxRecord {
-        let Some(Effect::SubOperation(mut sub)) = effects.into_iter().next() else {
-            panic!("expected announce sub-operation");
-        };
-        let _read = sub.start();
-        let write_effects = sub.step(Event::Storage(StorageEvent::ReadResult {
-            key: Key::from(vec![0u8]),
-            value: Some(aruna_core::types::Value::from(document_bytes)),
-        }));
-        let [Effect::Storage(StorageEffect::Write { value, .. })] = write_effects.as_slice() else {
-            panic!("expected announce outbox write, got {write_effects:?}");
-        };
-        let record: aruna_core::document::DocumentSyncOutboxRecord =
-            postcard::from_bytes(value.as_ref()).expect("outbox record decodes");
-        record
-    }
-
-    fn announce_outbox_allow_genesis(effects: Effects, document_bytes: Vec<u8>) -> bool {
-        announce_outbox_record(effects, document_bytes).allow_genesis
-    }
-
-    fn graph_lifecycle_fixture() -> (DocumentSyncTarget, Vec<u8>) {
-        let record = aruna_core::metadata::MetadataGraphLifecycleRecord::deleted(
-            "urn:graph:placement-test".to_string(),
-            RealmId::from_bytes([8u8; 32]),
-            aruna_core::types::GroupId::r#gen(),
-            Ulid::from_bytes([9u8; 16]),
-            42,
-        );
-        let bytes = postcard::to_allocvec(&record).expect("lifecycle record serializes");
-        let target = DocumentSyncTarget::MetadataGraphLifecycle {
-            graph_iri: record.graph_iri.clone(),
-        };
-        (target, bytes)
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 4);
     }
 
     #[test]
-    fn process_local_holder_is_counted_but_not_a_network_peer() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let local = node(1);
-        let remote = node(2);
-        let (target, bytes) = graph_lifecycle_fixture();
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: local,
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config_with(&[local, remote]));
-        operation.records = vec![new_placement(
-            realm_id,
-            target,
-            node(9),
-            2,
-            Vec::new(),
-            PlacementRef::NIL,
-        )];
-
-        let effects = operation.emit_next_record();
-
-        let current = operation.current.as_ref().expect("placement is active");
-        assert!(current.planned.selected_holders.contains(&local));
-        assert!(current.planned.selected_holders.contains(&remote));
-        assert_eq!(current.selected_holders_after_failure, vec![local]);
-        assert_eq!(current.newly_required_remote_holders, vec![remote]);
-        let expected_placement = current.planned.placement;
-        let outbox = announce_outbox_record(effects, bytes);
-        assert_eq!(outbox.peers, vec![remote]);
-        let aruna_core::document::DocumentSyncOutboxEvent::Upsert { change, .. } = outbox.event
-        else {
-            panic!("expected upsert outbox event");
-        };
-        assert_eq!(change.placement, expected_placement);
-    }
-
-    fn placement_announce_allow_genesis(
-        local: NodeId,
-        origin: NodeId,
-        target: DocumentSyncTarget,
-        document_bytes: Vec<u8>,
-    ) -> bool {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let mut operation = ProcessPlacementsOperation::new(PlacementConfig {
-            realm_id,
-            local_node_id: local,
-            retry_after: SYNC_PLACEMENT_RETRY_AFTER,
-        });
-        operation.realm_config = Some(config_with(&[node(1), node(2), node(3), local]));
-        operation.records = vec![new_placement(
-            realm_id,
-            target,
-            origin,
-            3,
-            Vec::new(),
-            PlacementRef::NIL,
-        )];
-        announce_outbox_allow_genesis(operation.emit_next_record(), document_bytes)
-    }
-
-    #[test]
-    fn ordinary_document_retry_allow_genesis_tracks_origin() {
-        let local = node(1);
-        let (target, bytes) = graph_lifecycle_fixture();
-        assert!(
-            placement_announce_allow_genesis(local, local, target.clone(), bytes.clone()),
-            "local origin may mint genesis"
-        );
-        assert!(
-            !placement_announce_allow_genesis(node(9), local, target, bytes),
-            "non-origin publisher must not mint genesis"
-        );
-    }
-
-    #[test]
-    fn node_info_origin_retry_disallows_genesis() {
-        let realm_id = RealmId::from_bytes([8u8; 32]);
-        let local = node(1);
-        let target = DocumentSyncTarget::NodeInfo {
-            realm_id,
-            node_id: local,
-        };
-
-        assert!(
-            !placement_announce_allow_genesis(local, local, target, b"node info".to_vec()),
-            "NodeInfo retries must not mint shared-topic genesis"
-        );
+    fn replica_capped_bucket_holder_set_is_bounded() {
+        let (config, placement) = config_with(&[node(1), node(2), node(3), node(4)], Some(2));
+        let holders = resolve_bucket_holders(&config, &placement);
+        assert_eq!(holders.len(), 2);
     }
 }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use aruna_core::NodeId;
@@ -50,6 +50,7 @@ async fn ensure_held_shard_topics(
     config: &RealmConfigDocument,
     realm_id: RealmId,
     local_node_id: NodeId,
+    verified: &BTreeSet<::irokle::TopicId>,
 ) -> HeldTopicOutcome {
     let mut rank0_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     let mut member_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
@@ -89,8 +90,15 @@ async fn ensure_held_shard_topics(
             co_holders = co_holders.len(),
             "Ensuring rank-0 shard topic geneses"
         );
-        outcome.withheld |=
-            ensure_rank0_shard_group(context, net_handle, local_node_id, co_holders, topics).await;
+        outcome.withheld |= ensure_rank0_shard_group(
+            context,
+            net_handle,
+            local_node_id,
+            co_holders,
+            topics,
+            verified,
+        )
+        .await;
     }
     // Non-rank-0 held shards. A topic not known locally is pulled from a
     // co-holder: `sync_document_topics` is join-only (it adopts an existing
@@ -111,7 +119,7 @@ async fn ensure_held_shard_topics(
         // missing topic is expected here; the exact membership pass below is
         // repeated after a successful pull.
         let _ = net_handle
-            .reconcile_shard_membership(&topics, current_holders.clone())
+            .reconcile_shard_membership(&topics, current_holders.clone(), verified)
             .await;
         let (mut known, missing): (Vec<::irokle::TopicId>, Vec<::irokle::TopicId>) =
             topics.into_iter().partition(|topic| {
@@ -147,7 +155,7 @@ async fn ensure_held_shard_topics(
             continue;
         }
         if let Err(error) = net_handle
-            .reconcile_shard_membership(&known, current_holders)
+            .reconcile_shard_membership(&known, current_holders, verified)
             .await
         {
             debug!(error = %error, "Could not complete held shard topic membership");
@@ -178,6 +186,7 @@ pub(crate) async fn ensure_rank0_shard_group(
     local_node_id: NodeId,
     co_holders: Vec<NodeId>,
     topics: Vec<::irokle::TopicId>,
+    verified: &BTreeSet<::irokle::TopicId>,
 ) -> bool {
     let mut current_holders = co_holders.clone();
     current_holders.push(local_node_id);
@@ -185,7 +194,7 @@ pub(crate) async fn ensure_rank0_shard_group(
     // This first pass installs publisher policy even when a topic still needs
     // to be adopted or created. Exact membership is retried once it exists.
     let _ = net_handle
-        .reconcile_shard_membership(&topics, current_holders.clone())
+        .reconcile_shard_membership(&topics, current_holders.clone(), verified)
         .await;
 
     let mut to_ensure: Vec<::irokle::TopicId> = Vec::new();
@@ -255,7 +264,7 @@ pub(crate) async fn ensure_rank0_shard_group(
         match net_handle.ensure_document_sync_topics(&to_ensure, co_holders) {
             Ok(()) => {
                 if let Err(error) = net_handle
-                    .reconcile_shard_membership(&to_ensure, current_holders)
+                    .reconcile_shard_membership(&to_ensure, current_holders, verified)
                     .await
                 {
                     warn!(error = %error, "Failed to reconcile rank-0 shard membership");
@@ -360,11 +369,21 @@ pub async fn process_shard_placements(
         return PlacementReconcileOutcome::clean();
     };
 
+    // Former-holder history cutoffs are frozen only for durably verified shards.
+    let verified = crate::shard::verify::load_verified_shard_topics(context, realm_id).await;
+
     // A withheld genesis or an unpulled held topic leaves no placement record,
     // so it alone must still arm the retry below (otherwise writes defer at 1s
     // forever).
-    let held =
-        ensure_held_shard_topics(context, net_handle, &config, realm_id, local_node_id).await;
+    let held = ensure_held_shard_topics(
+        context,
+        net_handle,
+        &config,
+        realm_id,
+        local_node_id,
+        &verified,
+    )
+    .await;
     let mut retry_needed = held.withheld || held.pull_pending;
 
     let mut start_after: Option<Key> = None;
@@ -464,7 +483,7 @@ pub async fn process_shard_placements(
             // The topic exists locally, so reconcile its exact canonical holder
             // set without creating a genesis or changing shared/default peers.
             let membership = net_handle
-                .reconcile_shard_membership(&[topic], holders)
+                .reconcile_shard_membership(&[topic], holders, &verified)
                 .await;
             match membership {
                 Ok(()) => {

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -68,30 +68,13 @@ async fn ensure_rank0_shard_topics(
         }
     }
     for (co_holders, topics) in rank0_groups {
-        let missing: Vec<::irokle::TopicId> = topics
-            .iter()
-            .copied()
-            .filter(|topic| {
-                !net_handle
-                    .document_sync_topic_exists(*topic)
-                    .unwrap_or(false)
-            })
-            .collect();
-        if !missing.is_empty() && !co_holders.is_empty() {
-            let event = net_handle
-                .sync_document_topics(missing, co_holders.clone())
-                .await;
-            crate::startup::apply_restored_reconcile(context, local_node_id, event).await;
-        }
         debug!(
             event = "placement.genesis.ensure",
             topics = topics.len(),
             co_holders = co_holders.len(),
             "Ensuring rank-0 shard topic geneses"
         );
-        if let Err(error) = net_handle.ensure_document_sync_topics(&topics, co_holders) {
-            warn!(error = %error, "Failed to ensure rank-0 shard topics");
-        }
+        ensure_rank0_shard_group(context, net_handle, local_node_id, co_holders, topics).await;
     }
     // Non-rank-0 held shards: a holder that is already a member (e.g. the
     // previous rank-0 after a config change moved the rank) completes the
@@ -116,6 +99,85 @@ async fn ensure_rank0_shard_topics(
         if let Err(error) = net_handle.allow_document_sync_peers(&known, co_holders) {
             debug!(error = %error, "Could not complete held shard topic membership");
         }
+    }
+}
+
+/// Ensures the shard topics of one rank-0 co-holder group, creating a fresh
+/// genesis only with positive confirmation that none exists.
+///
+/// Topics already known locally are ensured (membership top-up only, never a
+/// create). For a missing topic the co-holders are probed: one that a co-holder
+/// already holds is adopted via anti-entropy; one that every reached co-holder
+/// lacks is created fresh; but if any co-holder was unreachable, creation is
+/// withheld and left for the next placement pass — a down co-holder might hold a
+/// genesis, and forking a second one is a permanent split-brain. A sole holder
+/// (no co-holders) creates immediately: no peer can hold a divergent genesis.
+pub(crate) async fn ensure_rank0_shard_group(
+    context: &Arc<DriverContext>,
+    net_handle: &aruna_net::NetHandle,
+    local_node_id: NodeId,
+    co_holders: Vec<NodeId>,
+    topics: Vec<::irokle::TopicId>,
+) {
+    let mut to_ensure: Vec<::irokle::TopicId> = Vec::new();
+    let mut missing: Vec<::irokle::TopicId> = Vec::new();
+    for topic in topics {
+        if net_handle
+            .document_sync_topic_exists(topic)
+            .unwrap_or(false)
+        {
+            to_ensure.push(topic);
+        } else {
+            missing.push(topic);
+        }
+    }
+
+    if !missing.is_empty() {
+        if co_holders.is_empty() {
+            to_ensure.extend(missing);
+        } else {
+            let probe = net_handle
+                .probe_shard_topic_geneses(missing.clone(), co_holders.clone())
+                .await;
+            let mut to_adopt: Vec<::irokle::TopicId> = Vec::new();
+            for topic in missing {
+                if probe.known_by_co_holder.contains(&topic) {
+                    to_adopt.push(topic);
+                } else if probe.unreachable.is_empty() {
+                    to_ensure.push(topic);
+                }
+                // Otherwise a co-holder was unreachable: withhold this genesis.
+            }
+            if !to_adopt.is_empty() {
+                let event = net_handle
+                    .sync_document_topics(to_adopt.clone(), co_holders.clone())
+                    .await;
+                crate::startup::apply_restored_reconcile(context, local_node_id, event).await;
+                // Only ensure membership on topics whose genesis actually landed;
+                // an adopt that failed (co-holder now unreachable) must not fall
+                // through to a fresh create.
+                for topic in to_adopt {
+                    if net_handle
+                        .document_sync_topic_exists(topic)
+                        .unwrap_or(false)
+                    {
+                        to_ensure.push(topic);
+                    }
+                }
+            }
+            if !probe.unreachable.is_empty() {
+                warn!(
+                    unreachable = ?probe.unreachable,
+                    "Withholding shard genesis creation: co-holder(s) unreachable"
+                );
+            }
+        }
+    }
+
+    if !to_ensure.is_empty()
+        && let Err(error) = net_handle.ensure_document_sync_topics(&to_ensure, co_holders)
+    {
+        warn!(error = %error, "Failed to ensure rank-0 shard topics");
     }
 }
 
@@ -209,8 +271,34 @@ pub async fn process_shard_placements(
             }
 
             let topic = shard_topic_id(realm_id, &record.placement);
-            // Rank-0 may create the genesis; every other holder is join-only
-            // and can only add members to an already-known topic.
+            // Genesis creation is owned by `ensure_rank0_shard_topics` (gated on
+            // positive co-holder confirmation); this loop only tops up membership
+            // on a topic already known locally. A topic whose genesis is not yet
+            // local — a rank-0 create withheld for a down co-holder, or a
+            // non-rank-0 holder still awaiting gossip — is kept for the next pass
+            // rather than force-created into a fork.
+            if !net_handle
+                .document_sync_topic_exists(topic)
+                .unwrap_or(false)
+            {
+                debug!(
+                    ?topic,
+                    "Shard topic genesis not local yet; keeping placement record"
+                );
+                let refreshed = new_placement(
+                    realm_id,
+                    record.placement,
+                    local_node_id,
+                    record.selected_peers.clone(),
+                );
+                if let Ok(effect) = write_placement_effect(&refreshed) {
+                    let _ = context.storage_handle.send_effect(effect).await;
+                }
+                retry_needed = true;
+                continue;
+            }
+            // The topic exists locally, so ensure only adds members (never
+            // creates); a non-rank-0 holder likewise only adds members.
             let membership = if local_is_rank0 {
                 net_handle.ensure_document_sync_topics(&[topic], co_holders.clone())
             } else {

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -104,6 +104,15 @@ async fn ensure_held_shard_topics(
         if co_holders.is_empty() {
             continue;
         }
+        let mut current_holders = co_holders.clone();
+        current_holders.push(local_node_id);
+        sort_node_ids(&mut current_holders);
+        // Install the current publisher policy before pulling any history. A
+        // missing topic is expected here; the exact membership pass below is
+        // repeated after a successful pull.
+        let _ = net_handle
+            .reconcile_shard_membership(&topics, current_holders.clone())
+            .await;
         let (mut known, missing): (Vec<::irokle::TopicId>, Vec<::irokle::TopicId>) =
             topics.into_iter().partition(|topic| {
                 net_handle
@@ -137,7 +146,10 @@ async fn ensure_held_shard_topics(
         if known.is_empty() {
             continue;
         }
-        if let Err(error) = net_handle.allow_document_sync_peers(&known, co_holders) {
+        if let Err(error) = net_handle
+            .reconcile_shard_membership(&known, current_holders)
+            .await
+        {
             debug!(error = %error, "Could not complete held shard topic membership");
             outcome.withheld = true;
         }
@@ -167,6 +179,15 @@ pub(crate) async fn ensure_rank0_shard_group(
     co_holders: Vec<NodeId>,
     topics: Vec<::irokle::TopicId>,
 ) -> bool {
+    let mut current_holders = co_holders.clone();
+    current_holders.push(local_node_id);
+    sort_node_ids(&mut current_holders);
+    // This first pass installs publisher policy even when a topic still needs
+    // to be adopted or created. Exact membership is retried once it exists.
+    let _ = net_handle
+        .reconcile_shard_membership(&topics, current_holders.clone())
+        .await;
+
     let mut to_ensure: Vec<::irokle::TopicId> = Vec::new();
     let mut missing: Vec<::irokle::TopicId> = Vec::new();
     for topic in topics {
@@ -230,11 +251,22 @@ pub(crate) async fn ensure_rank0_shard_group(
         }
     }
 
-    if !to_ensure.is_empty()
-        && let Err(error) = net_handle.ensure_document_sync_topics(&to_ensure, co_holders)
-    {
-        warn!(error = %error, "Failed to ensure rank-0 shard topics");
-        withheld = true;
+    if !to_ensure.is_empty() {
+        match net_handle.ensure_document_sync_topics(&to_ensure, co_holders) {
+            Ok(()) => {
+                if let Err(error) = net_handle
+                    .reconcile_shard_membership(&to_ensure, current_holders)
+                    .await
+                {
+                    warn!(error = %error, "Failed to reconcile rank-0 shard membership");
+                    withheld = true;
+                }
+            }
+            Err(error) => {
+                warn!(error = %error, "Failed to ensure rank-0 shard topics");
+                withheld = true;
+            }
+        }
     }
     withheld
 }
@@ -298,10 +330,10 @@ enum RealmConfigLoadOutcome {
 /// from a co-holder. Then iterates the
 /// [`SYNC_PLACEMENT_KEYSPACE`] records the write path left behind (one per
 /// shard that was not fully replicated at write time), re-resolves each
-/// shard's holder set from the current realm config, and adds every co-holder
-/// as a member of the shard topic. Membership changes schedule an irokle topic
-/// recheck, so the resync loop then pushes the shard's events to any freshly
-/// added co-holder. A record whose co-holders are all members is removed; a
+/// shard's holder set from the current realm config, and makes those holders
+/// the shard topic's exact members and accepted publishers. Membership changes
+/// schedule an irokle topic recheck, so the resync loop then pushes the shard's
+/// events to any freshly added co-holder. A satisfied record is removed; a
 /// record the local node no longer holds is dropped; a record whose shard
 /// topic has no genesis locally yet (non-rank-0 holder, genesis in flight) is
 /// kept for retry.
@@ -391,9 +423,9 @@ pub async fn process_shard_placements(
                 .await;
                 continue;
             }
-            let local_is_rank0 = holders.first() == Some(&local_node_id);
             let mut co_holders: Vec<NodeId> = holders
-                .into_iter()
+                .iter()
+                .copied()
                 .filter(|node_id| *node_id != local_node_id)
                 .collect();
             sort_node_ids(&mut co_holders);
@@ -429,13 +461,11 @@ pub async fn process_shard_placements(
                 retry_needed = true;
                 continue;
             }
-            // The topic exists locally, so ensure only adds members (never
-            // creates); a non-rank-0 holder likewise only adds members.
-            let membership = if local_is_rank0 {
-                net_handle.ensure_document_sync_topics(&[topic], co_holders.clone())
-            } else {
-                net_handle.allow_document_sync_peers(&[topic], co_holders.clone())
-            };
+            // The topic exists locally, so reconcile its exact canonical holder
+            // set without creating a genesis or changing shared/default peers.
+            let membership = net_handle
+                .reconcile_shard_membership(&[topic], holders)
+                .await;
             match membership {
                 Ok(()) => {
                     // Every co-holder is now a member; the resync loop delivers

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -241,10 +241,50 @@ pub(crate) async fn ensure_rank0_shard_group(
 
 /// What a [`process_shard_placements`] pass decided about follow-up work.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PlacementReconcileStatus {
+    /// Reconciliation completed without scheduling more work.
+    #[default]
+    Clean,
+    /// A genesis was withheld or a record left incomplete, so the reconciler
+    /// scheduled its own [`TaskKey::SyncPlacements`] retry timer.
+    RetryScheduled,
+    /// Storage could not provide a trustworthy config or placement scan. A
+    /// timer consumer must re-arm the consumed timer.
+    StorageFailure,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct PlacementReconcileOutcome {
-    /// A genesis was withheld or a record left incomplete, so a
-    /// [`TaskKey::SyncPlacements`] retry timer was scheduled.
+    /// Compatibility signal for callers that only need to know whether the
+    /// reconciler armed its own retry.
     pub retry_scheduled: bool,
+    pub status: PlacementReconcileStatus,
+}
+
+impl PlacementReconcileOutcome {
+    fn clean() -> Self {
+        Self::default()
+    }
+
+    fn retry_scheduled() -> Self {
+        Self {
+            retry_scheduled: true,
+            status: PlacementReconcileStatus::RetryScheduled,
+        }
+    }
+
+    fn storage_failure() -> Self {
+        Self {
+            retry_scheduled: false,
+            status: PlacementReconcileStatus::StorageFailure,
+        }
+    }
+}
+
+enum RealmConfigLoadOutcome {
+    Found(RealmConfigDocument),
+    Absent,
+    StorageFailure,
 }
 
 /// Reconciles the local node's held shard topics with their co-holders.
@@ -270,13 +310,18 @@ pub async fn process_shard_placements(
     realm_id: RealmId,
     local_node_id: NodeId,
 ) -> PlacementReconcileOutcome {
-    let mut outcome = PlacementReconcileOutcome::default();
-    let Some(config) = load_realm_config(context, realm_id).await else {
-        warn!(%realm_id, "Cannot process shard placements without a realm config");
-        return outcome;
+    let config = match load_realm_config_outcome(context, realm_id).await {
+        RealmConfigLoadOutcome::Found(config) => config,
+        RealmConfigLoadOutcome::Absent => {
+            warn!(%realm_id, "Cannot process shard placements without a realm config");
+            return PlacementReconcileOutcome::clean();
+        }
+        RealmConfigLoadOutcome::StorageFailure => {
+            return PlacementReconcileOutcome::storage_failure();
+        }
     };
     let Some(net_handle) = context.net_handle.as_ref() else {
-        return outcome;
+        return PlacementReconcileOutcome::clean();
     };
 
     // A withheld genesis or an unpulled held topic leaves no placement record,
@@ -308,11 +353,11 @@ pub async fn process_shard_placements(
             }
             Event::Storage(StorageEvent::Error { error }) => {
                 warn!(error = %error, "Failed to list pending shard placements");
-                return outcome;
+                return PlacementReconcileOutcome::storage_failure();
             }
             other => {
                 warn!(event = ?other, "Unexpected pending shard placement iter result");
-                return outcome;
+                return PlacementReconcileOutcome::storage_failure();
             }
         };
 
@@ -426,15 +471,15 @@ pub async fn process_shard_placements(
         let effect =
             crate::sync_placement::schedule_placement_retry_after(realm_id, local_node_id, after);
         let _ = task_handle.send_effect(effect).await;
-        outcome.retry_scheduled = true;
+        return PlacementReconcileOutcome::retry_scheduled();
     }
-    outcome
+    PlacementReconcileOutcome::clean()
 }
 
-pub(crate) async fn load_realm_config(
+async fn load_realm_config_outcome(
     context: &Arc<DriverContext>,
     realm_id: RealmId,
-) -> Option<RealmConfigDocument> {
+) -> RealmConfigLoadOutcome {
     let target = DocumentSyncTarget::RealmConfig { realm_id };
     match context
         .storage_handle
@@ -445,10 +490,36 @@ pub(crate) async fn load_realm_config(
         })
         .await
     {
-        Event::Storage(StorageEvent::ReadResult { value, .. }) => {
-            value.and_then(|bytes| RealmConfigDocument::from_bytes(&bytes).ok())
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(bytes), ..
+        }) => match RealmConfigDocument::from_bytes(&bytes) {
+            Ok(config) => RealmConfigLoadOutcome::Found(config),
+            Err(error) => {
+                warn!(%realm_id, error = %error, "Failed to decode realm config for shard placements");
+                RealmConfigLoadOutcome::StorageFailure
+            }
+        },
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
+            RealmConfigLoadOutcome::Absent
         }
-        _ => None,
+        Event::Storage(StorageEvent::Error { error }) => {
+            warn!(%realm_id, error = %error, "Failed to read realm config for shard placements");
+            RealmConfigLoadOutcome::StorageFailure
+        }
+        other => {
+            warn!(%realm_id, event = ?other, "Unexpected realm config read result for shard placements");
+            RealmConfigLoadOutcome::StorageFailure
+        }
+    }
+}
+
+pub(crate) async fn load_realm_config(
+    context: &Arc<DriverContext>,
+    realm_id: RealmId,
+) -> Option<RealmConfigDocument> {
+    match load_realm_config_outcome(context, realm_id).await {
+        RealmConfigLoadOutcome::Found(config) => Some(config),
+        RealmConfigLoadOutcome::Absent | RealmConfigLoadOutcome::StorageFailure => None,
     }
 }
 

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -719,6 +719,7 @@ mod tests {
             replica_count: None,
             distinct_locations: false,
             affinity: Vec::new(),
+            bucket_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
         config.strategies = vec![strategy];

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -196,6 +196,7 @@ pub(crate) async fn ensure_rank0_shard_group(
         && let Err(error) = net_handle.ensure_document_sync_topics(&to_ensure, co_holders)
     {
         warn!(error = %error, "Failed to ensure rank-0 shard topics");
+        withheld = true;
     }
     withheld
 }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -431,7 +431,7 @@ pub async fn process_shard_placements(
     outcome
 }
 
-async fn load_realm_config(
+pub(crate) async fn load_realm_config(
     context: &Arc<DriverContext>,
     realm_id: RealmId,
 ) -> Option<RealmConfigDocument> {

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncTarget, bucket_topic_id};
+use aruna_core::document::{DocumentSyncTarget, shard_topic_id};
 use aruna_core::effects::{IterStart, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
@@ -13,24 +13,24 @@ use byteview::ByteView;
 use tracing::{debug, warn};
 
 use crate::driver::DriverContext;
-use crate::placement::resolve_bucket_holders;
+use crate::placement::resolve_shard_holders;
 use crate::sync_placement::{
     decode_placement, new_placement, placement_prefix, sort_node_ids, write_placement_effect,
 };
 
 const PENDING_PLACEMENT_PAGE_SIZE: usize = 256;
 
-/// Eagerly creates the genesis of every bucket topic whose rank-0 holder is the
-/// local node, so genesis creation has exactly one origin per bucket (race-free
+/// Eagerly creates the genesis of every shard topic whose rank-0 holder is the
+/// local node, so genesis creation has exactly one origin per shard (race-free
 /// by rank uniqueness). Every other node is join-only: it receives the genesis
 /// via gossip from the rank-0 holder or bootstraps it during anti-entropy.
 /// Runs on realm-config apply/change and at startup.
 ///
 /// Join-before-create: a config change can move rank-0 (e.g. a new node ranks
-/// first for a bucket whose genesis the previous rank-0 already created), so a
+/// first for a shard whose genesis the previous rank-0 already created), so a
 /// missing topic is first adopted from a co-holder; only what no co-holder
 /// knows either is created fresh.
-async fn ensure_rank0_bucket_topics(
+async fn ensure_rank0_shard_topics(
     context: &Arc<DriverContext>,
     net_handle: &aruna_net::NetHandle,
     config: &RealmConfigDocument,
@@ -40,13 +40,13 @@ async fn ensure_rank0_bucket_topics(
     let mut rank0_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     let mut member_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     for strategy in &config.strategies {
-        for bucket in 0..strategy.bucket_count {
+        for shard in 0..strategy.shard_count {
             let placement = PlacementRef {
                 strategy_id: strategy.strategy_id,
                 epoch: 0,
-                bucket,
+                shard,
             };
-            let holders = resolve_bucket_holders(config, &placement);
+            let holders = resolve_shard_holders(config, &placement);
             if !holders.contains(&local_node_id) {
                 continue;
             }
@@ -64,7 +64,7 @@ async fn ensure_rank0_bucket_topics(
             groups
                 .entry(co_holders)
                 .or_default()
-                .push(bucket_topic_id(realm_id, &placement));
+                .push(shard_topic_id(realm_id, &placement));
         }
     }
     for (co_holders, topics) in rank0_groups {
@@ -87,13 +87,13 @@ async fn ensure_rank0_bucket_topics(
             event = "placement.genesis.ensure",
             topics = topics.len(),
             co_holders = co_holders.len(),
-            "Ensuring rank-0 bucket topic geneses"
+            "Ensuring rank-0 shard topic geneses"
         );
         if let Err(error) = net_handle.ensure_document_sync_topics(&topics, co_holders) {
-            warn!(error = %error, "Failed to ensure rank-0 bucket topics");
+            warn!(error = %error, "Failed to ensure rank-0 shard topics");
         }
     }
-    // Non-rank-0 held buckets: a holder that is already a member (e.g. the
+    // Non-rank-0 held shards: a holder that is already a member (e.g. the
     // previous rank-0 after a config change moved the rank) completes the
     // membership of freshly added co-holders — a new holder cannot add itself.
     // Topics not known locally are skipped: their rank-0 creates them with the
@@ -114,38 +114,38 @@ async fn ensure_rank0_bucket_topics(
             continue;
         }
         if let Err(error) = net_handle.allow_document_sync_peers(&known, co_holders) {
-            debug!(error = %error, "Could not complete held bucket topic membership");
+            debug!(error = %error, "Could not complete held shard topic membership");
         }
     }
 }
 
-/// Reconciles the local node's held bucket topics with their co-holders.
+/// Reconciles the local node's held shard topics with their co-holders.
 ///
-/// First creates the genesis of every bucket the local node is rank-0 holder
-/// of (see [`ensure_rank0_bucket_topics`]). Then iterates the
+/// First creates the genesis of every shard the local node is rank-0 holder
+/// of (see [`ensure_rank0_shard_topics`]). Then iterates the
 /// [`SYNC_PLACEMENT_KEYSPACE`] records the write path left behind (one per
-/// bucket that was not fully replicated at write time), re-resolves each
-/// bucket's holder set from the current realm config, and adds every co-holder
-/// as a member of the bucket topic. Membership changes schedule an irokle topic
-/// recheck, so the resync loop then pushes the bucket's events to any freshly
+/// shard that was not fully replicated at write time), re-resolves each
+/// shard's holder set from the current realm config, and adds every co-holder
+/// as a member of the shard topic. Membership changes schedule an irokle topic
+/// recheck, so the resync loop then pushes the shard's events to any freshly
 /// added co-holder. A record whose co-holders are all members is removed; a
-/// record the local node no longer holds is dropped; a record whose bucket
+/// record the local node no longer holds is dropped; a record whose shard
 /// topic has no genesis locally yet (non-rank-0 holder, genesis in flight) is
 /// kept for retry.
-pub async fn process_bucket_placements(
+pub async fn process_shard_placements(
     context: &Arc<DriverContext>,
     realm_id: RealmId,
     local_node_id: NodeId,
 ) {
     let Some(config) = load_realm_config(context, realm_id).await else {
-        warn!(%realm_id, "Cannot process bucket placements without a realm config");
+        warn!(%realm_id, "Cannot process shard placements without a realm config");
         return;
     };
     let Some(net_handle) = context.net_handle.as_ref() else {
         return;
     };
 
-    ensure_rank0_bucket_topics(context, net_handle, &config, realm_id, local_node_id).await;
+    ensure_rank0_shard_topics(context, net_handle, &config, realm_id, local_node_id).await;
 
     let mut start_after: Option<Key> = None;
     let mut retry_needed = false;
@@ -169,11 +169,11 @@ pub async fn process_bucket_placements(
                 values
             }
             Event::Storage(StorageEvent::Error { error }) => {
-                warn!(error = %error, "Failed to list pending bucket placements");
+                warn!(error = %error, "Failed to list pending shard placements");
                 return;
             }
             other => {
-                warn!(event = ?other, "Unexpected pending bucket placement iter result");
+                warn!(event = ?other, "Unexpected pending shard placement iter result");
                 return;
             }
         };
@@ -182,7 +182,7 @@ pub async fn process_bucket_placements(
             let record = match decode_placement(value) {
                 Ok(record) => record,
                 Err(error) => {
-                    warn!(error = %error, "Deleting malformed bucket placement record");
+                    warn!(error = %error, "Deleting malformed shard placement record");
                     delete_record(context, key.to_vec()).await;
                     continue;
                 }
@@ -191,9 +191,9 @@ pub async fn process_bucket_placements(
                 continue;
             }
 
-            let holders = resolve_bucket_holders(&config, &record.placement);
+            let holders = resolve_shard_holders(&config, &record.placement);
             if !holders.contains(&local_node_id) {
-                // The local node is no longer a holder of this bucket.
+                // The local node is no longer a holder of this shard.
                 delete_record(context, key.to_vec()).await;
                 continue;
             }
@@ -208,7 +208,7 @@ pub async fn process_bucket_placements(
                 continue;
             }
 
-            let topic = bucket_topic_id(realm_id, &record.placement);
+            let topic = shard_topic_id(realm_id, &record.placement);
             // Rank-0 may create the genesis; every other holder is join-only
             // and can only add members to an already-known topic.
             let membership = if local_is_rank0 {
@@ -219,11 +219,11 @@ pub async fn process_bucket_placements(
             match membership {
                 Ok(()) => {
                     // Every co-holder is now a member; the resync loop delivers
-                    // the bucket's events. Record satisfied.
+                    // the shard's events. Record satisfied.
                     delete_record(context, key.to_vec()).await;
                 }
                 Err(error) => {
-                    debug!(error = %error, "Bucket topic membership incomplete; keeping placement record");
+                    debug!(error = %error, "Shard topic membership incomplete; keeping placement record");
                     let refreshed = new_placement(
                         realm_id,
                         record.placement,
@@ -302,7 +302,7 @@ mod tests {
             replica_count: replica,
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
         config.strategies = vec![strategy.clone()];
@@ -314,27 +314,27 @@ mod tests {
             PlacementRef {
                 strategy_id: strategy.strategy_id,
                 epoch: 0,
-                bucket: 3,
+                shard: 3,
             },
         )
     }
 
     #[test]
-    fn bucket_holders_are_deterministic_across_node_ordering() {
+    fn shard_holders_are_deterministic_across_node_ordering() {
         let (config, placement) = config_with(&[node(1), node(2), node(3), node(4)], None);
-        let first = resolve_bucket_holders(&config, &placement);
+        let first = resolve_shard_holders(&config, &placement);
 
         let (reversed, _) = config_with(&[node(4), node(3), node(2), node(1)], None);
-        let second = resolve_bucket_holders(&reversed, &placement);
+        let second = resolve_shard_holders(&reversed, &placement);
 
         assert_eq!(first, second);
         assert_eq!(first.len(), 4);
     }
 
     #[test]
-    fn replica_capped_bucket_holder_set_is_bounded() {
+    fn replica_capped_shard_holder_set_is_bounded() {
         let (config, placement) = config_with(&[node(1), node(2), node(3), node(4)], Some(2));
-        let holders = resolve_bucket_holders(&config, &placement);
+        let holders = resolve_shard_holders(&config, &placement);
         assert_eq!(holders.len(), 2);
     }
 }

--- a/operations/src/register_or_get_oidc_user.rs
+++ b/operations/src/register_or_get_oidc_user.rs
@@ -236,6 +236,7 @@ impl RegisterOrGetOidcUserOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                placement,
                 true,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/remove_group_role.rs
+++ b/operations/src/remove_group_role.rs
@@ -343,6 +343,9 @@ impl RemoveGroupRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/remove_group_role.rs
+++ b/operations/src/remove_group_role.rs
@@ -6,13 +6,18 @@ use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
-use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE, GROUP_KEYSPACE};
+use aruna_core::keyspaces::{
+    ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE, GROUP_KEYSPACE, REALM_CONFIG_KEYSPACE,
+};
 use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
-use aruna_core::structs::{Actor, AuthContext, Group, GroupAuthorizationDocument, RealmId};
+use aruna_core::structs::{
+    Actor, AuthContext, Group, GroupAuthorizationDocument, PlacementRef, RealmConfigDocument,
+    RealmId,
+};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, GroupId, KeySpace, RoleId, TxnId};
 use byteview::ByteView;
@@ -24,6 +29,7 @@ use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::placement::placement_ref_for_target;
 use aruna_core::structs::Permission;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -225,6 +231,10 @@ impl RemoveGroupRoleOperation {
                     ADMIN_DOCUMENT_STATE_KEYSPACE.to_string(),
                     admin_document_reducer_state_key(&target),
                 ),
+                (
+                    REALM_CONFIG_KEYSPACE.to_string(),
+                    ByteView::from(*self.input.actor.realm_id.as_bytes()),
+                ),
             ],
             txn_id: Some(txn_id),
         })])
@@ -244,10 +254,15 @@ impl RemoveGroupRoleOperation {
                 got,
             );
         };
-        let [(_, auth_doc_value), (_, reducer_state_value)] = values.as_slice() else {
+        let [
+            (_, auth_doc_value),
+            (_, reducer_state_value),
+            (_, realm_config_value),
+        ] = values.as_slice()
+        else {
             return self.unexpected_event(
                 self.state.clone(),
-                "Event::Storage(StorageEvent::BatchReadResult) with auth doc and admin state values",
+                "Event::Storage(StorageEvent::BatchReadResult) with auth doc, admin state, and realm config values",
                 got,
             );
         };
@@ -257,6 +272,7 @@ impl RemoveGroupRoleOperation {
             group,
             auth_doc_value.clone(),
             reducer_state_value.clone(),
+            realm_config_value.clone(),
         ) {
             Ok(effects) => effects,
             Err(err) => self.fail(err),
@@ -269,6 +285,7 @@ impl RemoveGroupRoleOperation {
         mut group: Group,
         auth_doc: Option<ByteView>,
         reducer_state_value: Option<ByteView>,
+        realm_config_value: Option<ByteView>,
     ) -> Result<Effects, RemoveGroupRoleError> {
         let mut auth_doc = GroupAuthorizationDocument::from_bytes(
             &auth_doc.ok_or_else(|| RemoveGroupRoleError::AuthDocNotFound)?,
@@ -334,6 +351,12 @@ impl RemoveGroupRoleOperation {
         let document_target = DocumentSyncTarget::GroupAuthorization {
             group_id: self.input.group_id,
         };
+        let placement = realm_config_value
+            .as_deref()
+            .map(RealmConfigDocument::from_bytes)
+            .transpose()?
+            .map(|config| placement_ref_for_target(&config, &document_target, Default::default()))
+            .unwrap_or(PlacementRef::NIL);
         for event in &admin_events {
             let record = new_outbox_record_with_id(
                 event.event_id,
@@ -343,9 +366,7 @@ impl RemoveGroupRoleOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
-                // No realm config in reach here; the stage-2 topic flip resolves
-                // the real ref for this target.
-                aruna_core::structs::PlacementRef::NIL,
+                placement,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
@@ -792,6 +813,7 @@ pub mod test {
                 TxnId::r#gen(),
                 group,
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
+                None,
                 None,
             )
             .unwrap();

--- a/operations/src/remove_user_from_group.rs
+++ b/operations/src/remove_user_from_group.rs
@@ -6,14 +6,15 @@ use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
-use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE};
+use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, AUTH_KEYSPACE, REALM_CONFIG_KEYSPACE};
 use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
 use aruna_core::structs::{
-    Actor, AuthContext, GroupAuthorizationDocument, Permission, ResourceEvent,
+    Actor, AuthContext, GroupAuthorizationDocument, Permission, PlacementRef, RealmConfigDocument,
+    ResourceEvent,
 };
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, GroupId, KeySpace, RoleId, TxnId, UserId};
@@ -29,6 +30,7 @@ use crate::document_sync_outbox::{
 };
 use crate::notifications::emit::emit_notifications_effect;
 use crate::notifications::routing::{RoutingContext, route_resource_event};
+use crate::placement::placement_ref_for_target;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RemoveUserFromGroupInput {
@@ -208,6 +210,10 @@ impl RemoveUserFromGroupOperation {
                     ADMIN_DOCUMENT_STATE_KEYSPACE.to_string(),
                     admin_document_reducer_state_key(&target),
                 ),
+                (
+                    REALM_CONFIG_KEYSPACE.to_string(),
+                    ByteView::from(*self.input.actor.realm_id.as_bytes()),
+                ),
             ],
             txn_id: Some(txn_id),
         })])
@@ -222,10 +228,15 @@ impl RemoveUserFromGroupOperation {
                 got,
             );
         };
-        let [(_, auth_doc_value), (_, reducer_state_value)] = values.as_slice() else {
+        let [
+            (_, auth_doc_value),
+            (_, reducer_state_value),
+            (_, realm_config_value),
+        ] = values.as_slice()
+        else {
             return self.unexpected_event(
                 self.state.clone(),
-                "Event::Storage(StorageEvent::BatchReadResult) with auth doc and admin state values",
+                "Event::Storage(StorageEvent::BatchReadResult) with auth doc, admin state, and realm config values",
                 got,
             );
         };
@@ -234,6 +245,7 @@ impl RemoveUserFromGroupOperation {
             txn_id,
             auth_doc_value.clone(),
             reducer_state_value.clone(),
+            realm_config_value.clone(),
         ) {
             Ok(effects) => effects,
             Err(err) => self.fail(err),
@@ -245,6 +257,7 @@ impl RemoveUserFromGroupOperation {
         txn_id: TxnId,
         auth_doc: Option<ByteView>,
         reducer_state_value: Option<ByteView>,
+        realm_config_value: Option<ByteView>,
     ) -> Result<Effects, RemoveUserFromGroupError> {
         let mut auth_doc = GroupAuthorizationDocument::from_bytes(
             &auth_doc.ok_or_else(|| RemoveUserFromGroupError::AuthDocNotFound)?,
@@ -363,6 +376,12 @@ impl RemoveUserFromGroupOperation {
         let document_target = DocumentSyncTarget::GroupAuthorization {
             group_id: self.input.group_id,
         };
+        let placement = realm_config_value
+            .as_deref()
+            .map(RealmConfigDocument::from_bytes)
+            .transpose()?
+            .map(|config| placement_ref_for_target(&config, &document_target, Default::default()))
+            .unwrap_or(PlacementRef::NIL);
         for event in &admin_events {
             let record = new_outbox_record_with_id(
                 event.event_id,
@@ -372,9 +391,7 @@ impl RemoveUserFromGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
-                // No realm config in reach here; the stage-2 topic flip resolves
-                // the real ref for this target.
-                aruna_core::structs::PlacementRef::NIL,
+                placement,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);
@@ -909,6 +926,7 @@ pub mod test {
                 TxnId::r#gen(),
                 Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 None,
+                None,
             )
             .unwrap();
 
@@ -1186,6 +1204,7 @@ pub mod test {
                     Some(auth_doc.to_bytes(&actor).unwrap().into()),
                 ),
                 (admin_document_reducer_state_key(&target), None),
+                (realm_id.as_bytes().to_vec().into(), None),
             ],
         }));
         operation.step(Event::Storage(StorageEvent::BatchWriteResult {

--- a/operations/src/remove_user_from_group.rs
+++ b/operations/src/remove_user_from_group.rs
@@ -372,6 +372,9 @@ impl RemoveUserFromGroupOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                // No realm config in reach here; the stage-2 topic flip resolves
+                // the real ref for this target.
+                aruna_core::structs::PlacementRef::NIL,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -1,10 +1,10 @@
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncTarget, PendingDocumentPlacement};
+use aruna_core::document::{DocumentSyncTarget, PendingBucketPlacement};
 use aruna_core::effects::Effect;
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::operation::{Operation, boxed_suboperation};
-use aruna_core::structs::{RealmConfigDocument, RealmId};
+use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::Effects;
 use smallvec::smallvec;
@@ -13,12 +13,9 @@ use tracing::warn;
 
 use crate::announce::AnnounceTopicOperation;
 use crate::document_repository::read_effect;
-use crate::placement::{
-    PlacementResolutionContext, placement_ref_for_target, plan_target_placement,
-    rank_eligible_holders_excluding,
-};
+use crate::placement::plan_target_placement;
 use crate::sync_placement::{
-    new_placement, placement_satisfied, schedule_placement_retry_effect, sort_node_ids,
+    delete_placement_effect, new_placement, placement_satisfied, schedule_placement_retry_effect,
     write_placement_effect,
 };
 
@@ -59,7 +56,8 @@ enum ReplicateDocumentsState {
 
 #[derive(Debug, Clone, PartialEq)]
 enum PlacementAction {
-    Write(PendingDocumentPlacement),
+    Write(PendingBucketPlacement),
+    Delete(PlacementRef),
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -153,50 +151,40 @@ impl ReplicateDocumentsOperation {
             return self.emit_next_publish();
         };
         // Placement plan for the document's bound strategy. `None` means the
-        // realm has no strategy for this target (skip, like the old zero-replica case).
-        let Some(plan) = plan_target_placement(
-            realm_config,
-            &document,
-            PlacementResolutionContext::default(),
-        ) else {
+        // realm has no strategy for this target (skip, like the old
+        // desired_peer_count == 0 case).
+        let Some(plan) = plan_target_placement(realm_config, &document, None) else {
             return self.emit_next_publish();
         };
         let desired_count = plan.desired_count;
         let placement = plan.placement;
 
+        // The origin is the authoritative holder; replicate to the remaining
+        // top-ranked holders (excluding self and any explicit exclusions).
         let local_node_id = self.config.local_node_id;
         let excluded_peers = &self.config.excluded_peers;
-        let mut selected_holders = rank_eligible_holders_excluding(
-            realm_config,
-            &document,
-            PlacementResolutionContext::default(),
-            excluded_peers,
-        )
-        .into_iter()
-        .take(desired_count)
-        .collect();
-        sort_node_ids(&mut selected_holders);
-        let network_peers: Vec<NodeId> = selected_holders
-            .iter()
-            .copied()
-            .filter(|node_id| *node_id != local_node_id)
+        let selected_peers: Vec<NodeId> = plan
+            .holders
+            .into_iter()
+            .filter(|node_id| *node_id != local_node_id && !excluded_peers.contains(node_id))
+            .take(desired_count.saturating_sub(1))
             .collect();
 
-        self.placement_action = Some(PlacementAction::Write(new_placement(
-            self.config.realm_id,
-            document.clone(),
-            local_node_id,
-            desired_count,
-            selected_holders,
-            placement,
-        )));
+        self.placement_action = if placement_satisfied(selected_peers.len(), desired_count) {
+            Some(PlacementAction::Delete(placement))
+        } else {
+            Some(PlacementAction::Write(new_placement(
+                self.config.realm_id,
+                placement,
+                local_node_id,
+                selected_peers.clone(),
+            )))
+        };
 
-        if network_peers.is_empty()
+        if selected_peers.is_empty()
             && !matches!(
                 document,
-                DocumentSyncTarget::NodeUsage { .. }
-                    | DocumentSyncTarget::WatchInterest { .. }
-                    | DocumentSyncTarget::NodeInfo { .. }
+                DocumentSyncTarget::NodeUsage { .. } | DocumentSyncTarget::WatchInterest { .. }
             )
         {
             return match self.emit_placement_update() {
@@ -207,12 +195,11 @@ impl ReplicateDocumentsOperation {
 
         self.state = ReplicateDocumentsState::Publish;
         smallvec![Effect::SubOperation(boxed_suboperation(
-            AnnounceTopicOperation::new_for_document_with_peers_and_placement(
+            AnnounceTopicOperation::new_for_document_with_peers(
                 document.topic_id(),
                 self.config.local_node_id,
                 Some(document),
-                network_peers,
-                placement,
+                selected_peers,
                 self.config.allow_genesis,
             ),
             |result| Event::SubOperation(SubOperationEvent::DocumentSyncResult {
@@ -228,14 +215,17 @@ impl ReplicateDocumentsOperation {
         self.state = ReplicateDocumentsState::StorePlacement;
         match action {
             PlacementAction::Write(record) => {
-                self.retry_needed = self.retry_needed
-                    || !placement_satisfied(
-                        record.selected_holders.len(),
-                        record.desired_holder_count,
-                    );
+                self.retry_needed = true;
                 Ok(smallvec![write_placement_effect(&record).map_err(
                     |error| ReplicateDocumentsError::Placement(error.to_string())
                 )?])
+            }
+            PlacementAction::Delete(placement) => {
+                self.retry_needed = false;
+                Ok(smallvec![delete_placement_effect(
+                    self.config.realm_id,
+                    &placement
+                )])
             }
         }
     }
@@ -244,53 +234,18 @@ impl ReplicateDocumentsOperation {
         let Some(action) = self.placement_action.take() else {
             return self.fail(ReplicateDocumentsError::DocumentSync(error));
         };
-        let PlacementAction::Write(previous) = action;
-        let target = previous.target;
-        warn!(target = ?target, error = %error, "Document sync failed; queued placement retry");
-        let (desired_count, selected_holders, placement) = match self.realm_config.as_ref() {
-            Some(realm_config) => match plan_target_placement(
-                realm_config,
-                &target,
-                PlacementResolutionContext::default(),
-            ) {
-                Some(plan) => (
-                    plan.desired_count,
-                    rank_eligible_holders_excluding(
-                        realm_config,
-                        &target,
-                        PlacementResolutionContext::default(),
-                        &self.config.excluded_peers,
-                    )
-                    .into_iter()
-                    .take(plan.desired_count)
-                    .filter(|node_id| *node_id == self.config.local_node_id)
-                    .collect(),
-                    plan.placement,
-                ),
-                None => (
-                    previous.desired_holder_count,
-                    Vec::new(),
-                    placement_ref_for_target(
-                        realm_config,
-                        &target,
-                        PlacementResolutionContext::default(),
-                    ),
-                ),
-            },
-            None => (
-                previous.desired_holder_count,
-                Vec::new(),
-                previous.placement,
-            ),
+        let placement = match action {
+            PlacementAction::Write(record) => record.placement,
+            PlacementAction::Delete(placement) => placement,
         };
-        self.retry_needed = true;
+        warn!(placement = ?placement, error = %error, "Document sync failed; queued bucket placement retry");
+        // Re-queue the bucket with no selected co-holders so the placement
+        // reconciler re-resolves and re-ensures topic membership.
         self.placement_action = Some(PlacementAction::Write(new_placement(
             self.config.realm_id,
-            target,
-            self.config.local_node_id,
-            desired_count,
-            selected_holders,
             placement,
+            self.config.local_node_id,
+            Vec::new(),
         )));
         match self.emit_placement_update() {
             Ok(effects) => effects,
@@ -396,9 +351,8 @@ impl Operation for ReplicateDocumentsOperation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aruna_core::structs::{NodePlacementEntry, PlacementRef, PlacementStrategy, RealmNodeKind};
+    use aruna_core::structs::{PlacementStrategy, RealmNodeKind};
     use aruna_core::task::TaskEvent;
-    use std::collections::BTreeMap;
     use ulid::Ulid;
 
     fn node(seed: u8) -> NodeId {
@@ -429,10 +383,6 @@ mod tests {
         DocumentSyncTarget::WatchInterest { realm_id, node_id }
     }
 
-    fn node_info_target(realm_id: RealmId, node_id: NodeId) -> DocumentSyncTarget {
-        DocumentSyncTarget::NodeInfo { realm_id, node_id }
-    }
-
     fn config_with(nodes: &[NodeId], replica: Option<u32>) -> RealmConfigDocument {
         let mut config = RealmConfigDocument::new(RealmId::from_bytes([7u8; 32]), Vec::new(), 3);
         let strategy = PlacementStrategy {
@@ -449,26 +399,6 @@ mod tests {
             config.ensure_node(*node_id, RealmNodeKind::Server);
         }
         config
-    }
-
-    fn node_info_outbox(
-        mut effects: Effects,
-        target: &DocumentSyncTarget,
-    ) -> aruna_core::document::DocumentSyncOutboxRecord {
-        let [Effect::SubOperation(announce)] = effects.as_mut_slice() else {
-            panic!("expected node info announce suboperation");
-        };
-        let _ = announce.start();
-        let outbox_effects = announce.step(Event::Storage(StorageEvent::ReadResult {
-            key: target.storage_key(),
-            value: Some(b"node info".to_vec().into()),
-        }));
-        let [Effect::Storage(aruna_core::effects::StorageEffect::Write { value, .. })] =
-            outbox_effects.as_slice()
-        else {
-            panic!("expected node info outbox write");
-        };
-        postcard::from_bytes(value.as_ref()).expect("outbox record decodes")
     }
 
     #[test]
@@ -495,7 +425,7 @@ mod tests {
     }
 
     #[test]
-    fn satisfied_placement_is_retained_after_successful_publication() {
+    fn two_remote_peers_satisfy_default_document_placement() {
         let target = metadata_target(4);
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id: RealmId::from_bytes([7u8; 32]),
@@ -508,28 +438,15 @@ mod tests {
 
         let effects = operation.emit_next_publish();
 
-        let Some(PlacementAction::Write(record)) = operation.placement_action.as_ref() else {
-            panic!("expected completed placement inventory");
-        };
-        assert_eq!(record.target, target);
-        assert_eq!(record.selected_holders.len(), 3);
+        assert!(matches!(
+            operation.placement_action,
+            Some(PlacementAction::Delete(_))
+        ));
         assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
-
-        let effects = operation.step(Event::SubOperation(SubOperationEvent::DocumentSyncResult {
-            result: Ok(()),
-        }));
-        let [Effect::Storage(aruna_core::effects::StorageEffect::Write { value, .. })] =
-            effects.as_slice()
-        else {
-            panic!("expected completed placement write");
-        };
-        let stored = crate::sync_placement::decode_placement(value.as_ref()).unwrap();
-        assert_eq!(stored.selected_holders.len(), 3);
-        assert!(!operation.retry_needed);
     }
 
     #[test]
-    fn pending_placement_records_origin_and_actual_holders_separately() {
+    fn pending_placement_records_authoritative_origin() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
         let target = metadata_target(5);
         let local_node_id = node(1);
@@ -549,177 +466,8 @@ mod tests {
         let Some(PlacementAction::Write(record)) = operation.placement_action else {
             panic!("expected pending placement write");
         };
-        assert_eq!(record.origin_node_id, local_node_id);
-        assert_eq!(record.group_id, None);
-        assert_eq!(record.metadata_path, None);
-        assert!(record.selected_holders.contains(&local_node_id));
-        assert!(record.selected_holders.contains(&node(2)));
-        assert_eq!(record.selected_holders.len(), 2);
-    }
-
-    #[test]
-    fn ineligible_origin_is_not_a_selected_holder() {
-        let realm_id = RealmId::from_bytes([7u8; 32]);
-        let origin = node(1);
-        let remote = node(2);
-        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
-            realm_id,
-            local_node_id: origin,
-            excluded_peers: Vec::new(),
-            documents: vec![metadata_target(15)],
-            allow_genesis: true,
-        });
-        operation.realm_config = Some(config_with(&[remote], Some(3)));
-
-        let _ = operation.emit_next_publish();
-
-        let Some(PlacementAction::Write(record)) = operation.placement_action else {
-            panic!("expected pending placement write");
-        };
-        assert_eq!(record.origin_node_id, origin);
-        assert_eq!(record.selected_holders, vec![remote]);
-        assert!(!record.selected_holders.contains(&origin));
-    }
-
-    #[test]
-    fn non_holder_origin_sends_the_full_replica_count() {
-        let realm_id = RealmId::from_bytes([7u8; 32]);
-        let origin = node(1);
-        let target = node_info_target(realm_id, origin);
-        let config = config_with(&[node(2), node(3), node(4)], Some(3));
-        let mut expected_holders =
-            plan_target_placement(&config, &target, PlacementResolutionContext::default())
-                .expect("placement plan")
-                .holders;
-        crate::sync_placement::sort_node_ids(&mut expected_holders);
-        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
-            realm_id,
-            local_node_id: origin,
-            excluded_peers: Vec::new(),
-            documents: vec![target.clone()],
-            allow_genesis: true,
-        });
-        operation.realm_config = Some(config);
-
-        let effects = operation.emit_next_publish();
-
-        let outbox = node_info_outbox(effects, &target);
-        assert_eq!(outbox.peers, expected_holders);
-        assert_eq!(outbox.peers.len(), 3);
-        assert!(!outbox.peers.contains(&origin));
-    }
-
-    #[test]
-    fn excluded_top_ranked_holder_is_replaced_for_publish_and_inventory() {
-        let realm_id = RealmId::from_bytes([7u8; 32]);
-        let origin = node(1);
-        let target = node_info_target(realm_id, origin);
-        let config = config_with(&[node(2), node(3), node(4)], Some(2));
-        let original =
-            plan_target_placement(&config, &target, PlacementResolutionContext::default())
-                .expect("placement plan")
-                .holders;
-        let excluded = original[0];
-        let mut expected = rank_eligible_holders_excluding(
-            &config,
-            &target,
-            PlacementResolutionContext::default(),
-            &[excluded],
-        )
-        .into_iter()
-        .take(2)
-        .collect();
-        sort_node_ids(&mut expected);
-        assert_eq!(expected.len(), 2);
-        assert!(!expected.contains(&excluded));
-        assert!(expected.iter().any(|holder| !original.contains(holder)));
-
-        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
-            realm_id,
-            local_node_id: origin,
-            excluded_peers: vec![excluded],
-            documents: vec![target.clone()],
-            allow_genesis: true,
-        });
-        operation.realm_config = Some(config);
-
-        let effects = operation.emit_next_publish();
-        let Some(PlacementAction::Write(record)) = operation.placement_action.as_ref() else {
-            panic!("expected placement inventory");
-        };
-        assert_eq!(record.selected_holders, expected);
-        assert!(!record.selected_holders.contains(&excluded));
-        let outbox = node_info_outbox(effects, &target);
-        assert_eq!(outbox.peers, expected);
-
-        let effects = operation.step(Event::SubOperation(SubOperationEvent::DocumentSyncResult {
-            result: Ok(()),
-        }));
-        let [Effect::Storage(aruna_core::effects::StorageEffect::Write { value, .. })] =
-            effects.as_slice()
-        else {
-            panic!("expected placement inventory write");
-        };
-        let stored = crate::sync_placement::decode_placement(value.as_ref()).unwrap();
-        assert_eq!(stored.selected_holders, expected);
-        assert!(!stored.selected_holders.contains(&excluded));
-    }
-
-    #[test]
-    fn distinct_location_holder_set_remains_resolver_identical() {
-        let realm_id = RealmId::from_bytes([7u8; 32]);
-        let origin = node(1);
-        let remotes = [node(2), node(3)];
-        let target = metadata_target(16);
-        let mut config = config_with(&[origin, remotes[0], remotes[1]], Some(3));
-        config.strategies[0].distinct_locations = true;
-        config.placement_map = vec![
-            NodePlacementEntry {
-                node_id: origin,
-                location: "origin".to_string(),
-                weight: 100,
-                full: false,
-                draining: false,
-                labels: BTreeMap::new(),
-            },
-            NodePlacementEntry {
-                node_id: remotes[0],
-                location: "remote".to_string(),
-                weight: 100,
-                full: false,
-                draining: false,
-                labels: BTreeMap::new(),
-            },
-            NodePlacementEntry {
-                node_id: remotes[1],
-                location: "remote".to_string(),
-                weight: 100,
-                full: false,
-                draining: false,
-                labels: BTreeMap::new(),
-            },
-        ];
-        let mut expected_holders =
-            plan_target_placement(&config, &target, PlacementResolutionContext::default())
-                .expect("placement plan")
-                .holders;
-        crate::sync_placement::sort_node_ids(&mut expected_holders);
-        assert!(expected_holders.contains(&origin));
-        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
-            realm_id,
-            local_node_id: origin,
-            excluded_peers: Vec::new(),
-            documents: vec![target],
-            allow_genesis: true,
-        });
-        operation.realm_config = Some(config);
-
-        let _ = operation.emit_next_publish();
-
-        let Some(PlacementAction::Write(record)) = operation.placement_action else {
-            panic!("expected pending placement write");
-        };
-        assert_eq!(record.selected_holders, expected_holders);
+        assert_eq!(record.authoritative_node_id, local_node_id);
+        assert_eq!(record.selected_peers, vec![node(2)]);
     }
 
     #[test]
@@ -767,59 +515,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_node_info_queues_upsert_without_remote_peers() {
-        let realm_id = RealmId::from_bytes([7u8; 32]);
-        let local_node_id = node(1);
-        let target = node_info_target(realm_id, local_node_id);
-        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
-            realm_id,
-            local_node_id,
-            excluded_peers: Vec::new(),
-            documents: vec![target.clone()],
-            allow_genesis: true,
-        });
-        operation.realm_config = Some(config_with(&[local_node_id], Some(3)));
-
-        let mut effects = operation.emit_next_publish();
-
-        let Some(PlacementAction::Write(record)) = operation.placement_action.as_ref() else {
-            panic!("expected pending placement write");
-        };
-        assert_eq!(record.target, target);
-        assert_eq!(record.selected_holders, vec![local_node_id]);
-
-        let [Effect::SubOperation(announce)] = effects.as_mut_slice() else {
-            panic!("expected node info announce suboperation");
-        };
-        assert!(matches!(
-            announce.start().as_slice(),
-            [Effect::Storage(
-                aruna_core::effects::StorageEffect::Read { .. }
-            )]
-        ));
-        let outbox_effects = announce.step(Event::Storage(StorageEvent::ReadResult {
-            key: target.storage_key(),
-            value: Some(b"node info".to_vec().into()),
-        }));
-        let [Effect::Storage(aruna_core::effects::StorageEffect::Write { value, .. })] =
-            outbox_effects.as_slice()
-        else {
-            panic!("expected node info outbox write");
-        };
-        let outbox: aruna_core::document::DocumentSyncOutboxRecord =
-            postcard::from_bytes(value.as_ref()).expect("outbox record decodes");
-        assert_eq!(outbox.target, target);
-        assert!(outbox.peers.is_empty());
-        let aruna_core::document::DocumentSyncOutboxEvent::Upsert { change, .. } = outbox.event
-        else {
-            panic!("expected upsert outbox event");
-        };
-        assert_eq!(change.placement, record.placement);
-        assert_ne!(change.placement, aruna_core::structs::PlacementRef::NIL);
-    }
-
-    #[test]
-    fn publish_failure_keeps_only_resolved_local_holder() {
+    fn publish_failure_keeps_authoritative_origin() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
         let target = metadata_target(6);
         let local_node_id = node(1);
@@ -832,14 +528,11 @@ mod tests {
         });
         operation.realm_config = Some(config_with(&[local_node_id, node(2)], Some(3)));
         operation.state = ReplicateDocumentsState::Publish;
-        operation.placement_action = Some(PlacementAction::Write(new_placement(
-            realm_id,
-            target,
-            local_node_id,
-            3,
-            vec![local_node_id, node(2)],
-            PlacementRef::NIL,
-        )));
+        operation.placement_action = Some(PlacementAction::Delete(PlacementRef {
+            strategy_id: ulid::Ulid::from_bytes([9u8; 16]),
+            epoch: 0,
+            bucket: 1,
+        }));
 
         let effects = operation.step(Event::SubOperation(SubOperationEvent::DocumentSyncResult {
             result: Err("publish failed".to_string()),
@@ -852,8 +545,8 @@ mod tests {
         };
         let record =
             crate::sync_placement::decode_placement(value.as_ref()).expect("placement decodes");
-        assert_eq!(record.origin_node_id, local_node_id);
-        assert_eq!(record.selected_holders, vec![local_node_id]);
+        assert_eq!(record.authoritative_node_id, local_node_id);
+        assert!(record.selected_peers.is_empty());
     }
 
     #[test]
@@ -878,7 +571,7 @@ mod tests {
             documents: vec![target],
             allow_genesis: true,
         });
-        second.realm_config = Some(config_with(&[node(1), node(2)], Some(3)));
+        second.realm_config = Some(config_with(&[node(9), node(2)], Some(3)));
         let _ = second.emit_next_publish();
 
         let Some(PlacementAction::Write(first_record)) = first.placement_action else {
@@ -887,11 +580,11 @@ mod tests {
         let Some(PlacementAction::Write(second_record)) = second.placement_action else {
             panic!("expected second placement");
         };
-        assert_eq!(
-            first_record.selected_holders,
-            second_record.selected_holders
+        assert_eq!(first_record.selected_peers, second_record.selected_peers);
+        assert_ne!(
+            first_record.authoritative_node_id,
+            second_record.authoritative_node_id
         );
-        assert_ne!(first_record.origin_node_id, second_record.origin_node_id);
     }
 
     #[test]

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -197,11 +197,12 @@ impl ReplicateDocumentsOperation {
 
         self.state = ReplicateDocumentsState::Publish;
         smallvec![Effect::SubOperation(boxed_suboperation(
-            AnnounceTopicOperation::new_for_document_with_peers(
+            AnnounceTopicOperation::new_for_document_with_peers_and_placement(
                 document.topic_id(),
                 self.config.local_node_id,
                 Some(document),
                 selected_peers,
+                placement,
                 self.config.allow_genesis,
             ),
             |result| Event::SubOperation(SubOperationEvent::DocumentSyncResult {

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -486,9 +486,11 @@ mod tests {
 
         let effects = operation.emit_next_publish();
 
-        assert!(
-            matches!(operation.placement_action, Some(PlacementAction::Write(ref record)) if record.target == target)
-        );
+        let Some(PlacementAction::Write(record)) = operation.placement_action else {
+            panic!("expected pending placement write");
+        };
+        assert_eq!(record.authoritative_node_id, local_node_id);
+        assert!(record.selected_peers.is_empty());
         assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
     }
 
@@ -508,9 +510,11 @@ mod tests {
 
         let effects = operation.emit_next_publish();
 
-        assert!(
-            matches!(operation.placement_action, Some(PlacementAction::Write(ref record)) if record.target == target)
-        );
+        let Some(PlacementAction::Write(record)) = operation.placement_action else {
+            panic!("expected pending placement write");
+        };
+        assert_eq!(record.authoritative_node_id, local_node_id);
+        assert!(record.selected_peers.is_empty());
         assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
     }
 

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -1,5 +1,5 @@
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncTarget, PendingBucketPlacement};
+use aruna_core::document::{DocumentSyncTarget, PendingShardPlacement};
 use aruna_core::effects::Effect;
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
@@ -56,7 +56,7 @@ enum ReplicateDocumentsState {
 
 #[derive(Debug, Clone, PartialEq)]
 enum PlacementAction {
-    Write(PendingBucketPlacement),
+    Write(PendingShardPlacement),
     Delete(PlacementRef),
 }
 
@@ -238,8 +238,8 @@ impl ReplicateDocumentsOperation {
             PlacementAction::Write(record) => record.placement,
             PlacementAction::Delete(placement) => placement,
         };
-        warn!(placement = ?placement, error = %error, "Document sync failed; queued bucket placement retry");
-        // Re-queue the bucket with no selected co-holders so the placement
+        warn!(placement = ?placement, error = %error, "Document sync failed; queued shard placement retry");
+        // Re-queue the shard with no selected co-holders so the placement
         // reconciler re-resolves and re-ensures topic membership.
         self.placement_action = Some(PlacementAction::Write(new_placement(
             self.config.realm_id,
@@ -391,7 +391,7 @@ mod tests {
             replica_count: replica,
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
         config.strategies = vec![strategy];
@@ -531,7 +531,7 @@ mod tests {
         operation.placement_action = Some(PlacementAction::Delete(PlacementRef {
             strategy_id: ulid::Ulid::from_bytes([9u8; 16]),
             epoch: 0,
-            bucket: 1,
+            shard: 1,
         }));
 
         let effects = operation.step(Event::SubOperation(SubOperationEvent::DocumentSyncResult {

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -441,6 +441,7 @@ mod tests {
             replica_count: replica,
             distinct_locations: false,
             affinity: Vec::new(),
+            bucket_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
         config.strategies = vec![strategy];

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -153,7 +153,7 @@ impl ReplicateDocumentsOperation {
         // Placement plan for the document's bound strategy. `None` means the
         // realm has no strategy for this target (skip, like the old
         // desired_peer_count == 0 case).
-        let Some(plan) = plan_target_placement(realm_config, &document, None) else {
+        let Some(plan) = plan_target_placement(realm_config, &document, Default::default()) else {
             return self.emit_next_publish();
         };
         let desired_count = plan.desired_count;
@@ -184,7 +184,9 @@ impl ReplicateDocumentsOperation {
         if selected_peers.is_empty()
             && !matches!(
                 document,
-                DocumentSyncTarget::NodeUsage { .. } | DocumentSyncTarget::WatchInterest { .. }
+                DocumentSyncTarget::NodeUsage { .. }
+                    | DocumentSyncTarget::WatchInterest { .. }
+                    | DocumentSyncTarget::NodeInfo { .. }
             )
         {
             return match self.emit_placement_update() {
@@ -383,6 +385,10 @@ mod tests {
         DocumentSyncTarget::WatchInterest { realm_id, node_id }
     }
 
+    fn node_info_target(realm_id: RealmId, node_id: NodeId) -> DocumentSyncTarget {
+        DocumentSyncTarget::NodeInfo { realm_id, node_id }
+    }
+
     fn config_with(nodes: &[NodeId], replica: Option<u32>) -> RealmConfigDocument {
         let mut config = RealmConfigDocument::new(RealmId::from_bytes([7u8; 32]), Vec::new(), 3);
         let strategy = PlacementStrategy {
@@ -499,6 +505,32 @@ mod tests {
         let realm_id = RealmId::from_bytes([7u8; 32]);
         let local_node_id = node(1);
         let target = watch_interest_target(realm_id, local_node_id);
+        let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
+            realm_id,
+            local_node_id,
+            excluded_peers: Vec::new(),
+            documents: vec![target.clone()],
+            allow_genesis: true,
+        });
+        operation.realm_config = Some(config_with(&[local_node_id], Some(3)));
+
+        let effects = operation.emit_next_publish();
+
+        let Some(PlacementAction::Write(record)) = operation.placement_action else {
+            panic!("expected pending placement write");
+        };
+        assert_eq!(record.authoritative_node_id, local_node_id);
+        assert!(record.selected_peers.is_empty());
+        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
+    }
+
+    // Node info rides the shared realm topic, so a single-node realm still
+    // publishes it instead of parking it behind a placement retry.
+    #[test]
+    fn node_info_publishes_peerless() {
+        let realm_id = RealmId::from_bytes([7u8; 32]);
+        let local_node_id = node(1);
+        let target = node_info_target(realm_id, local_node_id);
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,
             local_node_id,

--- a/operations/src/replicate_documents.rs
+++ b/operations/src/replicate_documents.rs
@@ -4,7 +4,7 @@ use aruna_core::effects::Effect;
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::operation::{Operation, boxed_suboperation};
-use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
+use aruna_core::structs::{DocumentClass, PlacementRef, RealmConfigDocument, RealmId};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::Effects;
 use smallvec::smallvec;
@@ -13,7 +13,7 @@ use tracing::warn;
 
 use crate::announce::AnnounceTopicOperation;
 use crate::document_repository::read_effect;
-use crate::placement::plan_target_placement;
+use crate::placement::{document_class, plan_target_placement};
 use crate::sync_placement::{
     delete_placement_effect, new_placement, placement_satisfied, schedule_placement_retry_effect,
     write_placement_effect,
@@ -144,6 +144,20 @@ impl ReplicateDocumentsOperation {
         // Admin documents replicate as operations over their shared topic; they never
         // take placements, so skip them without a placement write or publish attempt.
         if document.is_admin_document() {
+            return self.emit_next_publish();
+        }
+
+        // A metadata document's bucket is the one its create stamped on the
+        // registry record; deriving it from the target here would hash it onto a
+        // second topic. Metadata replicates through its own outbox, never here.
+        if matches!(
+            document_class(&document),
+            DocumentClass::Metadata | DocumentClass::MetadataRegistry
+        ) {
+            debug_assert!(
+                false,
+                "metadata target {document:?} must publish from its stored placement"
+            );
             return self.emit_next_publish();
         }
 
@@ -368,12 +382,6 @@ mod tests {
         }
     }
 
-    fn metadata_target(seed: u8) -> DocumentSyncTarget {
-        DocumentSyncTarget::MetadataDocumentLifecycle {
-            document_id: Ulid::from_bytes([seed; 16]),
-        }
-    }
-
     fn node_usage_target(realm_id: RealmId, node_id: NodeId) -> DocumentSyncTarget {
         DocumentSyncTarget::NodeUsage {
             realm_id,
@@ -433,9 +441,10 @@ mod tests {
 
     #[test]
     fn two_remote_peers_satisfy_default_document_placement() {
-        let target = metadata_target(4);
+        let realm_id = RealmId::from_bytes([7u8; 32]);
+        let target = node_usage_target(realm_id, node(4));
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
-            realm_id: RealmId::from_bytes([7u8; 32]),
+            realm_id,
             local_node_id: node(1),
             excluded_peers: Vec::new(),
             documents: vec![target.clone()],
@@ -455,7 +464,7 @@ mod tests {
     #[test]
     fn pending_placement_records_authoritative_origin() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
-        let target = metadata_target(5);
+        let target = node_usage_target(realm_id, node(5));
         let local_node_id = node(1);
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,
@@ -554,7 +563,7 @@ mod tests {
     #[test]
     fn publish_failure_keeps_authoritative_origin() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
-        let target = metadata_target(6);
+        let target = node_usage_target(realm_id, node(6));
         let local_node_id = node(1);
         let mut operation = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,
@@ -589,7 +598,7 @@ mod tests {
     #[test]
     fn replicate_documents_selection_uses_rendezvous_not_local_salt() {
         let realm_id = RealmId::from_bytes([7u8; 32]);
-        let target = metadata_target(7);
+        let target = node_usage_target(realm_id, node(7));
 
         let mut first = ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
             realm_id,

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -24,6 +24,7 @@ use tracing::warn;
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::placement::placement_ref_for_target;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetRealmQuotaConfig {
@@ -177,6 +178,7 @@ impl SetRealmQuotaOperation {
             Some(&reducer_state),
         );
         let document_target = self.document_ref();
+        let placement = placement_ref_for_target(&document, &document_target, None);
         let mut writes = vec![
             (
                 document_target.storage_keyspace().to_string(),
@@ -193,6 +195,7 @@ impl SetRealmQuotaOperation {
             DocumentSyncOutboxEvent::AdminOperation {
                 event: Box::new(admin_event),
             },
+            placement,
             false,
         );
         writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -178,7 +178,7 @@ impl SetRealmQuotaOperation {
             Some(&reducer_state),
         );
         let document_target = self.document_ref();
-        let placement = placement_ref_for_target(&document, &document_target, None);
+        let placement = placement_ref_for_target(&document, &document_target, Default::default());
         let mut writes = vec![
             (
                 document_target.storage_keyspace().to_string(),

--- a/operations/src/shard/client.rs
+++ b/operations/src/shard/client.rs
@@ -6,10 +6,11 @@ use aruna_core::document::ShardManifest;
 use aruna_core::structs::{PlacementRef, RealmId};
 use aruna_net::NetHandle;
 use aruna_net::streams::BiStream;
-use tokio::time::timeout;
+use tokio::time::{Instant, timeout};
 
 use crate::shard::protocol::{
-    ShardTransportMessage, ShardTransportResponse, read_shard_response, write_shard_request,
+    ManifestAssembler, ShardTransportMessage, ShardTransportResponse, read_shard_response,
+    write_shard_request,
 };
 
 pub const SHARD_IO_TIMEOUT: Duration = Duration::from_secs(10);
@@ -18,6 +19,83 @@ pub const SHARD_IO_TIMEOUT: Duration = Duration::from_secs(10);
 /// A `Reject` from the co-holder (foreign realm, untrusted peer, or a shard it
 /// does not hold) surfaces as `Err`.
 pub async fn fetch_shard_manifest(
+    net_handle: &NetHandle,
+    node_id: NodeId,
+    realm_id: RealmId,
+    placement: PlacementRef,
+) -> Result<ShardManifest, String> {
+    if let Some(manifest) =
+        fetch_shard_manifest_v2(net_handle, node_id, realm_id, placement).await?
+    {
+        return validate_manifest_response(manifest, node_id, placement);
+    }
+    fetch_shard_manifest_legacy(net_handle, node_id, realm_id, placement).await
+}
+
+async fn fetch_shard_manifest_v2(
+    net_handle: &NetHandle,
+    node_id: NodeId,
+    realm_id: RealmId,
+    placement: PlacementRef,
+) -> Result<Option<ShardManifest>, String> {
+    let mut stream = net_handle
+        .open_stream(node_id, Alpn::Shard)
+        .await
+        .map_err(|error| error.to_string())?;
+    let request = ShardTransportMessage::ManifestRequestV2 {
+        realm_id,
+        placement,
+    };
+    write_message(&mut stream, &request).await?;
+    stream.0.finish().map_err(|error| error.to_string())?;
+
+    let deadline = Instant::now() + SHARD_IO_TIMEOUT;
+    let mut assembler = ManifestAssembler::new(node_id, placement);
+    let mut received_v2 = false;
+    loop {
+        let response = match read_response_before(&mut stream, deadline).await {
+            Ok(response) => response,
+            Err(_) if !received_v2 => {
+                close_stream(&mut stream).await;
+                return Ok(None);
+            }
+            Err(error) => {
+                close_stream(&mut stream).await;
+                return Err(error);
+            }
+        };
+        match response {
+            ShardTransportResponse::ManifestPageV2(page) => {
+                received_v2 = true;
+                match assembler.push(*page) {
+                    Ok(Some(manifest)) => {
+                        close_stream(&mut stream).await;
+                        return Ok(Some(manifest));
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        close_stream(&mut stream).await;
+                        return Err(error);
+                    }
+                }
+            }
+            ShardTransportResponse::Reject(reason) => {
+                close_stream(&mut stream).await;
+                return Err(reason);
+            }
+            ShardTransportResponse::Manifest(_) if !received_v2 => {
+                close_stream(&mut stream).await;
+                return Ok(None);
+            }
+            ShardTransportResponse::Manifest(_) => {
+                close_stream(&mut stream).await;
+                return Err("received legacy shard manifest after V2 page".to_string());
+            }
+        }
+    }
+}
+
+async fn fetch_shard_manifest_legacy(
     net_handle: &NetHandle,
     node_id: NodeId,
     realm_id: RealmId,
@@ -40,6 +118,9 @@ pub async fn fetch_shard_manifest(
             validate_manifest_response(*manifest, node_id, placement)
         }
         ShardTransportResponse::Reject(reason) => Err(reason),
+        ShardTransportResponse::ManifestPageV2(_) => {
+            Err("received V2 shard page for legacy request".to_string())
+        }
     }
 }
 
@@ -73,7 +154,15 @@ async fn write_message(
 }
 
 async fn read_response(stream: &mut BiStream) -> Result<ShardTransportResponse, String> {
-    timeout(SHARD_IO_TIMEOUT, read_shard_response(stream))
+    read_response_before(stream, Instant::now() + SHARD_IO_TIMEOUT).await
+}
+
+async fn read_response_before(
+    stream: &mut BiStream,
+    deadline: Instant,
+) -> Result<ShardTransportResponse, String> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    timeout(remaining, read_shard_response(stream))
         .await
         .map_err(|_| "timed out waiting for shard response".to_string())?
 }

--- a/operations/src/shard/client.rs
+++ b/operations/src/shard/client.rs
@@ -36,9 +36,31 @@ pub async fn fetch_shard_manifest(
     let response = read_response(&mut stream).await?;
     close_stream(&mut stream).await;
     match response {
-        ShardTransportResponse::Manifest(manifest) => Ok(*manifest),
+        ShardTransportResponse::Manifest(manifest) => {
+            validate_manifest_response(*manifest, node_id, placement)
+        }
         ShardTransportResponse::Reject(reason) => Err(reason),
     }
+}
+
+fn validate_manifest_response(
+    manifest: ShardManifest,
+    node_id: NodeId,
+    placement: PlacementRef,
+) -> Result<ShardManifest, String> {
+    if manifest.placement != placement {
+        return Err(format!(
+            "shard manifest placement mismatch: requested {placement:?}, received {:?}",
+            manifest.placement
+        ));
+    }
+    if manifest.holder != node_id {
+        return Err(format!(
+            "shard manifest holder mismatch: requested {node_id}, received {}",
+            manifest.holder
+        ));
+    }
+    Ok(manifest)
 }
 
 async fn write_message(
@@ -59,4 +81,62 @@ async fn read_response(stream: &mut BiStream) -> Result<ShardTransportResponse, 
 pub(crate) async fn close_stream(stream: &mut BiStream) {
     let _ = stream.0.finish();
     let _ = stream.1.stop(0u32.into());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node_id(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    fn placement(shard: u32) -> PlacementRef {
+        PlacementRef {
+            strategy_id: ulid::Ulid::from_bytes([9; 16]),
+            epoch: 0,
+            shard,
+        }
+    }
+
+    fn manifest(holder: NodeId, placement: PlacementRef) -> ShardManifest {
+        ShardManifest {
+            placement,
+            holder,
+            entries: Vec::new(),
+            cursor: Vec::new(),
+            digest: [0; 32],
+            updated_at_ms: 0,
+        }
+    }
+
+    #[test]
+    fn manifest_response_rejects_wrong_placement() {
+        let holder = node_id(1);
+        let requested = placement(7);
+        let received = manifest(holder, placement(8));
+
+        let error = validate_manifest_response(received, holder, requested)
+            .expect_err("wrong placement must be rejected");
+
+        assert!(
+            error.contains("placement mismatch"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn manifest_response_rejects_wrong_holder() {
+        let requested_holder = node_id(1);
+        let placement = placement(7);
+        let received = manifest(node_id(2), placement);
+
+        let error = validate_manifest_response(received, requested_holder, placement)
+            .expect_err("wrong holder must be rejected");
+
+        assert!(
+            error.contains("holder mismatch"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/operations/src/shard/client.rs
+++ b/operations/src/shard/client.rs
@@ -1,0 +1,62 @@
+use std::time::Duration;
+
+use aruna_core::NodeId;
+use aruna_core::alpn::Alpn;
+use aruna_core::document::ShardManifest;
+use aruna_core::structs::{PlacementRef, RealmId};
+use aruna_net::NetHandle;
+use aruna_net::streams::BiStream;
+use tokio::time::timeout;
+
+use crate::shard::protocol::{
+    ShardTransportMessage, ShardTransportResponse, read_shard_response, write_shard_request,
+};
+
+pub const SHARD_IO_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Fetches a co-holder's assembled manifest for one shard over the shard ALPN.
+/// A `Reject` from the co-holder (foreign realm, untrusted peer, or a shard it
+/// does not hold) surfaces as `Err`.
+pub async fn fetch_shard_manifest(
+    net_handle: &NetHandle,
+    node_id: NodeId,
+    realm_id: RealmId,
+    placement: PlacementRef,
+) -> Result<ShardManifest, String> {
+    let mut stream = net_handle
+        .open_stream(node_id, Alpn::Shard)
+        .await
+        .map_err(|error| error.to_string())?;
+    let request = ShardTransportMessage::ManifestRequest {
+        realm_id,
+        placement,
+    };
+    write_message(&mut stream, &request).await?;
+    stream.0.finish().map_err(|error| error.to_string())?;
+    let response = read_response(&mut stream).await?;
+    close_stream(&mut stream).await;
+    match response {
+        ShardTransportResponse::Manifest(manifest) => Ok(*manifest),
+        ShardTransportResponse::Reject(reason) => Err(reason),
+    }
+}
+
+async fn write_message(
+    stream: &mut BiStream,
+    message: &ShardTransportMessage,
+) -> Result<(), String> {
+    timeout(SHARD_IO_TIMEOUT, write_shard_request(stream, message))
+        .await
+        .map_err(|_| "timed out writing shard message".to_string())?
+}
+
+async fn read_response(stream: &mut BiStream) -> Result<ShardTransportResponse, String> {
+    timeout(SHARD_IO_TIMEOUT, read_shard_response(stream))
+        .await
+        .map_err(|_| "timed out waiting for shard response".to_string())?
+}
+
+pub(crate) async fn close_stream(stream: &mut BiStream) {
+    let _ = stream.0.finish();
+    let _ = stream.1.stop(0u32.into());
+}

--- a/operations/src/shard/client.rs
+++ b/operations/src/shard/client.rs
@@ -15,87 +15,10 @@ use crate::shard::protocol::{
 
 pub const SHARD_IO_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Fetches a co-holder's assembled manifest for one shard over the shard ALPN.
-/// A `Reject` from the co-holder (foreign realm, untrusted peer, or a shard it
-/// does not hold) surfaces as `Err`.
+/// Fetches a co-holder's paged manifest for one shard over the shard ALPN and
+/// assembles it. A `Reject` from the co-holder (foreign realm, untrusted peer,
+/// or a shard it does not hold) surfaces as `Err`.
 pub async fn fetch_shard_manifest(
-    net_handle: &NetHandle,
-    node_id: NodeId,
-    realm_id: RealmId,
-    placement: PlacementRef,
-) -> Result<ShardManifest, String> {
-    if let Some(manifest) =
-        fetch_shard_manifest_v2(net_handle, node_id, realm_id, placement).await?
-    {
-        return validate_manifest_response(manifest, node_id, placement);
-    }
-    fetch_shard_manifest_legacy(net_handle, node_id, realm_id, placement).await
-}
-
-async fn fetch_shard_manifest_v2(
-    net_handle: &NetHandle,
-    node_id: NodeId,
-    realm_id: RealmId,
-    placement: PlacementRef,
-) -> Result<Option<ShardManifest>, String> {
-    let mut stream = net_handle
-        .open_stream(node_id, Alpn::Shard)
-        .await
-        .map_err(|error| error.to_string())?;
-    let request = ShardTransportMessage::ManifestRequestV2 {
-        realm_id,
-        placement,
-    };
-    write_message(&mut stream, &request).await?;
-    stream.0.finish().map_err(|error| error.to_string())?;
-
-    let deadline = Instant::now() + SHARD_IO_TIMEOUT;
-    let mut assembler = ManifestAssembler::new(node_id, placement);
-    let mut received_v2 = false;
-    loop {
-        let response = match read_response_before(&mut stream, deadline).await {
-            Ok(response) => response,
-            Err(_) if !received_v2 => {
-                close_stream(&mut stream).await;
-                return Ok(None);
-            }
-            Err(error) => {
-                close_stream(&mut stream).await;
-                return Err(error);
-            }
-        };
-        match response {
-            ShardTransportResponse::ManifestPageV2(page) => {
-                received_v2 = true;
-                match assembler.push(*page) {
-                    Ok(Some(manifest)) => {
-                        close_stream(&mut stream).await;
-                        return Ok(Some(manifest));
-                    }
-                    Ok(None) => {}
-                    Err(error) => {
-                        close_stream(&mut stream).await;
-                        return Err(error);
-                    }
-                }
-            }
-            ShardTransportResponse::Reject(reason) => {
-                close_stream(&mut stream).await;
-                return Err(reason);
-            }
-            ShardTransportResponse::Manifest(_) if !received_v2 => {
-                close_stream(&mut stream).await;
-                return Ok(None);
-            }
-            ShardTransportResponse::Manifest(_) => {
-                close_stream(&mut stream).await;
-                return Err("received legacy shard manifest after V2 page".to_string());
-            }
-        }
-    }
-}
-
-async fn fetch_shard_manifest_legacy(
     net_handle: &NetHandle,
     node_id: NodeId,
     realm_id: RealmId,
@@ -111,15 +34,33 @@ async fn fetch_shard_manifest_legacy(
     };
     write_message(&mut stream, &request).await?;
     stream.0.finish().map_err(|error| error.to_string())?;
-    let response = read_response(&mut stream).await?;
-    close_stream(&mut stream).await;
-    match response {
-        ShardTransportResponse::Manifest(manifest) => {
-            validate_manifest_response(*manifest, node_id, placement)
-        }
-        ShardTransportResponse::Reject(reason) => Err(reason),
-        ShardTransportResponse::ManifestPageV2(_) => {
-            Err("received V2 shard page for legacy request".to_string())
+
+    let deadline = Instant::now() + SHARD_IO_TIMEOUT;
+    let mut assembler = ManifestAssembler::new(node_id, placement);
+    loop {
+        let response = match read_response_before(&mut stream, deadline).await {
+            Ok(response) => response,
+            Err(error) => {
+                close_stream(&mut stream).await;
+                return Err(error);
+            }
+        };
+        match response {
+            ShardTransportResponse::ManifestPage(page) => match assembler.push(*page) {
+                Ok(Some(manifest)) => {
+                    close_stream(&mut stream).await;
+                    return validate_manifest_response(manifest, node_id, placement);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    close_stream(&mut stream).await;
+                    return Err(error);
+                }
+            },
+            ShardTransportResponse::Reject(reason) => {
+                close_stream(&mut stream).await;
+                return Err(reason);
+            }
         }
     }
 }
@@ -151,10 +92,6 @@ async fn write_message(
     timeout(SHARD_IO_TIMEOUT, write_shard_request(stream, message))
         .await
         .map_err(|_| "timed out writing shard message".to_string())?
-}
-
-async fn read_response(stream: &mut BiStream) -> Result<ShardTransportResponse, String> {
-    read_response_before(stream, Instant::now() + SHARD_IO_TIMEOUT).await
 }
 
 async fn read_response_before(

--- a/operations/src/shard/incoming.rs
+++ b/operations/src/shard/incoming.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use aruna_core::NodeId;
+use aruna_core::document::ShardManifest;
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
@@ -17,9 +18,17 @@ use crate::placement::resolve_shard_holders;
 use crate::shard::assemble_shard_manifest;
 use crate::shard::client::{SHARD_IO_TIMEOUT, close_stream};
 use crate::shard::protocol::{
-    SHARD_MAX_RESPONSE_SIZE, ShardTransportMessage, ShardTransportResponse, partition_manifest,
-    read_shard_request, write_shard_response,
+    ManifestPagePlan, SHARD_MAX_RESPONSE_SIZE, ShardTransportMessage, ShardTransportResponse,
+    plan_manifest_pages, read_shard_request, write_manifest_pages, write_shard_response,
 };
+
+enum PreparedShardResponse {
+    Message(ShardTransportResponse),
+    ManifestPages {
+        manifest: Box<ShardManifest>,
+        plan: ManifestPagePlan,
+    },
+}
 
 #[tracing::instrument(
     name = "shard.incoming.stream",
@@ -46,10 +55,10 @@ pub async fn handle_shard_stream(context: &DriverContext, mut stream: BiStream, 
         }
     };
 
-    let responses = build_responses(context, net_handle, peer, message).await;
+    let response = build_response(context, net_handle, peer, message).await;
     if let Err(error) = with_shard_io_timeout(
         "writing shard manifest response",
-        write_responses(&mut stream, &responses),
+        write_response(&mut stream, &response),
     )
     .await
     {
@@ -58,14 +67,16 @@ pub async fn handle_shard_stream(context: &DriverContext, mut stream: BiStream, 
     close_stream(&mut stream).await;
 }
 
-async fn write_responses(
+async fn write_response(
     stream: &mut BiStream,
-    responses: &[ShardTransportResponse],
+    response: &PreparedShardResponse,
 ) -> Result<(), String> {
-    for response in responses {
-        write_shard_response(stream, response).await?;
+    match response {
+        PreparedShardResponse::Message(message) => write_shard_response(stream, message).await,
+        PreparedShardResponse::ManifestPages { manifest, plan } => {
+            write_manifest_pages(stream, manifest, plan).await
+        }
     }
-    Ok(())
 }
 
 async fn with_shard_io_timeout<T>(
@@ -85,12 +96,12 @@ async fn with_shard_io_timeout_after<T>(
         .unwrap_or_else(|_| Err(format!("timed out {operation}")))
 }
 
-async fn build_responses(
+async fn build_response(
     context: &DriverContext,
     net_handle: &NetHandle,
     peer: NodeId,
     message: ShardTransportMessage,
-) -> Vec<ShardTransportResponse> {
+) -> PreparedShardResponse {
     let (realm_id, placement, paged) = match message {
         ShardTransportMessage::ManifestRequest {
             realm_id,
@@ -103,18 +114,20 @@ async fn build_responses(
     };
 
     if realm_id != *net_handle.realm_id() {
-        return vec![ShardTransportResponse::Reject(format!(
+        return PreparedShardResponse::Message(ShardTransportResponse::Reject(format!(
             "shard peer `{peer}` addressed foreign realm `{realm_id}`"
-        ))];
+        )));
     }
     let config = match read_realm_config(context, realm_id).await {
         Ok(Some(config)) => config,
         Ok(None) => {
-            return vec![ShardTransportResponse::Reject(format!(
+            return PreparedShardResponse::Message(ShardTransportResponse::Reject(format!(
                 "realm `{realm_id}` config unavailable"
-            ))];
+            )));
         }
-        Err(error) => return vec![ShardTransportResponse::Reject(error)],
+        Err(error) => {
+            return PreparedShardResponse::Message(ShardTransportResponse::Reject(error));
+        }
     };
 
     // Trust gate: only sync-eligible (server-class) realm nodes may fetch a
@@ -122,41 +135,47 @@ async fn build_responses(
     match config.sync_eligible_node_ids() {
         Ok(eligible) if eligible.contains(&peer) => {}
         Ok(_) => {
-            return vec![ShardTransportResponse::Reject(format!(
+            return PreparedShardResponse::Message(ShardTransportResponse::Reject(format!(
                 "shard peer `{peer}` is not a sync-eligible node in realm `{realm_id}`"
-            ))];
+            )));
         }
-        Err(error) => return vec![ShardTransportResponse::Reject(error.to_string())],
+        Err(error) => {
+            return PreparedShardResponse::Message(ShardTransportResponse::Reject(
+                error.to_string(),
+            ));
+        }
     }
 
     let holders = resolve_shard_holders(&config, &placement);
     // Only a current holder can answer authoritatively for a shard.
     if !holders.contains(&net_handle.node_id()) {
-        return vec![ShardTransportResponse::Reject(format!(
+        return PreparedShardResponse::Message(ShardTransportResponse::Reject(format!(
             "node does not hold shard {}/{} in realm `{realm_id}`",
             placement.strategy_id, placement.shard
-        ))];
+        )));
     }
     if !holders.contains(&peer) {
-        return vec![ShardTransportResponse::Reject(format!(
+        return PreparedShardResponse::Message(ShardTransportResponse::Reject(format!(
             "shard peer `{peer}` is not a holder for shard {}/{} in realm `{realm_id}`",
             placement.strategy_id, placement.shard
-        ))];
+        )));
     }
 
     match assemble_shard_manifest(context, realm_id, placement).await {
         Ok(manifest) => {
             let entries = manifest.entries.len();
-            let responses = if paged {
-                match partition_manifest(&manifest, SHARD_MAX_RESPONSE_SIZE) {
-                    Ok(pages) => pages
-                        .into_iter()
-                        .map(|page| ShardTransportResponse::ManifestPageV2(Box::new(page)))
-                        .collect(),
-                    Err(error) => return vec![ShardTransportResponse::Reject(error)],
+            let response = if paged {
+                match plan_manifest_pages(&manifest, SHARD_MAX_RESPONSE_SIZE) {
+                    Ok(plan) => PreparedShardResponse::ManifestPages {
+                        manifest: Box::new(manifest),
+                        plan,
+                    },
+                    Err(error) => {
+                        PreparedShardResponse::Message(ShardTransportResponse::Reject(error))
+                    }
                 }
             } else {
-                vec![ShardTransportResponse::Manifest(Box::new(manifest))]
+                PreparedShardResponse::Message(ShardTransportResponse::Manifest(Box::new(manifest)))
             };
             debug!(
                 strategy = %placement.strategy_id,
@@ -164,9 +183,9 @@ async fn build_responses(
                 entries,
                 "Served shard manifest"
             );
-            responses
+            response
         }
-        Err(error) => vec![ShardTransportResponse::Reject(error)],
+        Err(error) => PreparedShardResponse::Message(ShardTransportResponse::Reject(error)),
     }
 }
 

--- a/operations/src/shard/incoming.rs
+++ b/operations/src/shard/incoming.rs
@@ -102,16 +102,10 @@ async fn build_response(
     peer: NodeId,
     message: ShardTransportMessage,
 ) -> PreparedShardResponse {
-    let (realm_id, placement, paged) = match message {
-        ShardTransportMessage::ManifestRequest {
-            realm_id,
-            placement,
-        } => (realm_id, placement, false),
-        ShardTransportMessage::ManifestRequestV2 {
-            realm_id,
-            placement,
-        } => (realm_id, placement, true),
-    };
+    let ShardTransportMessage::ManifestRequest {
+        realm_id,
+        placement,
+    } = message;
 
     if realm_id != *net_handle.realm_id() {
         return PreparedShardResponse::Message(ShardTransportResponse::Reject(format!(
@@ -164,18 +158,12 @@ async fn build_response(
     match assemble_shard_manifest(context, realm_id, placement).await {
         Ok(manifest) => {
             let entries = manifest.entries.len();
-            let response = if paged {
-                match plan_manifest_pages(&manifest, SHARD_MAX_RESPONSE_SIZE) {
-                    Ok(plan) => PreparedShardResponse::ManifestPages {
-                        manifest: Box::new(manifest),
-                        plan,
-                    },
-                    Err(error) => {
-                        PreparedShardResponse::Message(ShardTransportResponse::Reject(error))
-                    }
-                }
-            } else {
-                PreparedShardResponse::Message(ShardTransportResponse::Manifest(Box::new(manifest)))
+            let response = match plan_manifest_pages(&manifest, SHARD_MAX_RESPONSE_SIZE) {
+                Ok(plan) => PreparedShardResponse::ManifestPages {
+                    manifest: Box::new(manifest),
+                    plan,
+                },
+                Err(error) => PreparedShardResponse::Message(ShardTransportResponse::Reject(error)),
             };
             debug!(
                 strategy = %placement.strategy_id,

--- a/operations/src/shard/incoming.rs
+++ b/operations/src/shard/incoming.rs
@@ -1,0 +1,128 @@
+use aruna_core::NodeId;
+use aruna_core::effects::StorageEffect;
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{RealmConfigDocument, RealmId};
+use aruna_net::NetHandle;
+use aruna_net::streams::BiStream;
+use byteview::ByteView;
+use tracing::{debug, warn};
+
+use crate::driver::DriverContext;
+use crate::placement::resolve_shard_holders;
+use crate::shard::assemble_shard_manifest;
+use crate::shard::client::close_stream;
+use crate::shard::protocol::{
+    ShardTransportMessage, ShardTransportResponse, read_shard_request, write_shard_response,
+};
+
+#[tracing::instrument(
+    name = "shard.incoming.stream",
+    level = "debug",
+    skip(context, stream),
+    fields(peer = %peer)
+)]
+pub async fn handle_shard_stream(context: &DriverContext, mut stream: BiStream, peer: NodeId) {
+    let Some(net_handle) = context.net_handle.as_ref() else {
+        warn!(peer = %peer, "Dropping inbound shard stream without net handle");
+        return;
+    };
+
+    let message = match read_shard_request(&mut stream).await {
+        Ok(message) => message,
+        Err(error) => {
+            warn!(peer = %peer, error = %error, "Failed to read shard manifest request");
+            return;
+        }
+    };
+
+    let response = build_response(context, net_handle, peer, message).await;
+    if let Err(error) = write_shard_response(&mut stream, &response).await {
+        warn!(peer = %peer, error = %error, "Failed to write shard manifest response");
+    }
+    close_stream(&mut stream).await;
+}
+
+async fn build_response(
+    context: &DriverContext,
+    net_handle: &NetHandle,
+    peer: NodeId,
+    message: ShardTransportMessage,
+) -> ShardTransportResponse {
+    let ShardTransportMessage::ManifestRequest {
+        realm_id,
+        placement,
+    } = message;
+
+    if realm_id != *net_handle.realm_id() {
+        return ShardTransportResponse::Reject(format!(
+            "shard peer `{peer}` addressed foreign realm `{realm_id}`"
+        ));
+    }
+    let config = match read_realm_config(context, realm_id).await {
+        Ok(Some(config)) => config,
+        Ok(None) => {
+            return ShardTransportResponse::Reject(format!(
+                "realm `{realm_id}` config unavailable"
+            ));
+        }
+        Err(error) => return ShardTransportResponse::Reject(error),
+    };
+
+    // Trust gate: only sync-eligible (server-class) realm nodes may fetch a
+    // manifest, mirroring the notification/metadata peer checks.
+    match config.sync_eligible_node_ids() {
+        Ok(eligible) if eligible.contains(&peer) => {}
+        Ok(_) => {
+            return ShardTransportResponse::Reject(format!(
+                "shard peer `{peer}` is not a sync-eligible node in realm `{realm_id}`"
+            ));
+        }
+        Err(error) => return ShardTransportResponse::Reject(error.to_string()),
+    }
+
+    // Only a current holder can answer authoritatively for a shard.
+    if !resolve_shard_holders(&config, &placement).contains(&net_handle.node_id()) {
+        return ShardTransportResponse::Reject(format!(
+            "node does not hold shard {}/{} in realm `{realm_id}`",
+            placement.strategy_id, placement.shard
+        ));
+    }
+
+    match assemble_shard_manifest(context, realm_id, placement).await {
+        Ok(manifest) => {
+            debug!(
+                strategy = %placement.strategy_id,
+                shard = placement.shard,
+                entries = manifest.entries.len(),
+                "Served shard manifest"
+            );
+            ShardTransportResponse::Manifest(Box::new(manifest))
+        }
+        Err(error) => ShardTransportResponse::Reject(error),
+    }
+}
+
+async fn read_realm_config(
+    context: &DriverContext,
+    realm_id: RealmId,
+) -> Result<Option<RealmConfigDocument>, String> {
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: REALM_CONFIG_KEYSPACE.to_string(),
+            key: ByteView::from(realm_id.as_bytes().to_vec()),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(bytes), ..
+        }) => RealmConfigDocument::from_bytes(&bytes)
+            .map(Some)
+            .map_err(|error| error.to_string()),
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(None),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected storage event: {other:?}")),
+    }
+}

--- a/operations/src/shard/incoming.rs
+++ b/operations/src/shard/incoming.rs
@@ -17,7 +17,8 @@ use crate::placement::resolve_shard_holders;
 use crate::shard::assemble_shard_manifest;
 use crate::shard::client::{SHARD_IO_TIMEOUT, close_stream};
 use crate::shard::protocol::{
-    ShardTransportMessage, ShardTransportResponse, read_shard_request, write_shard_response,
+    SHARD_MAX_RESPONSE_SIZE, ShardTransportMessage, ShardTransportResponse, partition_manifest,
+    read_shard_request, write_shard_response,
 };
 
 #[tracing::instrument(
@@ -45,16 +46,26 @@ pub async fn handle_shard_stream(context: &DriverContext, mut stream: BiStream, 
         }
     };
 
-    let response = build_response(context, net_handle, peer, message).await;
+    let responses = build_responses(context, net_handle, peer, message).await;
     if let Err(error) = with_shard_io_timeout(
         "writing shard manifest response",
-        write_shard_response(&mut stream, &response),
+        write_responses(&mut stream, &responses),
     )
     .await
     {
         warn!(peer = %peer, error = %error, "Failed to write shard manifest response");
     }
     close_stream(&mut stream).await;
+}
+
+async fn write_responses(
+    stream: &mut BiStream,
+    responses: &[ShardTransportResponse],
+) -> Result<(), String> {
+    for response in responses {
+        write_shard_response(stream, response).await?;
+    }
+    Ok(())
 }
 
 async fn with_shard_io_timeout<T>(
@@ -74,30 +85,36 @@ async fn with_shard_io_timeout_after<T>(
         .unwrap_or_else(|_| Err(format!("timed out {operation}")))
 }
 
-async fn build_response(
+async fn build_responses(
     context: &DriverContext,
     net_handle: &NetHandle,
     peer: NodeId,
     message: ShardTransportMessage,
-) -> ShardTransportResponse {
-    let ShardTransportMessage::ManifestRequest {
-        realm_id,
-        placement,
-    } = message;
+) -> Vec<ShardTransportResponse> {
+    let (realm_id, placement, paged) = match message {
+        ShardTransportMessage::ManifestRequest {
+            realm_id,
+            placement,
+        } => (realm_id, placement, false),
+        ShardTransportMessage::ManifestRequestV2 {
+            realm_id,
+            placement,
+        } => (realm_id, placement, true),
+    };
 
     if realm_id != *net_handle.realm_id() {
-        return ShardTransportResponse::Reject(format!(
+        return vec![ShardTransportResponse::Reject(format!(
             "shard peer `{peer}` addressed foreign realm `{realm_id}`"
-        ));
+        ))];
     }
     let config = match read_realm_config(context, realm_id).await {
         Ok(Some(config)) => config,
         Ok(None) => {
-            return ShardTransportResponse::Reject(format!(
+            return vec![ShardTransportResponse::Reject(format!(
                 "realm `{realm_id}` config unavailable"
-            ));
+            ))];
         }
-        Err(error) => return ShardTransportResponse::Reject(error),
+        Err(error) => return vec![ShardTransportResponse::Reject(error)],
     };
 
     // Trust gate: only sync-eligible (server-class) realm nodes may fetch a
@@ -105,39 +122,51 @@ async fn build_response(
     match config.sync_eligible_node_ids() {
         Ok(eligible) if eligible.contains(&peer) => {}
         Ok(_) => {
-            return ShardTransportResponse::Reject(format!(
+            return vec![ShardTransportResponse::Reject(format!(
                 "shard peer `{peer}` is not a sync-eligible node in realm `{realm_id}`"
-            ));
+            ))];
         }
-        Err(error) => return ShardTransportResponse::Reject(error.to_string()),
+        Err(error) => return vec![ShardTransportResponse::Reject(error.to_string())],
     }
 
     let holders = resolve_shard_holders(&config, &placement);
     // Only a current holder can answer authoritatively for a shard.
     if !holders.contains(&net_handle.node_id()) {
-        return ShardTransportResponse::Reject(format!(
+        return vec![ShardTransportResponse::Reject(format!(
             "node does not hold shard {}/{} in realm `{realm_id}`",
             placement.strategy_id, placement.shard
-        ));
+        ))];
     }
     if !holders.contains(&peer) {
-        return ShardTransportResponse::Reject(format!(
+        return vec![ShardTransportResponse::Reject(format!(
             "shard peer `{peer}` is not a holder for shard {}/{} in realm `{realm_id}`",
             placement.strategy_id, placement.shard
-        ));
+        ))];
     }
 
     match assemble_shard_manifest(context, realm_id, placement).await {
         Ok(manifest) => {
+            let entries = manifest.entries.len();
+            let responses = if paged {
+                match partition_manifest(&manifest, SHARD_MAX_RESPONSE_SIZE) {
+                    Ok(pages) => pages
+                        .into_iter()
+                        .map(|page| ShardTransportResponse::ManifestPageV2(Box::new(page)))
+                        .collect(),
+                    Err(error) => return vec![ShardTransportResponse::Reject(error)],
+                }
+            } else {
+                vec![ShardTransportResponse::Manifest(Box::new(manifest))]
+            };
             debug!(
                 strategy = %placement.strategy_id,
                 shard = placement.shard,
-                entries = manifest.entries.len(),
+                entries,
                 "Served shard manifest"
             );
-            ShardTransportResponse::Manifest(Box::new(manifest))
+            responses
         }
-        Err(error) => ShardTransportResponse::Reject(error),
+        Err(error) => vec![ShardTransportResponse::Reject(error)],
     }
 }
 

--- a/operations/src/shard/incoming.rs
+++ b/operations/src/shard/incoming.rs
@@ -81,10 +81,17 @@ async fn build_response(
         Err(error) => return ShardTransportResponse::Reject(error.to_string()),
     }
 
+    let holders = resolve_shard_holders(&config, &placement);
     // Only a current holder can answer authoritatively for a shard.
-    if !resolve_shard_holders(&config, &placement).contains(&net_handle.node_id()) {
+    if !holders.contains(&net_handle.node_id()) {
         return ShardTransportResponse::Reject(format!(
             "node does not hold shard {}/{} in realm `{realm_id}`",
+            placement.strategy_id, placement.shard
+        ));
+    }
+    if !holders.contains(&peer) {
+        return ShardTransportResponse::Reject(format!(
+            "shard peer `{peer}` is not a holder for shard {}/{} in realm `{realm_id}`",
             placement.strategy_id, placement.shard
         ));
     }

--- a/operations/src/shard/incoming.rs
+++ b/operations/src/shard/incoming.rs
@@ -141,24 +141,6 @@ async fn build_response(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn shard_io_timeout_reports_timed_out_operation() {
-        let error = with_shard_io_timeout_after(
-            Duration::from_millis(1),
-            "reading shard manifest request",
-            std::future::pending::<Result<(), String>>(),
-        )
-        .await
-        .expect_err("pending shard IO must time out");
-
-        assert_eq!(error, "timed out reading shard manifest request");
-    }
-}
-
 async fn read_realm_config(
     context: &DriverContext,
     realm_id: RealmId,
@@ -180,5 +162,23 @@ async fn read_realm_config(
         Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(None),
         Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
         other => Err(format!("unexpected storage event: {other:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shard_io_timeout_reports_timed_out_operation() {
+        let error = with_shard_io_timeout_after(
+            Duration::from_millis(1),
+            "reading shard manifest request",
+            std::future::pending::<Result<(), String>>(),
+        )
+        .await
+        .expect_err("pending shard IO must time out");
+
+        assert_eq!(error, "timed out reading shard manifest request");
     }
 }

--- a/operations/src/shard/incoming.rs
+++ b/operations/src/shard/incoming.rs
@@ -1,3 +1,6 @@
+use std::future::Future;
+use std::time::Duration;
+
 use aruna_core::NodeId;
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
@@ -6,12 +9,13 @@ use aruna_core::structs::{RealmConfigDocument, RealmId};
 use aruna_net::NetHandle;
 use aruna_net::streams::BiStream;
 use byteview::ByteView;
+use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::driver::DriverContext;
 use crate::placement::resolve_shard_holders;
 use crate::shard::assemble_shard_manifest;
-use crate::shard::client::close_stream;
+use crate::shard::client::{SHARD_IO_TIMEOUT, close_stream};
 use crate::shard::protocol::{
     ShardTransportMessage, ShardTransportResponse, read_shard_request, write_shard_response,
 };
@@ -28,7 +32,12 @@ pub async fn handle_shard_stream(context: &DriverContext, mut stream: BiStream, 
         return;
     };
 
-    let message = match read_shard_request(&mut stream).await {
+    let message = match with_shard_io_timeout(
+        "reading shard manifest request",
+        read_shard_request(&mut stream),
+    )
+    .await
+    {
         Ok(message) => message,
         Err(error) => {
             warn!(peer = %peer, error = %error, "Failed to read shard manifest request");
@@ -37,10 +46,32 @@ pub async fn handle_shard_stream(context: &DriverContext, mut stream: BiStream, 
     };
 
     let response = build_response(context, net_handle, peer, message).await;
-    if let Err(error) = write_shard_response(&mut stream, &response).await {
+    if let Err(error) = with_shard_io_timeout(
+        "writing shard manifest response",
+        write_shard_response(&mut stream, &response),
+    )
+    .await
+    {
         warn!(peer = %peer, error = %error, "Failed to write shard manifest response");
     }
     close_stream(&mut stream).await;
+}
+
+async fn with_shard_io_timeout<T>(
+    operation: &'static str,
+    future: impl Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    with_shard_io_timeout_after(SHARD_IO_TIMEOUT, operation, future).await
+}
+
+async fn with_shard_io_timeout_after<T>(
+    duration: Duration,
+    operation: &'static str,
+    future: impl Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    timeout(duration, future)
+        .await
+        .unwrap_or_else(|_| Err(format!("timed out {operation}")))
 }
 
 async fn build_response(
@@ -107,6 +138,24 @@ async fn build_response(
             ShardTransportResponse::Manifest(Box::new(manifest))
         }
         Err(error) => ShardTransportResponse::Reject(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shard_io_timeout_reports_timed_out_operation() {
+        let error = with_shard_io_timeout_after(
+            Duration::from_millis(1),
+            "reading shard manifest request",
+            std::future::pending::<Result<(), String>>(),
+        )
+        .await
+        .expect_err("pending shard IO must time out");
+
+        assert_eq!(error, "timed out reading shard manifest request");
     }
 }
 

--- a/operations/src/shard/mod.rs
+++ b/operations/src/shard/mod.rs
@@ -91,9 +91,11 @@ async fn scan_shard_manifest_entries(
     Ok(entries)
 }
 
-// Digest and cursor come straight from irokle: a topic with no local genesis
-// yields the zero digest and an empty cursor, which a non-holder compares as
-// "not converged" rather than erroring.
+// Digest and cursor come straight from irokle. A topic with no local genesis is
+// not special-cased here: it reports the (non-zero) empty fingerprint and an
+// empty cursor, and only a storage error falls back to the zero digest.
+// Verification therefore gates on the topic actually existing (see
+// `shard::verify`), never on the digest value.
 fn topic_digest_and_cursor(net_handle: &NetHandle, topic: irokle::TopicId) -> ([u8; 32], Vec<u8>) {
     let node = net_handle.document_sync_node();
     let digest = node

--- a/operations/src/shard/mod.rs
+++ b/operations/src/shard/mod.rs
@@ -1,0 +1,240 @@
+use aruna_core::document::{ShardManifest, ShardManifestEntry, shard_topic_id};
+use aruna_core::effects::{IterStart, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::SHARD_MANIFEST_KEYSPACE;
+use aruna_core::storage_entries::shard_manifest_prefix;
+use aruna_core::structs::{PlacementRef, RealmId};
+use aruna_core::types::Key;
+use aruna_core::util::unix_timestamp_millis;
+use aruna_net::NetHandle;
+use byteview::ByteView;
+use irokle::Storage as _;
+
+use crate::driver::DriverContext;
+
+const SHARD_MANIFEST_SCAN_PAGE: usize = 512;
+
+/// Builds the local node's [`ShardManifest`] for one shard on demand: a prefix
+/// scan of the manifest keyspace for the entry set, plus the shard topic's
+/// irokle `sync_fingerprint` (digest) and persisted `ActorClock` (cursor). Never
+/// persisted — a new holder fetches a co-holder's over the shard ALPN and
+/// compares digests. A digest match against a co-holder means convergence.
+pub async fn assemble_shard_manifest(
+    context: &DriverContext,
+    realm_id: RealmId,
+    placement: PlacementRef,
+) -> Result<ShardManifest, String> {
+    let net_handle = context
+        .net_handle
+        .as_ref()
+        .ok_or_else(|| "cannot assemble shard manifest without a net handle".to_string())?;
+    let entries = scan_shard_manifest_entries(context, &placement).await?;
+    let topic = shard_topic_id(realm_id, &placement);
+    let (digest, cursor) = topic_digest_and_cursor(net_handle, topic);
+    Ok(ShardManifest {
+        placement,
+        holder: net_handle.node_id(),
+        entries,
+        cursor,
+        digest,
+        updated_at_ms: unix_timestamp_millis(),
+    })
+}
+
+async fn scan_shard_manifest_entries(
+    context: &DriverContext,
+    placement: &PlacementRef,
+) -> Result<Vec<ShardManifestEntry>, String> {
+    let prefix = ByteView::from(shard_manifest_prefix(placement));
+    let mut entries = Vec::new();
+    let mut start_after: Option<Key> = None;
+    loop {
+        let batch = match context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: SHARD_MANIFEST_KEYSPACE.to_string(),
+                prefix: Some(prefix.clone()),
+                start: start_after.take().map(IterStart::After),
+                limit: SHARD_MANIFEST_SCAN_PAGE,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult {
+                values,
+                next_start_after,
+            }) => {
+                start_after = next_start_after;
+                values
+            }
+            Event::Storage(StorageEvent::Error { error }) => {
+                return Err(format!("failed to scan shard manifest: {error}"));
+            }
+            other => {
+                return Err(format!("unexpected shard manifest iter result: {other:?}"));
+            }
+        };
+        for (_, value) in &batch {
+            let entry: ShardManifestEntry = postcard::from_bytes(value)
+                .map_err(|error| format!("failed to decode shard manifest entry: {error}"))?;
+            entries.push(entry);
+        }
+        if start_after.is_none() {
+            break;
+        }
+    }
+    Ok(entries)
+}
+
+// Digest and cursor come straight from irokle: a topic with no local genesis
+// yields the zero digest and an empty cursor, which a non-holder compares as
+// "not converged" rather than erroring.
+fn topic_digest_and_cursor(net_handle: &NetHandle, topic: irokle::TopicId) -> ([u8; 32], Vec<u8>) {
+    let node = net_handle.document_sync_node();
+    let digest = node
+        .sync_fingerprint(topic)
+        .map(|fingerprint| fingerprint.fingerprint)
+        .unwrap_or([0u8; 32]);
+    let cursor = node
+        .storage()
+        .actor_clock(&topic)
+        .ok()
+        .and_then(|clock| postcard::to_allocvec(&clock).ok())
+        .unwrap_or_default();
+    (digest, cursor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_core::document::{DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncRevision};
+    use aruna_core::storage_entries::shard_manifest_write_entry;
+    use aruna_net::{DiscoveryMethod, NetConfig, RelayMethod};
+    use aruna_storage::FjallStorage;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use ulid::Ulid;
+
+    fn placement(shard: u32) -> PlacementRef {
+        PlacementRef {
+            strategy_id: Ulid::from_bytes([9; 16]),
+            epoch: 0,
+            shard,
+        }
+    }
+
+    fn lifecycle_change(placement: PlacementRef, seed: u8) -> DocumentSyncChange {
+        DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: u64::from(seed),
+                event_id: Ulid::from_bytes([seed; 16]),
+                actor: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
+                updated_at_ms: u64::from(seed),
+            },
+            kind: DocumentSyncChangeKind::Upsert,
+            placement,
+        }
+    }
+
+    async fn write_manifest_row(storage: &aruna_storage::StorageHandle, shard: u32, doc: u8) {
+        let target = aruna_core::document::DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([doc; 16]),
+        };
+        let (key_space, key, value) =
+            shard_manifest_write_entry(&target, &lifecycle_change(placement(shard), doc))
+                .unwrap()
+                .unwrap();
+        match storage
+            .send_storage_effect(StorageEffect::Write {
+                key_space,
+                key,
+                value,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected manifest write event: {other:?}"),
+        }
+    }
+
+    async fn spawn_context() -> (TempDir, Arc<DriverContext>) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let storage =
+            FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
+        let net = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().expect("bind addr"),
+                realm_id: RealmId::from_bytes([5u8; 32]),
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage.clone(),
+        )
+        .await
+        .expect("net handle");
+        let context = Arc::new(DriverContext {
+            storage_handle: storage,
+            net_handle: Some(net),
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        (dir, context)
+    }
+
+    #[tokio::test]
+    async fn scan_isolates_entries_by_shard() {
+        let (_dir, context) = spawn_context().await;
+        write_manifest_row(&context.storage_handle, 3, 1).await;
+        write_manifest_row(&context.storage_handle, 3, 2).await;
+        write_manifest_row(&context.storage_handle, 4, 3).await;
+
+        let shard3 = scan_shard_manifest_entries(&context, &placement(3))
+            .await
+            .expect("scan shard 3");
+        let shard4 = scan_shard_manifest_entries(&context, &placement(4))
+            .await
+            .expect("scan shard 4");
+
+        assert_eq!(shard3.len(), 2);
+        assert_eq!(shard4.len(), 1);
+        assert!(shard3.iter().all(|entry| entry.target
+            != aruna_core::document::DocumentSyncTarget::MetadataDocumentLifecycle {
+                document_id: Ulid::from_bytes([3; 16])
+            }));
+    }
+
+    #[tokio::test]
+    async fn assembled_digest_and_cursor_track_the_live_shard_topic() {
+        let (_dir, context) = spawn_context().await;
+        let realm_id = RealmId::from_bytes([5u8; 32]);
+        let placement = placement(7);
+        write_manifest_row(&context.storage_handle, 7, 1).await;
+
+        // Ensure the shard topic genesis so the topic has a well-defined
+        // fingerprint and clock to read back.
+        let net = context.net_handle.as_ref().unwrap();
+        let topic = shard_topic_id(realm_id, &placement);
+        net.ensure_document_sync_topics(&[topic], Vec::new())
+            .expect("ensure topic");
+
+        let manifest = assemble_shard_manifest(&context, realm_id, placement)
+            .await
+            .expect("assemble manifest");
+
+        assert_eq!(manifest.placement, placement);
+        assert_eq!(manifest.holder, net.node_id());
+        assert_eq!(manifest.entries.len(), 1);
+        // The digest and cursor are read straight from the live shard topic.
+        let expected_digest = net
+            .document_sync_node()
+            .sync_fingerprint(topic)
+            .expect("fingerprint")
+            .fingerprint;
+        assert_eq!(manifest.digest, expected_digest);
+        assert!(postcard::from_bytes::<irokle::ActorClock>(&manifest.cursor).is_ok());
+    }
+}

--- a/operations/src/shard/mod.rs
+++ b/operations/src/shard/mod.rs
@@ -7,7 +7,7 @@ use aruna_core::document::{ShardManifest, ShardManifestEntry, shard_topic_id};
 use aruna_core::effects::{IterStart, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::SHARD_MANIFEST_KEYSPACE;
-use aruna_core::storage_entries::shard_manifest_prefix;
+use aruna_core::storage_entries::{document_sync_revision_key, shard_manifest_prefix};
 use aruna_core::structs::{PlacementRef, RealmId};
 use aruna_core::types::Key;
 use aruna_core::util::unix_timestamp_millis;
@@ -44,6 +44,32 @@ pub async fn assemble_shard_manifest(
         digest,
         updated_at_ms: unix_timestamp_millis(),
     })
+}
+
+pub(crate) fn manifest_entry_digest(entries: &[ShardManifestEntry]) -> [u8; 32] {
+    let mut encoded_entries: Vec<Vec<u8>> = entries.iter().map(canonical_entry_bytes).collect();
+    encoded_entries.sort();
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&(encoded_entries.len() as u64).to_be_bytes());
+    for encoded in encoded_entries {
+        hasher.update(&(encoded.len() as u64).to_be_bytes());
+        hasher.update(&encoded);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn canonical_entry_bytes(entry: &ShardManifestEntry) -> Vec<u8> {
+    let target_key = document_sync_revision_key(&entry.target);
+    let target_key = target_key.as_ref();
+    let mut bytes = Vec::with_capacity(4 + target_key.len() + 8 + 16 + 32 + 8);
+    bytes.extend_from_slice(&(target_key.len() as u32).to_be_bytes());
+    bytes.extend_from_slice(target_key);
+    bytes.extend_from_slice(&entry.revision.generation.to_be_bytes());
+    bytes.extend_from_slice(&entry.revision.event_id.to_bytes());
+    bytes.extend_from_slice(entry.revision.actor.as_bytes());
+    bytes.extend_from_slice(&entry.revision.updated_at_ms.to_be_bytes());
+    bytes
 }
 
 async fn scan_shard_manifest_entries(
@@ -243,5 +269,36 @@ mod tests {
             .fingerprint;
         assert_eq!(manifest.digest, expected_digest);
         assert!(postcard::from_bytes::<irokle::ActorClock>(&manifest.cursor).is_ok());
+    }
+
+    #[test]
+    fn manifest_entry_digest_is_order_independent_and_revision_sensitive() {
+        let actor = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
+        let first = ShardManifestEntry {
+            target: aruna_core::document::DocumentSyncTarget::MetadataDocumentLifecycle {
+                document_id: Ulid::from_bytes([1; 16]),
+            },
+            revision: DocumentSyncRevision {
+                generation: 1,
+                event_id: Ulid::from_bytes([2; 16]),
+                actor,
+                updated_at_ms: 3,
+            },
+        };
+        let mut second = first.clone();
+        second.target = aruna_core::document::DocumentSyncTarget::MetadataDocumentLifecycle {
+            document_id: Ulid::from_bytes([4; 16]),
+        };
+        let mut changed = second.clone();
+        changed.revision.generation += 1;
+
+        assert_eq!(
+            manifest_entry_digest(&[first.clone(), second.clone()]),
+            manifest_entry_digest(&[second.clone(), first.clone()])
+        );
+        assert_ne!(
+            manifest_entry_digest(&[first, second]),
+            manifest_entry_digest(&[changed])
+        );
     }
 }

--- a/operations/src/shard/mod.rs
+++ b/operations/src/shard/mod.rs
@@ -1,3 +1,8 @@
+pub mod client;
+pub mod incoming;
+pub mod protocol;
+pub mod verify;
+
 use aruna_core::document::{ShardManifest, ShardManifestEntry, shard_topic_id};
 use aruna_core::effects::{IterStart, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};

--- a/operations/src/shard/protocol.rs
+++ b/operations/src/shard/protocol.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use aruna_core::NodeId;
 use aruna_core::document::{ShardManifest, ShardManifestEntry};
 use aruna_core::structs::{PlacementRef, RealmId};
@@ -53,42 +55,61 @@ pub enum ShardTransportResponse {
     ManifestPageV2(Box<ShardManifestPage>),
 }
 
-/// Partitions a manifest greedily and deterministically while measuring the
-/// actual postcard representation used by response frames.
-pub(crate) fn partition_manifest(
+pub(crate) struct ManifestPagePlan {
+    entry_count: u64,
+    entry_digest: [u8; 32],
+    ranges: Vec<Range<usize>>,
+}
+
+#[allow(dead_code)]
+#[derive(Serialize)]
+enum BorrowedShardTransportResponse<'a> {
+    Manifest,
+    Reject,
+    ManifestPageV2(BorrowedShardManifestPage<'a>),
+}
+
+#[derive(Serialize)]
+struct BorrowedShardManifestPage<'a> {
+    placement: PlacementRef,
+    holder: NodeId,
+    cursor: &'a [u8],
+    digest: [u8; 32],
+    updated_at_ms: u64,
+    entry_count: u64,
+    entry_digest: [u8; 32],
+    page_index: u32,
+    last: bool,
+    entries: &'a [ShardManifestEntry],
+}
+
+pub(crate) fn plan_manifest_pages(
     manifest: &ShardManifest,
     max_size: usize,
-) -> Result<Vec<ShardManifestPage>, String> {
+) -> Result<ManifestPagePlan, String> {
     let entry_count = u64::try_from(manifest.entries.len())
         .map_err(|_| "shard manifest entry count exceeds protocol range".to_string())?;
     let entry_digest = manifest_entry_digest(&manifest.entries);
     let entry_sizes = manifest
         .entries
         .iter()
-        .map(|entry| {
-            postcard::to_allocvec(entry)
-                .map(|bytes| bytes.len())
-                .map_err(|error| error.to_string())
-        })
+        .map(serialized_size)
         .collect::<Result<Vec<_>, _>>()?;
-    let empty_entries_size = postcard::to_allocvec(&Vec::<ShardManifestEntry>::new())
-        .map_err(|error| error.to_string())?
-        .len();
+    let empty_entries_size = serialized_size(&Vec::<ShardManifestEntry>::new())?;
 
-    let mut pages = Vec::new();
+    let mut ranges = Vec::new();
     let mut start = 0;
     loop {
-        let page_index = u32::try_from(pages.len())
+        let page_index = u32::try_from(ranges.len())
             .map_err(|_| "shard manifest requires too many pages".to_string())?;
-        let empty_page = manifest_page(
+        let empty_page_size = serialized_size(&borrowed_page_response(
             manifest,
             entry_count,
             entry_digest,
             page_index,
             false,
-            Vec::new(),
-        );
-        let empty_page_size = encoded_page_size(&empty_page)?;
+            &[],
+        ))?;
         let fixed_size = empty_page_size
             .checked_sub(empty_entries_size)
             .ok_or_else(|| "invalid shard manifest page encoding".to_string())?;
@@ -119,29 +140,110 @@ pub(crate) fn partition_manifest(
             return Err("shard manifest entry exceeds maximum page size".to_string());
         }
 
-        pages.push(manifest_page(
-            manifest,
-            entry_count,
-            entry_digest,
-            page_index,
-            false,
-            manifest.entries[start..end].to_vec(),
-        ));
+        ranges.push(start..end);
         start = end;
         if start == manifest.entries.len() {
             break;
         }
     }
 
-    pages.last_mut().expect("at least one manifest page").last = true;
-    for page in &pages {
-        if encoded_page_size(page)? > max_size {
+    for (index, range) in ranges.iter().enumerate() {
+        let page_index = u32::try_from(index)
+            .map_err(|_| "shard manifest requires too many pages".to_string())?;
+        let response = borrowed_page_response(
+            manifest,
+            entry_count,
+            entry_digest,
+            page_index,
+            index + 1 == ranges.len(),
+            &manifest.entries[range.clone()],
+        );
+        if serialized_size(&response)? > max_size {
             return Err("shard manifest page exceeds maximum size".to_string());
         }
     }
-    Ok(pages)
+
+    Ok(ManifestPagePlan {
+        entry_count,
+        entry_digest,
+        ranges,
+    })
 }
 
+pub(crate) async fn write_manifest_pages(
+    stream: &mut BiStream,
+    manifest: &ShardManifest,
+    plan: &ManifestPagePlan,
+) -> Result<(), String> {
+    for (index, range) in plan.ranges.iter().enumerate() {
+        let page_index = u32::try_from(index)
+            .map_err(|_| "shard manifest requires too many pages".to_string())?;
+        let response = borrowed_page_response(
+            manifest,
+            plan.entry_count,
+            plan.entry_digest,
+            page_index,
+            index + 1 == plan.ranges.len(),
+            &manifest.entries[range.clone()],
+        );
+        write_frame(stream, &response, SHARD_MAX_RESPONSE_SIZE).await?;
+    }
+    Ok(())
+}
+
+fn borrowed_page_response<'a>(
+    manifest: &'a ShardManifest,
+    entry_count: u64,
+    entry_digest: [u8; 32],
+    page_index: u32,
+    last: bool,
+    entries: &'a [ShardManifestEntry],
+) -> BorrowedShardTransportResponse<'a> {
+    BorrowedShardTransportResponse::ManifestPageV2(BorrowedShardManifestPage {
+        placement: manifest.placement,
+        holder: manifest.holder,
+        cursor: &manifest.cursor,
+        digest: manifest.digest,
+        updated_at_ms: manifest.updated_at_ms,
+        entry_count,
+        entry_digest,
+        page_index,
+        last,
+        entries,
+    })
+}
+
+fn serialized_size<T: Serialize + ?Sized>(value: &T) -> Result<usize, String> {
+    postcard::serialize_with_flavor(value, postcard::ser_flavors::Size::default())
+        .map_err(|error| error.to_string())
+}
+
+/// Partitions a manifest greedily and deterministically while measuring the
+/// actual postcard representation used by response frames.
+#[cfg(test)]
+pub(crate) fn partition_manifest(
+    manifest: &ShardManifest,
+    max_size: usize,
+) -> Result<Vec<ShardManifestPage>, String> {
+    let plan = plan_manifest_pages(manifest, max_size)?;
+    Ok(plan
+        .ranges
+        .iter()
+        .enumerate()
+        .map(|(index, range)| {
+            manifest_page(
+                manifest,
+                plan.entry_count,
+                plan.entry_digest,
+                index as u32,
+                index + 1 == plan.ranges.len(),
+                manifest.entries[range.clone()].to_vec(),
+            )
+        })
+        .collect())
+}
+
+#[cfg(test)]
 fn manifest_page(
     manifest: &ShardManifest,
     entry_count: u64,
@@ -164,6 +266,7 @@ fn manifest_page(
     }
 }
 
+#[cfg(test)]
 fn encoded_page_size(page: &ShardManifestPage) -> Result<usize, String> {
     postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
         page.clone(),
@@ -173,9 +276,7 @@ fn encoded_page_size(page: &ShardManifestPage) -> Result<usize, String> {
 }
 
 fn encoded_len(len: usize) -> Result<usize, String> {
-    postcard::to_allocvec(&len)
-        .map(|bytes| bytes.len())
-        .map_err(|error| error.to_string())
+    serialized_size(&len)
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/operations/src/shard/protocol.rs
+++ b/operations/src/shard/protocol.rs
@@ -1,9 +1,12 @@
-use aruna_core::document::ShardManifest;
+use aruna_core::NodeId;
+use aruna_core::document::{ShardManifest, ShardManifestEntry};
 use aruna_core::structs::{PlacementRef, RealmId};
 use aruna_net::streams::BiStream;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::io::AsyncWriteExt;
+
+use crate::shard::manifest_entry_digest;
 
 /// A manifest request has only fixed-size identifiers and integer fields. This
 /// small envelope leaves encoding headroom without permitting a large body to
@@ -21,6 +24,24 @@ pub enum ShardTransportMessage {
         realm_id: RealmId,
         placement: PlacementRef,
     },
+    ManifestRequestV2 {
+        realm_id: RealmId,
+        placement: PlacementRef,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+pub struct ShardManifestPage {
+    pub placement: PlacementRef,
+    pub holder: NodeId,
+    pub cursor: Vec<u8>,
+    pub digest: [u8; 32],
+    pub updated_at_ms: u64,
+    pub entry_count: u64,
+    pub entry_digest: [u8; 32],
+    pub page_index: u32,
+    pub last: bool,
+    pub entries: Vec<ShardManifestEntry>,
 }
 
 /// Co-holder reply: the assembled manifest, or a rejection (foreign realm,
@@ -29,6 +50,236 @@ pub enum ShardTransportMessage {
 pub enum ShardTransportResponse {
     Manifest(Box<ShardManifest>),
     Reject(String),
+    ManifestPageV2(Box<ShardManifestPage>),
+}
+
+/// Partitions a manifest greedily and deterministically while measuring the
+/// actual postcard representation used by response frames.
+pub(crate) fn partition_manifest(
+    manifest: &ShardManifest,
+    max_size: usize,
+) -> Result<Vec<ShardManifestPage>, String> {
+    let entry_count = u64::try_from(manifest.entries.len())
+        .map_err(|_| "shard manifest entry count exceeds protocol range".to_string())?;
+    let entry_digest = manifest_entry_digest(&manifest.entries);
+    let entry_sizes = manifest
+        .entries
+        .iter()
+        .map(|entry| {
+            postcard::to_allocvec(entry)
+                .map(|bytes| bytes.len())
+                .map_err(|error| error.to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let empty_entries_size = postcard::to_allocvec(&Vec::<ShardManifestEntry>::new())
+        .map_err(|error| error.to_string())?
+        .len();
+
+    let mut pages = Vec::new();
+    let mut start = 0;
+    loop {
+        let page_index = u32::try_from(pages.len())
+            .map_err(|_| "shard manifest requires too many pages".to_string())?;
+        let empty_page = manifest_page(
+            manifest,
+            entry_count,
+            entry_digest,
+            page_index,
+            false,
+            Vec::new(),
+        );
+        let empty_page_size = encoded_page_size(&empty_page)?;
+        let fixed_size = empty_page_size
+            .checked_sub(empty_entries_size)
+            .ok_or_else(|| "invalid shard manifest page encoding".to_string())?;
+        if fixed_size
+            .checked_add(encoded_len(0)?)
+            .is_none_or(|size| size > max_size)
+        {
+            return Err("shard manifest page metadata exceeds maximum size".to_string());
+        }
+
+        let mut end = start;
+        let mut entries_size = 0usize;
+        while end < manifest.entries.len() {
+            entries_size = entries_size
+                .checked_add(entry_sizes[end])
+                .ok_or_else(|| "shard manifest page size overflow".to_string())?;
+            let page_len = end - start + 1;
+            let candidate_size = fixed_size
+                .checked_add(encoded_len(page_len)?)
+                .and_then(|size| size.checked_add(entries_size))
+                .ok_or_else(|| "shard manifest page size overflow".to_string())?;
+            if candidate_size > max_size {
+                break;
+            }
+            end += 1;
+        }
+        if end == start && start < manifest.entries.len() {
+            return Err("shard manifest entry exceeds maximum page size".to_string());
+        }
+
+        pages.push(manifest_page(
+            manifest,
+            entry_count,
+            entry_digest,
+            page_index,
+            false,
+            manifest.entries[start..end].to_vec(),
+        ));
+        start = end;
+        if start == manifest.entries.len() {
+            break;
+        }
+    }
+
+    pages.last_mut().expect("at least one manifest page").last = true;
+    for page in &pages {
+        if encoded_page_size(page)? > max_size {
+            return Err("shard manifest page exceeds maximum size".to_string());
+        }
+    }
+    Ok(pages)
+}
+
+fn manifest_page(
+    manifest: &ShardManifest,
+    entry_count: u64,
+    entry_digest: [u8; 32],
+    page_index: u32,
+    last: bool,
+    entries: Vec<ShardManifestEntry>,
+) -> ShardManifestPage {
+    ShardManifestPage {
+        placement: manifest.placement,
+        holder: manifest.holder,
+        cursor: manifest.cursor.clone(),
+        digest: manifest.digest,
+        updated_at_ms: manifest.updated_at_ms,
+        entry_count,
+        entry_digest,
+        page_index,
+        last,
+        entries,
+    }
+}
+
+fn encoded_page_size(page: &ShardManifestPage) -> Result<usize, String> {
+    postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+        page.clone(),
+    )))
+    .map(|bytes| bytes.len())
+    .map_err(|error| error.to_string())
+}
+
+fn encoded_len(len: usize) -> Result<usize, String> {
+    postcard::to_allocvec(&len)
+        .map(|bytes| bytes.len())
+        .map_err(|error| error.to_string())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ManifestMetadata {
+    cursor: Vec<u8>,
+    digest: [u8; 32],
+    updated_at_ms: u64,
+    entry_count: u64,
+    entry_digest: [u8; 32],
+}
+
+pub(crate) struct ManifestAssembler {
+    holder: NodeId,
+    placement: PlacementRef,
+    metadata: Option<ManifestMetadata>,
+    entries: Vec<ShardManifestEntry>,
+    next_page: u32,
+    complete: bool,
+}
+
+impl ManifestAssembler {
+    pub(crate) fn new(holder: NodeId, placement: PlacementRef) -> Self {
+        Self {
+            holder,
+            placement,
+            metadata: None,
+            entries: Vec::new(),
+            next_page: 0,
+            complete: false,
+        }
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        page: ShardManifestPage,
+    ) -> Result<Option<ShardManifest>, String> {
+        if self.complete {
+            return Err("received shard manifest page after final page".to_string());
+        }
+        if page.placement != self.placement {
+            return Err("shard manifest page placement mismatch".to_string());
+        }
+        if page.holder != self.holder {
+            return Err("shard manifest page holder mismatch".to_string());
+        }
+        if page.page_index != self.next_page {
+            return Err(format!(
+                "shard manifest page index mismatch: expected {}, received {}",
+                self.next_page, page.page_index
+            ));
+        }
+        if !page.last && page.entries.is_empty() {
+            return Err("non-final shard manifest page is empty".to_string());
+        }
+
+        let metadata = ManifestMetadata {
+            cursor: page.cursor,
+            digest: page.digest,
+            updated_at_ms: page.updated_at_ms,
+            entry_count: page.entry_count,
+            entry_digest: page.entry_digest,
+        };
+        if let Some(expected) = &self.metadata {
+            if *expected != metadata {
+                return Err("shard manifest page metadata mismatch".to_string());
+            }
+        } else {
+            self.metadata = Some(metadata);
+        }
+        let metadata = self.metadata.as_ref().expect("manifest metadata set");
+        let received_count = u64::try_from(self.entries.len())
+            .ok()
+            .and_then(|count| u64::try_from(page.entries.len()).ok()?.checked_add(count))
+            .ok_or_else(|| "shard manifest entry count overflow".to_string())?;
+        if received_count > metadata.entry_count {
+            return Err("shard manifest contains more entries than declared".to_string());
+        }
+        self.entries.extend(page.entries);
+
+        if !page.last {
+            self.next_page = self
+                .next_page
+                .checked_add(1)
+                .ok_or_else(|| "shard manifest page index overflow".to_string())?;
+            return Ok(None);
+        }
+        if received_count != metadata.entry_count {
+            return Err("final shard manifest page has incomplete entry count".to_string());
+        }
+        if manifest_entry_digest(&self.entries) != metadata.entry_digest {
+            return Err("shard manifest entry digest mismatch".to_string());
+        }
+
+        self.complete = true;
+        let metadata = self.metadata.take().expect("manifest metadata set");
+        Ok(Some(ShardManifest {
+            placement: self.placement,
+            holder: self.holder,
+            entries: std::mem::take(&mut self.entries),
+            cursor: metadata.cursor,
+            digest: metadata.digest,
+            updated_at_ms: metadata.updated_at_ms,
+        }))
+    }
 }
 
 pub async fn write_shard_request(
@@ -143,6 +394,19 @@ mod tests {
         };
         let bytes = postcard::to_allocvec(&message).unwrap();
         assert!(bytes.len() <= SHARD_MAX_REQUEST_SIZE);
+        assert_eq!(bytes[0], 0, "legacy request variant index changed");
+        assert_eq!(
+            postcard::from_bytes::<ShardTransportMessage>(&bytes).unwrap(),
+            message
+        );
+
+        let message = ShardTransportMessage::ManifestRequestV2 {
+            realm_id: RealmId::from_bytes([2; 32]),
+            placement,
+        };
+        let bytes = postcard::to_allocvec(&message).unwrap();
+        assert!(bytes.len() <= SHARD_MAX_REQUEST_SIZE);
+        assert_eq!(bytes[0], 1, "V2 request must follow the legacy variant");
         assert_eq!(
             postcard::from_bytes::<ShardTransportMessage>(&bytes).unwrap(),
             message
@@ -170,8 +434,9 @@ mod tests {
             digest: [7u8; 32],
             updated_at_ms: 99,
         };
-        let response = ShardTransportResponse::Manifest(Box::new(manifest));
+        let response = ShardTransportResponse::Manifest(Box::new(manifest.clone()));
         let bytes = postcard::to_allocvec(&response).unwrap();
+        assert_eq!(bytes[0], 0, "legacy manifest variant index changed");
         assert_eq!(
             postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
             response
@@ -179,10 +444,174 @@ mod tests {
 
         let reject = ShardTransportResponse::Reject("nope".to_string());
         let bytes = postcard::to_allocvec(&reject).unwrap();
+        assert_eq!(bytes[0], 1, "legacy reject variant index changed");
         assert_eq!(
             postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
             reject
         );
+
+        let page = partition_manifest(&manifest, SHARD_MAX_RESPONSE_SIZE)
+            .unwrap()
+            .remove(0);
+        let response = ShardTransportResponse::ManifestPageV2(Box::new(page));
+        let bytes = postcard::to_allocvec(&response).unwrap();
+        assert_eq!(bytes[0], 2, "V2 page must follow the legacy variants");
+        assert_eq!(
+            postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
+            response
+        );
+    }
+
+    #[test]
+    fn tiny_budget_pages() {
+        let holder = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
+        let entries = (1..=4)
+            .map(|seed| ShardManifestEntry {
+                target: DocumentSyncTarget::MetadataDocumentLifecycle {
+                    document_id: Ulid::from_bytes([seed; 16]),
+                },
+                revision: DocumentSyncRevision {
+                    generation: u64::from(seed),
+                    event_id: Ulid::from_bytes([seed + 4; 16]),
+                    actor: holder,
+                    updated_at_ms: u64::from(seed),
+                },
+            })
+            .collect::<Vec<_>>();
+        let manifest = ShardManifest {
+            placement: placement(),
+            holder,
+            cursor: vec![1, 2, 3],
+            digest: [7; 32],
+            updated_at_ms: 99,
+            entries,
+        };
+        let entry_digest = crate::shard::manifest_entry_digest(&manifest.entries);
+        let sample_page = |entries: Vec<ShardManifestEntry>| ShardManifestPage {
+            placement: manifest.placement,
+            holder,
+            cursor: manifest.cursor.clone(),
+            digest: manifest.digest,
+            updated_at_ms: manifest.updated_at_ms,
+            entry_count: manifest.entries.len() as u64,
+            entry_digest,
+            page_index: 0,
+            last: false,
+            entries,
+        };
+        let budget = postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+            sample_page(vec![manifest.entries[0].clone()]),
+        )))
+        .unwrap()
+        .len();
+        assert!(
+            postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+                sample_page(manifest.entries[..2].to_vec()),
+            )))
+            .unwrap()
+            .len()
+                > budget
+        );
+
+        let pages = partition_manifest(&manifest, budget).expect("manifest pages");
+        assert_eq!(pages.len(), manifest.entries.len());
+        for (index, page) in pages.iter().enumerate() {
+            assert_eq!(page.page_index, index as u32);
+            assert_eq!(page.last, index + 1 == pages.len());
+            assert!(
+                postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+                    page.clone(),
+                )))
+                .unwrap()
+                .len()
+                    <= budget
+            );
+        }
+
+        let mut assembler = ManifestAssembler::new(holder, manifest.placement);
+        let mut assembled = None;
+        for page in pages {
+            assembled = assembler.push(page).expect("valid page");
+        }
+        assert_eq!(assembled, Some(manifest));
+    }
+
+    #[test]
+    fn invalid_pages_fail() {
+        let holder = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
+        let other_holder = iroh::SecretKey::from_bytes(&[2u8; 32]).public();
+        let entries = (1..=2)
+            .map(|seed| ShardManifestEntry {
+                target: DocumentSyncTarget::MetadataDocumentLifecycle {
+                    document_id: Ulid::from_bytes([seed; 16]),
+                },
+                revision: DocumentSyncRevision {
+                    generation: u64::from(seed),
+                    event_id: Ulid::from_bytes([seed + 4; 16]),
+                    actor: holder,
+                    updated_at_ms: u64::from(seed),
+                },
+            })
+            .collect::<Vec<_>>();
+        let manifest = ShardManifest {
+            placement: placement(),
+            holder,
+            cursor: vec![1, 2, 3],
+            digest: [7; 32],
+            updated_at_ms: 99,
+            entries,
+        };
+        let entry_digest = manifest_entry_digest(&manifest.entries);
+        let one_entry = manifest_page(
+            &manifest,
+            manifest.entries.len() as u64,
+            entry_digest,
+            0,
+            false,
+            vec![manifest.entries[0].clone()],
+        );
+        let pages = partition_manifest(&manifest, encoded_page_size(&one_entry).unwrap()).unwrap();
+        assert_eq!(pages.len(), 2);
+        let first = pages[0].clone();
+        let second = pages[1].clone();
+        let rejects_second = |changed: ShardManifestPage| {
+            let mut assembler = ManifestAssembler::new(holder, manifest.placement);
+            assert_eq!(assembler.push(first.clone()).unwrap(), None);
+            assert!(assembler.push(changed).is_err());
+        };
+
+        let mut changed = second.clone();
+        changed.placement.shard += 1;
+        rejects_second(changed);
+        let mut changed = second.clone();
+        changed.holder = other_holder;
+        rejects_second(changed);
+        let mut changed = second.clone();
+        changed.cursor.push(4);
+        rejects_second(changed);
+        let mut changed = second.clone();
+        changed.digest[0] ^= 1;
+        rejects_second(changed);
+        let mut changed = second.clone();
+        changed.updated_at_ms += 1;
+        rejects_second(changed);
+        let mut changed = second.clone();
+        changed.entry_count += 1;
+        rejects_second(changed);
+        let mut changed = second.clone();
+        changed.entry_digest[0] ^= 1;
+        rejects_second(changed);
+        let mut changed = second.clone();
+        changed.page_index += 1;
+        rejects_second(changed);
+        let mut changed = second;
+        changed.entries[0].revision.generation += 1;
+        rejects_second(changed);
+
+        let mut early_last = first;
+        early_last.last = true;
+        let mut assembler = ManifestAssembler::new(holder, manifest.placement);
+        assert!(assembler.push(early_last).is_err());
     }
 
     #[tokio::test]

--- a/operations/src/shard/protocol.rs
+++ b/operations/src/shard/protocol.rs
@@ -1,0 +1,154 @@
+use aruna_core::document::ShardManifest;
+use aruna_core::structs::{PlacementRef, RealmId};
+use aruna_net::streams::BiStream;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::io::AsyncWriteExt;
+
+/// A shard manifest can carry one entry per document held in the shard; 16 MiB
+/// bounds a large shard while still refusing a hostile oversized frame.
+pub const SHARD_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
+/// New-holder request: give me your manifest for this shard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+pub enum ShardTransportMessage {
+    ManifestRequest {
+        realm_id: RealmId,
+        placement: PlacementRef,
+    },
+}
+
+/// Co-holder reply: the assembled manifest, or a rejection (foreign realm,
+/// untrusted peer, or a shard the responder does not hold).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+pub enum ShardTransportResponse {
+    Manifest(Box<ShardManifest>),
+    Reject(String),
+}
+
+pub async fn write_shard_request(
+    stream: &mut BiStream,
+    message: &ShardTransportMessage,
+) -> Result<(), String> {
+    write_frame(stream, message).await
+}
+
+pub async fn read_shard_request(stream: &mut BiStream) -> Result<ShardTransportMessage, String> {
+    read_frame(stream).await
+}
+
+pub async fn write_shard_response(
+    stream: &mut BiStream,
+    message: &ShardTransportResponse,
+) -> Result<(), String> {
+    write_frame(stream, message).await
+}
+
+pub async fn read_shard_response(stream: &mut BiStream) -> Result<ShardTransportResponse, String> {
+    read_frame(stream).await
+}
+
+async fn write_frame<T: Serialize>(stream: &mut BiStream, message: &T) -> Result<(), String> {
+    let bytes = postcard::to_allocvec(message).map_err(|err| err.to_string())?;
+    if bytes.len() > SHARD_MAX_MESSAGE_SIZE {
+        return Err("shard message exceeds maximum size".to_string());
+    }
+    stream
+        .0
+        .write_all(&(bytes.len() as u32).to_be_bytes())
+        .await
+        .map_err(|err| err.to_string())?;
+    stream
+        .0
+        .write_all(&bytes)
+        .await
+        .map_err(|err| err.to_string())?;
+    stream.0.flush().await.map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+async fn read_frame<T: DeserializeOwned>(stream: &mut BiStream) -> Result<T, String> {
+    let mut len_buf = [0u8; 4];
+    stream
+        .1
+        .read_exact(&mut len_buf)
+        .await
+        .map_err(|err| err.to_string())?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > SHARD_MAX_MESSAGE_SIZE {
+        return Err("shard frame exceeds maximum size".to_string());
+    }
+    let mut bytes = vec![0u8; len];
+    stream
+        .1
+        .read_exact(&mut bytes)
+        .await
+        .map_err(|err| err.to_string())?;
+    postcard::from_bytes(&bytes).map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_core::document::{
+        DocumentSyncRevision, DocumentSyncTarget, ShardManifest, ShardManifestEntry,
+    };
+    use ulid::Ulid;
+
+    fn placement() -> PlacementRef {
+        PlacementRef {
+            strategy_id: Ulid::from_bytes([9; 16]),
+            epoch: 0,
+            shard: 7,
+        }
+    }
+
+    #[test]
+    fn manifest_request_round_trips() {
+        let message = ShardTransportMessage::ManifestRequest {
+            realm_id: RealmId::from_bytes([2; 32]),
+            placement: placement(),
+        };
+        let bytes = postcard::to_allocvec(&message).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<ShardTransportMessage>(&bytes).unwrap(),
+            message
+        );
+    }
+
+    #[test]
+    fn manifest_response_round_trips() {
+        let holder = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
+        let manifest = ShardManifest {
+            placement: placement(),
+            holder,
+            entries: vec![ShardManifestEntry {
+                target: DocumentSyncTarget::MetadataDocumentLifecycle {
+                    document_id: Ulid::from_bytes([4; 16]),
+                },
+                revision: DocumentSyncRevision {
+                    generation: 3,
+                    event_id: Ulid::from_bytes([5; 16]),
+                    actor: holder,
+                    updated_at_ms: 42,
+                },
+            }],
+            cursor: vec![1, 2, 3],
+            digest: [7u8; 32],
+            updated_at_ms: 99,
+        };
+        let response = ShardTransportResponse::Manifest(Box::new(manifest));
+        let bytes = postcard::to_allocvec(&response).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
+            response
+        );
+
+        let reject = ShardTransportResponse::Reject("nope".to_string());
+        let bytes = postcard::to_allocvec(&reject).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
+            reject
+        );
+    }
+}

--- a/operations/src/shard/protocol.rs
+++ b/operations/src/shard/protocol.rs
@@ -5,9 +5,14 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::io::AsyncWriteExt;
 
+/// A manifest request has only fixed-size identifiers and integer fields. This
+/// small envelope leaves encoding headroom without permitting a large body to
+/// be allocated before peer authorization.
+pub const SHARD_MAX_REQUEST_SIZE: usize = 128;
+
 /// A shard manifest can carry one entry per document held in the shard; 16 MiB
-/// bounds a large shard while still refusing a hostile oversized frame.
-pub const SHARD_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+/// bounds a large response while still refusing a hostile oversized frame.
+pub const SHARD_MAX_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
 
 /// New-holder request: give me your manifest for this shard.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
@@ -30,27 +35,31 @@ pub async fn write_shard_request(
     stream: &mut BiStream,
     message: &ShardTransportMessage,
 ) -> Result<(), String> {
-    write_frame(stream, message).await
+    write_frame(stream, message, SHARD_MAX_REQUEST_SIZE).await
 }
 
 pub async fn read_shard_request(stream: &mut BiStream) -> Result<ShardTransportMessage, String> {
-    read_frame(stream).await
+    read_frame(stream, SHARD_MAX_REQUEST_SIZE).await
 }
 
 pub async fn write_shard_response(
     stream: &mut BiStream,
     message: &ShardTransportResponse,
 ) -> Result<(), String> {
-    write_frame(stream, message).await
+    write_frame(stream, message, SHARD_MAX_RESPONSE_SIZE).await
 }
 
 pub async fn read_shard_response(stream: &mut BiStream) -> Result<ShardTransportResponse, String> {
-    read_frame(stream).await
+    read_frame(stream, SHARD_MAX_RESPONSE_SIZE).await
 }
 
-async fn write_frame<T: Serialize>(stream: &mut BiStream, message: &T) -> Result<(), String> {
+async fn write_frame<T: Serialize>(
+    stream: &mut BiStream,
+    message: &T,
+    max_size: usize,
+) -> Result<(), String> {
     let bytes = postcard::to_allocvec(message).map_err(|err| err.to_string())?;
-    if bytes.len() > SHARD_MAX_MESSAGE_SIZE {
+    if bytes.len() > max_size {
         return Err("shard message exceeds maximum size".to_string());
     }
     stream
@@ -67,7 +76,10 @@ async fn write_frame<T: Serialize>(stream: &mut BiStream, message: &T) -> Result
     Ok(())
 }
 
-async fn read_frame<T: DeserializeOwned>(stream: &mut BiStream) -> Result<T, String> {
+async fn read_frame<T: DeserializeOwned>(
+    stream: &mut BiStream,
+    max_size: usize,
+) -> Result<T, String> {
     let mut len_buf = [0u8; 4];
     stream
         .1
@@ -75,7 +87,7 @@ async fn read_frame<T: DeserializeOwned>(stream: &mut BiStream) -> Result<T, Str
         .await
         .map_err(|err| err.to_string())?;
     let len = u32::from_be_bytes(len_buf) as usize;
-    if len > SHARD_MAX_MESSAGE_SIZE {
+    if len > max_size {
         return Err("shard frame exceeds maximum size".to_string());
     }
     let mut bytes = vec![0u8; len];
@@ -93,7 +105,24 @@ mod tests {
     use aruna_core::document::{
         DocumentSyncRevision, DocumentSyncTarget, ShardManifest, ShardManifestEntry,
     };
+    use aruna_core::{NodeId, alpn::Alpn};
+    use aruna_net::{DiscoveryMethod, InboundEventHandler, NetConfig, NetHandle, RelayMethod};
+    use aruna_storage::FjallStorage;
+    use async_trait::async_trait;
+    use std::{sync::Arc, time::Duration};
+    use tempfile::tempdir;
+    use tokio::sync::mpsc;
     use ulid::Ulid;
+
+    #[derive(Debug)]
+    struct StreamCapture(mpsc::UnboundedSender<BiStream>);
+
+    #[async_trait]
+    impl InboundEventHandler for StreamCapture {
+        async fn handle_incoming_stream(&self, _alpn: Alpn, stream: BiStream, _node_id: NodeId) {
+            self.0.send(stream).expect("capture shard stream");
+        }
+    }
 
     fn placement() -> PlacementRef {
         PlacementRef {
@@ -105,11 +134,15 @@ mod tests {
 
     #[test]
     fn manifest_request_round_trips() {
+        let mut placement = placement();
+        placement.epoch = u64::MAX;
+        placement.shard = u32::MAX;
         let message = ShardTransportMessage::ManifestRequest {
             realm_id: RealmId::from_bytes([2; 32]),
-            placement: placement(),
+            placement,
         };
         let bytes = postcard::to_allocvec(&message).unwrap();
+        assert!(bytes.len() <= SHARD_MAX_REQUEST_SIZE);
         assert_eq!(
             postcard::from_bytes::<ShardTransportMessage>(&bytes).unwrap(),
             message
@@ -150,5 +183,56 @@ mod tests {
             postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
             reject
         );
+    }
+
+    #[tokio::test]
+    async fn oversized_request_rejected() {
+        let dir_a = tempdir().expect("client temp dir");
+        let dir_b = tempdir().expect("server temp dir");
+        let storage_a = FjallStorage::open(dir_a.path().to_str().expect("client temp path"))
+            .expect("client storage");
+        let storage_b = FjallStorage::open(dir_b.path().to_str().expect("server temp path"))
+            .expect("server storage");
+        let config = || NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("bind address"),
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        };
+        let client = NetHandle::new(config(), storage_a)
+            .await
+            .expect("client net handle");
+        let server = NetHandle::new(config(), storage_b)
+            .await
+            .expect("server net handle");
+        client.add_peer_addr(server.endpoint_addr()).await;
+        server.add_peer_addr(client.endpoint_addr()).await;
+        let (stream_tx, mut stream_rx) = mpsc::unbounded_channel();
+        server.set_inbound_handler(Arc::new(StreamCapture(stream_tx)));
+
+        let mut outbound = client
+            .open_stream(server.node_id(), Alpn::Shard)
+            .await
+            .expect("open shard stream");
+        outbound
+            .0
+            .write_all(&1024u32.to_be_bytes())
+            .await
+            .expect("write oversized request header");
+        outbound.0.flush().await.expect("flush request header");
+        let mut inbound = tokio::time::timeout(Duration::from_secs(5), stream_rx.recv())
+            .await
+            .expect("receive shard stream promptly")
+            .expect("capture remains open");
+
+        let error =
+            tokio::time::timeout(Duration::from_millis(250), read_shard_request(&mut inbound))
+                .await
+                .expect("oversized header must be rejected without reading its body")
+                .expect_err("oversized request must be rejected");
+        assert_eq!(error, "shard frame exceeds maximum size");
+
+        client.shutdown().await;
+        server.shutdown().await;
     }
 }

--- a/operations/src/shard/protocol.rs
+++ b/operations/src/shard/protocol.rs
@@ -19,14 +19,10 @@ pub const SHARD_MAX_REQUEST_SIZE: usize = 128;
 /// bounds a large response while still refusing a hostile oversized frame.
 pub const SHARD_MAX_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
 
-/// New-holder request: give me your manifest for this shard.
+/// New-holder request: give me your paged manifest for this shard.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub enum ShardTransportMessage {
     ManifestRequest {
-        realm_id: RealmId,
-        placement: PlacementRef,
-    },
-    ManifestRequestV2 {
         realm_id: RealmId,
         placement: PlacementRef,
     },
@@ -46,13 +42,12 @@ pub struct ShardManifestPage {
     pub entries: Vec<ShardManifestEntry>,
 }
 
-/// Co-holder reply: the assembled manifest, or a rejection (foreign realm,
-/// untrusted peer, or a shard the responder does not hold).
+/// Co-holder reply: a rejection (foreign realm, untrusted peer, or a shard the
+/// responder does not hold), or one page of the assembled manifest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub enum ShardTransportResponse {
-    Manifest(Box<ShardManifest>),
     Reject(String),
-    ManifestPageV2(Box<ShardManifestPage>),
+    ManifestPage(Box<ShardManifestPage>),
 }
 
 pub(crate) struct ManifestPagePlan {
@@ -64,9 +59,8 @@ pub(crate) struct ManifestPagePlan {
 #[allow(dead_code)]
 #[derive(Serialize)]
 enum BorrowedShardTransportResponse<'a> {
-    Manifest,
     Reject,
-    ManifestPageV2(BorrowedShardManifestPage<'a>),
+    ManifestPage(BorrowedShardManifestPage<'a>),
 }
 
 #[derive(Serialize)]
@@ -199,7 +193,7 @@ fn borrowed_page_response<'a>(
     last: bool,
     entries: &'a [ShardManifestEntry],
 ) -> BorrowedShardTransportResponse<'a> {
-    BorrowedShardTransportResponse::ManifestPageV2(BorrowedShardManifestPage {
+    BorrowedShardTransportResponse::ManifestPage(BorrowedShardManifestPage {
         placement: manifest.placement,
         holder: manifest.holder,
         cursor: &manifest.cursor,
@@ -268,7 +262,7 @@ fn manifest_page(
 
 #[cfg(test)]
 fn encoded_page_size(page: &ShardManifestPage) -> Result<usize, String> {
-    postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+    postcard::to_allocvec(&ShardTransportResponse::ManifestPage(Box::new(
         page.clone(),
     )))
     .map(|bytes| bytes.len())
@@ -495,19 +489,6 @@ mod tests {
         };
         let bytes = postcard::to_allocvec(&message).unwrap();
         assert!(bytes.len() <= SHARD_MAX_REQUEST_SIZE);
-        assert_eq!(bytes[0], 0, "legacy request variant index changed");
-        assert_eq!(
-            postcard::from_bytes::<ShardTransportMessage>(&bytes).unwrap(),
-            message
-        );
-
-        let message = ShardTransportMessage::ManifestRequestV2 {
-            realm_id: RealmId::from_bytes([2; 32]),
-            placement,
-        };
-        let bytes = postcard::to_allocvec(&message).unwrap();
-        assert!(bytes.len() <= SHARD_MAX_REQUEST_SIZE);
-        assert_eq!(bytes[0], 1, "V2 request must follow the legacy variant");
         assert_eq!(
             postcard::from_bytes::<ShardTransportMessage>(&bytes).unwrap(),
             message
@@ -535,17 +516,9 @@ mod tests {
             digest: [7u8; 32],
             updated_at_ms: 99,
         };
-        let response = ShardTransportResponse::Manifest(Box::new(manifest.clone()));
-        let bytes = postcard::to_allocvec(&response).unwrap();
-        assert_eq!(bytes[0], 0, "legacy manifest variant index changed");
-        assert_eq!(
-            postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
-            response
-        );
-
         let reject = ShardTransportResponse::Reject("nope".to_string());
         let bytes = postcard::to_allocvec(&reject).unwrap();
-        assert_eq!(bytes[0], 1, "legacy reject variant index changed");
+        assert_eq!(bytes[0], 0, "reject variant index changed");
         assert_eq!(
             postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
             reject
@@ -554,9 +527,9 @@ mod tests {
         let page = partition_manifest(&manifest, SHARD_MAX_RESPONSE_SIZE)
             .unwrap()
             .remove(0);
-        let response = ShardTransportResponse::ManifestPageV2(Box::new(page));
+        let response = ShardTransportResponse::ManifestPage(Box::new(page));
         let bytes = postcard::to_allocvec(&response).unwrap();
-        assert_eq!(bytes[0], 2, "V2 page must follow the legacy variants");
+        assert_eq!(bytes[0], 1, "manifest page must follow reject");
         assert_eq!(
             postcard::from_bytes::<ShardTransportResponse>(&bytes).unwrap(),
             response
@@ -600,13 +573,13 @@ mod tests {
             last: false,
             entries,
         };
-        let budget = postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+        let budget = postcard::to_allocvec(&ShardTransportResponse::ManifestPage(Box::new(
             sample_page(vec![manifest.entries[0].clone()]),
         )))
         .unwrap()
         .len();
         assert!(
-            postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+            postcard::to_allocvec(&ShardTransportResponse::ManifestPage(Box::new(
                 sample_page(manifest.entries[..2].to_vec()),
             )))
             .unwrap()
@@ -620,7 +593,7 @@ mod tests {
             assert_eq!(page.page_index, index as u32);
             assert_eq!(page.last, index + 1 == pages.len());
             assert!(
-                postcard::to_allocvec(&ShardTransportResponse::ManifestPageV2(Box::new(
+                postcard::to_allocvec(&ShardTransportResponse::ManifestPage(Box::new(
                     page.clone(),
                 )))
                 .unwrap()

--- a/operations/src/shard/verify.rs
+++ b/operations/src/shard/verify.rs
@@ -15,8 +15,8 @@ use tracing::{debug, info, warn};
 
 use crate::driver::DriverContext;
 use crate::placement::resolve_shard_holders;
-use crate::shard::assemble_shard_manifest;
 use crate::shard::client::fetch_shard_manifest;
+use crate::shard::{assemble_shard_manifest, manifest_entry_digest};
 use crate::startup::apply_restored_reconcile;
 use crate::sync_placement::placement_key;
 
@@ -46,11 +46,12 @@ pub struct ShardVerificationSummary {
 }
 
 /// Reconciles every shard the local node newly holds against a co-holder: fetch
-/// the first reachable co-holder's manifest in rank order and compare digests.
-/// Equal ⇒ mark verified; differing ⇒ one anti-entropy pass against that
-/// co-holder and retry, bounded by [`SHARD_VERIFICATION_MAX_ATTEMPTS`]. Already
-/// verified shards (a persisted marker) are skipped, so this is idempotent and
-/// cheap in steady state and resumes unverified shards after a restart.
+/// the first reachable co-holder's manifest in rank order and compare the topic
+/// digest plus manifest entry digest. Equal ⇒ mark verified; differing ⇒ one
+/// anti-entropy pass against that co-holder and retry, bounded by
+/// [`SHARD_VERIFICATION_MAX_ATTEMPTS`]. Already verified shards (a persisted
+/// marker) are skipped, so this is idempotent and cheap in steady state and
+/// resumes unverified shards after a restart.
 pub async fn verify_held_shards(
     context: &Arc<DriverContext>,
     node_id: NodeId,
@@ -177,7 +178,7 @@ async fn verify_one_shard(
             if net_handle
                 .document_sync_topic_exists(topic)
                 .unwrap_or(false)
-                && local.digest == remote.digest
+                && manifests_converged(&local, &remote)
             {
                 mark_verified(context, realm_id, placement, Some(*co_holder), local.digest).await;
                 info!(
@@ -189,7 +190,7 @@ async fn verify_one_shard(
                 );
                 return true;
             }
-            // Digests differ: pull the co-holder's events and re-compare.
+            // Topic or entry digests differ: pull the co-holder's events and re-compare.
             let event = net_handle
                 .sync_document_topics(vec![topic], vec![*co_holder])
                 .await;
@@ -207,6 +208,14 @@ async fn verify_one_shard(
         return false;
     }
     false
+}
+
+fn manifests_converged(
+    local: &aruna_core::document::ShardManifest,
+    remote: &aruna_core::document::ShardManifest,
+) -> bool {
+    local.digest == remote.digest
+        && manifest_entry_digest(&local.entries) == manifest_entry_digest(&remote.entries)
 }
 
 /// Deletes a shard's verification marker (e.g. when the local node leaves the
@@ -303,5 +312,60 @@ async fn load_realm_config(
             value.and_then(|bytes| RealmConfigDocument::from_bytes(&bytes).ok())
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_core::document::{
+        DocumentSyncRevision, DocumentSyncTarget, ShardManifest, ShardManifestEntry,
+    };
+    use ulid::Ulid;
+
+    fn node_id(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    fn placement() -> PlacementRef {
+        PlacementRef {
+            strategy_id: Ulid::from_bytes([9; 16]),
+            epoch: 0,
+            shard: 7,
+        }
+    }
+
+    fn entry(document: u8, generation: u64) -> ShardManifestEntry {
+        ShardManifestEntry {
+            target: DocumentSyncTarget::MetadataDocumentLifecycle {
+                document_id: Ulid::from_bytes([document; 16]),
+            },
+            revision: DocumentSyncRevision {
+                generation,
+                event_id: Ulid::from_bytes([generation as u8; 16]),
+                actor: node_id(3),
+                updated_at_ms: generation,
+            },
+        }
+    }
+
+    fn manifest(entries: Vec<ShardManifestEntry>) -> ShardManifest {
+        ShardManifest {
+            placement: placement(),
+            holder: node_id(1),
+            entries,
+            cursor: Vec::new(),
+            digest: [7; 32],
+            updated_at_ms: 0,
+        }
+    }
+
+    #[test]
+    fn equal_topic_digest_with_different_entries_does_not_converge() {
+        let local = manifest(vec![entry(1, 1)]);
+        let remote = manifest(vec![entry(2, 1)]);
+
+        assert_eq!(local.digest, remote.digest);
+        assert!(!manifests_converged(&local, &remote));
     }
 }

--- a/operations/src/shard/verify.rs
+++ b/operations/src/shard/verify.rs
@@ -26,7 +26,9 @@ pub const SHARD_VERIFICATION_MAX_ATTEMPTS: usize = 3;
 
 /// Persisted proof that the local node reconciled a shard against a co-holder.
 /// Presence of the row (keyed like a pending placement) means verified; a
-/// restart resumes only shards without one.
+/// restart resumes only shards without one. The marker is a one-shot join-time
+/// signal, not a continuous consistency guarantee: it is written once on the
+/// first successful reconcile and deleted when the node leaves the holder set.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShardVerificationRecord {
     pub placement: PlacementRef,
@@ -111,13 +113,31 @@ async fn verify_one_shard(
     placement: PlacementRef,
     co_holders: &[NodeId],
 ) -> bool {
-    // A sole holder has no co-holder to reconcile against; it is trivially
-    // consistent with itself, so mark it verified immediately.
+    let topic = shard_topic_id(realm_id, &placement);
+
+    // A sole holder is trivially consistent with itself, but only once its
+    // genesis exists. A genesis-less topic still reports the (non-zero) empty
+    // fingerprint, so gate on the local topic actually existing — never on the
+    // digest value — or a rank-0 create still pending would be marked verified.
     if co_holders.is_empty() {
-        let digest = assemble_shard_manifest(context, realm_id, placement)
-            .await
-            .map(|manifest| manifest.digest)
-            .unwrap_or([0u8; 32]);
+        if !net_handle
+            .document_sync_topic_exists(topic)
+            .unwrap_or(false)
+        {
+            debug!(
+                strategy = %placement.strategy_id,
+                shard = placement.shard,
+                "Sole-holder shard has no local genesis yet; deferring verification"
+            );
+            return false;
+        }
+        let digest = match assemble_shard_manifest(context, realm_id, placement).await {
+            Ok(manifest) => manifest.digest,
+            Err(error) => {
+                warn!(error = %error, "Failed to assemble sole-holder shard manifest for verification");
+                return false;
+            }
+        };
         mark_verified(context, realm_id, placement, None, digest).await;
         info!(
             strategy = %placement.strategy_id,
@@ -127,7 +147,6 @@ async fn verify_one_shard(
         return true;
     }
 
-    let topic = shard_topic_id(realm_id, &placement);
     for co_holder in co_holders {
         let mut remote =
             match fetch_shard_manifest(net_handle, *co_holder, realm_id, placement).await {
@@ -152,7 +171,14 @@ async fn verify_one_shard(
                     return false;
                 }
             };
-            if local.digest == remote.digest {
+            // Never certify convergence without a local genesis: two genesis-less
+            // holders share the (non-zero) empty fingerprint and would otherwise
+            // match, so require the local topic to exist before comparing.
+            if net_handle
+                .document_sync_topic_exists(topic)
+                .unwrap_or(false)
+                && local.digest == remote.digest
+            {
                 mark_verified(context, realm_id, placement, Some(*co_holder), local.digest).await;
                 info!(
                     strategy = %placement.strategy_id,
@@ -181,6 +207,26 @@ async fn verify_one_shard(
         return false;
     }
     false
+}
+
+/// Deletes a shard's verification marker (e.g. when the local node leaves the
+/// shard's holder set), so a later re-entry re-verifies from scratch.
+pub async fn delete_shard_verification(
+    context: &DriverContext,
+    realm_id: RealmId,
+    placement: &PlacementRef,
+) {
+    if let Event::Storage(StorageEvent::Error { error }) = context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Delete {
+            key_space: SHARD_VERIFICATION_KEYSPACE.to_string(),
+            key: verification_key(realm_id, placement),
+            txn_id: None,
+        })
+        .await
+    {
+        warn!(error = %error, "Failed to delete shard verification marker");
+    }
 }
 
 /// Whether the local node has a persisted verification marker for a shard.

--- a/operations/src/shard/verify.rs
+++ b/operations/src/shard/verify.rs
@@ -10,6 +10,7 @@ use aruna_core::types::Key;
 use aruna_core::util::unix_timestamp_millis;
 use aruna_net::NetHandle;
 use byteview::ByteView;
+use futures_util::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
@@ -23,6 +24,10 @@ use crate::sync_placement::placement_key;
 /// A new holder retries digest reconciliation this many times against the first
 /// reachable co-holder before leaving the shard unverified for the next pass.
 pub const SHARD_VERIFICATION_MAX_ATTEMPTS: usize = 3;
+
+/// Limits startup verification work while allowing independent shards to make
+/// progress concurrently. Matches the existing bounded metadata fanout.
+const SHARD_VERIFICATION_CONCURRENCY_LIMIT: usize = 8;
 
 /// Persisted proof that the local node reconciled a shard against a co-holder.
 /// Presence of the row (keyed like a pending placement) means verified; a
@@ -45,13 +50,13 @@ pub struct ShardVerificationSummary {
     pub unverified: usize,
 }
 
-/// Reconciles every shard the local node newly holds against a co-holder: fetch
-/// the first reachable co-holder's manifest in rank order and compare the topic
-/// digest plus manifest entry digest. Equal ⇒ mark verified; differing ⇒ one
-/// anti-entropy pass against that co-holder and retry, bounded by
-/// [`SHARD_VERIFICATION_MAX_ATTEMPTS`]. Already verified shards (a persisted
-/// marker) are skipped, so this is idempotent and cheap in steady state and
-/// resumes unverified shards after a restart.
+/// Reconciles every shard the local node newly holds against a co-holder with
+/// bounded concurrency: fetch the first reachable co-holder's manifest in rank
+/// order and compare the topic digest plus manifest entry digest. Equal ⇒ mark
+/// verified; differing ⇒ one anti-entropy pass against that co-holder and retry,
+/// bounded by [`SHARD_VERIFICATION_MAX_ATTEMPTS`]. Already verified shards (a
+/// persisted marker) are skipped, so this is idempotent and cheap in steady
+/// state and resumes unverified shards after a restart.
 pub async fn verify_held_shards(
     context: &Arc<DriverContext>,
     node_id: NodeId,
@@ -65,31 +70,42 @@ pub async fn verify_held_shards(
         return summary;
     };
 
-    for strategy in &config.strategies {
-        for shard in 0..strategy.shard_count {
-            let placement = PlacementRef {
-                strategy_id: strategy.strategy_id,
-                epoch: 0,
-                shard,
+    let held_shards: Vec<_> = config
+        .strategies
+        .iter()
+        .flat_map(|strategy| {
+            (0..strategy.shard_count).filter_map(|shard| {
+                let placement = PlacementRef {
+                    strategy_id: strategy.strategy_id,
+                    epoch: 0,
+                    shard,
+                };
+                let holders = resolve_shard_holders(&config, &placement);
+                holders.contains(&node_id).then(|| {
+                    // Rank order is preserved by `resolve_shard_holders`; keep it so the
+                    // first reachable co-holder is the highest-ranked one.
+                    let co_holders: Vec<NodeId> = holders
+                        .into_iter()
+                        .filter(|candidate| *candidate != node_id)
+                        .collect();
+                    (placement, co_holders)
+                })
+            })
+        })
+        .collect();
+
+    let net_handle = &net_handle;
+    let pending = stream::iter(held_shards.into_iter().enumerate().map(
+        |(shard_index, (placement, co_holders))| async move {
+            let mut shard_summary = ShardVerificationSummary {
+                held: 1,
+                ..ShardVerificationSummary::default()
             };
-            let holders = resolve_shard_holders(&config, &placement);
-            if !holders.contains(&node_id) {
-                continue;
-            }
-            summary.held += 1;
             if is_shard_verified(context, realm_id, &placement).await {
-                summary.already_verified += 1;
-                continue;
-            }
-            // Rank order is preserved by `resolve_shard_holders`; keep it so the
-            // first reachable co-holder is the highest-ranked one.
-            let co_holders: Vec<NodeId> = holders
-                .into_iter()
-                .filter(|candidate| *candidate != node_id)
-                .collect();
-            if verify_one_shard(
+                shard_summary.already_verified = 1;
+            } else if verify_one_shard(
                 context,
-                &net_handle,
+                net_handle,
                 node_id,
                 realm_id,
                 placement,
@@ -97,11 +113,27 @@ pub async fn verify_held_shards(
             )
             .await
             {
-                summary.newly_verified += 1;
+                shard_summary.newly_verified = 1;
             } else {
-                summary.unverified += 1;
+                shard_summary.unverified = 1;
             }
-        }
+
+            (shard_index, shard_summary)
+        },
+    ))
+    .buffer_unordered(SHARD_VERIFICATION_CONCURRENCY_LIMIT);
+    futures_util::pin_mut!(pending);
+
+    let mut shard_summaries = Vec::new();
+    while let Some(shard_summary) = pending.next().await {
+        shard_summaries.push(shard_summary);
+    }
+    shard_summaries.sort_unstable_by_key(|(shard_index, _)| *shard_index);
+    for (_, shard_summary) in shard_summaries {
+        summary.held += shard_summary.held;
+        summary.already_verified += shard_summary.already_verified;
+        summary.newly_verified += shard_summary.newly_verified;
+        summary.unverified += shard_summary.unverified;
     }
     summary
 }

--- a/operations/src/shard/verify.rs
+++ b/operations/src/shard/verify.rs
@@ -1,0 +1,261 @@
+use std::sync::Arc;
+
+use aruna_core::NodeId;
+use aruna_core::document::shard_topic_id;
+use aruna_core::effects::StorageEffect;
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::SHARD_VERIFICATION_KEYSPACE;
+use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
+use aruna_core::types::Key;
+use aruna_core::util::unix_timestamp_millis;
+use aruna_net::NetHandle;
+use byteview::ByteView;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use crate::driver::DriverContext;
+use crate::placement::resolve_shard_holders;
+use crate::shard::assemble_shard_manifest;
+use crate::shard::client::fetch_shard_manifest;
+use crate::startup::apply_restored_reconcile;
+use crate::sync_placement::placement_key;
+
+/// A new holder retries digest reconciliation this many times against the first
+/// reachable co-holder before leaving the shard unverified for the next pass.
+pub const SHARD_VERIFICATION_MAX_ATTEMPTS: usize = 3;
+
+/// Persisted proof that the local node reconciled a shard against a co-holder.
+/// Presence of the row (keyed like a pending placement) means verified; a
+/// restart resumes only shards without one.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardVerificationRecord {
+    pub placement: PlacementRef,
+    pub verified_against: Option<NodeId>,
+    pub digest: [u8; 32],
+    pub verified_at_ms: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ShardVerificationSummary {
+    pub held: usize,
+    pub already_verified: usize,
+    pub newly_verified: usize,
+    pub unverified: usize,
+}
+
+/// Reconciles every shard the local node newly holds against a co-holder: fetch
+/// the first reachable co-holder's manifest in rank order and compare digests.
+/// Equal ⇒ mark verified; differing ⇒ one anti-entropy pass against that
+/// co-holder and retry, bounded by [`SHARD_VERIFICATION_MAX_ATTEMPTS`]. Already
+/// verified shards (a persisted marker) are skipped, so this is idempotent and
+/// cheap in steady state and resumes unverified shards after a restart.
+pub async fn verify_held_shards(
+    context: &Arc<DriverContext>,
+    node_id: NodeId,
+    realm_id: RealmId,
+) -> ShardVerificationSummary {
+    let mut summary = ShardVerificationSummary::default();
+    let Some(config) = load_realm_config(context, realm_id).await else {
+        return summary;
+    };
+    let Some(net_handle) = context.net_handle.clone() else {
+        return summary;
+    };
+
+    for strategy in &config.strategies {
+        for shard in 0..strategy.shard_count {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard,
+            };
+            let holders = resolve_shard_holders(&config, &placement);
+            if !holders.contains(&node_id) {
+                continue;
+            }
+            summary.held += 1;
+            if is_shard_verified(context, realm_id, &placement).await {
+                summary.already_verified += 1;
+                continue;
+            }
+            // Rank order is preserved by `resolve_shard_holders`; keep it so the
+            // first reachable co-holder is the highest-ranked one.
+            let co_holders: Vec<NodeId> = holders
+                .into_iter()
+                .filter(|candidate| *candidate != node_id)
+                .collect();
+            if verify_one_shard(
+                context,
+                &net_handle,
+                node_id,
+                realm_id,
+                placement,
+                &co_holders,
+            )
+            .await
+            {
+                summary.newly_verified += 1;
+            } else {
+                summary.unverified += 1;
+            }
+        }
+    }
+    summary
+}
+
+async fn verify_one_shard(
+    context: &Arc<DriverContext>,
+    net_handle: &NetHandle,
+    node_id: NodeId,
+    realm_id: RealmId,
+    placement: PlacementRef,
+    co_holders: &[NodeId],
+) -> bool {
+    // A sole holder has no co-holder to reconcile against; it is trivially
+    // consistent with itself, so mark it verified immediately.
+    if co_holders.is_empty() {
+        let digest = assemble_shard_manifest(context, realm_id, placement)
+            .await
+            .map(|manifest| manifest.digest)
+            .unwrap_or([0u8; 32]);
+        mark_verified(context, realm_id, placement, None, digest).await;
+        info!(
+            strategy = %placement.strategy_id,
+            shard = placement.shard,
+            "Verified sole-holder shard",
+        );
+        return true;
+    }
+
+    let topic = shard_topic_id(realm_id, &placement);
+    for co_holder in co_holders {
+        let mut remote =
+            match fetch_shard_manifest(net_handle, *co_holder, realm_id, placement).await {
+                Ok(manifest) => manifest,
+                Err(error) => {
+                    debug!(
+                        co_holder = %co_holder,
+                        error = %error,
+                        "Shard manifest fetch failed; trying next co-holder"
+                    );
+                    continue;
+                }
+            };
+
+        // First reachable co-holder: reconcile against it with a bounded number
+        // of anti-entropy passes.
+        for _ in 0..SHARD_VERIFICATION_MAX_ATTEMPTS {
+            let local = match assemble_shard_manifest(context, realm_id, placement).await {
+                Ok(manifest) => manifest,
+                Err(error) => {
+                    warn!(error = %error, "Failed to assemble local shard manifest for verification");
+                    return false;
+                }
+            };
+            if local.digest == remote.digest {
+                mark_verified(context, realm_id, placement, Some(*co_holder), local.digest).await;
+                info!(
+                    strategy = %placement.strategy_id,
+                    shard = placement.shard,
+                    co_holder = %co_holder,
+                    entries = local.entries.len(),
+                    "Verified shard against co-holder",
+                );
+                return true;
+            }
+            // Digests differ: pull the co-holder's events and re-compare.
+            let event = net_handle
+                .sync_document_topics(vec![topic], vec![*co_holder])
+                .await;
+            apply_restored_reconcile(context, node_id, event).await;
+            remote = match fetch_shard_manifest(net_handle, *co_holder, realm_id, placement).await {
+                Ok(manifest) => manifest,
+                Err(error) => {
+                    debug!(co_holder = %co_holder, error = %error, "Re-fetch of shard manifest failed");
+                    break;
+                }
+            };
+        }
+        // The first reachable co-holder did not converge within the retry
+        // budget; leave the shard unverified for the next pass.
+        return false;
+    }
+    false
+}
+
+/// Whether the local node has a persisted verification marker for a shard.
+pub async fn is_shard_verified(
+    context: &DriverContext,
+    realm_id: RealmId,
+    placement: &PlacementRef,
+) -> bool {
+    matches!(
+        context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Read {
+                key_space: SHARD_VERIFICATION_KEYSPACE.to_string(),
+                key: verification_key(realm_id, placement),
+                txn_id: None,
+            })
+            .await,
+        Event::Storage(StorageEvent::ReadResult { value: Some(_), .. })
+    )
+}
+
+async fn mark_verified(
+    context: &DriverContext,
+    realm_id: RealmId,
+    placement: PlacementRef,
+    verified_against: Option<NodeId>,
+    digest: [u8; 32],
+) {
+    let record = ShardVerificationRecord {
+        placement,
+        verified_against,
+        digest,
+        verified_at_ms: unix_timestamp_millis(),
+    };
+    let value = match postcard::to_allocvec(&record) {
+        Ok(value) => value,
+        Err(error) => {
+            warn!(error = %error, "Failed to encode shard verification record");
+            return;
+        }
+    };
+    if let Event::Storage(StorageEvent::Error { error }) = context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Write {
+            key_space: SHARD_VERIFICATION_KEYSPACE.to_string(),
+            key: verification_key(realm_id, &placement),
+            value: ByteView::from(value),
+            txn_id: None,
+        })
+        .await
+    {
+        warn!(error = %error, "Failed to persist shard verification marker");
+    }
+}
+
+fn verification_key(realm_id: RealmId, placement: &PlacementRef) -> Key {
+    placement_key(realm_id, placement)
+}
+
+async fn load_realm_config(
+    context: &DriverContext,
+    realm_id: RealmId,
+) -> Option<RealmConfigDocument> {
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: aruna_core::keyspaces::REALM_CONFIG_KEYSPACE.to_string(),
+            key: ByteView::from(realm_id.as_bytes().to_vec()),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => {
+            value.and_then(|bytes| RealmConfigDocument::from_bytes(&bytes).ok())
+        }
+        _ => None,
+    }
+}

--- a/operations/src/shard/verify.rs
+++ b/operations/src/shard/verify.rs
@@ -1,8 +1,9 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use aruna_core::NodeId;
 use aruna_core::document::shard_topic_id;
-use aruna_core::effects::StorageEffect;
+use aruna_core::effects::{IterStart, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::SHARD_VERIFICATION_KEYSPACE;
 use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
@@ -19,7 +20,10 @@ use crate::placement::resolve_shard_holders;
 use crate::shard::client::fetch_shard_manifest;
 use crate::shard::{assemble_shard_manifest, manifest_entry_digest};
 use crate::startup::apply_restored_reconcile;
-use crate::sync_placement::placement_key;
+use crate::sync_placement::{placement_key, placement_prefix};
+
+/// Page size for scanning persisted shard verification markers.
+const VERIFIED_SHARD_SCAN_PAGE_SIZE: usize = 256;
 
 /// A new holder retries digest reconciliation this many times against the first
 /// reachable co-holder before leaving the shard unverified for the next pass.
@@ -268,6 +272,55 @@ pub async fn delete_shard_verification(
     {
         warn!(error = %error, "Failed to delete shard verification marker");
     }
+}
+
+/// Topic ids of every shard the local node has durably verified in `realm_id`.
+///
+/// Reconciliation installs a former-holder history cutoff only for these topics:
+/// an unverified shard's local clock is not a trustworthy cutover boundary, so
+/// its history is left admissible until verification proves the transfer.
+pub async fn load_verified_shard_topics(
+    context: &DriverContext,
+    realm_id: RealmId,
+) -> BTreeSet<::irokle::TopicId> {
+    let mut topics = BTreeSet::new();
+    let mut start_after: Option<Key> = None;
+    loop {
+        let (values, next) = match context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: SHARD_VERIFICATION_KEYSPACE.to_string(),
+                prefix: Some(placement_prefix(realm_id)),
+                start: start_after.take().map(IterStart::After),
+                limit: VERIFIED_SHARD_SCAN_PAGE_SIZE,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult {
+                values,
+                next_start_after,
+            }) => (values, next_start_after),
+            Event::Storage(StorageEvent::Error { error }) => {
+                warn!(%realm_id, error = %error, "Failed to scan verified shards");
+                return topics;
+            }
+            other => {
+                warn!(%realm_id, event = ?other, "Unexpected verified shard scan result");
+                return topics;
+            }
+        };
+        for (_, value) in &values {
+            if let Ok(record) = postcard::from_bytes::<ShardVerificationRecord>(value) {
+                topics.insert(shard_topic_id(realm_id, &record.placement));
+            }
+        }
+        match next {
+            Some(next) => start_after = Some(next),
+            None => break,
+        }
+    }
+    topics
 }
 
 /// Whether the local node has a persisted verification marker for a shard.

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -38,6 +38,16 @@ fn shared_targets(realm_id: RealmId, node_id: NodeId) -> [DocumentSyncTarget; 5]
     ]
 }
 
+fn shared_topic_peers(config: &RealmConfigDocument, node_id: NodeId) -> Vec<NodeId> {
+    config
+        .nodes
+        .iter()
+        .filter(|node| node.kind.is_sync_eligible())
+        .filter_map(|node| NodeId::from_str(&node.node_id).ok())
+        .filter(|candidate| *candidate != node_id)
+        .collect()
+}
+
 /// Fixed realm-scoped topics restored on every start (see [`shared_targets`]).
 pub const SHARED_RESTORE_TOPIC_COUNT: usize = 5;
 
@@ -86,13 +96,6 @@ pub async fn restore_shard_subscriptions(
         return summary;
     };
 
-    let realm_nodes: Vec<NodeId> = config
-        .nodes
-        .iter()
-        .filter_map(|node| NodeId::from_str(&node.node_id).ok())
-        .filter(|candidate| *candidate != node_id)
-        .collect();
-
     // Group topics by their co-holder peer set so co-located shards ride one
     // ensure + one sync instead of one round trip each. Shared realm topics are
     // ensured directly. Shards the local node is rank-0 holder of go through the
@@ -104,7 +107,7 @@ pub async fn restore_shard_subscriptions(
     let mut rank0_shard_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     let mut join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
 
-    let mut shared_peers = realm_nodes.clone();
+    let mut shared_peers = shared_topic_peers(&config, node_id);
     shared_peers.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
     for target in shared_targets(realm_id, node_id) {
         let topic = target.sync_topic_id(realm_id, &PlacementRef::NIL);
@@ -348,5 +351,56 @@ async fn load_realm_config(
             value.and_then(|bytes| RealmConfigDocument::from_bytes(&bytes).ok())
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_core::structs::{RealmNode, RealmNodeKind};
+
+    fn node(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    #[test]
+    fn shared_peers_filter() {
+        let self_id = node(1);
+        let management = node(2);
+        let server = node(3);
+        let local = node(4);
+        let user = node(5);
+        let mut config = RealmConfigDocument::default_for_realm(RealmId([9; 32]), Vec::new());
+        config.nodes = vec![
+            RealmNode {
+                node_id: self_id.to_string(),
+                kind: RealmNodeKind::Management,
+            },
+            RealmNode {
+                node_id: management.to_string(),
+                kind: RealmNodeKind::Management,
+            },
+            RealmNode {
+                node_id: user.to_string(),
+                kind: RealmNodeKind::User,
+            },
+            RealmNode {
+                node_id: "malformed-eligible-id".to_string(),
+                kind: RealmNodeKind::Server,
+            },
+            RealmNode {
+                node_id: server.to_string(),
+                kind: RealmNodeKind::Server,
+            },
+            RealmNode {
+                node_id: local.to_string(),
+                kind: RealmNodeKind::Local,
+            },
+        ];
+
+        assert_eq!(
+            shared_topic_peers(&config, self_id),
+            vec![management, server, local]
+        );
     }
 }

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -150,6 +150,9 @@ pub async fn restore_shard_subscriptions(
         }
     }
 
+    // Former-holder history cutoffs are frozen only for shards a prior run
+    // durably verified; join verification below happens after this restore.
+    let verified = crate::shard::verify::load_verified_shard_topics(context, realm_id).await;
     let withheld = restore_held_shard_topics(
         context,
         &net_handle,
@@ -157,6 +160,7 @@ pub async fn restore_shard_subscriptions(
         shared_ensure_groups,
         rank0_shard_groups,
         join_groups,
+        &verified,
     )
     .await;
 
@@ -183,6 +187,7 @@ async fn restore_held_shard_topics(
     shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
     rank0_shard_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
     join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
+    verified: &BTreeSet<::irokle::TopicId>,
 ) -> bool {
     // Shared realm topics: ensured directly (every node's genesis of a shared
     // topic is deterministic, not a shard-holder decision).
@@ -227,6 +232,7 @@ async fn restore_held_shard_topics(
             node_id,
             co_holders.clone(),
             topics.clone(),
+            verified,
         )
         .await;
         // Fetch events for the topics whose genesis is now local (created,
@@ -256,7 +262,7 @@ async fn restore_held_shard_topics(
         // Install publisher policy before pulling history. Missing topics are
         // expected and get an exact membership pass after a successful join.
         let _ = net_handle
-            .reconcile_shard_membership(&topics, current_holders.clone())
+            .reconcile_shard_membership(&topics, current_holders.clone(), verified)
             .await;
         let event = net_handle.sync_document_topics(topics.clone(), peers).await;
         apply_restored_reconcile(context, node_id, event).await;
@@ -270,7 +276,7 @@ async fn restore_held_shard_topics(
             .collect();
         if !present.is_empty()
             && let Err(error) = net_handle
-                .reconcile_shard_membership(&present, current_holders)
+                .reconcile_shard_membership(&present, current_holders, verified)
                 .await
         {
             warn!(error = %error, "Failed to reconcile joined shard membership on restart");

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -250,8 +250,32 @@ async fn restore_held_shard_topics(
         if peers.is_empty() || topics.is_empty() {
             continue;
         }
-        let event = net_handle.sync_document_topics(topics, peers).await;
+        let mut current_holders = peers.clone();
+        current_holders.push(node_id);
+        current_holders.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        // Install publisher policy before pulling history. Missing topics are
+        // expected and get an exact membership pass after a successful join.
+        let _ = net_handle
+            .reconcile_shard_membership(&topics, current_holders.clone())
+            .await;
+        let event = net_handle.sync_document_topics(topics.clone(), peers).await;
         apply_restored_reconcile(context, node_id, event).await;
+        let present: Vec<::irokle::TopicId> = topics
+            .into_iter()
+            .filter(|topic| {
+                net_handle
+                    .document_sync_topic_exists(*topic)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !present.is_empty()
+            && let Err(error) = net_handle
+                .reconcile_shard_membership(&present, current_holders)
+                .await
+        {
+            warn!(error = %error, "Failed to reconcile joined shard membership on restart");
+            withheld = true;
+        }
     }
     withheld
 }

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -115,6 +115,20 @@ pub async fn restore_shard_subscriptions(
         }
     }
 
+    restore_held_shard_topics(context, &net_handle, node_id, ensure_groups, join_groups).await;
+
+    // New-holder verification: reconcile each held shard against a co-holder and
+    // persist a marker so a restart resumes only unverified shards.
+    crate::shard::verify::verify_held_shards(context, node_id, realm_id).await;
+}
+
+async fn restore_held_shard_topics(
+    context: &Arc<DriverContext>,
+    net_handle: &aruna_net::NetHandle,
+    node_id: NodeId,
+    ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
+    join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
+) {
     for (groups, may_create) in [(ensure_groups, true), (join_groups, false)] {
         for (peers, topics) in groups {
             if peers.is_empty() || topics.is_empty() {

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -93,19 +93,21 @@ pub async fn restore_shard_subscriptions(
         .collect();
 
     // Group topics by their co-holder peer set so co-located shards ride one
-    // ensure + one sync instead of one round trip each. Only topics the local
-    // node may create the genesis of (shared realm topics, and shards it is
-    // rank-0 holder of) are ensured; the rest are join-only — synced if their
-    // genesis is known or bootstrappable from a co-holder, otherwise left for
-    // the rank-0 holder's gossip to deliver.
-    let mut ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+    // ensure + one sync instead of one round trip each. Shared realm topics are
+    // ensured directly. Shards the local node is rank-0 holder of go through the
+    // join-before-create gate (a fresh genesis only with positive co-holder
+    // confirmation); the rest are join-only — synced if their genesis is known
+    // or bootstrappable from a co-holder, otherwise left for the rank-0 holder's
+    // gossip to deliver.
+    let mut shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+    let mut rank0_shard_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
     let mut join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
 
     let mut shared_peers = realm_nodes.clone();
     shared_peers.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
     for target in shared_targets(realm_id, node_id) {
         let topic = target.sync_topic_id(realm_id, &PlacementRef::NIL);
-        ensure_groups
+        shared_ensure_groups
             .entry(shared_peers.clone())
             .or_default()
             .push(topic);
@@ -135,7 +137,7 @@ pub async fn restore_shard_subscriptions(
             }
             let topic = shard_topic_id(realm_id, &placement);
             let groups = if local_is_rank0 {
-                &mut ensure_groups
+                &mut rank0_shard_groups
             } else {
                 &mut join_groups
             };
@@ -144,7 +146,15 @@ pub async fn restore_shard_subscriptions(
         }
     }
 
-    restore_held_shard_topics(context, &net_handle, node_id, ensure_groups, join_groups).await;
+    restore_held_shard_topics(
+        context,
+        &net_handle,
+        node_id,
+        shared_ensure_groups,
+        rank0_shard_groups,
+        join_groups,
+    )
+    .await;
 
     // New-holder verification: reconcile each held shard against a co-holder and
     // persist a marker so a restart resumes only unverified shards.
@@ -157,41 +167,77 @@ async fn restore_held_shard_topics(
     context: &Arc<DriverContext>,
     net_handle: &aruna_net::NetHandle,
     node_id: NodeId,
-    ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
+    shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
+    rank0_shard_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
     join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
 ) {
-    for (groups, may_create) in [(ensure_groups, true), (join_groups, false)] {
-        for (peers, topics) in groups {
-            if peers.is_empty() || topics.is_empty() {
-                continue;
-            }
-            if may_create {
-                // Join-before-create: rank-0 may have just inherited a shard
-                // whose genesis a previous rank-0 created — adopt that genesis
-                // from a co-holder rather than forking a second one. Only what
-                // no peer knows either is created fresh.
-                let missing: Vec<::irokle::TopicId> = topics
-                    .iter()
-                    .copied()
-                    .filter(|topic| {
-                        !net_handle
-                            .document_sync_topic_exists(*topic)
-                            .unwrap_or(false)
-                    })
-                    .collect();
-                if !missing.is_empty() {
-                    let event = net_handle
-                        .sync_document_topics(missing, peers.clone())
-                        .await;
-                    apply_restored_reconcile(context, node_id, event).await;
-                }
-                if let Err(error) = net_handle.ensure_document_sync_topics(&topics, peers.clone()) {
-                    warn!(error = %error, "Failed to ensure held shard topics on restart");
-                }
-            }
-            let event = net_handle.sync_document_topics(topics, peers).await;
+    // Shared realm topics: ensured directly (every node's genesis of a shared
+    // topic is deterministic, not a shard-holder decision).
+    for (peers, topics) in shared_ensure_groups {
+        if peers.is_empty() || topics.is_empty() {
+            continue;
+        }
+        let missing: Vec<::irokle::TopicId> = topics
+            .iter()
+            .copied()
+            .filter(|topic| {
+                !net_handle
+                    .document_sync_topic_exists(*topic)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !missing.is_empty() {
+            let event = net_handle
+                .sync_document_topics(missing, peers.clone())
+                .await;
             apply_restored_reconcile(context, node_id, event).await;
         }
+        if let Err(error) = net_handle.ensure_document_sync_topics(&topics, peers.clone()) {
+            warn!(error = %error, "Failed to ensure shared realm topics on restart");
+        }
+        let event = net_handle.sync_document_topics(topics, peers).await;
+        apply_restored_reconcile(context, node_id, event).await;
+    }
+
+    // Rank-0 shard topics: create a fresh genesis only with positive co-holder
+    // confirmation (see [`ensure_rank0_shard_group`]); a config change may have
+    // just moved rank-0 onto this node, so an unreachable co-holder that might
+    // still hold the genesis withholds creation rather than forking one.
+    for (co_holders, topics) in rank0_shard_groups {
+        if co_holders.is_empty() || topics.is_empty() {
+            continue;
+        }
+        crate::process_placements::ensure_rank0_shard_group(
+            context,
+            net_handle,
+            node_id,
+            co_holders.clone(),
+            topics.clone(),
+        )
+        .await;
+        // Fetch events for the topics whose genesis is now local (created,
+        // adopted, or already present); withheld ones retry on the next pass.
+        let present: Vec<::irokle::TopicId> = topics
+            .into_iter()
+            .filter(|topic| {
+                net_handle
+                    .document_sync_topic_exists(*topic)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !present.is_empty() {
+            let event = net_handle.sync_document_topics(present, co_holders).await;
+            apply_restored_reconcile(context, node_id, event).await;
+        }
+    }
+
+    // Non-rank-0 held shards: join-only, synced if bootstrappable.
+    for (peers, topics) in join_groups {
+        if peers.is_empty() || topics.is_empty() {
+            continue;
+        }
+        let event = net_handle.sync_document_topics(topics, peers).await;
+        apply_restored_reconcile(context, node_id, event).await;
     }
 }
 

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -8,6 +8,7 @@ use aruna_core::document::{
 };
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
 use aruna_core::metadata::MetadataCreateEventRecord;
 use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
 use tracing::warn;
@@ -146,7 +147,7 @@ pub async fn restore_shard_subscriptions(
         }
     }
 
-    restore_held_shard_topics(
+    let withheld = restore_held_shard_topics(
         context,
         &net_handle,
         node_id,
@@ -156,6 +157,14 @@ pub async fn restore_shard_subscriptions(
     )
     .await;
 
+    // A withheld genesis (co-holder down or refusing) has no placement record to
+    // drive a re-run, so arm the retry timer here — the reconciler re-probes when
+    // the co-holder returns instead of deferring writes at 1s until restart.
+    if withheld && let Some(task_handle) = context.task_handle.as_ref() {
+        let effect = crate::sync_placement::schedule_placement_retry_effect(realm_id, node_id);
+        let _ = task_handle.send_effect(effect).await;
+    }
+
     // New-holder verification: reconcile each held shard against a co-holder and
     // persist a marker so a restart resumes only unverified shards.
     crate::shard::verify::verify_held_shards(context, node_id, realm_id).await;
@@ -163,6 +172,7 @@ pub async fn restore_shard_subscriptions(
     summary
 }
 
+/// Returns whether any rank-0 genesis was withheld, so the caller arms a retry.
 async fn restore_held_shard_topics(
     context: &Arc<DriverContext>,
     net_handle: &aruna_net::NetHandle,
@@ -170,7 +180,7 @@ async fn restore_held_shard_topics(
     shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
     rank0_shard_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
     join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
-) {
+) -> bool {
     // Shared realm topics: ensured directly (every node's genesis of a shared
     // topic is deterministic, not a shard-holder decision).
     for (peers, topics) in shared_ensure_groups {
@@ -203,11 +213,12 @@ async fn restore_held_shard_topics(
     // confirmation (see [`ensure_rank0_shard_group`]); a config change may have
     // just moved rank-0 onto this node, so an unreachable co-holder that might
     // still hold the genesis withholds creation rather than forking one.
+    let mut withheld = false;
     for (co_holders, topics) in rank0_shard_groups {
         if co_holders.is_empty() || topics.is_empty() {
             continue;
         }
-        crate::process_placements::ensure_rank0_shard_group(
+        withheld |= crate::process_placements::ensure_rank0_shard_group(
             context,
             net_handle,
             node_id,
@@ -239,6 +250,7 @@ async fn restore_held_shard_topics(
         let event = net_handle.sync_document_topics(topics, peers).await;
         apply_restored_reconcile(context, node_id, event).await;
     }
+    withheld
 }
 
 pub(crate) async fn apply_restored_reconcile(

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -37,6 +37,29 @@ fn shared_targets(realm_id: RealmId, node_id: NodeId) -> [DocumentSyncTarget; 5]
     ]
 }
 
+/// Fixed realm-scoped topics restored on every start (see [`shared_targets`]).
+pub const SHARED_RESTORE_TOPIC_COUNT: usize = 5;
+
+/// What a [`restore_shard_subscriptions`] pass touched. The load-bearing
+/// invariant is `shard_topics == held_shards`, i.e. one topic per held shard,
+/// never one per stored document — asserted by the restart-traffic gate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RestoreShardSummary {
+    /// Shards the local node resolves into a holder of.
+    pub held_shards: usize,
+    /// Shard sync topics ensured (rank-0) or joined that this pass touched.
+    pub shard_topics: usize,
+    /// Fixed shared realm topics restored ([`SHARED_RESTORE_TOPIC_COUNT`]).
+    pub shared_topics: usize,
+}
+
+impl RestoreShardSummary {
+    /// Total distinct topics the restore ensured or joined.
+    pub fn total_topics(&self) -> usize {
+        self.shard_topics + self.shared_topics
+    }
+}
+
 /// Restarts the local node's document-sync subscriptions from the shards it
 /// holds instead of re-announcing every stored document.
 ///
@@ -45,18 +68,21 @@ fn shared_targets(realm_id: RealmId, node_id: NodeId) -> [DocumentSyncTarget; 5]
 /// and runs one anti-entropy pass against them (digest exchange, not a
 /// per-document re-announce). The fixed shared realm topics are restored the
 /// same way. Topics that share a co-holder set are batched into one ensure and
-/// one sync so a restart costs O(held shards), not O(stored documents).
+/// one sync so a restart costs O(held shards), not O(stored documents). The
+/// returned [`RestoreShardSummary`] reports the (small) topic count for callers
+/// and the restart-traffic gate.
 pub async fn restore_shard_subscriptions(
     context: &Arc<DriverContext>,
     node_id: NodeId,
     realm_id: RealmId,
-) {
+) -> RestoreShardSummary {
+    let mut summary = RestoreShardSummary::default();
     let Some(net_handle) = context.net_handle.clone() else {
-        return;
+        return summary;
     };
     let Some(config) = load_realm_config(context, realm_id).await else {
         // No config yet (fresh/onboarding node): nothing sharded to restore.
-        return;
+        return summary;
     };
 
     let realm_nodes: Vec<NodeId> = config
@@ -83,6 +109,7 @@ pub async fn restore_shard_subscriptions(
             .entry(shared_peers.clone())
             .or_default()
             .push(topic);
+        summary.shared_topics += 1;
     }
 
     for strategy in &config.strategies {
@@ -96,6 +123,7 @@ pub async fn restore_shard_subscriptions(
             if !holders.contains(&node_id) {
                 continue;
             }
+            summary.held_shards += 1;
             let local_is_rank0 = holders.first() == Some(&node_id);
             let mut co_holders: Vec<NodeId> = holders
                 .into_iter()
@@ -112,6 +140,7 @@ pub async fn restore_shard_subscriptions(
                 &mut join_groups
             };
             groups.entry(co_holders).or_default().push(topic);
+            summary.shard_topics += 1;
         }
     }
 
@@ -120,6 +149,8 @@ pub async fn restore_shard_subscriptions(
     // New-holder verification: reconcile each held shard against a co-holder and
     // persist a marker so a restart resumes only unverified shards.
     crate::shard::verify::verify_held_shards(context, node_id, realm_id).await;
+
+    summary
 }
 
 async fn restore_held_shard_topics(

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -1,365 +1,249 @@
-use std::collections::HashSet;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use std::sync::Arc;
 
 use aruna_core::NodeId;
-use aruna_core::document::DocumentSyncTarget;
-use aruna_core::effects::{Effect, IterStart, StorageEffect};
-use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
-use aruna_core::keyspaces::{
-    AUTH_KEYSPACE, GROUP_KEYSPACE, METADATA_DOCUMENT_INDEX_KEYSPACE,
-    METADATA_GRAPH_LIFECYCLE_KEYSPACE, REALM_CONFIG_KEYSPACE, USER_KEYSPACE,
+use aruna_core::document::{
+    DocumentSyncNetEvent, DocumentSyncReconcileResult, DocumentSyncTarget, bucket_topic_id,
 };
-use aruna_core::metadata::MetadataGraphLifecycleRecord;
-use aruna_core::operation::{Operation, boxed_suboperation};
-use aruna_core::structs::RealmId;
-use aruna_core::types::{Key, UserId};
-use smallvec::smallvec;
-use thiserror::Error;
+use aruna_core::effects::StorageEffect;
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::metadata::MetadataCreateEventRecord;
+use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
 use tracing::warn;
 
-use crate::announce::AnnounceTopicOperation;
-use crate::document_repository::{
-    parse_auth_document, parse_group_document, parse_realm_config_document,
+use crate::driver::DriverContext;
+use crate::metadata::projector::{
+    project_metadata_create_events, project_metadata_create_events_from_log,
 };
-use crate::metadata::repository::parse_registry_iter;
+use crate::metadata::prune_queue::process_metadata_graph_tombstones;
+use crate::notifications::watch::interest::refresh_watch_interest_for_targets;
+use crate::placement::resolve_bucket_holders;
+use crate::usage_stats::refresh_realm_usage_summary_for_targets;
 
-const STARTUP_DOCUMENT_PAGE_SIZE: usize = 256;
-
-#[derive(Debug, PartialEq)]
-pub struct RestoreTopicSubscriptionsOperation {
-    realm_id: RealmId,
-    local_node_id: NodeId,
-    state: RestoreTopicSubscriptionsState,
-    scan_state: RestoreTopicSubscriptionsState,
-    documents: Vec<DocumentSyncTarget>,
-    discovered_documents: HashSet<DocumentSyncTarget>,
-    next_start_after: Option<Key>,
-    output: Option<Result<(), RestoreTopicSubscriptionsError>>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-enum RestoreTopicSubscriptionsState {
-    Init,
-    ListAuth,
-    ListGroups,
-    ListRealmConfig,
-    ListMetadata,
-    ListMetadataLifecycle,
-    ListUsers,
-    WaitAnnouncement,
-    Finish,
-    Error,
-}
-
-#[derive(Debug, Error, PartialEq)]
-pub enum RestoreTopicSubscriptionsError {
-    #[error(transparent)]
-    StorageError(#[from] StorageError),
-    #[error(transparent)]
-    ConversionError(#[from] ConversionError),
-    #[error("topic announcement failed: {0}")]
-    TopicAnnouncement(String),
-    #[error("unexpected event in state {state:?}: expected {expected}, got {got}")]
-    UnexpectedEvent {
-        state: String,
-        expected: &'static str,
-        got: String,
-    },
-}
-
-impl RestoreTopicSubscriptionsOperation {
-    pub fn new(local_node_id: NodeId, realm_id: RealmId) -> Self {
-        Self {
+/// Shared realm-scoped topics every node subscribes to (placement is inert on
+/// these; see [`DocumentSyncTarget::sync_topic_id`]).
+fn shared_targets(realm_id: RealmId, node_id: NodeId) -> [DocumentSyncTarget; 5] {
+    [
+        DocumentSyncTarget::RealmAuthorization { realm_id },
+        DocumentSyncTarget::RealmConfig { realm_id },
+        DocumentSyncTarget::NodeUsage {
             realm_id,
-            local_node_id,
-            state: RestoreTopicSubscriptionsState::Init,
-            scan_state: RestoreTopicSubscriptionsState::ListAuth,
-            documents: Vec::new(),
-            discovered_documents: HashSet::new(),
-            next_start_after: None,
-            output: None,
+            node_id,
+            group_id: None,
+        },
+        DocumentSyncTarget::NodeInfo { realm_id, node_id },
+        DocumentSyncTarget::WatchInterest { realm_id, node_id },
+    ]
+}
+
+/// Restarts the local node's document-sync subscriptions from the buckets it
+/// holds instead of re-announcing every stored document.
+///
+/// Loads the realm config, and for each bound strategy × bucket the local node
+/// resolves into a holder of, ensures the bucket sync topic with its co-holders
+/// and runs one anti-entropy pass against them (digest exchange, not a
+/// per-document re-announce). The fixed shared realm topics are restored the
+/// same way. Topics that share a co-holder set are batched into one ensure and
+/// one sync so a restart costs O(held buckets), not O(stored documents).
+pub async fn restore_bucket_subscriptions(
+    context: &Arc<DriverContext>,
+    node_id: NodeId,
+    realm_id: RealmId,
+) {
+    let Some(net_handle) = context.net_handle.clone() else {
+        return;
+    };
+    let Some(config) = load_realm_config(context, realm_id).await else {
+        // No config yet (fresh/onboarding node): nothing bucketed to restore.
+        return;
+    };
+
+    let realm_nodes: Vec<NodeId> = config
+        .nodes
+        .iter()
+        .filter_map(|node| NodeId::from_str(&node.node_id).ok())
+        .filter(|candidate| *candidate != node_id)
+        .collect();
+
+    // Group topics by their co-holder peer set so co-located buckets ride one
+    // ensure + one sync instead of one round trip each. Only topics the local
+    // node may create the genesis of (shared realm topics, and buckets it is
+    // rank-0 holder of) are ensured; the rest are join-only — synced if their
+    // genesis is known or bootstrappable from a co-holder, otherwise left for
+    // the rank-0 holder's gossip to deliver.
+    let mut ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+    let mut join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+
+    let mut shared_peers = realm_nodes.clone();
+    shared_peers.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+    for target in shared_targets(realm_id, node_id) {
+        let topic = target.sync_topic_id(realm_id, &PlacementRef::NIL);
+        ensure_groups
+            .entry(shared_peers.clone())
+            .or_default()
+            .push(topic);
+    }
+
+    for strategy in &config.strategies {
+        for bucket in 0..strategy.bucket_count {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                bucket,
+            };
+            let holders = resolve_bucket_holders(&config, &placement);
+            if !holders.contains(&node_id) {
+                continue;
+            }
+            let local_is_rank0 = holders.first() == Some(&node_id);
+            let mut co_holders: Vec<NodeId> = holders
+                .into_iter()
+                .filter(|candidate| *candidate != node_id)
+                .collect();
+            co_holders.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+            if co_holders.is_empty() {
+                continue;
+            }
+            let topic = bucket_topic_id(realm_id, &placement);
+            let groups = if local_is_rank0 {
+                &mut ensure_groups
+            } else {
+                &mut join_groups
+            };
+            groups.entry(co_holders).or_default().push(topic);
         }
     }
 
-    fn fail(&mut self, error: RestoreTopicSubscriptionsError) -> aruna_core::types::Effects {
-        self.state = RestoreTopicSubscriptionsState::Error;
-        self.output = Some(Err(error));
-        smallvec![]
-    }
-
-    fn unexpected_event(
-        &mut self,
-        expected: &'static str,
-        got: String,
-    ) -> aruna_core::types::Effects {
-        let state = format!("{:?}", self.state);
-        self.fail(RestoreTopicSubscriptionsError::UnexpectedEvent {
-            state,
-            expected,
-            got,
-        })
-    }
-
-    fn push_document(&mut self, document: DocumentSyncTarget) {
-        if self.discovered_documents.insert(document.clone()) {
-            self.documents.push(document);
-        }
-    }
-
-    fn next_announcement(&mut self) -> aruna_core::types::Effects {
-        if let Some(document) = self.documents.pop() {
-            self.state = RestoreTopicSubscriptionsState::WaitAnnouncement;
-            smallvec![Effect::SubOperation(boxed_suboperation(
-                AnnounceTopicOperation::new_for_document(
-                    document.topic_id(),
-                    self.local_node_id,
-                    Some(document),
-                    // Placement reconciliation is the only path that knows the
-                    // authoritative origin for metadata documents. Startup restore
-                    // must not let a replica-holder mint a rival genesis.
-                    false,
-                ),
-                |result| {
-                    Event::SubOperation(SubOperationEvent::DocumentSyncResult {
-                        result: result.map_err(|error| error.to_string()),
+    for (groups, may_create) in [(ensure_groups, true), (join_groups, false)] {
+        for (peers, topics) in groups {
+            if peers.is_empty() || topics.is_empty() {
+                continue;
+            }
+            if may_create {
+                // Join-before-create: rank-0 may have just inherited a bucket
+                // whose genesis a previous rank-0 created — adopt that genesis
+                // from a co-holder rather than forking a second one. Only what
+                // no peer knows either is created fresh.
+                let missing: Vec<::irokle::TopicId> = topics
+                    .iter()
+                    .copied()
+                    .filter(|topic| {
+                        !net_handle
+                            .document_sync_topic_exists(*topic)
+                            .unwrap_or(false)
                     })
-                },
-            ))]
-        } else {
-            self.continue_scan_or_advance(self.scan_state.clone())
+                    .collect();
+                if !missing.is_empty() {
+                    let event = net_handle
+                        .sync_document_topics(missing, peers.clone())
+                        .await;
+                    apply_restored_reconcile(context, node_id, event).await;
+                }
+                if let Err(error) = net_handle.ensure_document_sync_topics(&topics, peers.clone()) {
+                    warn!(error = %error, "Failed to ensure held bucket topics on restart");
+                }
+            }
+            let event = net_handle.sync_document_topics(topics, peers).await;
+            apply_restored_reconcile(context, node_id, event).await;
         }
     }
+}
 
-    fn emit_iter(&mut self, state: RestoreTopicSubscriptionsState) -> aruna_core::types::Effects {
-        let key_space = match state {
-            RestoreTopicSubscriptionsState::ListAuth => AUTH_KEYSPACE,
-            RestoreTopicSubscriptionsState::ListGroups => GROUP_KEYSPACE,
-            RestoreTopicSubscriptionsState::ListRealmConfig => REALM_CONFIG_KEYSPACE,
-            RestoreTopicSubscriptionsState::ListMetadata => METADATA_DOCUMENT_INDEX_KEYSPACE,
-            RestoreTopicSubscriptionsState::ListMetadataLifecycle => {
-                METADATA_GRAPH_LIFECYCLE_KEYSPACE
+pub(crate) async fn apply_restored_reconcile(
+    context: &Arc<DriverContext>,
+    node_id: NodeId,
+    event: DocumentSyncNetEvent,
+) {
+    let result = match event {
+        DocumentSyncNetEvent::DocumentsReconciled {
+            applied,
+            targets,
+            metadata_create_events,
+            metadata_graph_tombstones,
+        } => {
+            if applied == 0 {
+                return;
             }
-            RestoreTopicSubscriptionsState::ListUsers => USER_KEYSPACE,
-            _ => {
-                self.state = RestoreTopicSubscriptionsState::Finish;
-                self.output = Some(Ok(()));
-                return smallvec![];
+            DocumentSyncReconcileResult {
+                targets,
+                metadata_create_events,
+                metadata_graph_tombstones,
             }
-        };
-        self.scan_state = state.clone();
-        self.state = state;
-        let prefix = if matches!(self.state, RestoreTopicSubscriptionsState::ListUsers) {
-            Some(UserId::storage_prefix(self.realm_id))
-        } else {
-            None
-        };
-        smallvec![Effect::Storage(StorageEffect::Iter {
-            key_space: key_space.to_string(),
-            prefix,
-            start: self.next_start_after.take().map(IterStart::After),
-            limit: STARTUP_DOCUMENT_PAGE_SIZE,
+        }
+        DocumentSyncNetEvent::Error { error, .. } => {
+            warn!(error = %error, "Failed to sync held bucket topics on restart");
+            return;
+        }
+        other => {
+            warn!(event = ?other, "Unexpected restart bucket sync result");
+            return;
+        }
+    };
+
+    let tombstones = result.metadata_graph_tombstones.clone();
+    refresh_realm_usage_summary_for_targets(context, node_id, &result.targets).await;
+    refresh_watch_interest_for_targets(context, &result.targets).await;
+    project_restored_metadata_create_events(
+        context,
+        node_id,
+        result.targets,
+        result.metadata_create_events,
+    )
+    .await;
+    process_metadata_graph_tombstones(context, tombstones).await;
+}
+
+async fn project_restored_metadata_create_events(
+    context: &Arc<DriverContext>,
+    node_id: NodeId,
+    targets: Vec<DocumentSyncTarget>,
+    metadata_create_events: Vec<MetadataCreateEventRecord>,
+) {
+    if !metadata_create_events.is_empty() {
+        if let Err(error) =
+            project_metadata_create_events(context, metadata_create_events, Some(node_id)).await
+        {
+            warn!(error = ?error, "Failed to project restored metadata create events");
+        }
+        return;
+    }
+
+    let mut pairs = Vec::new();
+    for target in targets {
+        if let DocumentSyncTarget::MetadataCreateEvent {
+            document_id,
+            event_id,
+        } = target
+        {
+            pairs.push((document_id, event_id));
+        }
+    }
+    if pairs.is_empty() {
+        return;
+    }
+    if let Err(error) = project_metadata_create_events_from_log(context, pairs).await {
+        warn!(error = ?error, "Failed to project restored metadata create events from log");
+    }
+}
+
+async fn load_realm_config(
+    context: &Arc<DriverContext>,
+    realm_id: RealmId,
+) -> Option<RealmConfigDocument> {
+    let target = DocumentSyncTarget::RealmConfig { realm_id };
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: target.storage_keyspace().to_string(),
+            key: target.storage_key(),
             txn_id: None,
-        })]
-    }
-
-    fn continue_scan_or_advance(
-        &mut self,
-        current: RestoreTopicSubscriptionsState,
-    ) -> aruna_core::types::Effects {
-        if self.next_start_after.is_some() {
-            return self.emit_iter(current);
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => {
+            value.and_then(|bytes| RealmConfigDocument::from_bytes(&bytes).ok())
         }
-        self.next_start_after = None;
-        match current {
-            RestoreTopicSubscriptionsState::ListAuth => {
-                self.emit_iter(RestoreTopicSubscriptionsState::ListGroups)
-            }
-            RestoreTopicSubscriptionsState::ListGroups => {
-                self.emit_iter(RestoreTopicSubscriptionsState::ListRealmConfig)
-            }
-            RestoreTopicSubscriptionsState::ListRealmConfig => {
-                self.emit_iter(RestoreTopicSubscriptionsState::ListMetadata)
-            }
-            RestoreTopicSubscriptionsState::ListMetadata => {
-                self.emit_iter(RestoreTopicSubscriptionsState::ListMetadataLifecycle)
-            }
-            RestoreTopicSubscriptionsState::ListMetadataLifecycle => {
-                self.emit_iter(RestoreTopicSubscriptionsState::ListUsers)
-            }
-            RestoreTopicSubscriptionsState::ListUsers => {
-                self.state = RestoreTopicSubscriptionsState::Finish;
-                self.output = Some(Ok(()));
-                smallvec![]
-            }
-            _ => smallvec![],
-        }
-    }
-}
-
-impl Default for RestoreTopicSubscriptionsOperation {
-    fn default() -> Self {
-        Self::new(
-            iroh::SecretKey::from_bytes(&[0u8; 32]).public(),
-            RealmId::from_bytes([0u8; 32]),
-        )
-    }
-}
-
-impl Operation for RestoreTopicSubscriptionsOperation {
-    type Output = ();
-    type Error = RestoreTopicSubscriptionsError;
-
-    fn start(&mut self) -> aruna_core::types::Effects {
-        self.next_start_after = None;
-        self.emit_iter(RestoreTopicSubscriptionsState::ListAuth)
-    }
-
-    fn step(&mut self, event: Event) -> aruna_core::types::Effects {
-        match self.state {
-            RestoreTopicSubscriptionsState::ListAuth => match event {
-                Event::Storage(StorageEvent::IterResult {
-                    values,
-                    next_start_after,
-                }) => {
-                    for (key, _) in values {
-                        match parse_auth_document(&key) {
-                            Ok(document) => self.push_document(document),
-                            Err(error) => return self.fail(error.into()),
-                        }
-                    }
-                    self.next_start_after = next_start_after;
-                    self.next_announcement()
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("storage iteration result", format!("{other:?}")),
-            },
-            RestoreTopicSubscriptionsState::ListGroups => match event {
-                Event::Storage(StorageEvent::IterResult {
-                    values,
-                    next_start_after,
-                }) => {
-                    for (key, _) in values {
-                        match parse_group_document(&key) {
-                            Ok(document) => self.push_document(document),
-                            Err(error) => return self.fail(error.into()),
-                        }
-                    }
-                    self.next_start_after = next_start_after;
-                    self.next_announcement()
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("storage iteration result", format!("{other:?}")),
-            },
-            RestoreTopicSubscriptionsState::ListRealmConfig => match event {
-                Event::Storage(StorageEvent::IterResult {
-                    values,
-                    next_start_after,
-                }) => {
-                    for (key, _) in values {
-                        match parse_realm_config_document(&key) {
-                            Ok(document) => self.push_document(document),
-                            Err(error) => return self.fail(error.into()),
-                        }
-                    }
-                    self.next_start_after = next_start_after;
-                    self.next_announcement()
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("storage iteration result", format!("{other:?}")),
-            },
-            RestoreTopicSubscriptionsState::ListMetadata => match parse_registry_iter(event) {
-                Ok((records, next_start_after)) => {
-                    for record in records {
-                        self.push_document(DocumentSyncTarget::MetadataRegistry {
-                            group_id: record.group_id,
-                            document_id: record.document_id,
-                        });
-                    }
-                    self.next_start_after = next_start_after;
-                    self.next_announcement()
-                }
-                Err(crate::metadata::repository::StorageReadError::Storage(error)) => {
-                    self.fail(error.into())
-                }
-                Err(crate::metadata::repository::StorageReadError::Conversion(error)) => {
-                    self.fail(error.into())
-                }
-            },
-            RestoreTopicSubscriptionsState::ListMetadataLifecycle => match event {
-                Event::Storage(StorageEvent::IterResult {
-                    values,
-                    next_start_after,
-                }) => {
-                    for (_, value) in values {
-                        let record: MetadataGraphLifecycleRecord =
-                            match postcard::from_bytes(&value) {
-                                Ok(record) => record,
-                                Err(error) => {
-                                    return self.fail(ConversionError::from(error).into());
-                                }
-                            };
-                        if record.realm_id == self.realm_id {
-                            self.push_document(DocumentSyncTarget::MetadataGraphLifecycle {
-                                graph_iri: record.graph_iri,
-                            });
-                        }
-                    }
-                    self.next_start_after = next_start_after;
-                    self.next_announcement()
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("storage iteration result", format!("{other:?}")),
-            },
-            RestoreTopicSubscriptionsState::ListUsers => match event {
-                Event::Storage(StorageEvent::IterResult {
-                    values,
-                    next_start_after,
-                }) => {
-                    for (key, _) in values {
-                        match UserId::from_storage_key(&key) {
-                            Ok(user_id) if user_id.realm_id == self.realm_id => {
-                                self.push_document(DocumentSyncTarget::User { user_id })
-                            }
-                            Ok(_) => {}
-                            Err(error) => return self.fail(error.into()),
-                        }
-                    }
-                    self.next_start_after = next_start_after;
-                    self.next_announcement()
-                }
-                Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
-                other => self.unexpected_event("storage iteration result", format!("{other:?}")),
-            },
-            RestoreTopicSubscriptionsState::WaitAnnouncement => match event {
-                Event::SubOperation(SubOperationEvent::DocumentSyncResult { result }) => {
-                    match result {
-                        Ok(()) => self.next_announcement(),
-                        Err(error) => {
-                            warn!(error = %error, "Failed to restore topic subscription; continuing best-effort");
-                            self.next_announcement()
-                        }
-                    }
-                }
-                other => self.unexpected_event("document sync result", format!("{other:?}")),
-            },
-            RestoreTopicSubscriptionsState::Finish
-            | RestoreTopicSubscriptionsState::Error
-            | RestoreTopicSubscriptionsState::Init => smallvec![],
-        }
-    }
-
-    fn is_complete(&self) -> bool {
-        matches!(
-            self.state,
-            RestoreTopicSubscriptionsState::Finish | RestoreTopicSubscriptionsState::Error
-        )
-    }
-
-    fn finalize(self) -> Result<Self::Output, Self::Error> {
-        self.output.unwrap_or(Ok(()))
-    }
-
-    fn abort(&mut self) -> aruna_core::types::Effects {
-        smallvec![]
+        _ => None,
     }
 }

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use aruna_core::NodeId;
 use aruna_core::document::{
-    DocumentSyncNetEvent, DocumentSyncReconcileResult, DocumentSyncTarget, bucket_topic_id,
+    DocumentSyncNetEvent, DocumentSyncReconcileResult, DocumentSyncTarget, shard_topic_id,
 };
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
@@ -18,7 +18,7 @@ use crate::metadata::projector::{
 };
 use crate::metadata::prune_queue::process_metadata_graph_tombstones;
 use crate::notifications::watch::interest::refresh_watch_interest_for_targets;
-use crate::placement::resolve_bucket_holders;
+use crate::placement::resolve_shard_holders;
 use crate::usage_stats::refresh_realm_usage_summary_for_targets;
 
 /// Shared realm-scoped topics every node subscribes to (placement is inert on
@@ -37,16 +37,16 @@ fn shared_targets(realm_id: RealmId, node_id: NodeId) -> [DocumentSyncTarget; 5]
     ]
 }
 
-/// Restarts the local node's document-sync subscriptions from the buckets it
+/// Restarts the local node's document-sync subscriptions from the shards it
 /// holds instead of re-announcing every stored document.
 ///
-/// Loads the realm config, and for each bound strategy × bucket the local node
-/// resolves into a holder of, ensures the bucket sync topic with its co-holders
+/// Loads the realm config, and for each bound strategy × shard the local node
+/// resolves into a holder of, ensures the shard sync topic with its co-holders
 /// and runs one anti-entropy pass against them (digest exchange, not a
 /// per-document re-announce). The fixed shared realm topics are restored the
 /// same way. Topics that share a co-holder set are batched into one ensure and
-/// one sync so a restart costs O(held buckets), not O(stored documents).
-pub async fn restore_bucket_subscriptions(
+/// one sync so a restart costs O(held shards), not O(stored documents).
+pub async fn restore_shard_subscriptions(
     context: &Arc<DriverContext>,
     node_id: NodeId,
     realm_id: RealmId,
@@ -55,7 +55,7 @@ pub async fn restore_bucket_subscriptions(
         return;
     };
     let Some(config) = load_realm_config(context, realm_id).await else {
-        // No config yet (fresh/onboarding node): nothing bucketed to restore.
+        // No config yet (fresh/onboarding node): nothing sharded to restore.
         return;
     };
 
@@ -66,9 +66,9 @@ pub async fn restore_bucket_subscriptions(
         .filter(|candidate| *candidate != node_id)
         .collect();
 
-    // Group topics by their co-holder peer set so co-located buckets ride one
+    // Group topics by their co-holder peer set so co-located shards ride one
     // ensure + one sync instead of one round trip each. Only topics the local
-    // node may create the genesis of (shared realm topics, and buckets it is
+    // node may create the genesis of (shared realm topics, and shards it is
     // rank-0 holder of) are ensured; the rest are join-only — synced if their
     // genesis is known or bootstrappable from a co-holder, otherwise left for
     // the rank-0 holder's gossip to deliver.
@@ -86,13 +86,13 @@ pub async fn restore_bucket_subscriptions(
     }
 
     for strategy in &config.strategies {
-        for bucket in 0..strategy.bucket_count {
+        for shard in 0..strategy.shard_count {
             let placement = PlacementRef {
                 strategy_id: strategy.strategy_id,
                 epoch: 0,
-                bucket,
+                shard,
             };
-            let holders = resolve_bucket_holders(&config, &placement);
+            let holders = resolve_shard_holders(&config, &placement);
             if !holders.contains(&node_id) {
                 continue;
             }
@@ -105,7 +105,7 @@ pub async fn restore_bucket_subscriptions(
             if co_holders.is_empty() {
                 continue;
             }
-            let topic = bucket_topic_id(realm_id, &placement);
+            let topic = shard_topic_id(realm_id, &placement);
             let groups = if local_is_rank0 {
                 &mut ensure_groups
             } else {
@@ -121,7 +121,7 @@ pub async fn restore_bucket_subscriptions(
                 continue;
             }
             if may_create {
-                // Join-before-create: rank-0 may have just inherited a bucket
+                // Join-before-create: rank-0 may have just inherited a shard
                 // whose genesis a previous rank-0 created — adopt that genesis
                 // from a co-holder rather than forking a second one. Only what
                 // no peer knows either is created fresh.
@@ -141,7 +141,7 @@ pub async fn restore_bucket_subscriptions(
                     apply_restored_reconcile(context, node_id, event).await;
                 }
                 if let Err(error) = net_handle.ensure_document_sync_topics(&topics, peers.clone()) {
-                    warn!(error = %error, "Failed to ensure held bucket topics on restart");
+                    warn!(error = %error, "Failed to ensure held shard topics on restart");
                 }
             }
             let event = net_handle.sync_document_topics(topics, peers).await;
@@ -172,11 +172,11 @@ pub(crate) async fn apply_restored_reconcile(
             }
         }
         DocumentSyncNetEvent::Error { error, .. } => {
-            warn!(error = %error, "Failed to sync held bucket topics on restart");
+            warn!(error = %error, "Failed to sync held shard topics on restart");
             return;
         }
         other => {
-            warn!(event = ?other, "Unexpected restart bucket sync result");
+            warn!(event = ?other, "Unexpected restart shard sync result");
             return;
         }
     };

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -19,6 +19,14 @@ pub const SYNC_PLACEMENT_RETRY_AFTER: Duration = Duration::from_secs(30);
 /// holder creates it eagerly on config apply).
 pub const DOCUMENT_SYNC_DEFER_RETRY_AFTER: Duration = Duration::from_secs(1);
 
+/// Retry interval for a held shard topic the local node could not pull yet
+/// (its rank-0 holder has not created the genesis, or no co-holder served it).
+/// Short, for the same reason as [`DOCUMENT_SYNC_DEFER_RETRY_AFTER`]: the pull
+/// is join-only and cannot fork, so retrying it eagerly is free, and a holder
+/// must not sit idle for a whole [`SYNC_PLACEMENT_RETRY_AFTER`] waiting to be
+/// pushed to. Passes are serialized by the task timer, so this cannot spin.
+pub const SHARD_TOPIC_PULL_RETRY_AFTER: Duration = Duration::from_secs(1);
+
 pub fn placement_prefix(realm_id: RealmId) -> Key {
     ByteView::from(realm_id.as_bytes().to_vec())
 }

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -21,10 +21,11 @@ pub const DOCUMENT_SYNC_DEFER_RETRY_AFTER: Duration = Duration::from_secs(1);
 
 /// Retry interval for a held shard topic the local node could not pull yet
 /// (its rank-0 holder has not created the genesis, or no co-holder served it).
-/// Short, for the same reason as [`DOCUMENT_SYNC_DEFER_RETRY_AFTER`]: the pull
-/// is join-only and cannot fork, so retrying it eagerly is free, and a holder
-/// must not sit idle for a whole [`SYNC_PLACEMENT_RETRY_AFTER`] waiting to be
-/// pushed to. Passes are serialized by the task timer, so this cannot spin.
+/// The first retry is short, for the same reason as
+/// [`DOCUMENT_SYNC_DEFER_RETRY_AFTER`]: the pull is join-only and cannot fork,
+/// and a holder should not initially wait a whole
+/// [`SYNC_PLACEMENT_RETRY_AFTER`] to be pushed to. Consecutive failed pulls are
+/// backed off by the task handler because each attempt scans every shard.
 pub const SHARD_TOPIC_PULL_RETRY_AFTER: Duration = Duration::from_secs(1);
 
 pub fn placement_prefix(realm_id: RealmId) -> Key {

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -1,138 +1,120 @@
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::time::Duration;
 
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncTarget, PendingDocumentPlacement};
+use aruna_core::document::{DocumentSyncTarget, PendingBucketPlacement};
 use aruna_core::effects::{Effect, StorageEffect};
-use aruna_core::errors::ConversionError;
-use aruna_core::storage_entries::{
-    document_placement_delete_entry, document_placement_key, document_placement_write_entry,
-};
-use aruna_core::structs::{PlacementRef, RealmId};
+use aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE;
+use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
 use aruna_core::task::{TaskEffect, TaskKey};
-use aruna_core::types::{GroupId, Key, TxnId};
+use aruna_core::types::Key;
 use aruna_core::util::unix_timestamp_secs;
 use byteview::ByteView;
 
+use crate::placement::rank_eligible_holders;
+
 pub const DOCUMENT_SYNC_RETRY_AFTER: Duration = Duration::from_secs(30);
 pub const SYNC_PLACEMENT_RETRY_AFTER: Duration = Duration::from_secs(30);
+
+/// Retry interval for outbox records deferred on a missing bucket-topic
+/// genesis. Short: the genesis is usually one gossip push away (the rank-0
+/// holder creates it eagerly on config apply).
+pub const DOCUMENT_SYNC_DEFER_RETRY_AFTER: Duration = Duration::from_secs(1);
+
+/// Monotonic top-up: keeps every `existing_holders` entry and appends
+/// resolver-ranked eligible nodes (best-first, skipping already-held ones)
+/// until `desired_holder_count` is reached. The stored set is node-id sorted so
+/// any two nodes materialise an identical holder set from an identical record.
+pub fn complete_authoritative_holders(
+    config: &RealmConfigDocument,
+    target: &DocumentSyncTarget,
+    metadata_path: Option<&str>,
+    existing_holders: &[NodeId],
+    desired_holder_count: usize,
+) -> Vec<NodeId> {
+    let mut holders = existing_holders.to_vec();
+    sort_node_ids(&mut holders);
+    if holders.len() >= desired_holder_count {
+        return holders;
+    }
+
+    let held: HashSet<NodeId> = holders.iter().copied().collect();
+    for candidate in rank_eligible_holders(config, target, metadata_path) {
+        if holders.len() >= desired_holder_count {
+            break;
+        }
+        if !held.contains(&candidate) {
+            holders.push(candidate);
+        }
+    }
+    sort_node_ids(&mut holders);
+    holders
+}
 
 pub fn placement_prefix(realm_id: RealmId) -> Key {
     ByteView::from(realm_id.as_bytes().to_vec())
 }
 
-pub fn placement_key(realm_id: RealmId, target: &DocumentSyncTarget) -> Key {
-    document_placement_key(realm_id, target)
+/// Bucket-scoped record key: `realm(32) ‖ strategy(16) ‖ epoch(8, le) ‖
+/// bucket(4, be)`. One record per bucket the local node authoritatively holds.
+pub fn placement_key(realm_id: RealmId, placement: &PlacementRef) -> Key {
+    let mut bytes = realm_id.as_bytes().to_vec();
+    bytes.extend_from_slice(&placement.strategy_id.to_bytes());
+    bytes.extend_from_slice(&placement.epoch.to_le_bytes());
+    bytes.extend_from_slice(&placement.bucket.to_be_bytes());
+    ByteView::from(bytes)
 }
 
 pub fn new_placement(
     realm_id: RealmId,
-    target: DocumentSyncTarget,
-    origin_node_id: NodeId,
-    desired_holder_count: usize,
-    selected_holders: Vec<NodeId>,
     placement: PlacementRef,
-) -> PendingDocumentPlacement {
-    new_placement_with_context(
+    authoritative_node_id: NodeId,
+    mut selected_peers: Vec<NodeId>,
+) -> PendingBucketPlacement {
+    selected_peers.retain(|node_id| *node_id != authoritative_node_id);
+    sort_node_ids(&mut selected_peers);
+    PendingBucketPlacement {
         realm_id,
-        target,
-        origin_node_id,
-        None,
-        None,
-        desired_holder_count,
-        selected_holders,
         placement,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn new_placement_with_context(
-    realm_id: RealmId,
-    target: DocumentSyncTarget,
-    origin_node_id: NodeId,
-    group_id: Option<GroupId>,
-    metadata_path: Option<String>,
-    desired_holder_count: usize,
-    mut selected_holders: Vec<NodeId>,
-    placement: PlacementRef,
-) -> PendingDocumentPlacement {
-    sort_node_ids(&mut selected_holders);
-    PendingDocumentPlacement {
-        realm_id,
-        target,
-        group_id,
-        metadata_path,
-        desired_holder_count,
-        selected_holders,
+        selected_peers,
         updated_at: unix_timestamp_secs(),
-        origin_node_id,
-        placement,
+        authoritative_node_id,
     }
 }
 
-pub fn missing_holder_count(record: &PendingDocumentPlacement) -> usize {
-    let mut selected_holders = record.selected_holders.clone();
-    sort_node_ids(&mut selected_holders);
-    record
-        .desired_holder_count
-        .saturating_sub(selected_holders.len())
+/// Co-holders still to add to a bucket to reach `desired_peer_count` total
+/// holders (the authoritative node counts as one).
+pub fn missing_peer_count(record: &PendingBucketPlacement, desired_peer_count: usize) -> usize {
+    let mut selected_peers = record.selected_peers.clone();
+    selected_peers.retain(|node_id| *node_id != record.authoritative_node_id);
+    sort_node_ids(&mut selected_peers);
+    desired_peer_count.saturating_sub(selected_peers.len().saturating_add(1))
 }
 
-pub fn placement_satisfied(selected_holder_count: usize, desired_holder_count: usize) -> bool {
-    selected_holder_count >= desired_holder_count
+pub fn placement_satisfied(selected_peer_count: usize, desired_peer_count: usize) -> bool {
+    selected_peer_count.saturating_add(1) >= desired_peer_count
 }
 
-pub fn schedule_document_sync_effect(
-    node_id: NodeId,
-    target: DocumentSyncTarget,
-    mut peers: Vec<NodeId>,
-) -> Effect {
-    sort_node_ids(&mut peers);
-    Effect::Task(TaskEffect::ResetTimer {
-        key: TaskKey::SyncDocument {
-            node_id,
-            target,
-            peers,
-        },
-        after: Duration::ZERO,
-    })
-}
-
-pub fn write_placement_effect(
-    record: &PendingDocumentPlacement,
-) -> Result<Effect, ConversionError> {
-    let (key_space, key, value) = document_placement_write_entry(record)?;
+pub fn write_placement_effect(record: &PendingBucketPlacement) -> Result<Effect, postcard::Error> {
     Ok(Effect::Storage(StorageEffect::Write {
-        key_space,
-        key,
-        value,
+        key_space: SYNC_PLACEMENT_KEYSPACE.to_string(),
+        key: placement_key(record.realm_id, &record.placement),
+        value: ByteView::from(postcard::to_allocvec(record)?),
         txn_id: None,
     }))
 }
 
-pub fn delete_placement_effect(realm_id: RealmId, target: &DocumentSyncTarget) -> Effect {
-    delete_placement_effect_with_txn(realm_id, target, None)
-}
-
-pub fn delete_placement_effect_with_txn(
-    realm_id: RealmId,
-    target: &DocumentSyncTarget,
-    txn_id: Option<TxnId>,
-) -> Effect {
-    let (key_space, key) = document_placement_delete_entry(realm_id, target);
+pub fn delete_placement_effect(realm_id: RealmId, placement: &PlacementRef) -> Effect {
     Effect::Storage(StorageEffect::Delete {
-        key_space,
-        key,
-        txn_id,
+        key_space: SYNC_PLACEMENT_KEYSPACE.to_string(),
+        key: placement_key(realm_id, placement),
+        txn_id: None,
     })
 }
 
 pub fn schedule_placement_retry_effect(realm_id: RealmId, local_node_id: NodeId) -> Effect {
     schedule_placement_retry_after(realm_id, local_node_id, SYNC_PLACEMENT_RETRY_AFTER)
-}
-
-pub fn schedule_placement_revalidation_effect(realm_id: RealmId, local_node_id: NodeId) -> Effect {
-    schedule_placement_retry_after(realm_id, local_node_id, Duration::ZERO)
 }
 
 pub fn schedule_placement_retry_after(
@@ -149,7 +131,7 @@ pub fn schedule_placement_retry_after(
     })
 }
 
-pub fn decode_placement(value: &[u8]) -> Result<PendingDocumentPlacement, postcard::Error> {
+pub fn decode_placement(value: &[u8]) -> Result<PendingBucketPlacement, postcard::Error> {
     postcard::from_bytes(value)
 }
 
@@ -165,7 +147,8 @@ fn compare_node_ids(left: &NodeId, right: &NodeId) -> Ordering {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aruna_core::structs::RealmId;
+    use aruna_core::structs::{RealmConfigDocument, RealmId, RealmNodeKind};
+    use ulid::Ulid;
 
     fn node(seed: u8) -> NodeId {
         let mut bytes = [0u8; 32];
@@ -179,17 +162,73 @@ mod tests {
         }
     }
 
+    fn config_with(nodes: &[NodeId]) -> RealmConfigDocument {
+        let mut config = RealmConfigDocument::new(RealmId::from_bytes([7u8; 32]), Vec::new(), 3);
+        let strategy = aruna_core::structs::PlacementStrategy {
+            strategy_id: Ulid::from_bytes([9u8; 16]),
+            name: "test".to_string(),
+            replica_count: None,
+            distinct_locations: false,
+            affinity: Vec::new(),
+            bucket_count: 64,
+        };
+        config.default_strategy_id = Some(strategy.strategy_id);
+        config.strategies = vec![strategy];
+        for node_id in nodes {
+            config.ensure_node(*node_id, RealmNodeKind::Server);
+        }
+        config
+    }
+
     #[test]
-    fn placement_key_is_realm_scoped() {
-        let target = target();
+    fn authoritative_holder_completion_is_monotonic() {
+        let existing = vec![node(1), node(3), node(3)];
+        let config = config_with(&[node(1), node(2), node(3), node(4), node(5)]);
+
+        let holders = complete_authoritative_holders(&config, &target(), None, &existing, 4);
+
+        assert!(holders.contains(&node(1)));
+        assert!(holders.contains(&node(3)));
+        assert_eq!(holders.len(), 4);
+    }
+
+    #[test]
+    fn authoritative_holder_completion_is_cross_node_identical() {
+        let config = config_with(&[node(1), node(2), node(3), node(4), node(5)]);
+        let existing = vec![node(2)];
+
+        let first = complete_authoritative_holders(&config, &target(), None, &existing, 3);
+        // A node observing the members in a different order derives the same set.
+        let reversed = config_with(&[node(5), node(4), node(3), node(2), node(1)]);
+        let second = complete_authoritative_holders(&reversed, &target(), None, &existing, 3);
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 3);
+        assert!(first.contains(&node(2)));
+    }
+
+    fn placement(bucket: u32) -> PlacementRef {
+        PlacementRef {
+            strategy_id: Ulid::from_bytes([9u8; 16]),
+            epoch: 0,
+            bucket,
+        }
+    }
+
+    #[test]
+    fn placement_key_is_realm_and_bucket_scoped() {
         let first_realm = RealmId::from_bytes([1u8; 32]);
         let second_realm = RealmId::from_bytes([2u8; 32]);
 
-        let first_key = placement_key(first_realm, &target);
-        let second_key = placement_key(second_realm, &target);
+        let first_key = placement_key(first_realm, &placement(3));
+        let second_key = placement_key(second_realm, &placement(3));
+        let other_bucket = placement_key(first_realm, &placement(4));
 
         assert_ne!(first_key, second_key);
+        assert_ne!(first_key, other_bucket);
         assert!(first_key.as_ref().starts_with(first_realm.as_bytes()));
+        // Layout: realm(32) ‖ strategy(16) ‖ epoch(8) ‖ bucket(4) = 60 bytes.
+        assert_eq!(first_key.as_ref().len(), 60);
         assert_eq!(
             placement_prefix(first_realm).as_ref(),
             first_realm.as_bytes()
@@ -197,108 +236,50 @@ mod tests {
     }
 
     #[test]
-    fn placement_deduplicates_holders_and_computes_missing_count() {
+    fn placement_deduplicates_peers_and_computes_missing_count() {
         let realm_id = RealmId::from_bytes([3u8; 32]);
-        let origin = node(1);
-        let holder = node(5);
-        let placement = new_placement(
-            realm_id,
-            target(),
-            origin,
-            3,
-            vec![holder, holder],
-            PlacementRef::NIL,
-        );
+        let authoritative = node(1);
+        let peer = node(5);
+        let record = new_placement(realm_id, placement(2), authoritative, vec![peer, peer]);
 
-        assert_eq!(placement.realm_id, realm_id);
-        assert_eq!(placement.origin_node_id, origin);
-        assert_eq!(placement.selected_holders, vec![holder]);
-        assert_eq!(missing_holder_count(&placement), 2);
+        assert_eq!(record.realm_id, realm_id);
+        assert_eq!(record.authoritative_node_id, authoritative);
+        assert_eq!(record.selected_peers, vec![peer]);
+        assert_eq!(missing_peer_count(&record, 3), 1);
     }
 
     #[test]
-    fn placement_does_not_count_origin_implicitly() {
+    fn placement_counts_authoritative_node_toward_desired_peer_count() {
         let realm_id = RealmId::from_bytes([4u8; 32]);
-        let placement = new_placement(
-            realm_id,
-            target(),
-            node(1),
-            3,
-            vec![node(5), node(6)],
-            PlacementRef::NIL,
-        );
+        let record = new_placement(realm_id, placement(2), node(1), vec![node(5), node(6)]);
 
-        assert_eq!(missing_holder_count(&placement), 1);
-        assert!(!placement_satisfied(
-            placement.selected_holders.len(),
-            placement.desired_holder_count
-        ));
+        assert_eq!(missing_peer_count(&record, 3), 0);
+        assert!(placement_satisfied(record.selected_peers.len(), 3));
     }
 
     #[test]
-    fn placement_records_origin_separately() {
+    fn placement_records_authoritative_holder_explicitly() {
         let realm_id = RealmId::from_bytes([5u8; 32]);
-        let origin = node(7);
+        let authoritative = node(7);
 
-        let placement = new_placement(
-            realm_id,
-            target(),
-            origin,
-            3,
-            vec![node(8)],
-            PlacementRef::NIL,
-        );
+        let record = new_placement(realm_id, placement(2), authoritative, vec![node(8)]);
 
-        assert_eq!(placement.origin_node_id, origin);
-        assert!(!placement.selected_holders.contains(&origin));
+        assert_eq!(record.authoritative_node_id, authoritative);
     }
 
     #[test]
-    fn placement_counts_origin_only_when_selected_as_holder() {
+    fn placement_deduplicates_selected_peers_and_excludes_authoritative() {
         let realm_id = RealmId::from_bytes([6u8; 32]);
-        let origin = node(7);
+        let authoritative = node(7);
 
-        let placement = new_placement(
+        let record = new_placement(
             realm_id,
-            target(),
-            origin,
-            3,
-            vec![node(8), origin, node(8), node(9)],
-            PlacementRef::NIL,
+            placement(2),
+            authoritative,
+            vec![node(8), authoritative, node(8), node(9)],
         );
 
-        assert_eq!(placement.selected_holders, vec![origin, node(9), node(8)]);
-        assert_eq!(missing_holder_count(&placement), 0);
-        assert!(placement_satisfied(
-            placement.selected_holders.len(),
-            placement.desired_holder_count
-        ));
-    }
-
-    #[test]
-    fn metadata_resolution_context_survives_placement_roundtrip() {
-        let group_id = GroupId::from_bytes([8; 16]);
-        let placement = new_placement_with_context(
-            RealmId::from_bytes([7; 32]),
-            DocumentSyncTarget::MetadataDocumentLifecycle {
-                document_id: GroupId::from_bytes([9; 16]),
-            },
-            node(1),
-            Some(group_id),
-            Some("datasets/context/object".to_string()),
-            2,
-            vec![node(1), node(2)],
-            PlacementRef::NIL,
-        );
-
-        let bytes = postcard::to_allocvec(&placement).expect("placement serializes");
-        let decoded = decode_placement(&bytes).expect("placement decodes");
-
-        assert_eq!(decoded.group_id, Some(group_id));
-        assert_eq!(
-            decoded.metadata_path.as_deref(),
-            Some("datasets/context/object")
-        );
-        assert_eq!(decoded, placement);
+        assert_eq!(record.selected_peers, vec![node(9), node(8)]);
+        assert_eq!(missing_peer_count(&record, 3), 0);
     }
 }

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -1,18 +1,15 @@
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::time::Duration;
 
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncTarget, PendingShardPlacement};
+use aruna_core::document::PendingShardPlacement;
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE;
-use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
+use aruna_core::structs::{PlacementRef, RealmId};
 use aruna_core::task::{TaskEffect, TaskKey};
 use aruna_core::types::Key;
 use aruna_core::util::unix_timestamp_secs;
 use byteview::ByteView;
-
-use crate::placement::rank_eligible_holders;
 
 pub const DOCUMENT_SYNC_RETRY_AFTER: Duration = Duration::from_secs(30);
 pub const SYNC_PLACEMENT_RETRY_AFTER: Duration = Duration::from_secs(30);
@@ -21,36 +18,6 @@ pub const SYNC_PLACEMENT_RETRY_AFTER: Duration = Duration::from_secs(30);
 /// genesis. Short: the genesis is usually one gossip push away (the rank-0
 /// holder creates it eagerly on config apply).
 pub const DOCUMENT_SYNC_DEFER_RETRY_AFTER: Duration = Duration::from_secs(1);
-
-/// Monotonic top-up: keeps every `existing_holders` entry and appends
-/// resolver-ranked eligible nodes (best-first, skipping already-held ones)
-/// until `desired_holder_count` is reached. The stored set is node-id sorted so
-/// any two nodes materialise an identical holder set from an identical record.
-pub fn complete_authoritative_holders(
-    config: &RealmConfigDocument,
-    target: &DocumentSyncTarget,
-    metadata_path: Option<&str>,
-    existing_holders: &[NodeId],
-    desired_holder_count: usize,
-) -> Vec<NodeId> {
-    let mut holders = existing_holders.to_vec();
-    sort_node_ids(&mut holders);
-    if holders.len() >= desired_holder_count {
-        return holders;
-    }
-
-    let held: HashSet<NodeId> = holders.iter().copied().collect();
-    for candidate in rank_eligible_holders(config, target, metadata_path) {
-        if holders.len() >= desired_holder_count {
-            break;
-        }
-        if !held.contains(&candidate) {
-            holders.push(candidate);
-        }
-    }
-    sort_node_ids(&mut holders);
-    holders
-}
 
 pub fn placement_prefix(realm_id: RealmId) -> Key {
     ByteView::from(realm_id.as_bytes().to_vec())
@@ -117,6 +84,10 @@ pub fn schedule_placement_retry_effect(realm_id: RealmId, local_node_id: NodeId)
     schedule_placement_retry_after(realm_id, local_node_id, SYNC_PLACEMENT_RETRY_AFTER)
 }
 
+pub fn schedule_placement_revalidation_effect(realm_id: RealmId, local_node_id: NodeId) -> Effect {
+    schedule_placement_retry_after(realm_id, local_node_id, Duration::ZERO)
+}
+
 pub fn schedule_placement_retry_after(
     realm_id: RealmId,
     local_node_id: NodeId,
@@ -147,64 +118,13 @@ fn compare_node_ids(left: &NodeId, right: &NodeId) -> Ordering {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aruna_core::structs::{RealmConfigDocument, RealmId, RealmNodeKind};
+    use aruna_core::structs::RealmId;
     use ulid::Ulid;
 
     fn node(seed: u8) -> NodeId {
         let mut bytes = [0u8; 32];
         bytes[0] = seed;
         iroh::SecretKey::from_bytes(&bytes).public()
-    }
-
-    fn target() -> DocumentSyncTarget {
-        DocumentSyncTarget::RealmConfig {
-            realm_id: RealmId::from_bytes([7u8; 32]),
-        }
-    }
-
-    fn config_with(nodes: &[NodeId]) -> RealmConfigDocument {
-        let mut config = RealmConfigDocument::new(RealmId::from_bytes([7u8; 32]), Vec::new(), 3);
-        let strategy = aruna_core::structs::PlacementStrategy {
-            strategy_id: Ulid::from_bytes([9u8; 16]),
-            name: "test".to_string(),
-            replica_count: None,
-            distinct_locations: false,
-            affinity: Vec::new(),
-            shard_count: 64,
-        };
-        config.default_strategy_id = Some(strategy.strategy_id);
-        config.strategies = vec![strategy];
-        for node_id in nodes {
-            config.ensure_node(*node_id, RealmNodeKind::Server);
-        }
-        config
-    }
-
-    #[test]
-    fn authoritative_holder_completion_is_monotonic() {
-        let existing = vec![node(1), node(3), node(3)];
-        let config = config_with(&[node(1), node(2), node(3), node(4), node(5)]);
-
-        let holders = complete_authoritative_holders(&config, &target(), None, &existing, 4);
-
-        assert!(holders.contains(&node(1)));
-        assert!(holders.contains(&node(3)));
-        assert_eq!(holders.len(), 4);
-    }
-
-    #[test]
-    fn authoritative_holder_completion_is_cross_node_identical() {
-        let config = config_with(&[node(1), node(2), node(3), node(4), node(5)]);
-        let existing = vec![node(2)];
-
-        let first = complete_authoritative_holders(&config, &target(), None, &existing, 3);
-        // A node observing the members in a different order derives the same set.
-        let reversed = config_with(&[node(5), node(4), node(3), node(2), node(1)]);
-        let second = complete_authoritative_holders(&reversed, &target(), None, &existing, 3);
-
-        assert_eq!(first, second);
-        assert_eq!(first.len(), 3);
-        assert!(first.contains(&node(2)));
     }
 
     fn placement(shard: u32) -> PlacementRef {

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use aruna_core::NodeId;
-use aruna_core::document::{DocumentSyncTarget, PendingBucketPlacement};
+use aruna_core::document::{DocumentSyncTarget, PendingShardPlacement};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE;
 use aruna_core::structs::{PlacementRef, RealmConfigDocument, RealmId};
@@ -17,7 +17,7 @@ use crate::placement::rank_eligible_holders;
 pub const DOCUMENT_SYNC_RETRY_AFTER: Duration = Duration::from_secs(30);
 pub const SYNC_PLACEMENT_RETRY_AFTER: Duration = Duration::from_secs(30);
 
-/// Retry interval for outbox records deferred on a missing bucket-topic
+/// Retry interval for outbox records deferred on a missing shard-topic
 /// genesis. Short: the genesis is usually one gossip push away (the rank-0
 /// holder creates it eagerly on config apply).
 pub const DOCUMENT_SYNC_DEFER_RETRY_AFTER: Duration = Duration::from_secs(1);
@@ -56,13 +56,13 @@ pub fn placement_prefix(realm_id: RealmId) -> Key {
     ByteView::from(realm_id.as_bytes().to_vec())
 }
 
-/// Bucket-scoped record key: `realm(32) ‖ strategy(16) ‖ epoch(8, le) ‖
-/// bucket(4, be)`. One record per bucket the local node authoritatively holds.
+/// Shard-scoped record key: `realm(32) ‖ strategy(16) ‖ epoch(8, le) ‖
+/// shard(4, be)`. One record per shard the local node authoritatively holds.
 pub fn placement_key(realm_id: RealmId, placement: &PlacementRef) -> Key {
     let mut bytes = realm_id.as_bytes().to_vec();
     bytes.extend_from_slice(&placement.strategy_id.to_bytes());
     bytes.extend_from_slice(&placement.epoch.to_le_bytes());
-    bytes.extend_from_slice(&placement.bucket.to_be_bytes());
+    bytes.extend_from_slice(&placement.shard.to_be_bytes());
     ByteView::from(bytes)
 }
 
@@ -71,10 +71,10 @@ pub fn new_placement(
     placement: PlacementRef,
     authoritative_node_id: NodeId,
     mut selected_peers: Vec<NodeId>,
-) -> PendingBucketPlacement {
+) -> PendingShardPlacement {
     selected_peers.retain(|node_id| *node_id != authoritative_node_id);
     sort_node_ids(&mut selected_peers);
-    PendingBucketPlacement {
+    PendingShardPlacement {
         realm_id,
         placement,
         selected_peers,
@@ -83,9 +83,9 @@ pub fn new_placement(
     }
 }
 
-/// Co-holders still to add to a bucket to reach `desired_peer_count` total
+/// Co-holders still to add to a shard to reach `desired_peer_count` total
 /// holders (the authoritative node counts as one).
-pub fn missing_peer_count(record: &PendingBucketPlacement, desired_peer_count: usize) -> usize {
+pub fn missing_peer_count(record: &PendingShardPlacement, desired_peer_count: usize) -> usize {
     let mut selected_peers = record.selected_peers.clone();
     selected_peers.retain(|node_id| *node_id != record.authoritative_node_id);
     sort_node_ids(&mut selected_peers);
@@ -96,7 +96,7 @@ pub fn placement_satisfied(selected_peer_count: usize, desired_peer_count: usize
     selected_peer_count.saturating_add(1) >= desired_peer_count
 }
 
-pub fn write_placement_effect(record: &PendingBucketPlacement) -> Result<Effect, postcard::Error> {
+pub fn write_placement_effect(record: &PendingShardPlacement) -> Result<Effect, postcard::Error> {
     Ok(Effect::Storage(StorageEffect::Write {
         key_space: SYNC_PLACEMENT_KEYSPACE.to_string(),
         key: placement_key(record.realm_id, &record.placement),
@@ -131,7 +131,7 @@ pub fn schedule_placement_retry_after(
     })
 }
 
-pub fn decode_placement(value: &[u8]) -> Result<PendingBucketPlacement, postcard::Error> {
+pub fn decode_placement(value: &[u8]) -> Result<PendingShardPlacement, postcard::Error> {
     postcard::from_bytes(value)
 }
 
@@ -170,7 +170,7 @@ mod tests {
             replica_count: None,
             distinct_locations: false,
             affinity: Vec::new(),
-            bucket_count: 64,
+            shard_count: 64,
         };
         config.default_strategy_id = Some(strategy.strategy_id);
         config.strategies = vec![strategy];
@@ -207,27 +207,27 @@ mod tests {
         assert!(first.contains(&node(2)));
     }
 
-    fn placement(bucket: u32) -> PlacementRef {
+    fn placement(shard: u32) -> PlacementRef {
         PlacementRef {
             strategy_id: Ulid::from_bytes([9u8; 16]),
             epoch: 0,
-            bucket,
+            shard,
         }
     }
 
     #[test]
-    fn placement_key_is_realm_and_bucket_scoped() {
+    fn placement_key_is_realm_and_shard_scoped() {
         let first_realm = RealmId::from_bytes([1u8; 32]);
         let second_realm = RealmId::from_bytes([2u8; 32]);
 
         let first_key = placement_key(first_realm, &placement(3));
         let second_key = placement_key(second_realm, &placement(3));
-        let other_bucket = placement_key(first_realm, &placement(4));
+        let other_shard = placement_key(first_realm, &placement(4));
 
         assert_ne!(first_key, second_key);
-        assert_ne!(first_key, other_bucket);
+        assert_ne!(first_key, other_shard);
         assert!(first_key.as_ref().starts_with(first_realm.as_bytes()));
-        // Layout: realm(32) ‖ strategy(16) ‖ epoch(8) ‖ bucket(4) = 60 bytes.
+        // Layout: realm(32) ‖ strategy(16) ‖ epoch(8) ‖ shard(4) = 60 bytes.
         assert_eq!(first_key.as_ref().len(), 60);
         assert_eq!(
             placement_prefix(first_realm).as_ref(),

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -68,7 +68,9 @@ use crate::s3::refresh_reference_metadata::{
     REFERENCE_METADATA_REFRESH_RETRY_AFTER, process_reference_metadata_refresh_batch,
     restore_reference_metadata_refresh_timer,
 };
-use crate::sync_placement::{DOCUMENT_SYNC_DEFER_RETRY_AFTER, SYNC_PLACEMENT_RETRY_AFTER};
+use crate::sync_placement::{
+    DOCUMENT_SYNC_DEFER_RETRY_AFTER, SHARD_TOPIC_PULL_RETRY_AFTER, SYNC_PLACEMENT_RETRY_AFTER,
+};
 use crate::task_persistence::{
     delete_persisted_timer, persist_task_effect, restore_persisted_task_timers,
 };
@@ -403,6 +405,26 @@ impl OperationsTaskHandler {
             .lock()
             .expect("retry backoff mutex poisoned")
             .remove(key);
+    }
+
+    /// Keeps the first missing-topic pull retry prompt, then backs off each
+    /// subsequent full placement scan using the existing per-key retry state.
+    fn placement_pull_retry_after(&self, key: &TaskKey) -> Duration {
+        let mut backoff = self
+            .retry_backoff
+            .lock()
+            .expect("retry backoff mutex poisoned");
+        match backoff.entry(key.clone()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(0);
+                SHARD_TOPIC_PULL_RETRY_AFTER
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let attempts = *entry.get();
+                entry.insert(attempts.saturating_add(1));
+                Duration::from_secs(timer_retry_after_secs(attempts))
+            }
+        }
     }
 
     /// Re-arms `key` at its current backoff interval and records the attempt.
@@ -1531,16 +1553,18 @@ impl InboundTaskHandler for OperationsTaskHandler {
                 }
             }
             TaskKey::SyncPlacements { realm_id, node_id } => {
-                if process_shard_placements(&self.context, realm_id, node_id)
-                    .await
-                    .status
-                    == PlacementReconcileStatus::StorageFailure
-                {
-                    self.reschedule_timer(
-                        TaskKey::SyncPlacements { realm_id, node_id },
-                        SYNC_PLACEMENT_RETRY_AFTER,
-                    )
-                    .await;
+                let key = TaskKey::SyncPlacements { realm_id, node_id };
+                let outcome = process_shard_placements(&self.context, realm_id, node_id).await;
+                match outcome.status {
+                    PlacementReconcileStatus::Clean => self.reset_backoff(&key),
+                    PlacementReconcileStatus::RetryScheduled if outcome.pull_pending => {
+                        let after = self.placement_pull_retry_after(&key);
+                        self.reschedule_timer(key, after).await;
+                    }
+                    PlacementReconcileStatus::RetryScheduled => {}
+                    PlacementReconcileStatus::StorageFailure => {
+                        self.reschedule_timer(key, SYNC_PLACEMENT_RETRY_AFTER).await;
+                    }
                 }
             }
             TaskKey::DrainDocumentSyncOutbox => {

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -57,7 +57,7 @@ use crate::notifications::watch::interest::{
     WATCH_INTEREST_PUBLISH_DEBOUNCE, rebuild_watch_interest_table,
     refresh_watch_interest_for_targets, restore_watch_interest_publish_timer,
 };
-use crate::process_placements::process_bucket_placements;
+use crate::process_placements::process_shard_placements;
 use crate::queue_backoff::timer_retry_after_secs;
 use crate::replication::queue::{
     BLOB_REPLICATION_RETRY_AFTER, process_blob_replication_batch, restore_blob_replication_timer,
@@ -117,7 +117,7 @@ struct DrainSyncOutcome {
     retry_needed: bool,
 }
 
-/// Resolves the bucket placement a drained record publishes under. A record
+/// Resolves the shard placement a drained record publishes under. A record
 /// that already carries a real ref keeps it; a NIL ref (admin-operation
 /// emitters leave one) is resolved from the realm config for the target. Shared
 /// realm targets ignore the placement, so resolving them is harmless.
@@ -302,8 +302,8 @@ impl OperationsTaskHandler {
 
         let realm_id = *net_handle.realm_id();
         // Admin-operation records (group/user document ops) are stamped NIL by
-        // their emitters; resolve their bucket placement here from the realm
-        // config so they publish onto the right bucket topic. Records that
+        // their emitters; resolve their shard placement here from the realm
+        // config so they publish onto the right shard topic. Records that
         // already carry a real ref (metadata upserts/deletes) keep it.
         let realm_config = load_realm_config_for_drain(&self.context, realm_id).await;
         let mut totals = DrainSyncOutcome::default();
@@ -326,16 +326,16 @@ impl OperationsTaskHandler {
             })
             .collect();
 
-        // Bucket topics are join-only for this node unless it is the bucket's
+        // Shard topics are join-only for this node unless it is the shard's
         // rank-0 holder: a record whose topic has no local genesis yet cannot
         // publish. Try one bootstrap pass against the record's peers (falling
-        // back to the bucket's resolved holders when the record carries none,
+        // back to the shard's resolved holders when the record carries none,
         // as admin operations do), then defer whatever is still missing to a
         // short retry — the genesis arrives via gossip or the next pass.
         let mut missing_topics: BTreeMap<Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>> =
             BTreeMap::new();
         for (_, record, topic) in &records {
-            if !record.target.uses_bucket_topic()
+            if !record.target.uses_shard_topic()
                 || net_handle
                     .document_sync_topic_exists(*topic)
                     .unwrap_or(false)
@@ -347,7 +347,7 @@ impl OperationsTaskHandler {
                 && let Some(config) = realm_config.as_ref()
             {
                 bootstrap_peers =
-                    crate::placement::resolve_bucket_holders(config, &record.placement);
+                    crate::placement::resolve_shard_holders(config, &record.placement);
                 bootstrap_peers.retain(|peer| *peer != net_handle.node_id());
                 crate::sync_placement::sort_node_ids(&mut bootstrap_peers);
             }
@@ -378,7 +378,7 @@ impl OperationsTaskHandler {
         let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
             BTreeMap::new();
         for (record_key, record, topic) in records {
-            if record.target.uses_bucket_topic()
+            if record.target.uses_shard_topic()
                 && !net_handle
                     .document_sync_topic_exists(topic)
                     .unwrap_or(false)
@@ -387,7 +387,7 @@ impl OperationsTaskHandler {
                     event = "pipeline.drain.deferred",
                     target = ?record.target,
                     %topic,
-                    "Deferring outbox record: bucket topic genesis not yet known"
+                    "Deferring outbox record: shard topic genesis not yet known"
                 );
                 deferred += 1;
                 continue;
@@ -521,7 +521,7 @@ impl OperationsTaskHandler {
             self.reschedule_with_backoff(retry_key).await;
         } else if deferred > 0 {
             // Deferred records wait only for a genesis to arrive from the
-            // bucket's rank-0 holder; retry quickly rather than on the failure
+            // shard's rank-0 holder; retry quickly rather than on the failure
             // backoff.
             self.reschedule_timer(retry_key, DOCUMENT_SYNC_DEFER_RETRY_AFTER)
                 .await;
@@ -1271,7 +1271,7 @@ impl InboundTaskHandler for OperationsTaskHandler {
                 }
             }
             TaskKey::SyncPlacements { realm_id, node_id } => {
-                process_bucket_placements(&self.context, realm_id, node_id).await;
+                process_shard_placements(&self.context, realm_id, node_id).await;
             }
             TaskKey::DrainDocumentSyncOutbox => {
                 self.drain_document_sync_outbox().await;

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -96,20 +96,24 @@ struct DrainSubBatch {
     peers: Vec<aruna_core::NodeId>,
     documents: Vec<DocumentSyncPublish>,
     topics: Vec<irokle::TopicId>,
+    targets: Vec<DocumentSyncTarget>,
     record_keys: Vec<Vec<u8>>,
 }
 
 impl DrainSubBatch {
     fn sync_subset(&self, indices: &[usize]) -> Option<Self> {
+        let mut topics = Vec::with_capacity(indices.len());
         let mut targets = Vec::with_capacity(indices.len());
         let mut record_keys = Vec::with_capacity(indices.len());
         for &index in indices {
+            topics.push(*self.topics.get(index)?);
             targets.push(self.targets.get(index)?.clone());
             record_keys.push(self.record_keys.get(index)?.clone());
         }
         Some(Self {
             peers: self.peers.clone(),
             documents: Vec::new(),
+            topics,
             targets,
             record_keys,
         })
@@ -201,29 +205,39 @@ impl DrainSyncOutcome {
     }
 }
 
+/// Per-run defer state, carried across the drain's pages so a topic deferred on
+/// one page keeps deferring on later pages (preserving FIFO within a topic) and
+/// each topic's genesis presence is probed at most once per run.
+#[derive(Default)]
+struct DrainDeferState {
+    topic_exists: HashMap<irokle::TopicId, bool>,
+    deferred_topics: HashSet<irokle::TopicId>,
+}
+
 /// Splits FIFO-ordered drain records into those to publish now and a count of
 /// those deferred because their shard topic has no local genesis yet. Each
-/// topic's availability is evaluated once per run; once a topic defers, every
-/// later record of that topic defers too. Splitting FIFO-adjacent records of one
-/// topic across a defer/publish boundary would let the newer op publish first,
-/// invert its origin sequence on receivers, and drop the older op forever as
-/// StaleOriginSequence — so a topic never straddles that boundary within a run.
+/// topic's availability is evaluated once per run (state persists in `defer`);
+/// once a topic defers, every later record of that topic defers too. Splitting
+/// FIFO-adjacent records of one topic across a defer/publish boundary would let
+/// the newer op publish first, invert its origin sequence on receivers, and drop
+/// the older op forever as StaleOriginSequence — so a topic never straddles that
+/// boundary within a run, across pages included.
 fn partition_drain_records(
     records: Vec<DrainRecord>,
+    defer: &mut DrainDeferState,
     mut topic_available: impl FnMut(irokle::TopicId) -> bool,
 ) -> (Vec<DrainRecord>, usize) {
-    let mut topic_exists: HashMap<irokle::TopicId, bool> = HashMap::new();
-    let mut deferred_topics: HashSet<irokle::TopicId> = HashSet::new();
     let mut to_publish = Vec::with_capacity(records.len());
     let mut deferred = 0usize;
     for (record_key, record, topic) in records {
         if record.target.uses_shard_topic() {
-            let available = !deferred_topics.contains(&topic)
-                && *topic_exists
+            let available = !defer.deferred_topics.contains(&topic)
+                && *defer
+                    .topic_exists
                     .entry(topic)
                     .or_insert_with(|| topic_available(topic));
             if !available {
-                deferred_topics.insert(topic);
+                defer.deferred_topics.insert(topic);
                 debug!(
                     event = "pipeline.drain.deferred",
                     target = ?record.target,
@@ -312,32 +326,6 @@ impl OperationsTaskHandler {
     async fn drain_document_sync_outbox(&self) {
         let retry_key = TaskKey::DrainDocumentSyncOutbox;
         let drain_started = Instant::now();
-        let batch =
-            match read_outbox_records(&self.context.storage_handle, &[], OUTBOX_DRAIN_BATCH_SIZE)
-                .await
-            {
-                Ok(batch) if batch.records.is_empty() => {
-                    if batch.has_more {
-                        self.reschedule_timer(retry_key, Duration::ZERO).await;
-                    } else {
-                        self.reset_backoff(&retry_key);
-                    }
-                    return;
-                }
-                Ok(batch) => batch,
-                Err(error) => {
-                    warn!(error = %error, "Failed to read document sync outbox record");
-                    self.reschedule_with_backoff(retry_key).await;
-                    return;
-                }
-            };
-        let scan_elapsed = drain_started.elapsed();
-        let record_count = batch.records.len();
-        let oldest_record_ms = batch
-            .records
-            .iter()
-            .map(|(_, record)| record.outbox_id.timestamp_ms())
-            .min();
 
         let Some(net_handle) = self.context.net_handle.as_ref() else {
             warn!(key = ?retry_key, "Cannot drain document sync outbox without net handle");
@@ -351,185 +339,260 @@ impl OperationsTaskHandler {
         // config so they publish onto the right shard topic. Records that
         // already carry a real ref (metadata upserts/deletes) keep it.
         let realm_config = load_realm_config_for_drain(&self.context, realm_id).await;
+
         let mut totals = DrainSyncOutcome::default();
-
-        let records: Vec<(
-            Vec<u8>,
-            aruna_core::document::DocumentSyncOutboxRecord,
-            irokle::TopicId,
-        )> = batch
-            .records
-            .into_iter()
-            .map(|(record_key, mut record)| {
-                record.placement = resolve_publish_placement(
-                    realm_config.as_ref(),
-                    &record.target,
-                    record.placement,
-                );
-                let topic = record.target.sync_topic_id(realm_id, &record.placement);
-                (record_key, record, topic)
-            })
-            .collect();
-
-        // Shard topics are join-only for this node unless it is the shard's
-        // rank-0 holder: a record whose topic has no local genesis yet cannot
-        // publish. Try one bootstrap pass against the record's peers (falling
-        // back to the shard's resolved holders when the record carries none,
-        // as admin operations do), then defer whatever is still missing to a
-        // short retry — the genesis arrives via gossip or the next pass.
-        let mut missing_topics: BTreeMap<Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>> =
-            BTreeMap::new();
-        for (_, record, topic) in &records {
-            if !record.target.uses_shard_topic()
-                || net_handle
-                    .document_sync_topic_exists(*topic)
-                    .unwrap_or(false)
-            {
-                continue;
-            }
-            let mut bootstrap_peers = record.peers.clone();
-            if bootstrap_peers.is_empty()
-                && let Some(config) = realm_config.as_ref()
-            {
-                bootstrap_peers =
-                    crate::placement::resolve_shard_holders(config, &record.placement);
-                bootstrap_peers.retain(|peer| *peer != net_handle.node_id());
-                crate::sync_placement::sort_node_ids(&mut bootstrap_peers);
-            }
-            if bootstrap_peers.is_empty() {
-                continue;
-            }
-            missing_topics
-                .entry(bootstrap_peers)
-                .or_default()
-                .insert(*topic);
-        }
-        for (peers, topics) in missing_topics {
-            let event = net_handle
-                .sync_document_topics(topics.into_iter().collect(), peers)
-                .await;
-            let outcome = self
-                .finish_sync_drain_subbatch(
-                    &retry_key,
-                    Vec::new(),
-                    Event::Net(NetEvent::DocumentSync(event)),
-                    Default::default(),
-                )
-                .await;
-            totals.merge(outcome);
-        }
-
-        let (to_publish, deferred) = partition_drain_records(records, |topic| {
-            net_handle
-                .document_sync_topic_exists(topic)
-                .unwrap_or(false)
-        });
-        let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
-            BTreeMap::new();
-        for (record_key, record, topic) in to_publish {
-            let document = document_publish_from_outbox(
-                record.outbox_id,
-                record.target.clone(),
-                record.event,
-                record.placement,
-                record.allow_genesis,
-            );
-
-            let subbatches = publish_groups.entry(record.peers.clone()).or_default();
-            if subbatches
-                .last()
-                .is_none_or(|subbatch| subbatch.documents.len() >= DRAIN_SUBBATCH_RECORDS)
-            {
-                subbatches.push(DrainSubBatch {
-                    peers: record.peers,
-                    documents: Vec::new(),
-                    topics: Vec::new(),
-                    record_keys: Vec::new(),
-                });
-            }
-            let subbatch = subbatches.last_mut().expect("sub-batch was just pushed");
-            subbatch.documents.push(document);
-            subbatch.topics.push(topic);
-            subbatch.record_keys.push(record_key);
-        }
-
-        let group_count = publish_groups.len();
-        let subbatches: Vec<DrainSubBatch> = publish_groups.into_values().flatten().collect();
-        let subbatch_count = subbatches.len();
-
-        // Two-slot pipeline: publish sub-batch N+1 while sub-batch N syncs;
-        // sub-batches enter the sync stage strictly in submission order.
+        let mut defer_state = DrainDeferState::default();
+        let mut start_after: Option<Vec<u8>> = None;
+        let mut scan_elapsed = Duration::ZERO;
         let mut publish_elapsed = Duration::ZERO;
-        let mut awaiting_sync: Option<DrainSubBatch> = None;
-        for mut subbatch in subbatches {
-            let documents = std::mem::take(&mut subbatch.documents);
-            let peers = subbatch.peers.clone();
-            let publish = async {
-                let publish_started = Instant::now();
-                let event = net_handle
-                    .send_effect(Effect::Net(NetEffect::DocumentSync(
-                        DocumentSyncEffect::PublishDocuments { documents, peers },
-                    )))
-                    .await;
-                (event, publish_started.elapsed())
-            };
-            let ((publish_event, publish_time), sync_outcome) = tokio::join!(
-                publish,
-                self.sync_drain_subbatch(&retry_key, net_handle, awaiting_sync.take())
-            );
-            publish_elapsed += publish_time;
-            totals.merge(sync_outcome);
-            match publish_event {
-                Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::DocumentsPublished {
-                    ..
-                })) => {
-                    awaiting_sync = Some(subbatch);
+        let mut record_count = 0usize;
+        let mut deferred_total = 0usize;
+        let mut group_count = 0usize;
+        let mut subbatch_count = 0usize;
+        let mut pages = 0usize;
+        let mut oldest_record_ms: Option<u64> = None;
+        let mut read_failed = false;
+
+        // Drain the whole outbox in pages every run rather than only the FIFO
+        // head: a page of permanently-deferred records (a missing shard genesis)
+        // at the head must never starve records for other topics sitting behind
+        // it. Deferred records are left in place but paged past; published
+        // records are deleted, so the next run reads from the head again. The
+        // per-topic defer state carries across pages so a topic deferred on one
+        // page keeps deferring on the next (FIFO within a topic).
+        loop {
+            let scan_started = Instant::now();
+            let batch = match read_outbox_records(
+                &self.context.storage_handle,
+                &[],
+                start_after.clone(),
+                OUTBOX_DRAIN_BATCH_SIZE,
+            )
+            .await
+            {
+                Ok(batch) => batch,
+                Err(error) => {
+                    warn!(error = %error, "Failed to read document sync outbox record");
+                    read_failed = true;
+                    break;
                 }
-                Event::Net(NetEvent::DocumentSync(
-                    DocumentSyncNetEvent::DocumentsPartiallyPublished {
-                        published_indices,
-                        retry_indices,
-                        error,
-                    },
-                )) => {
-                    warn!(
-                        key = ?retry_key,
-                        published = published_indices.len(),
-                        retry = retry_indices.len(),
-                        error = %error,
-                        "Partially created local document sync batch"
+            };
+            scan_elapsed += scan_started.elapsed();
+            if batch.records.is_empty() {
+                break;
+            }
+            pages += 1;
+            let has_more = batch.has_more;
+            start_after = batch.records.last().map(|(key, _)| key.clone());
+            record_count += batch.records.len();
+            if let Some(page_oldest) = batch
+                .records
+                .iter()
+                .map(|(_, record)| record.outbox_id.timestamp_ms())
+                .min()
+            {
+                oldest_record_ms =
+                    Some(oldest_record_ms.map_or(page_oldest, |current| current.min(page_oldest)));
+            }
+
+            let records: Vec<DrainRecord> = batch
+                .records
+                .into_iter()
+                .map(|(record_key, mut record)| {
+                    record.placement = resolve_publish_placement(
+                        realm_config.as_ref(),
+                        &record.target,
+                        record.placement,
                     );
-                    totals.retry_needed = true;
-                    match subbatch.sync_subset(&published_indices) {
-                        Some(published_subbatch) if !published_subbatch.record_keys.is_empty() => {
-                            awaiting_sync = Some(published_subbatch);
-                        }
-                        Some(_) => {}
-                        None => {
-                            warn!(key = ?retry_key, "Invalid partial document publish indices");
+                    let topic = record.target.sync_topic_id(realm_id, &record.placement);
+                    (record_key, record, topic)
+                })
+                .collect();
+
+            // Shard topics are join-only for this node unless it is the shard's
+            // rank-0 holder: a record whose topic has no local genesis yet cannot
+            // publish. Try one bootstrap pass against the record's peers (falling
+            // back to the shard's resolved holders when the record carries none,
+            // as admin operations do), then defer whatever is still missing to a
+            // short retry — the genesis arrives via gossip or the next pass. A
+            // topic already deferred earlier this run is skipped: its records
+            // stay deferred regardless, and re-probing would only waste RPCs.
+            let mut missing_topics: BTreeMap<Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>> =
+                BTreeMap::new();
+            for (_, record, topic) in &records {
+                if !record.target.uses_shard_topic()
+                    || defer_state.deferred_topics.contains(topic)
+                    || net_handle
+                        .document_sync_topic_exists(*topic)
+                        .unwrap_or(false)
+                {
+                    continue;
+                }
+                let mut bootstrap_peers = record.peers.clone();
+                if bootstrap_peers.is_empty()
+                    && let Some(config) = realm_config.as_ref()
+                {
+                    bootstrap_peers =
+                        crate::placement::resolve_shard_holders(config, &record.placement);
+                    bootstrap_peers.retain(|peer| *peer != net_handle.node_id());
+                    crate::sync_placement::sort_node_ids(&mut bootstrap_peers);
+                }
+                if bootstrap_peers.is_empty() {
+                    continue;
+                }
+                missing_topics
+                    .entry(bootstrap_peers)
+                    .or_default()
+                    .insert(*topic);
+            }
+            for (peers, topics) in missing_topics {
+                let event = net_handle
+                    .sync_document_topics(topics.into_iter().collect(), peers)
+                    .await;
+                let outcome = self
+                    .finish_sync_drain_subbatch(
+                        &retry_key,
+                        Vec::new(),
+                        Vec::new(),
+                        Event::Net(NetEvent::DocumentSync(event)),
+                        Default::default(),
+                    )
+                    .await;
+                totals.merge(outcome);
+            }
+
+            let (to_publish, deferred) =
+                partition_drain_records(records, &mut defer_state, |topic| {
+                    net_handle
+                        .document_sync_topic_exists(topic)
+                        .unwrap_or(false)
+                });
+            deferred_total += deferred;
+
+            let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
+                BTreeMap::new();
+            for (record_key, record, topic) in to_publish {
+                let document = document_publish_from_outbox(
+                    record.outbox_id,
+                    record.target.clone(),
+                    record.event,
+                    record.placement,
+                    record.allow_genesis,
+                );
+
+                let subbatches = publish_groups.entry(record.peers.clone()).or_default();
+                if subbatches
+                    .last()
+                    .is_none_or(|subbatch| subbatch.documents.len() >= DRAIN_SUBBATCH_RECORDS)
+                {
+                    subbatches.push(DrainSubBatch {
+                        peers: record.peers,
+                        documents: Vec::new(),
+                        topics: Vec::new(),
+                        targets: Vec::new(),
+                        record_keys: Vec::new(),
+                    });
+                }
+                let subbatch = subbatches.last_mut().expect("sub-batch was just pushed");
+                subbatch.documents.push(document);
+                subbatch.topics.push(topic);
+                subbatch.targets.push(record.target);
+                subbatch.record_keys.push(record_key);
+            }
+
+            group_count += publish_groups.len();
+            let subbatches: Vec<DrainSubBatch> = publish_groups.into_values().flatten().collect();
+            subbatch_count += subbatches.len();
+
+            // Two-slot pipeline: publish sub-batch N+1 while sub-batch N syncs;
+            // sub-batches enter the sync stage strictly in submission order.
+            let mut awaiting_sync: Option<DrainSubBatch> = None;
+            for mut subbatch in subbatches {
+                let documents = std::mem::take(&mut subbatch.documents);
+                let peers = subbatch.peers.clone();
+                let publish = async {
+                    let publish_started = Instant::now();
+                    let event = net_handle
+                        .send_effect(Effect::Net(NetEffect::DocumentSync(
+                            DocumentSyncEffect::PublishDocuments { documents, peers },
+                        )))
+                        .await;
+                    (event, publish_started.elapsed())
+                };
+                let ((publish_event, publish_time), sync_outcome) = tokio::join!(
+                    publish,
+                    self.sync_drain_subbatch(&retry_key, net_handle, awaiting_sync.take())
+                );
+                publish_elapsed += publish_time;
+                totals.merge(sync_outcome);
+                match publish_event {
+                    Event::Net(NetEvent::DocumentSync(
+                        DocumentSyncNetEvent::DocumentsPublished { .. },
+                    )) => {
+                        awaiting_sync = Some(subbatch);
+                    }
+                    Event::Net(NetEvent::DocumentSync(
+                        DocumentSyncNetEvent::DocumentsPartiallyPublished {
+                            published_indices,
+                            retry_indices,
+                            error,
+                        },
+                    )) => {
+                        warn!(
+                            key = ?retry_key,
+                            published = published_indices.len(),
+                            retry = retry_indices.len(),
+                            error = %error,
+                            "Partially created local document sync batch"
+                        );
+                        totals.retry_needed = true;
+                        match subbatch.sync_subset(&published_indices) {
+                            Some(published_subbatch)
+                                if !published_subbatch.record_keys.is_empty() =>
+                            {
+                                awaiting_sync = Some(published_subbatch);
+                            }
+                            Some(_) => {}
+                            None => {
+                                warn!(key = ?retry_key, "Invalid partial document publish indices");
+                            }
                         }
                     }
-                }
-                Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
-                    error, ..
-                })) => {
-                    warn!(key = ?retry_key, error = %error, "Failed to create local document sync batch");
-                    totals.retry_needed = true;
-                }
-                Event::Net(NetEvent::Error(error)) => {
-                    warn!(key = ?retry_key, error = ?error, "Failed to create local document sync batch");
-                    totals.retry_needed = true;
-                }
-                other => {
-                    warn!(key = ?retry_key, event = ?other, "Unexpected local document sync batch result");
-                    totals.retry_needed = true;
+                    Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
+                        error,
+                        ..
+                    })) => {
+                        warn!(key = ?retry_key, error = %error, "Failed to create local document sync batch");
+                        totals.retry_needed = true;
+                    }
+                    Event::Net(NetEvent::Error(error)) => {
+                        warn!(key = ?retry_key, error = ?error, "Failed to create local document sync batch");
+                        totals.retry_needed = true;
+                    }
+                    other => {
+                        warn!(key = ?retry_key, event = ?other, "Unexpected local document sync batch result");
+                        totals.retry_needed = true;
+                    }
                 }
             }
+            let sync_outcome = self
+                .sync_drain_subbatch(&retry_key, net_handle, awaiting_sync.take())
+                .await;
+            totals.merge(sync_outcome);
+
+            if !has_more {
+                break;
+            }
         }
-        let sync_outcome = self
-            .sync_drain_subbatch(&retry_key, net_handle, awaiting_sync.take())
-            .await;
-        totals.merge(sync_outcome);
+
+        if record_count == 0 {
+            if read_failed {
+                self.reschedule_with_backoff(retry_key).await;
+            } else {
+                self.reset_backoff(&retry_key);
+            }
+            return;
+        }
 
         let oldest_age_ms = oldest_record_ms
             .map(|record_ms| unix_timestamp_millis().saturating_sub(record_ms))
@@ -537,9 +600,10 @@ impl OperationsTaskHandler {
         info!(
             event = "pipeline.drain.summary",
             records = record_count,
-            deferred,
+            deferred = deferred_total,
             groups = group_count,
             subbatches = subbatch_count,
+            pages,
             scan_ms = duration_ms(scan_elapsed),
             publish_ms = duration_ms(publish_elapsed),
             sync_ms = duration_ms(totals.sync_elapsed),
@@ -548,20 +612,16 @@ impl OperationsTaskHandler {
             total_ms = duration_ms(drain_started.elapsed()),
             oldest_age_ms,
             retry = totals.retry_needed,
-            has_more = batch.has_more,
             "Document sync outbox drain summary"
         );
 
-        if totals.retry_needed {
+        if totals.retry_needed || read_failed {
             self.reschedule_with_backoff(retry_key).await;
-        } else if deferred > 0 {
+        } else if deferred_total > 0 {
             // Deferred records wait only for a genesis to arrive from the
             // shard's rank-0 holder; retry quickly rather than on the failure
             // backoff.
             self.reschedule_timer(retry_key, DOCUMENT_SYNC_DEFER_RETRY_AFTER)
-                .await;
-        } else if batch.has_more {
-            self.reschedule_timer(retry_key, std::time::Duration::ZERO)
                 .await;
         } else {
             self.reset_backoff(&retry_key);
@@ -1485,6 +1545,11 @@ mod tests {
         let subbatch = DrainSubBatch {
             peers: vec![node(2)],
             documents: Vec::new(),
+            topics: vec![
+                irokle::TopicId::hash(b"first"),
+                irokle::TopicId::hash(b"second"),
+                irokle::TopicId::hash(b"third"),
+            ],
             targets: vec![
                 duplicate_target.clone(),
                 other_target,
@@ -1498,6 +1563,7 @@ mod tests {
             .expect("published index selects a record");
 
         assert_eq!(selected.targets, vec![duplicate_target]);
+        assert_eq!(selected.topics, vec![irokle::TopicId::hash(b"third")]);
         assert_eq!(selected.record_keys, vec![b"third".to_vec()]);
         assert!(selected.documents.is_empty());
         assert!(subbatch.sync_subset(&[3]).is_none());
@@ -1513,6 +1579,7 @@ mod tests {
                 change: change(),
             },
             aruna_core::structs::PlacementRef::NIL,
+            false,
         )
     }
 
@@ -1533,7 +1600,8 @@ mod tests {
         ];
 
         let mut calls = 0usize;
-        let (to_publish, deferred) = partition_drain_records(records, |_| {
+        let mut defer = DrainDeferState::default();
+        let (to_publish, deferred) = partition_drain_records(records, &mut defer, |_| {
             calls += 1;
             calls > 1
         });
@@ -1554,11 +1622,132 @@ mod tests {
             (b"newer".to_vec(), shard_topic_record(2), topic),
         ];
 
-        let (to_publish, deferred) = partition_drain_records(records, |_| true);
+        let mut defer = DrainDeferState::default();
+        let (to_publish, deferred) = partition_drain_records(records, &mut defer, |_| true);
 
         assert_eq!(deferred, 0);
         let keys: Vec<Vec<u8>> = to_publish.into_iter().map(|(key, _, _)| key).collect();
         assert_eq!(keys, vec![b"older".to_vec(), b"newer".to_vec()]);
+    }
+
+    // A full first page of records for a genesis-less shard topic (all deferred)
+    // must not starve records for other topics behind it in the FIFO: the drain
+    // pages the whole outbox per run, so a later-page record still publishes.
+    #[tokio::test]
+    async fn drain_paginates_past_a_deferred_head_page_to_publish_later_records() {
+        let realm_id = RealmId::from_bytes([44u8; 32]);
+        let temp_dir = tempdir().expect("temp dir");
+        let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))
+            .expect("storage opens");
+        let net = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().expect("bind addr"),
+                realm_id,
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage.clone(),
+        )
+        .await
+        .expect("net handle");
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: Some(net.clone()),
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: Some(TaskHandle::new()),
+        });
+
+        // Every head-page record targets one shard topic with no local genesis,
+        // so all of them defer.
+        let deferred_change = DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id: Ulid::from_parts(8, 1),
+                actor: node(1),
+                updated_at_ms: 9,
+            },
+            kind: DocumentSyncChangeKind::Upsert,
+            placement: aruna_core::structs::PlacementRef {
+                strategy_id: Ulid::from_parts(42, 1),
+                epoch: 0,
+                shard: 3,
+            },
+        };
+        let deferred_target = DocumentSyncTarget::MetadataRegistry {
+            group_id: Ulid::from_parts(1, 1),
+            document_id: Ulid::from_parts(2, 2),
+        };
+        let mut writes = Vec::with_capacity(OUTBOX_DRAIN_BATCH_SIZE + 1);
+        for index in 0..OUTBOX_DRAIN_BATCH_SIZE {
+            let record = crate::document_sync_outbox::new_outbox_record_with_id(
+                Ulid::from_parts(1, index as u128),
+                node(1),
+                deferred_target.clone(),
+                Vec::new(),
+                DocumentSyncOutboxEvent::Upsert {
+                    bytes: Vec::new(),
+                    change: deferred_change,
+                },
+                aruna_core::structs::PlacementRef::NIL,
+                false,
+            );
+            writes.push(
+                crate::document_sync_outbox::outbox_write_entry(&record).expect("outbox entry"),
+            );
+        }
+
+        // One later record for a shared (non-shard) topic, ordered strictly after
+        // the head page, so only pagination reaches it.
+        let publish_record = crate::document_sync_outbox::new_outbox_record_with_id(
+            Ulid::from_parts(2, 0),
+            node(1),
+            DocumentSyncTarget::RealmAuthorization { realm_id },
+            Vec::new(),
+            DocumentSyncOutboxEvent::Upsert {
+                bytes: b"realm-auth".to_vec(),
+                change: change(),
+            },
+            aruna_core::structs::PlacementRef::NIL,
+            false,
+        );
+        let publish_key = outbox_key(&publish_record).to_vec();
+        writes
+            .push(crate::document_sync_outbox::outbox_write_entry(&publish_record).expect("entry"));
+
+        match storage
+            .send_effect(Effect::Storage(StorageEffect::BatchWrite {
+                writes,
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::BatchWriteResult { .. }) => {}
+            other => panic!("unexpected batch write event: {other:?}"),
+        }
+
+        let handler = OperationsTaskHandler::new(context);
+        handler.drain_document_sync_outbox().await;
+
+        assert_eq!(
+            read_outbox_record(&storage, &publish_key)
+                .await
+                .expect("read publish record"),
+            None,
+            "the later-page record must publish despite an all-deferred first page"
+        );
+        let remaining = read_outbox_records(&storage, &[], None, OUTBOX_DRAIN_BATCH_SIZE + 8)
+            .await
+            .expect("read remaining");
+        assert_eq!(
+            remaining.records.len(),
+            OUTBOX_DRAIN_BATCH_SIZE,
+            "every deferred record is retained for the next run"
+        );
+
+        net.shutdown().await;
     }
 
     async fn restore_document_sync_outbox_timer_and_receive_key(

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -214,19 +214,20 @@ impl DrainSyncOutcome {
 
 /// Per-run defer state, carried across the drain's pages so a topic deferred on
 /// one page keeps deferring on later pages (preserving FIFO within a topic) and
-/// each topic's genesis presence is probed at most once per run.
+/// each topic's holdership and genesis presence are decided at most once per run.
 #[derive(Default)]
 struct DrainDeferState {
     topic_exists: HashMap<irokle::TopicId, bool>,
+    topic_held: HashMap<irokle::TopicId, bool>,
     deferred_topics: HashSet<irokle::TopicId>,
     undeliverable_topics: HashSet<irokle::TopicId>,
 }
 
-/// What a record whose shard topic has no local genesis is waiting for.
+/// Whether a shard-classed record can ever publish from this node.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DeferOutcome {
-    /// The local node holds the bucket, so the genesis is on its way (rank-0
-    /// creates it, every other holder pulls it): keep the record and retry.
+    /// The local node holds the bucket, so it may publish onto the bucket's topic
+    /// once the genesis is there (rank-0 creates it, every other holder pulls it).
     Retry,
     /// The local node holds none of the record's bucket. Topic membership is the
     /// holder set, so it may neither mint the genesis nor join the topic: this
@@ -236,14 +237,22 @@ enum DeferOutcome {
 
 /// Splits FIFO-ordered drain records into those to publish now, those deferred
 /// because their shard topic has no local genesis yet, and those that can never
-/// publish from this node at all. Each topic's availability is evaluated once
-/// per run (state persists in `defer`); once a topic defers, every later record
-/// of that topic defers too. Splitting FIFO-adjacent records of one topic across
-/// a defer/publish boundary would let the newer op publish first, invert its
-/// origin sequence on receivers, and drop the older op forever as
-/// StaleOriginSequence — so a topic never straddles that boundary within a run,
-/// across pages included. A shard topic's holder set is a function of its
-/// placement, so undeliverability is likewise decided once per topic.
+/// publish from this node at all.
+///
+/// Holdership is checked *before* topic availability, and it is the only thing
+/// that decides publishability. Joining a shard topic is not holder-gated — a
+/// non-holder can adopt a co-holder's genesis, and the drain's own bootstrap pass
+/// will happily pull one — but its publishes onto that topic are not accepted. So
+/// "the topic exists locally" is not evidence this node may publish onto it, and
+/// classifying on that first would route a non-holder's records into a publish
+/// that silently goes nowhere instead of into the forwarding path.
+///
+/// Each topic's holdership and genesis presence are decided once per run (state
+/// persists in `defer`); once a topic defers, every later record of that topic
+/// defers too. Splitting FIFO-adjacent records of one topic across a
+/// defer/publish boundary would let the newer op publish first, invert its origin
+/// sequence on receivers, and drop the older op forever as StaleOriginSequence —
+/// so a topic never straddles that boundary within a run, across pages included.
 fn partition_drain_records(
     records: Vec<DrainRecord>,
     defer: &mut DrainDeferState,
@@ -262,6 +271,15 @@ fn partition_drain_records(
             undeliverable.push((record_key, record, topic));
             continue;
         }
+        let held = *defer
+            .topic_held
+            .entry(topic)
+            .or_insert_with(|| classify_defer(&record) == DeferOutcome::Retry);
+        if !held {
+            defer.undeliverable_topics.insert(topic);
+            undeliverable.push((record_key, record, topic));
+            continue;
+        }
         let already_deferred = defer.deferred_topics.contains(&topic);
         let available = !already_deferred
             && *defer
@@ -270,11 +288,6 @@ fn partition_drain_records(
                 .or_insert_with(|| topic_available(topic));
         if available {
             to_publish.push((record_key, record, topic));
-            continue;
-        }
-        if !already_deferred && classify_defer(&record) == DeferOutcome::Undeliverable {
-            defer.undeliverable_topics.insert(topic);
-            undeliverable.push((record_key, record, topic));
             continue;
         }
         defer.deferred_topics.insert(topic);
@@ -557,11 +570,23 @@ impl OperationsTaskHandler {
             // short retry — the genesis arrives via gossip or the next pass. A
             // topic already deferred earlier this run is skipped: its records
             // stay deferred regardless, and re-probing would only waste RPCs.
+            //
+            // Only buckets this node holds are pulled. Joining is not holder-gated,
+            // so a non-holder could adopt the genesis here — and would then look
+            // publishable while its publishes went nowhere. Its records belong in
+            // the forwarding path instead.
             let mut missing_topics: BTreeMap<Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>> =
                 BTreeMap::new();
             for (_, record, topic) in &records {
                 if !record.target.uses_shard_topic()
                     || defer_state.deferred_topics.contains(topic)
+                    || !realm_config.as_ref().is_none_or(|config| {
+                        crate::placement::holds_placement(
+                            config,
+                            &record.placement,
+                            net_handle.node_id(),
+                        )
+                    })
                     || net_handle
                         .document_sync_topic_exists(*topic)
                         .unwrap_or(false)

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1449,6 +1449,7 @@ mod tests {
                 bytes: b"restore durable work".to_vec(),
                 change: change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         write_outbox_record(&storage, &record).await;
@@ -1522,6 +1523,7 @@ mod tests {
                 bytes: b"retained work".to_vec(),
                 change: change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         let key = outbox_key(&record).to_vec();
@@ -1569,6 +1571,7 @@ mod tests {
                 bytes: b"retry after restart".to_vec(),
                 change: change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         let key = outbox_key(&record).to_vec();

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -349,48 +349,31 @@ impl OperationsTaskHandler {
         }
     }
 
-    /// Relays records this node can never publish to a holder of their bucket.
+    /// Surfaces records this node can never publish, loudly, and leaves them in
+    /// the outbox.
     ///
     /// This node holds none of the record's bucket, so it may neither mint that
-    /// bucket's topic genesis nor join the topic: retrying locally would never
-    /// drain it. Deleting it would be silent data loss instead — the caller
-    /// already holds a 200, and an admin-operation outbox record has no replay
-    /// source — so the record goes to a holder, which publishes it. Only a
-    /// successfully relayed record is deleted; one that cannot be relayed (no
-    /// reachable holder) is left in the outbox to be retried on the next drain,
-    /// loudly, rather than thrown away because a peer was briefly down.
-    async fn forward_undeliverable_records(&self, undeliverable: Vec<DrainRecord>) -> usize {
-        let mut keys = Vec::with_capacity(undeliverable.len());
-        for (record_key, record, topic) in undeliverable {
-            match crate::metadata::forward::forward_outbox_record(&self.context, &record).await {
-                Ok(()) => {
-                    debug!(
-                        event = "pipeline.drain.forwarded",
-                        target = ?record.target,
-                        %topic,
-                        "Relayed an unpublishable document sync outbox record to a bucket holder"
-                    );
-                    keys.push(record_key);
-                }
-                Err(error) => error!(
-                    event = "pipeline.drain.undeliverable",
-                    target = ?record.target,
-                    %topic,
-                    strategy = %record.placement.strategy_id,
-                    shard = record.placement.shard,
-                    age_ms = unix_timestamp_millis().saturating_sub(record.outbox_id.timestamp_ms()),
-                    error = %error,
-                    "Cannot publish a document sync outbox record from this node and no holder accepted the relay; retrying"
-                ),
-            }
+    /// bucket's topic genesis nor join the topic: it can never publish the record
+    /// from here. The record is never relayed to a holder — a peer-relayed
+    /// upsert/delete would publish under the holder's signature with no proof it
+    /// was permission-checked — and never deleted, since the caller already holds
+    /// a 200 and there is no replay source. It stays in the outbox, error-logged
+    /// on every drain, until a config change makes this node a holder or an
+    /// operator intervenes. In practice the only record that lands here is the
+    /// rare rebalance race: a node that held the bucket when it accepted the
+    /// write and lost holdership before draining.
+    fn report_undeliverable_records(&self, undeliverable: &[DrainRecord]) {
+        for (_, record, topic) in undeliverable {
+            error!(
+                event = "pipeline.drain.undeliverable",
+                target = ?record.target,
+                %topic,
+                strategy = %record.placement.strategy_id,
+                shard = record.placement.shard,
+                age_ms = unix_timestamp_millis().saturating_sub(record.outbox_id.timestamp_ms()),
+                "Cannot publish a document sync outbox record from this node and it is not relayable; leaving it in the outbox"
+            );
         }
-        let forwarded = keys.len();
-        if !keys.is_empty()
-            && let Err(error) = delete_outbox_records(&self.context.storage_handle, keys).await
-        {
-            error!(error = %error, "Failed to delete relayed document sync outbox records");
-        }
-        forwarded
     }
 
     /// Backoff interval for the next re-arm of `key`, derived from the in-memory
@@ -497,7 +480,7 @@ impl OperationsTaskHandler {
         let mut publish_elapsed = Duration::ZERO;
         let mut record_count = 0usize;
         let mut deferred_total = 0usize;
-        let mut forwarded_total = 0usize;
+        let mut undeliverable_total = 0usize;
         let mut group_count = 0usize;
         let mut subbatch_count = 0usize;
         let mut pages = 0usize;
@@ -638,7 +621,8 @@ impl OperationsTaskHandler {
             );
             deferred_total += deferred.len();
             report_stuck_records(&deferred);
-            forwarded_total += self.forward_undeliverable_records(undeliverable).await;
+            undeliverable_total += undeliverable.len();
+            self.report_undeliverable_records(&undeliverable);
 
             let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
                 BTreeMap::new();
@@ -781,7 +765,7 @@ impl OperationsTaskHandler {
             event = "pipeline.drain.summary",
             records = record_count,
             deferred = deferred_total,
-            forwarded = forwarded_total,
+            undeliverable = undeliverable_total,
             groups = group_count,
             subbatches = subbatch_count,
             pages,

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -141,7 +141,9 @@ fn resolve_publish_placement(
         return current;
     }
     match config {
-        Some(config) => crate::placement::placement_ref_for_target(config, target, None),
+        Some(config) => {
+            crate::placement::placement_ref_for_target(config, target, Default::default())
+        }
         None => aruna_core::structs::PlacementRef::NIL,
     }
 }

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
-use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncPublish, DocumentSyncTarget};
+use aruna_core::document::{
+    DocumentSyncOutboxEvent, DocumentSyncOutboxRecord, DocumentSyncPublish, DocumentSyncTarget,
+};
 use aruna_core::effects::{Effect, NetEffect, StorageEffect};
 use aruna_core::events::{Event, NetEvent, StorageEvent};
 use aruna_core::handle::Handle;
@@ -76,6 +78,9 @@ use crate::usage_stats::{
 
 const DRAIN_SUBBATCH_RECORDS: usize = 512;
 const DURABLE_QUEUE_REARM_AFTER: Duration = Duration::from_secs(5);
+/// How long a record may wait for its shard topic's genesis before the drain
+/// stops treating the wait as normal and says so at error level.
+const OUTBOX_STUCK_AFTER: Duration = Duration::from_secs(300);
 
 /// One drained outbox record with its resolved publish topic.
 type DrainRecord = (
@@ -214,45 +219,113 @@ impl DrainSyncOutcome {
 struct DrainDeferState {
     topic_exists: HashMap<irokle::TopicId, bool>,
     deferred_topics: HashSet<irokle::TopicId>,
+    undeliverable_topics: HashSet<irokle::TopicId>,
 }
 
-/// Splits FIFO-ordered drain records into those to publish now and a count of
-/// those deferred because their shard topic has no local genesis yet. Each
-/// topic's availability is evaluated once per run (state persists in `defer`);
-/// once a topic defers, every later record of that topic defers too. Splitting
-/// FIFO-adjacent records of one topic across a defer/publish boundary would let
-/// the newer op publish first, invert its origin sequence on receivers, and drop
-/// the older op forever as StaleOriginSequence — so a topic never straddles that
-/// boundary within a run, across pages included.
+/// What a record whose shard topic has no local genesis is waiting for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeferOutcome {
+    /// The local node holds the bucket, so the genesis is on its way (rank-0
+    /// creates it, every other holder pulls it): keep the record and retry.
+    Retry,
+    /// The local node holds none of the record's bucket. Topic membership is the
+    /// holder set, so it may neither mint the genesis nor join the topic: this
+    /// record can never publish from here, however long it waits.
+    Undeliverable,
+}
+
+/// Splits FIFO-ordered drain records into those to publish now, those deferred
+/// because their shard topic has no local genesis yet, and those that can never
+/// publish from this node at all. Each topic's availability is evaluated once
+/// per run (state persists in `defer`); once a topic defers, every later record
+/// of that topic defers too. Splitting FIFO-adjacent records of one topic across
+/// a defer/publish boundary would let the newer op publish first, invert its
+/// origin sequence on receivers, and drop the older op forever as
+/// StaleOriginSequence — so a topic never straddles that boundary within a run,
+/// across pages included. A shard topic's holder set is a function of its
+/// placement, so undeliverability is likewise decided once per topic.
 fn partition_drain_records(
     records: Vec<DrainRecord>,
     defer: &mut DrainDeferState,
     mut topic_available: impl FnMut(irokle::TopicId) -> bool,
-) -> (Vec<DrainRecord>, usize) {
+    mut classify_defer: impl FnMut(&DocumentSyncOutboxRecord) -> DeferOutcome,
+) -> (Vec<DrainRecord>, Vec<DrainRecord>, Vec<DrainRecord>) {
     let mut to_publish = Vec::with_capacity(records.len());
-    let mut deferred = 0usize;
+    let mut deferred = Vec::new();
+    let mut undeliverable = Vec::new();
     for (record_key, record, topic) in records {
-        if record.target.uses_shard_topic() {
-            let available = !defer.deferred_topics.contains(&topic)
-                && *defer
-                    .topic_exists
-                    .entry(topic)
-                    .or_insert_with(|| topic_available(topic));
-            if !available {
-                defer.deferred_topics.insert(topic);
-                debug!(
-                    event = "pipeline.drain.deferred",
-                    target = ?record.target,
-                    %topic,
-                    "Deferring outbox record: shard topic genesis not yet known"
-                );
-                deferred += 1;
-                continue;
-            }
+        if !record.target.uses_shard_topic() {
+            to_publish.push((record_key, record, topic));
+            continue;
         }
-        to_publish.push((record_key, record, topic));
+        if defer.undeliverable_topics.contains(&topic) {
+            undeliverable.push((record_key, record, topic));
+            continue;
+        }
+        let already_deferred = defer.deferred_topics.contains(&topic);
+        let available = !already_deferred
+            && *defer
+                .topic_exists
+                .entry(topic)
+                .or_insert_with(|| topic_available(topic));
+        if available {
+            to_publish.push((record_key, record, topic));
+            continue;
+        }
+        if !already_deferred && classify_defer(&record) == DeferOutcome::Undeliverable {
+            defer.undeliverable_topics.insert(topic);
+            undeliverable.push((record_key, record, topic));
+            continue;
+        }
+        defer.deferred_topics.insert(topic);
+        debug!(
+            event = "pipeline.drain.deferred",
+            target = ?record.target,
+            %topic,
+            "Deferring outbox record: shard topic genesis not yet known"
+        );
+        deferred.push((record_key, record, topic));
     }
-    (to_publish, deferred)
+    (to_publish, deferred, undeliverable)
+}
+
+/// Whether a record whose shard topic is missing locally can ever publish from
+/// here. Holdership is read from the live realm config, never from the presence
+/// of a local copy: a rebalance leaves a stale copy on a node that has lost the
+/// bucket. Without a readable config nothing is decided and the record retries.
+fn classify_deferred_record(
+    config: Option<&aruna_core::structs::RealmConfigDocument>,
+    net_handle: &aruna_net::NetHandle,
+    record: &DocumentSyncOutboxRecord,
+) -> DeferOutcome {
+    let Some(config) = config else {
+        return DeferOutcome::Retry;
+    };
+    if crate::placement::holds_placement(config, &record.placement, net_handle.node_id()) {
+        DeferOutcome::Retry
+    } else {
+        DeferOutcome::Undeliverable
+    }
+}
+
+/// Escalates a record that has been waiting for its shard topic far longer than
+/// a genesis takes to arrive. It is still retried, but it stops being silent.
+fn report_stuck_records(deferred: &[DrainRecord]) {
+    let now_ms = unix_timestamp_millis();
+    for (_, record, topic) in deferred {
+        let age_ms = now_ms.saturating_sub(record.outbox_id.timestamp_ms());
+        if age_ms >= OUTBOX_STUCK_AFTER.as_millis() as u64 {
+            error!(
+                event = "pipeline.drain.stuck",
+                target = ?record.target,
+                %topic,
+                age_ms,
+                strategy = %record.placement.strategy_id,
+                shard = record.placement.shard,
+                "Document sync outbox record is stuck: this node holds the bucket but its shard topic genesis has never arrived"
+            );
+        }
+    }
 }
 
 impl OperationsTaskHandler {
@@ -261,6 +334,34 @@ impl OperationsTaskHandler {
             context,
             retry_backoff: std::sync::Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Drops records that can never publish from this node, loudly. Leaving them
+    /// in the outbox would retry them forever against a topic this node may not
+    /// join: a deferred record that can never drain is silent data loss, so the
+    /// operator is told instead.
+    async fn drop_undeliverable_records(&self, undeliverable: Vec<DrainRecord>) -> usize {
+        if undeliverable.is_empty() {
+            return 0;
+        }
+        let mut keys = Vec::with_capacity(undeliverable.len());
+        for (record_key, record, topic) in undeliverable {
+            error!(
+                event = "pipeline.drain.undeliverable",
+                target = ?record.target,
+                %topic,
+                strategy = %record.placement.strategy_id,
+                shard = record.placement.shard,
+                age_ms = unix_timestamp_millis().saturating_sub(record.outbox_id.timestamp_ms()),
+                "Dropping undeliverable document sync outbox record: this node holds none of its bucket, so it can neither mint nor join the shard topic"
+            );
+            keys.push(record_key);
+        }
+        let dropped = keys.len();
+        if let Err(error) = delete_outbox_records(&self.context.storage_handle, keys).await {
+            error!(error = %error, "Failed to delete undeliverable document sync outbox records");
+        }
+        dropped
     }
 
     /// Backoff interval for the next re-arm of `key`, derived from the in-memory
@@ -367,6 +468,7 @@ impl OperationsTaskHandler {
         let mut publish_elapsed = Duration::ZERO;
         let mut record_count = 0usize;
         let mut deferred_total = 0usize;
+        let mut undeliverable_total = 0usize;
         let mut group_count = 0usize;
         let mut subbatch_count = 0usize;
         let mut pages = 0usize;
@@ -483,13 +585,19 @@ impl OperationsTaskHandler {
                 totals.merge(outcome);
             }
 
-            let (to_publish, deferred) =
-                partition_drain_records(records, &mut defer_state, |topic| {
+            let (to_publish, deferred, undeliverable) = partition_drain_records(
+                records,
+                &mut defer_state,
+                |topic| {
                     net_handle
                         .document_sync_topic_exists(topic)
                         .unwrap_or(false)
-                });
-            deferred_total += deferred;
+                },
+                |record| classify_deferred_record(realm_config.as_ref(), net_handle, record),
+            );
+            deferred_total += deferred.len();
+            report_stuck_records(&deferred);
+            undeliverable_total += self.drop_undeliverable_records(undeliverable).await;
 
             let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
                 BTreeMap::new();
@@ -632,6 +740,7 @@ impl OperationsTaskHandler {
             event = "pipeline.drain.summary",
             records = record_count,
             deferred = deferred_total,
+            undeliverable = undeliverable_total,
             groups = group_count,
             subbatches = subbatch_count,
             pages,
@@ -1628,17 +1737,23 @@ mod tests {
 
         let mut calls = 0usize;
         let mut defer = DrainDeferState::default();
-        let (to_publish, deferred) = partition_drain_records(records, &mut defer, |_| {
-            calls += 1;
-            calls > 1
-        });
+        let (to_publish, deferred, undeliverable) = partition_drain_records(
+            records,
+            &mut defer,
+            |_| {
+                calls += 1;
+                calls > 1
+            },
+            |_| DeferOutcome::Retry,
+        );
 
         assert_eq!(calls, 1, "topic availability is evaluated once per run");
         assert!(
             to_publish.is_empty(),
             "no record of a deferred topic may publish"
         );
-        assert_eq!(deferred, 2);
+        assert_eq!(deferred.len(), 2);
+        assert!(undeliverable.is_empty());
     }
 
     #[test]
@@ -1650,10 +1765,42 @@ mod tests {
         ];
 
         let mut defer = DrainDeferState::default();
-        let (to_publish, deferred) = partition_drain_records(records, &mut defer, |_| true);
+        let (to_publish, deferred, undeliverable) =
+            partition_drain_records(records, &mut defer, |_| true, |_| DeferOutcome::Retry);
 
-        assert_eq!(deferred, 0);
+        assert!(deferred.is_empty());
+        assert!(undeliverable.is_empty());
         let keys: Vec<Vec<u8>> = to_publish.into_iter().map(|(key, _, _)| key).collect();
+        assert_eq!(keys, vec![b"older".to_vec(), b"newer".to_vec()]);
+    }
+
+    // A record for a bucket this node does not hold can never publish: it may
+    // neither mint the topic's genesis nor join the topic. Deferring it forever
+    // would be silent data loss, so it is separated out to be dropped loudly.
+    #[test]
+    fn unheld_bucket_records_are_undeliverable() {
+        let topic = irokle::TopicId::hash(b"unheld-bucket");
+        let records = vec![
+            (b"older".to_vec(), shard_topic_record(1), topic),
+            (b"newer".to_vec(), shard_topic_record(2), topic),
+        ];
+
+        let mut classified = 0usize;
+        let mut defer = DrainDeferState::default();
+        let (to_publish, deferred, undeliverable) = partition_drain_records(
+            records,
+            &mut defer,
+            |_| false,
+            |_| {
+                classified += 1;
+                DeferOutcome::Undeliverable
+            },
+        );
+
+        assert_eq!(classified, 1, "holdership is decided once per topic");
+        assert!(to_publish.is_empty());
+        assert!(deferred.is_empty());
+        let keys: Vec<Vec<u8>> = undeliverable.into_iter().map(|(key, _, _)| key).collect();
         assert_eq!(keys, vec![b"older".to_vec(), b"newer".to_vec()]);
     }
 

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -323,6 +323,23 @@ impl OperationsTaskHandler {
         }
     }
 
+    // Kicks the placement reconciler immediately (not persisted; it is re-derived
+    // from the realm config at startup by `restore_shard_subscriptions`).
+    async fn schedule_sync_placements(&self, realm_id: RealmId, node_id: aruna_core::NodeId) {
+        let Some(task_handle) = self.context.task_handle.as_ref() else {
+            warn!("Cannot schedule shard placement sync without task handle");
+            return;
+        };
+        let effect = Effect::Task(TaskEffect::ResetTimer {
+            key: TaskKey::SyncPlacements { realm_id, node_id },
+            after: Duration::ZERO,
+        });
+        if let Event::Task(TaskEvent::Error { message, .. }) = task_handle.send_effect(effect).await
+        {
+            warn!(message = %message, "Failed to schedule shard placement sync after local realm config change");
+        }
+    }
+
     async fn drain_document_sync_outbox(&self) {
         let retry_key = TaskKey::DrainDocumentSyncOutbox;
         let drain_started = Instant::now();
@@ -342,6 +359,7 @@ impl OperationsTaskHandler {
 
         let mut totals = DrainSyncOutcome::default();
         let mut defer_state = DrainDeferState::default();
+        let mut realm_config_drained = false;
         let mut start_after: Option<Vec<u8>> = None;
         let mut scan_elapsed = Duration::ZERO;
         let mut publish_elapsed = Duration::ZERO;
@@ -399,6 +417,8 @@ impl OperationsTaskHandler {
                 .records
                 .into_iter()
                 .map(|(record_key, mut record)| {
+                    realm_config_drained |=
+                        matches!(record.target, DocumentSyncTarget::RealmConfig { .. });
                     record.placement = resolve_publish_placement(
                         realm_config.as_ref(),
                         &record.target,
@@ -583,6 +603,15 @@ impl OperationsTaskHandler {
             if !has_more {
                 break;
             }
+        }
+
+        // A locally-originated realm-config change (strategy upsert, node
+        // placement, quota) must re-run the placement reconciler on this origin
+        // so its rank-0 shard topic geneses are created without a restart; the
+        // inbound reconcile path does the same for remote changes.
+        if realm_config_drained {
+            self.schedule_sync_placements(realm_id, net_handle.node_id())
+                .await;
         }
 
         if record_count == 0 {
@@ -1746,6 +1775,108 @@ mod tests {
             OUTBOX_DRAIN_BATCH_SIZE,
             "every deferred record is retained for the next run"
         );
+
+        net.shutdown().await;
+    }
+
+    // A realm-config change originated locally lands only in the outbox; draining
+    // it must kick the placement reconciler so this rank-0 node creates its shard
+    // topic geneses without waiting for a restart.
+    #[tokio::test]
+    async fn draining_a_local_realm_config_change_creates_rank0_shard_topics() {
+        let realm_id = RealmId::from_bytes([61u8; 32]);
+        let temp_dir = tempdir().expect("temp dir");
+        let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))
+            .expect("storage opens");
+        let net = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().expect("bind addr"),
+                realm_id,
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage.clone(),
+        )
+        .await
+        .expect("net handle");
+        let task_handle = TaskHandle::new();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: Some(net.clone()),
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: Some(task_handle.clone()),
+        });
+
+        // Install the config so this sole node is rank-0 of every shard, but do
+        // not run the placement reconciler yet.
+        let mut config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+        config.seed_default_placement();
+        config.ensure_node(net.node_id(), RealmNodeKind::Management);
+        let actor = Actor {
+            node_id: net.node_id(),
+            user_id: UserId::nil(realm_id),
+            realm_id,
+        };
+        match storage
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: config.to_bytes(&actor).expect("config bytes").into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected realm config write: {other:?}"),
+        }
+        net.refresh_realm_peers_from_document(&config)
+            .await
+            .expect("refresh peers");
+
+        initialize_task_incoming(context.clone(), task_handle.clone()).await;
+
+        let strategy_id = config.strategies.first().expect("a strategy").strategy_id;
+        let topic = aruna_core::document::shard_topic_id(
+            realm_id,
+            &aruna_core::structs::PlacementRef {
+                strategy_id,
+                epoch: 0,
+                shard: 0,
+            },
+        );
+        assert!(
+            !net.document_sync_topic_exists(topic).unwrap_or(false),
+            "the rank-0 shard topic must not exist before the config change is drained"
+        );
+
+        let record = crate::document_sync_outbox::new_outbox_record(
+            net.node_id(),
+            DocumentSyncTarget::RealmConfig { realm_id },
+            Vec::new(),
+            DocumentSyncOutboxEvent::Upsert {
+                bytes: b"config".to_vec(),
+                change: change(),
+            },
+            aruna_core::structs::PlacementRef::NIL,
+        );
+        write_outbox_record(&storage, &record).await;
+        task_handle
+            .send_effect(crate::document_sync_outbox::schedule_outbox_drain_effect())
+            .await;
+
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            if net.document_sync_topic_exists(topic).unwrap_or(false) {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "rank-0 shard topic was not created after the local config change drained"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
 
         net.shutdown().await;
     }

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -59,7 +59,7 @@ use crate::notifications::watch::interest::{
     WATCH_INTEREST_PUBLISH_DEBOUNCE, rebuild_watch_interest_table,
     refresh_watch_interest_for_targets, restore_watch_interest_publish_timer,
 };
-use crate::process_placements::process_shard_placements;
+use crate::process_placements::{PlacementReconcileStatus, process_shard_placements};
 use crate::queue_backoff::timer_retry_after_secs;
 use crate::replication::queue::{
     BLOB_REPLICATION_RETRY_AFTER, process_blob_replication_batch, restore_blob_replication_timer,
@@ -68,7 +68,7 @@ use crate::s3::refresh_reference_metadata::{
     REFERENCE_METADATA_REFRESH_RETRY_AFTER, process_reference_metadata_refresh_batch,
     restore_reference_metadata_refresh_timer,
 };
-use crate::sync_placement::DOCUMENT_SYNC_DEFER_RETRY_AFTER;
+use crate::sync_placement::{DOCUMENT_SYNC_DEFER_RETRY_AFTER, SYNC_PLACEMENT_RETRY_AFTER};
 use crate::task_persistence::{
     delete_persisted_timer, persist_task_effect, restore_persisted_task_timers,
 };
@@ -1531,7 +1531,17 @@ impl InboundTaskHandler for OperationsTaskHandler {
                 }
             }
             TaskKey::SyncPlacements { realm_id, node_id } => {
-                process_shard_placements(&self.context, realm_id, node_id).await;
+                if process_shard_placements(&self.context, realm_id, node_id)
+                    .await
+                    .status
+                    == PlacementReconcileStatus::StorageFailure
+                {
+                    self.reschedule_timer(
+                        TaskKey::SyncPlacements { realm_id, node_id },
+                        SYNC_PLACEMENT_RETRY_AFTER,
+                    )
+                    .await;
+                }
             }
             TaskKey::DrainDocumentSyncOutbox => {
                 self.drain_document_sync_outbox().await;
@@ -1582,7 +1592,9 @@ mod tests {
     };
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::StorageEvent;
-    use aruna_core::keyspaces::{METADATA_GRAPH_PRUNE_JOB_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE};
+    use aruna_core::keyspaces::{
+        METADATA_GRAPH_PRUNE_JOB_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE, TASK_TIMER_KEYSPACE,
+    };
     use aruna_core::metadata::{MetadataGraphLifecycleRecord, MetadataGraphPruneJobRecord};
     use aruna_core::storage_entries::notification_outbox_write_entry;
     use aruna_core::structs::{
@@ -1669,6 +1681,64 @@ mod tests {
             Event::Storage(StorageEvent::WriteResult { .. }) => {}
             other => panic!("unexpected outbox write event: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn placement_storage_rearms() {
+        let realm_id = RealmId::from_bytes([43u8; 32]);
+        let node_id = node(7);
+        let key = TaskKey::SyncPlacements { realm_id, node_id };
+        let temp_dir = tempdir().expect("temp dir");
+        let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))
+            .expect("storage opens");
+        match storage
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: ByteView::from(realm_id.as_bytes().to_vec()),
+                value: ByteView::from(b"malformed config".to_vec()),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected realm config write: {other:?}"),
+        }
+
+        let task_handle = TaskHandle::new();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: Some(task_handle),
+        });
+
+        let before_ms = unix_timestamp_millis();
+        OperationsTaskHandler::new(context)
+            .handle_timer(key.clone())
+            .await;
+        let after_ms = unix_timestamp_millis();
+
+        let persisted = match storage
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: TASK_TIMER_KEYSPACE.to_string(),
+                prefix: None,
+                start: None,
+                limit: 2,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult { values, .. }) => values,
+            other => panic!("unexpected timer iter result: {other:?}"),
+        };
+        assert_eq!(persisted.len(), 1, "one retry timer must be persisted");
+        let timer: aruna_core::task::PersistedTaskTimer =
+            postcard::from_bytes(&persisted[0].1).expect("persisted timer decodes");
+        assert_eq!(timer.key, key);
+        let retry_ms = crate::sync_placement::SYNC_PLACEMENT_RETRY_AFTER.as_millis() as u64;
+        assert!(timer.due_at_unix_millis >= before_ms.saturating_add(retry_ms));
+        assert!(timer.due_at_unix_millis <= after_ms.saturating_add(retry_ms));
     }
 
     #[test]

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1440,8 +1440,7 @@ impl InboundTaskHandler for OperationsTaskHandler {
 mod tests {
     use super::*;
     use crate::document_sync_outbox::{
-        new_outbox_record_with_id, outbox_key, read_outbox_record,
-        restore_document_sync_outbox_timers, write_outbox_effect,
+        outbox_key, read_outbox_record, restore_document_sync_outbox_timers, write_outbox_effect,
     };
     use aruna_core::document::{
         DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncOutboxEvent,
@@ -1543,11 +1542,9 @@ mod tests {
         let event_id = Ulid::from_parts(10, 1);
         let target = target();
         let change = change();
-        let record = new_outbox_record_with_id(
+        let publish = document_publish_from_outbox(
             event_id,
-            node(1),
             target.clone(),
-            Vec::new(),
             DocumentSyncOutboxEvent::Upsert {
                 bytes: vec![1, 2, 3],
                 change,
@@ -1555,7 +1552,6 @@ mod tests {
             aruna_core::structs::PlacementRef::NIL,
             true,
         );
-        let publish = document_publish_from_outbox(&record);
 
         assert_eq!(publish.target(), &target);
         assert_eq!(publish.event_id(), event_id);

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -323,26 +323,6 @@ fn classify_deferred_record(
     }
 }
 
-/// Escalates a record that has been waiting for its shard topic far longer than
-/// a genesis takes to arrive. It is still retried, but it stops being silent.
-fn report_stuck_records(deferred: &[DrainRecord]) {
-    let now_ms = unix_timestamp_millis();
-    for (_, record, topic) in deferred {
-        let age_ms = now_ms.saturating_sub(record.outbox_id.timestamp_ms());
-        if age_ms >= OUTBOX_STUCK_AFTER.as_millis() as u64 {
-            error!(
-                event = "pipeline.drain.stuck",
-                target = ?record.target,
-                %topic,
-                age_ms,
-                strategy = %record.placement.strategy_id,
-                shard = record.placement.shard,
-                "Document sync outbox record is stuck: this node holds the bucket but its shard topic genesis has never arrived"
-            );
-        }
-    }
-}
-
 impl OperationsTaskHandler {
     fn new(context: Arc<DriverContext>) -> Self {
         Self {
@@ -502,6 +482,13 @@ impl OperationsTaskHandler {
         let mut publish_elapsed = Duration::ZERO;
         let mut record_count = 0usize;
         let mut deferred_total = 0usize;
+        let mut stuck_total = 0usize;
+        let mut oldest_stuck: Option<(
+            u64,
+            DocumentSyncTarget,
+            irokle::TopicId,
+            aruna_core::structs::PlacementRef,
+        )> = None;
         let mut undeliverable_total = 0usize;
         let mut group_count = 0usize;
         let mut subbatch_count = 0usize;
@@ -642,7 +629,21 @@ impl OperationsTaskHandler {
                 |record| classify_deferred_record(realm_config.as_ref(), net_handle, record),
             );
             deferred_total += deferred.len();
-            report_stuck_records(&deferred);
+            let now_ms = unix_timestamp_millis();
+            for (_, record, topic) in &deferred {
+                let record_ms = record.outbox_id.timestamp_ms();
+                if now_ms.saturating_sub(record_ms) < OUTBOX_STUCK_AFTER.as_millis() as u64 {
+                    continue;
+                }
+                stuck_total += 1;
+                if oldest_stuck
+                    .as_ref()
+                    .is_none_or(|(oldest_ms, ..)| record_ms < *oldest_ms)
+                {
+                    oldest_stuck =
+                        Some((record_ms, record.target.clone(), *topic, record.placement));
+                }
+            }
             undeliverable_total += undeliverable.len();
             self.report_undeliverable_records(&undeliverable);
 
@@ -760,6 +761,19 @@ impl OperationsTaskHandler {
             if !has_more {
                 break;
             }
+        }
+
+        if let Some((oldest_ms, target, topic, placement)) = oldest_stuck {
+            error!(
+                event = "pipeline.drain.stuck",
+                count = stuck_total,
+                oldest_age_ms = unix_timestamp_millis().saturating_sub(oldest_ms),
+                representative_target = ?target,
+                representative_topic = %topic,
+                representative_strategy = %placement.strategy_id,
+                representative_shard = placement.shard,
+                "Document sync outbox records are stuck: this node holds their buckets but their shard topic geneses have never arrived"
+            );
         }
 
         // A locally-originated realm-config change (strategy upsert, node

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1728,8 +1728,8 @@ mod tests {
             );
         }
 
-        // One later record for a shared (non-shard) topic, ordered strictly after
-        // the head page, so only pagination reaches it.
+        // One later origin record for a shared (non-shard) topic, ordered
+        // strictly after the head page, so only pagination reaches it.
         let publish_record = crate::document_sync_outbox::new_outbox_record_with_id(
             Ulid::from_parts(2, 0),
             node(1),
@@ -1740,7 +1740,7 @@ mod tests {
                 change: change(),
             },
             aruna_core::structs::PlacementRef::NIL,
-            false,
+            true,
         );
         let publish_key = outbox_key(&publish_record).to_vec();
         writes

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -336,32 +336,48 @@ impl OperationsTaskHandler {
         }
     }
 
-    /// Drops records that can never publish from this node, loudly. Leaving them
-    /// in the outbox would retry them forever against a topic this node may not
-    /// join: a deferred record that can never drain is silent data loss, so the
-    /// operator is told instead.
-    async fn drop_undeliverable_records(&self, undeliverable: Vec<DrainRecord>) -> usize {
-        if undeliverable.is_empty() {
-            return 0;
-        }
+    /// Relays records this node can never publish to a holder of their bucket.
+    ///
+    /// This node holds none of the record's bucket, so it may neither mint that
+    /// bucket's topic genesis nor join the topic: retrying locally would never
+    /// drain it. Deleting it would be silent data loss instead — the caller
+    /// already holds a 200, and an admin-operation outbox record has no replay
+    /// source — so the record goes to a holder, which publishes it. Only a
+    /// successfully relayed record is deleted; one that cannot be relayed (no
+    /// reachable holder) is left in the outbox to be retried on the next drain,
+    /// loudly, rather than thrown away because a peer was briefly down.
+    async fn forward_undeliverable_records(&self, undeliverable: Vec<DrainRecord>) -> usize {
         let mut keys = Vec::with_capacity(undeliverable.len());
         for (record_key, record, topic) in undeliverable {
-            error!(
-                event = "pipeline.drain.undeliverable",
-                target = ?record.target,
-                %topic,
-                strategy = %record.placement.strategy_id,
-                shard = record.placement.shard,
-                age_ms = unix_timestamp_millis().saturating_sub(record.outbox_id.timestamp_ms()),
-                "Dropping undeliverable document sync outbox record: this node holds none of its bucket, so it can neither mint nor join the shard topic"
-            );
-            keys.push(record_key);
+            match crate::metadata::forward::forward_outbox_record(&self.context, &record).await {
+                Ok(()) => {
+                    debug!(
+                        event = "pipeline.drain.forwarded",
+                        target = ?record.target,
+                        %topic,
+                        "Relayed an unpublishable document sync outbox record to a bucket holder"
+                    );
+                    keys.push(record_key);
+                }
+                Err(error) => error!(
+                    event = "pipeline.drain.undeliverable",
+                    target = ?record.target,
+                    %topic,
+                    strategy = %record.placement.strategy_id,
+                    shard = record.placement.shard,
+                    age_ms = unix_timestamp_millis().saturating_sub(record.outbox_id.timestamp_ms()),
+                    error = %error,
+                    "Cannot publish a document sync outbox record from this node and no holder accepted the relay; retrying"
+                ),
+            }
         }
-        let dropped = keys.len();
-        if let Err(error) = delete_outbox_records(&self.context.storage_handle, keys).await {
-            error!(error = %error, "Failed to delete undeliverable document sync outbox records");
+        let forwarded = keys.len();
+        if !keys.is_empty()
+            && let Err(error) = delete_outbox_records(&self.context.storage_handle, keys).await
+        {
+            error!(error = %error, "Failed to delete relayed document sync outbox records");
         }
-        dropped
+        forwarded
     }
 
     /// Backoff interval for the next re-arm of `key`, derived from the in-memory
@@ -468,7 +484,7 @@ impl OperationsTaskHandler {
         let mut publish_elapsed = Duration::ZERO;
         let mut record_count = 0usize;
         let mut deferred_total = 0usize;
-        let mut undeliverable_total = 0usize;
+        let mut forwarded_total = 0usize;
         let mut group_count = 0usize;
         let mut subbatch_count = 0usize;
         let mut pages = 0usize;
@@ -597,7 +613,7 @@ impl OperationsTaskHandler {
             );
             deferred_total += deferred.len();
             report_stuck_records(&deferred);
-            undeliverable_total += self.drop_undeliverable_records(undeliverable).await;
+            forwarded_total += self.forward_undeliverable_records(undeliverable).await;
 
             let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
                 BTreeMap::new();
@@ -740,7 +756,7 @@ impl OperationsTaskHandler {
             event = "pipeline.drain.summary",
             records = record_count,
             deferred = deferred_total,
-            undeliverable = undeliverable_total,
+            forwarded = forwarded_total,
             groups = group_count,
             subbatches = subbatch_count,
             pages,

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1860,6 +1860,7 @@ mod tests {
                 change: change(),
             },
             aruna_core::structs::PlacementRef::NIL,
+            true,
         );
         write_outbox_record(&storage, &record).await;
         task_handle
@@ -1934,6 +1935,7 @@ mod tests {
                 bytes: b"restore durable work".to_vec(),
                 change: change(),
             },
+            aruna_core::structs::PlacementRef::NIL,
             false,
         );
         write_outbox_record(&storage, &record).await;

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
@@ -15,7 +15,7 @@ use aruna_core::{DocumentSyncEffect, DocumentSyncNetEvent};
 use aruna_tasks::{InboundTaskHandler, TaskHandle};
 use async_trait::async_trait;
 use byteview::ByteView;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::announce_realm_presence::{
     AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation, REALM_PRESENCE_REFRESH_AFTER,
@@ -57,7 +57,7 @@ use crate::notifications::watch::interest::{
     WATCH_INTEREST_PUBLISH_DEBOUNCE, rebuild_watch_interest_table,
     refresh_watch_interest_for_targets, restore_watch_interest_publish_timer,
 };
-use crate::process_placements::{PlacementConfig, ProcessPlacementsOperation};
+use crate::process_placements::process_bucket_placements;
 use crate::queue_backoff::timer_retry_after_secs;
 use crate::replication::queue::{
     BLOB_REPLICATION_RETRY_AFTER, process_blob_replication_batch, restore_blob_replication_timer,
@@ -66,7 +66,7 @@ use crate::s3::refresh_reference_metadata::{
     REFERENCE_METADATA_REFRESH_RETRY_AFTER, process_reference_metadata_refresh_batch,
     restore_reference_metadata_refresh_timer,
 };
-use crate::sync_placement::DOCUMENT_SYNC_RETRY_AFTER;
+use crate::sync_placement::DOCUMENT_SYNC_DEFER_RETRY_AFTER;
 use crate::task_persistence::{
     delete_persisted_timer, persist_task_effect, restore_persisted_task_timers,
 };
@@ -88,7 +88,7 @@ struct OperationsTaskHandler {
 struct DrainSubBatch {
     peers: Vec<aruna_core::NodeId>,
     documents: Vec<DocumentSyncPublish>,
-    targets: Vec<DocumentSyncTarget>,
+    topics: Vec<irokle::TopicId>,
     record_keys: Vec<Vec<u8>>,
 }
 
@@ -117,27 +117,70 @@ struct DrainSyncOutcome {
     retry_needed: bool,
 }
 
-pub(crate) fn document_publish_from_outbox(
-    record: &aruna_core::document::DocumentSyncOutboxRecord,
+/// Resolves the bucket placement a drained record publishes under. A record
+/// that already carries a real ref keeps it; a NIL ref (admin-operation
+/// emitters leave one) is resolved from the realm config for the target. Shared
+/// realm targets ignore the placement, so resolving them is harmless.
+fn resolve_publish_placement(
+    config: Option<&aruna_core::structs::RealmConfigDocument>,
+    target: &DocumentSyncTarget,
+    current: aruna_core::structs::PlacementRef,
+) -> aruna_core::structs::PlacementRef {
+    if current != aruna_core::structs::PlacementRef::NIL {
+        return current;
+    }
+    match config {
+        Some(config) => crate::placement::placement_ref_for_target(config, target, None),
+        None => aruna_core::structs::PlacementRef::NIL,
+    }
+}
+
+async fn load_realm_config_for_drain(
+    context: &Arc<DriverContext>,
+    realm_id: aruna_core::structs::RealmId,
+) -> Option<aruna_core::structs::RealmConfigDocument> {
+    let target = DocumentSyncTarget::RealmConfig { realm_id };
+    match context
+        .storage_handle
+        .send_storage_effect(aruna_core::effects::StorageEffect::Read {
+            key_space: target.storage_keyspace().to_string(),
+            key: target.storage_key(),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => value
+            .and_then(|bytes| aruna_core::structs::RealmConfigDocument::from_bytes(&bytes).ok()),
+        _ => None,
+    }
+}
+
+fn document_publish_from_outbox(
+    event_id: ulid::Ulid,
+    target: DocumentSyncTarget,
+    event: DocumentSyncOutboxEvent,
+    placement: aruna_core::structs::PlacementRef,
+    allow_genesis: bool,
 ) -> DocumentSyncPublish {
-    match &record.event {
+    match event {
         DocumentSyncOutboxEvent::Upsert { bytes, change } => DocumentSyncPublish::Upsert {
-            event_id: record.outbox_id,
-            target: record.target.clone(),
-            bytes: bytes.clone(),
-            change: *change,
-            allow_genesis: record.allow_genesis,
+            event_id,
+            target,
+            bytes,
+            change,
+            allow_genesis,
         },
         DocumentSyncOutboxEvent::Delete { change } => DocumentSyncPublish::Delete {
-            event_id: record.outbox_id,
-            target: record.target.clone(),
-            change: *change,
-            allow_genesis: record.allow_genesis,
+            event_id,
+            target,
+            change,
+            allow_genesis,
         },
         DocumentSyncOutboxEvent::AdminOperation { event } => DocumentSyncPublish::AdminOperation {
-            target: record.target.clone(),
-            event: event.clone(),
-            allow_genesis: record.allow_genesis,
+            target,
+            event,
+            placement,
+            allow_genesis,
         },
     }
 }
@@ -257,10 +300,105 @@ impl OperationsTaskHandler {
             return;
         };
 
+        let realm_id = *net_handle.realm_id();
+        // Admin-operation records (group/user document ops) are stamped NIL by
+        // their emitters; resolve their bucket placement here from the realm
+        // config so they publish onto the right bucket topic. Records that
+        // already carry a real ref (metadata upserts/deletes) keep it.
+        let realm_config = load_realm_config_for_drain(&self.context, realm_id).await;
+        let mut totals = DrainSyncOutcome::default();
+
+        let records: Vec<(
+            Vec<u8>,
+            aruna_core::document::DocumentSyncOutboxRecord,
+            irokle::TopicId,
+        )> = batch
+            .records
+            .into_iter()
+            .map(|(record_key, mut record)| {
+                record.placement = resolve_publish_placement(
+                    realm_config.as_ref(),
+                    &record.target,
+                    record.placement,
+                );
+                let topic = record.target.sync_topic_id(realm_id, &record.placement);
+                (record_key, record, topic)
+            })
+            .collect();
+
+        // Bucket topics are join-only for this node unless it is the bucket's
+        // rank-0 holder: a record whose topic has no local genesis yet cannot
+        // publish. Try one bootstrap pass against the record's peers (falling
+        // back to the bucket's resolved holders when the record carries none,
+        // as admin operations do), then defer whatever is still missing to a
+        // short retry — the genesis arrives via gossip or the next pass.
+        let mut missing_topics: BTreeMap<Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>> =
+            BTreeMap::new();
+        for (_, record, topic) in &records {
+            if !record.target.uses_bucket_topic()
+                || net_handle
+                    .document_sync_topic_exists(*topic)
+                    .unwrap_or(false)
+            {
+                continue;
+            }
+            let mut bootstrap_peers = record.peers.clone();
+            if bootstrap_peers.is_empty()
+                && let Some(config) = realm_config.as_ref()
+            {
+                bootstrap_peers =
+                    crate::placement::resolve_bucket_holders(config, &record.placement);
+                bootstrap_peers.retain(|peer| *peer != net_handle.node_id());
+                crate::sync_placement::sort_node_ids(&mut bootstrap_peers);
+            }
+            if bootstrap_peers.is_empty() {
+                continue;
+            }
+            missing_topics
+                .entry(bootstrap_peers)
+                .or_default()
+                .insert(*topic);
+        }
+        for (peers, topics) in missing_topics {
+            let event = net_handle
+                .sync_document_topics(topics.into_iter().collect(), peers)
+                .await;
+            let outcome = self
+                .finish_sync_drain_subbatch(
+                    &retry_key,
+                    Vec::new(),
+                    Event::Net(NetEvent::DocumentSync(event)),
+                    Default::default(),
+                )
+                .await;
+            totals.merge(outcome);
+        }
+
+        let mut deferred = 0usize;
         let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
             BTreeMap::new();
-        for (record_key, record) in batch.records {
-            let document = document_publish_from_outbox(&record);
+        for (record_key, record, topic) in records {
+            if record.target.uses_bucket_topic()
+                && !net_handle
+                    .document_sync_topic_exists(topic)
+                    .unwrap_or(false)
+            {
+                debug!(
+                    event = "pipeline.drain.deferred",
+                    target = ?record.target,
+                    %topic,
+                    "Deferring outbox record: bucket topic genesis not yet known"
+                );
+                deferred += 1;
+                continue;
+            }
+            let document = document_publish_from_outbox(
+                record.outbox_id,
+                record.target.clone(),
+                record.event,
+                record.placement,
+                record.allow_genesis,
+            );
 
             let subbatches = publish_groups.entry(record.peers.clone()).or_default();
             if subbatches
@@ -270,13 +408,13 @@ impl OperationsTaskHandler {
                 subbatches.push(DrainSubBatch {
                     peers: record.peers,
                     documents: Vec::new(),
-                    targets: Vec::new(),
+                    topics: Vec::new(),
                     record_keys: Vec::new(),
                 });
             }
             let subbatch = subbatches.last_mut().expect("sub-batch was just pushed");
             subbatch.documents.push(document);
-            subbatch.targets.push(record.target);
+            subbatch.topics.push(topic);
             subbatch.record_keys.push(record_key);
         }
 
@@ -287,7 +425,6 @@ impl OperationsTaskHandler {
         // Two-slot pipeline: publish sub-batch N+1 while sub-batch N syncs;
         // sub-batches enter the sync stage strictly in submission order.
         let mut publish_elapsed = Duration::ZERO;
-        let mut totals = DrainSyncOutcome::default();
         let mut awaiting_sync: Option<DrainSubBatch> = None;
         for mut subbatch in subbatches {
             let documents = std::mem::take(&mut subbatch.documents);
@@ -365,6 +502,7 @@ impl OperationsTaskHandler {
         info!(
             event = "pipeline.drain.summary",
             records = record_count,
+            deferred,
             groups = group_count,
             subbatches = subbatch_count,
             scan_ms = duration_ms(scan_elapsed),
@@ -381,6 +519,12 @@ impl OperationsTaskHandler {
 
         if totals.retry_needed {
             self.reschedule_with_backoff(retry_key).await;
+        } else if deferred > 0 {
+            // Deferred records wait only for a genesis to arrive from the
+            // bucket's rank-0 holder; retry quickly rather than on the failure
+            // backoff.
+            self.reschedule_timer(retry_key, DOCUMENT_SYNC_DEFER_RETRY_AFTER)
+                .await;
         } else if batch.has_more {
             self.reschedule_timer(retry_key, std::time::Duration::ZERO)
                 .await;
@@ -404,7 +548,7 @@ impl OperationsTaskHandler {
         let event = net_handle
             .send_effect(Effect::Net(NetEffect::DocumentSync(
                 DocumentSyncEffect::SyncDocuments {
-                    targets: subbatch.targets,
+                    topics: subbatch.topics,
                     peers: subbatch.peers,
                 },
             )))
@@ -1127,103 +1271,7 @@ impl InboundTaskHandler for OperationsTaskHandler {
                 }
             }
             TaskKey::SyncPlacements { realm_id, node_id } => {
-                let retry_key = TaskKey::SyncPlacements { realm_id, node_id };
-                let op = ProcessPlacementsOperation::new(PlacementConfig {
-                    realm_id,
-                    local_node_id: node_id,
-                    retry_after: self.backoff_after(&retry_key),
-                });
-                match drive(op, self.context.as_ref()).await {
-                    // The sweep re-armed itself for still-pending placements: grow the
-                    // backoff so a persistently unsatisfiable placement stops hot-looping.
-                    Ok(true) => self.note_retry_backoff(&retry_key),
-                    // A clean sweep clears the backoff for the next unrelated re-arm.
-                    Ok(false) => self.reset_backoff(&retry_key),
-                    Err(err) => {
-                        error!(error = ?err, "Failed to process pending sync placements timer event");
-                        self.reschedule_with_backoff(retry_key).await;
-                    }
-                }
-            }
-            TaskKey::SyncDocument {
-                node_id,
-                target,
-                peers,
-            } => {
-                let requested_target = target.clone();
-                let retry_key = TaskKey::SyncDocument {
-                    node_id,
-                    target: target.clone(),
-                    peers: peers.clone(),
-                };
-                let Some(net_handle) = self.context.net_handle.as_ref() else {
-                    warn!(key = ?retry_key, "Cannot sync document without net handle");
-                    self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                        .await;
-                    return;
-                };
-                let event = net_handle
-                    .send_effect(Effect::Net(NetEffect::DocumentSync(
-                        DocumentSyncEffect::SyncDocument { target, peers },
-                    )))
-                    .await;
-                match event {
-                    Event::Net(NetEvent::DocumentSync(
-                        DocumentSyncNetEvent::DocumentsReconciled {
-                            targets,
-                            metadata_create_events,
-                            metadata_graph_tombstones,
-                            ..
-                        },
-                    )) => {
-                        process_metadata_graph_tombstones(
-                            self.context.as_ref(),
-                            metadata_graph_tombstones,
-                        )
-                        .await;
-                        let mut refresh_targets = targets.clone();
-                        refresh_targets.push(requested_target);
-                        refresh_realm_usage_summary_for_targets(
-                            self.context.as_ref(),
-                            net_handle.node_id(),
-                            &refresh_targets,
-                        )
-                        .await;
-                        refresh_watch_interest_for_targets(self.context.as_ref(), &refresh_targets)
-                            .await;
-                        if self
-                            .project_reconciled_metadata_create_events(
-                                &retry_key,
-                                targets,
-                                metadata_create_events,
-                            )
-                            .await
-                            .is_err()
-                        {
-                            self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                                .await;
-                            return;
-                        }
-                    }
-                    Event::Net(NetEvent::DocumentSync(DocumentSyncNetEvent::Error {
-                        error,
-                        ..
-                    })) => {
-                        warn!(key = ?retry_key, error = %error, "Failed to process durable document sync timer event");
-                        self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                            .await;
-                    }
-                    Event::Net(NetEvent::Error(error)) => {
-                        warn!(key = ?retry_key, error = ?error, "Failed to process durable document sync timer event");
-                        self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                            .await;
-                    }
-                    other => {
-                        warn!(key = ?retry_key, event = ?other, "Unexpected durable document sync timer result");
-                        self.reschedule_timer(retry_key, DOCUMENT_SYNC_RETRY_AFTER)
-                            .await;
-                    }
-                }
+                process_bucket_placements(&self.context, realm_id, node_id).await;
             }
             TaskKey::DrainDocumentSyncOutbox => {
                 self.drain_document_sync_outbox().await;
@@ -1378,6 +1426,7 @@ mod tests {
                 bytes: vec![1, 2, 3],
                 change,
             },
+            aruna_core::structs::PlacementRef::NIL,
             true,
         );
         let publish = document_publish_from_outbox(&record);

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -567,8 +567,10 @@ impl OperationsTaskHandler {
             // so a non-holder could adopt the genesis here — and would then look
             // publishable while its publishes went nowhere. Its records belong in
             // the forwarding path instead.
-            let mut missing_topics: BTreeMap<Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>> =
-                BTreeMap::new();
+            let mut missing_topics: BTreeMap<
+                Vec<aruna_core::NodeId>,
+                (Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>),
+            > = BTreeMap::new();
             for (_, record, topic) in &records {
                 if !record.target.uses_shard_topic()
                     || defer_state.deferred_topics.contains(topic)
@@ -592,17 +594,19 @@ impl OperationsTaskHandler {
                     bootstrap_peers =
                         crate::placement::resolve_shard_holders(config, &record.placement);
                     bootstrap_peers.retain(|peer| *peer != net_handle.node_id());
-                    crate::sync_placement::sort_node_ids(&mut bootstrap_peers);
                 }
                 if bootstrap_peers.is_empty() {
                     continue;
                 }
+                let mut peer_key = bootstrap_peers.clone();
+                crate::sync_placement::sort_node_ids(&mut peer_key);
                 missing_topics
-                    .entry(bootstrap_peers)
-                    .or_default()
+                    .entry(peer_key)
+                    .or_insert_with(|| (bootstrap_peers, BTreeSet::new()))
+                    .1
                     .insert(*topic);
             }
-            for (peers, topics) in missing_topics {
+            for (_, (peers, topics)) in missing_topics {
                 let event = net_handle
                     .sync_document_topics(topics.into_iter().collect(), peers)
                     .await;
@@ -647,8 +651,10 @@ impl OperationsTaskHandler {
             undeliverable_total += undeliverable.len();
             self.report_undeliverable_records(&undeliverable);
 
-            let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
-                BTreeMap::new();
+            let mut publish_groups: BTreeMap<
+                Vec<aruna_core::NodeId>,
+                (Vec<aruna_core::NodeId>, Vec<DrainSubBatch>),
+            > = BTreeMap::new();
             for (record_key, record, topic) in to_publish {
                 let document = document_publish_from_outbox(
                     record.outbox_id,
@@ -658,13 +664,17 @@ impl OperationsTaskHandler {
                     record.allow_genesis,
                 );
 
-                let subbatches = publish_groups.entry(record.peers.clone()).or_default();
+                let mut peer_key = record.peers.clone();
+                crate::sync_placement::sort_node_ids(&mut peer_key);
+                let (peers, subbatches) = publish_groups
+                    .entry(peer_key)
+                    .or_insert_with(|| (record.peers.clone(), Vec::new()));
                 if subbatches
                     .last()
                     .is_none_or(|subbatch| subbatch.documents.len() >= DRAIN_SUBBATCH_RECORDS)
                 {
                     subbatches.push(DrainSubBatch {
-                        peers: record.peers,
+                        peers: peers.clone(),
                         documents: Vec::new(),
                         topics: Vec::new(),
                         targets: Vec::new(),
@@ -679,7 +689,10 @@ impl OperationsTaskHandler {
             }
 
             group_count += publish_groups.len();
-            let subbatches: Vec<DrainSubBatch> = publish_groups.into_values().flatten().collect();
+            let subbatches: Vec<DrainSubBatch> = publish_groups
+                .into_values()
+                .flat_map(|(_, subbatches)| subbatches)
+                .collect();
             subbatch_count += subbatches.len();
 
             // Two-slot pipeline: publish sub-batch N+1 while sub-batch N syncs;

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -77,6 +77,13 @@ use crate::usage_stats::{
 const DRAIN_SUBBATCH_RECORDS: usize = 512;
 const DURABLE_QUEUE_REARM_AFTER: Duration = Duration::from_secs(5);
 
+/// One drained outbox record with its resolved publish topic.
+type DrainRecord = (
+    Vec<u8>,
+    aruna_core::document::DocumentSyncOutboxRecord,
+    irokle::TopicId,
+);
+
 #[derive(Debug)]
 struct OperationsTaskHandler {
     context: Arc<DriverContext>,
@@ -192,6 +199,44 @@ impl DrainSyncOutcome {
         self.delete_elapsed += other.delete_elapsed;
         self.retry_needed |= other.retry_needed;
     }
+}
+
+/// Splits FIFO-ordered drain records into those to publish now and a count of
+/// those deferred because their shard topic has no local genesis yet. Each
+/// topic's availability is evaluated once per run; once a topic defers, every
+/// later record of that topic defers too. Splitting FIFO-adjacent records of one
+/// topic across a defer/publish boundary would let the newer op publish first,
+/// invert its origin sequence on receivers, and drop the older op forever as
+/// StaleOriginSequence — so a topic never straddles that boundary within a run.
+fn partition_drain_records(
+    records: Vec<DrainRecord>,
+    mut topic_available: impl FnMut(irokle::TopicId) -> bool,
+) -> (Vec<DrainRecord>, usize) {
+    let mut topic_exists: HashMap<irokle::TopicId, bool> = HashMap::new();
+    let mut deferred_topics: HashSet<irokle::TopicId> = HashSet::new();
+    let mut to_publish = Vec::with_capacity(records.len());
+    let mut deferred = 0usize;
+    for (record_key, record, topic) in records {
+        if record.target.uses_shard_topic() {
+            let available = !deferred_topics.contains(&topic)
+                && *topic_exists
+                    .entry(topic)
+                    .or_insert_with(|| topic_available(topic));
+            if !available {
+                deferred_topics.insert(topic);
+                debug!(
+                    event = "pipeline.drain.deferred",
+                    target = ?record.target,
+                    %topic,
+                    "Deferring outbox record: shard topic genesis not yet known"
+                );
+                deferred += 1;
+                continue;
+            }
+        }
+        to_publish.push((record_key, record, topic));
+    }
+    (to_publish, deferred)
 }
 
 impl OperationsTaskHandler {
@@ -374,24 +419,14 @@ impl OperationsTaskHandler {
             totals.merge(outcome);
         }
 
-        let mut deferred = 0usize;
+        let (to_publish, deferred) = partition_drain_records(records, |topic| {
+            net_handle
+                .document_sync_topic_exists(topic)
+                .unwrap_or(false)
+        });
         let mut publish_groups: BTreeMap<Vec<aruna_core::NodeId>, Vec<DrainSubBatch>> =
             BTreeMap::new();
-        for (record_key, record, topic) in records {
-            if record.target.uses_shard_topic()
-                && !net_handle
-                    .document_sync_topic_exists(topic)
-                    .unwrap_or(false)
-            {
-                debug!(
-                    event = "pipeline.drain.deferred",
-                    target = ?record.target,
-                    %topic,
-                    "Deferring outbox record: shard topic genesis not yet known"
-                );
-                deferred += 1;
-                continue;
-            }
+        for (record_key, record, topic) in to_publish {
             let document = document_publish_from_outbox(
                 record.outbox_id,
                 record.target.clone(),
@@ -1466,6 +1501,64 @@ mod tests {
         assert_eq!(selected.record_keys, vec![b"third".to_vec()]);
         assert!(selected.documents.is_empty());
         assert!(subbatch.sync_subset(&[3]).is_none());
+    }
+
+    fn shard_topic_record(origin_seq: u64) -> DocumentSyncOutboxRecord {
+        crate::document_sync_outbox::new_outbox_record(
+            node(1),
+            target(),
+            vec![node(2)],
+            DocumentSyncOutboxEvent::Upsert {
+                bytes: vec![origin_seq as u8],
+                change: change(),
+            },
+            aruna_core::structs::PlacementRef::NIL,
+        )
+    }
+
+    // Two FIFO-adjacent records for one shard topic must never split across a
+    // defer/publish boundary: if the genesis "arrives" (availability flips
+    // false→true) between the two records, the older would defer and the newer
+    // publish first, inverting their origin sequence on receivers. The fix
+    // evaluates availability once per topic, so both defer together.
+    #[test]
+    fn drain_partition_never_splits_a_topic_when_availability_flips() {
+        let topic = irokle::TopicId::hash(b"shard-genesis-race");
+        let older = shard_topic_record(1);
+        let newer = shard_topic_record(2);
+        assert!(older.target.uses_shard_topic());
+        let records = vec![
+            (b"older".to_vec(), older, topic),
+            (b"newer".to_vec(), newer, topic),
+        ];
+
+        let mut calls = 0usize;
+        let (to_publish, deferred) = partition_drain_records(records, |_| {
+            calls += 1;
+            calls > 1
+        });
+
+        assert_eq!(calls, 1, "topic availability is evaluated once per run");
+        assert!(
+            to_publish.is_empty(),
+            "no record of a deferred topic may publish"
+        );
+        assert_eq!(deferred, 2);
+    }
+
+    #[test]
+    fn drain_partition_publishes_all_records_of_an_available_topic_in_fifo_order() {
+        let topic = irokle::TopicId::hash(b"shard-genesis-present");
+        let records = vec![
+            (b"older".to_vec(), shard_topic_record(1), topic),
+            (b"newer".to_vec(), shard_topic_record(2), topic),
+        ];
+
+        let (to_publish, deferred) = partition_drain_records(records, |_| true);
+
+        assert_eq!(deferred, 0);
+        let keys: Vec<Vec<u8>> = to_publish.into_iter().map(|(key, _, _)| key).collect();
+        assert_eq!(keys, vec![b"older".to_vec(), b"newer".to_vec()]);
     }
 
     async fn restore_document_sync_outbox_timer_and_receive_key(

--- a/operations/src/update_metadata_document.rs
+++ b/operations/src/update_metadata_document.rs
@@ -15,6 +15,7 @@ use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, GroupId, TxnId};
 use byteview::ByteView;
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
 use thiserror::Error;
 use tracing::warn;
@@ -41,7 +42,7 @@ pub struct UpdateMetadataDocumentConfig {
     pub mutation: UpdateMetadataDocumentMutation,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum UpdateMetadataDocumentMutation {
     ReplaceRoCrate { jsonld: String },
     UpsertDataEntity { jsonld: String },

--- a/operations/src/update_metadata_document.rs
+++ b/operations/src/update_metadata_document.rs
@@ -21,13 +21,13 @@ use thiserror::Error;
 use tracing::warn;
 use ulid::Ulid;
 
-use crate::document_sync_outbox::schedule_outbox_drain_effect;
+use crate::document_sync_outbox::{outbox_write_entry, schedule_outbox_drain_effect};
 use crate::driver::{DriverContext, drive};
 use crate::metadata::materialization_queue::{
     new_materialization_job, new_pending_materialization_status,
     schedule_metadata_materialization_drain_effect,
 };
-use crate::metadata::projector::create_event_outbox_record;
+use crate::metadata::projector::{create_event_outbox_record, registry_outbox_record};
 use crate::metadata::repository::{
     StorageReadError, metadata_event_projection_write_entries, parse_registry_read,
     read_registry_effect,
@@ -230,6 +230,16 @@ impl UpdateMetadataDocumentOperation {
         let job = new_materialization_job(event, now);
         let mut writes =
             metadata_event_projection_write_entries(event, &audit, outbox, &status, &job)?;
+        // Refresh the everywhere-bound registry row so non-holders see the new
+        // revision, not just the bucket's holders.
+        if let Some(registry_outbox) =
+            registry_outbox_record(event, self.realm_config.as_ref(), false)
+        {
+            writes.push(
+                outbox_write_entry(&registry_outbox)
+                    .map_err(aruna_core::errors::ConversionError::from)?,
+            );
+        }
         let lifecycle = MetadataDocumentLifecycleRecord::Upsert {
             event: Box::new(event.clone()),
         };

--- a/operations/src/update_metadata_document.rs
+++ b/operations/src/update_metadata_document.rs
@@ -509,7 +509,7 @@ mod tests {
         METADATA_MATERIALIZATION_STATUS_KEYSPACE,
     };
     use aruna_core::storage_entries::{document_sync_revision_key, metadata_registry_key};
-    use aruna_core::structs::{Actor, RealmId};
+    use aruna_core::structs::{Actor, PlacementRef, RealmId};
 
     fn actor() -> Actor {
         let realm_id = RealmId::from_bytes([9u8; 32]);
@@ -537,6 +537,7 @@ mod tests {
                 document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![actor.node_id],
             created_at_ms: 1,
             updated_at_ms: 1,
@@ -702,6 +703,40 @@ mod tests {
             }
         );
         event
+    }
+
+    // The bucket is chosen once, by the create-receiving node; re-choosing it on
+    // an update under a changed config would fork the document across topics.
+    #[test]
+    fn update_keeps_placement() {
+        let actor = actor();
+        let mut record = record(&actor);
+        record.placement = PlacementRef {
+            strategy_id: Ulid::from_bytes([5u8; 16]),
+            epoch: 0,
+            shard: 11,
+        };
+        let txn_id = Ulid::r#gen();
+        let mut operation = UpdateMetadataDocumentOperation::new(config(
+            actor,
+            &record,
+            UpdateMetadataDocumentMutation::ReplaceRoCrate {
+                jsonld: replace_jsonld(record.document_id, "Placement Preserved"),
+            },
+        ));
+
+        operation.start();
+        operation.step(registry_read(&record));
+        operation.step(realm_config_read(&record));
+        operation.step(Event::Metadata(MetadataEvent::ValidationResult {
+            graph_iri: record.graph_iri.clone(),
+        }));
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
+
+        let event = assert_update_batch(effects.as_slice(), txn_id, |payload| {
+            matches!(payload, MetadataCreateEventPayload::ReplaceRoCrate { .. })
+        });
+        assert_eq!(event.record.placement, record.placement);
     }
 
     #[test]

--- a/operations/src/update_user.rs
+++ b/operations/src/update_user.rs
@@ -386,6 +386,7 @@ impl UpdateUserOperation {
                 DocumentSyncOutboxEvent::AdminOperation {
                     event: Box::new(event.clone()),
                 },
+                placement,
                 false,
             );
             writes.push(outbox_write_entry(&record).map_err(ConversionError::from)?);

--- a/operations/tests/group_replication.rs
+++ b/operations/tests/group_replication.rs
@@ -147,10 +147,10 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             *realm_id,
             node.net.node_id(),

--- a/operations/tests/group_replication.rs
+++ b/operations/tests/group_replication.rs
@@ -147,6 +147,16 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
 
     Ok(())
 }

--- a/operations/tests/group_replication.rs
+++ b/operations/tests/group_replication.rs
@@ -1,18 +1,24 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use aruna_core::NodeId;
+use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
 use aruna_core::structs::{
-    Actor, Group, GroupAuthorizationDocument, RealmConfigDocument, RealmId, RealmNodeKind,
+    Actor, Group, GroupAuthorizationDocument, PlacementRef, RealmConfigDocument, RealmId,
+    RealmNodeKind, shard_for_subject,
 };
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_group::{GetGroupConfig, GetGroupOperation};
 use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::placement::{
+    PlacementResolutionContext, placement_ref_for_target, resolve_shard_holders,
+};
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
@@ -31,7 +37,7 @@ struct TestNode {
 #[tokio::test]
 async fn group_creation_replicates_to_all_realm_nodes() -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([31u8; 32]);
-    let nodes = build_realm_nodes(&realm_id, 3).await?;
+    let (nodes, _config) = build_realm_nodes(&realm_id, 3).await?;
 
     let creator = Actor {
         node_id: nodes[0].net.node_id(),
@@ -54,10 +60,95 @@ async fn group_creation_replicates_to_all_realm_nodes() -> Result<(), Box<dyn st
     Ok(())
 }
 
+/// Five nodes at replication factor three, so a replica-capped bucket leaves real
+/// non-holders — the three- and four-node fixtures cannot see this class of bug,
+/// since there every node holds every bucket. The group is created on a node that
+/// holds none of the group id's bucket under the realm's capped default strategy:
+/// binding the group class to that strategy would leave the create unpublishable
+/// (its shard topic cannot exist locally), the outbox record undeliverable, and
+/// the group silently lost after an HTTP 200. Binding the class to `everywhere`
+/// instead is what makes this converge — including the authorization document,
+/// which `CheckPermissionsOperation` reads from the local `AUTH_KEYSPACE` and
+/// hard-fails without.
+#[tokio::test]
+async fn unheld_group_replicates() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([33u8; 32]);
+    let (nodes, config) = build_realm_nodes(&realm_id, 5).await?;
+    let origin = nodes[0].net.node_id();
+
+    let mut expected = None;
+    for attempt in 0..32 {
+        let created = drive(
+            CreateGroupOperation::new(CreateGroupConfig {
+                actor: Actor {
+                    node_id: origin,
+                    user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
+                    realm_id,
+                },
+                display_name: format!("unheld group {attempt}"),
+                owner_cap: None,
+            }),
+            nodes[0].context.as_ref(),
+        )
+        .await?;
+        if !capped_holders(&config, created.0.group_id).contains(&origin) {
+            expected = Some(created);
+            break;
+        }
+    }
+    let expected = expected.ok_or("no group id hashed outside the origin's capped buckets")?;
+
+    wait_for_group_convergence(&nodes, expected.0.group_id, &expected.0, &expected.1).await?;
+
+    // What makes the create publishable from an origin the capped strategy would
+    // have excluded: every node holds the group's real bucket.
+    let holders = group_holders(&config, expected.0.group_id);
+    for node in &nodes {
+        assert!(holders.contains(&node.net.node_id()));
+    }
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+/// Holders of the bucket the group's authorization document hashes into, under
+/// the strategy the realm actually binds the group class to.
+fn group_holders(config: &RealmConfigDocument, group_id: Ulid) -> Vec<NodeId> {
+    let target = DocumentSyncTarget::GroupAuthorization { group_id };
+    let placement = placement_ref_for_target(
+        config,
+        &target,
+        PlacementResolutionContext {
+            group_id: Some(group_id),
+            metadata_path: None,
+        },
+    );
+    resolve_shard_holders(config, &placement)
+}
+
+/// Holders the group would have had under the realm's replica-capped default
+/// strategy: the set the group class was wrongly bound to, and the one that
+/// leaves non-holders at all.
+fn capped_holders(config: &RealmConfigDocument, group_id: Ulid) -> Vec<NodeId> {
+    let strategy = config
+        .default_strategy_id
+        .and_then(|id| config.strategy(&id))
+        .expect("seeded default strategy");
+    assert_eq!(strategy.replica_count, Some(3));
+    resolve_shard_holders(
+        config,
+        &PlacementRef {
+            strategy_id: strategy.strategy_id,
+            epoch: 0,
+            shard: shard_for_subject(&group_id.to_bytes(), strategy.shard_count),
+        },
+    )
+}
+
 async fn build_realm_nodes(
     realm_id: &RealmId,
     count: usize,
-) -> Result<Vec<TestNode>, Box<dyn std::error::Error>> {
+) -> Result<(Vec<TestNode>, RealmConfigDocument), Box<dyn std::error::Error>> {
     let mut nodes = Vec::with_capacity(count);
     for _ in 0..count {
         nodes.push(spawn_node(*realm_id).await?);
@@ -76,8 +167,8 @@ async fn build_realm_nodes(
         }
     }
 
-    install_realm_config(&nodes, realm_id).await?;
-    Ok(nodes)
+    let config = install_realm_config(&nodes, realm_id).await?;
+    Ok((nodes, config))
 }
 
 async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
@@ -117,7 +208,7 @@ async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::E
 async fn install_realm_config(
     nodes: &[TestNode],
     realm_id: &RealmId,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
     let mut config = RealmConfigDocument::default_for_realm(*realm_id, Vec::new());
     config.seed_default_placement();
     for node in nodes {
@@ -147,18 +238,35 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the shard's rank-0 holder eagerly creates each
-    // shard topic genesis (mirrors the production realm-config apply path).
-    for node in nodes {
-        aruna_operations::process_placements::process_shard_placements(
-            &node.context,
-            *realm_id,
-            node.net.node_id(),
-        )
-        .await;
+    // Config apply hook: the shard's rank-0 holder eagerly creates each shard
+    // topic genesis and every other holder pulls it (mirrors the production
+    // realm-config apply path). A holder whose rank-0 co-holder has not created
+    // the genesis yet defers, so run the hook until nothing is left pending.
+    for _ in 0..5 {
+        for node in nodes {
+            aruna_operations::startup::restore_shard_subscriptions(
+                &node.context,
+                node.net.node_id(),
+                *realm_id,
+            )
+            .await;
+        }
+        let mut retry = false;
+        for node in nodes {
+            retry |= aruna_operations::process_placements::process_shard_placements(
+                &node.context,
+                *realm_id,
+                node.net.node_id(),
+            )
+            .await
+            .retry_scheduled;
+        }
+        if !retry {
+            break;
+        }
     }
 
-    Ok(())
+    Ok(config)
 }
 
 async fn wait_for_group_convergence(

--- a/operations/tests/metadata_cold_start.rs
+++ b/operations/tests/metadata_cold_start.rs
@@ -9,7 +9,7 @@ use aruna_core::metadata::{
     MetadataQueryResults, MetadataRequestDurability,
 };
 use aruna_core::storage_entries::metadata_registry_key;
-use aruna_core::structs::{MetadataRegistryRecord, RealmId};
+use aruna_core::structs::{MetadataRegistryRecord, PlacementRef, RealmId};
 use aruna_core::types::GroupId;
 use aruna_operations::metadata::{MetadataHandle, MetadataHandleOptions, MetadataSearchStorage};
 use aruna_storage::FjallStorage;
@@ -56,6 +56,7 @@ fn registry_record(group_id: GroupId, index: usize) -> MetadataRegistryRecord {
         graph_iri: graph_iri(index),
         public: true,
         permission_path: format!("/realm/g/{group_id}/meta/datasets/doc-{index:05}@{document_id}"),
+        placement: PlacementRef::NIL,
         holder_node_ids: Vec::new(),
         created_at_ms: 0,
         updated_at_ms: 0,

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -22,7 +22,8 @@ use aruna_core::structs::{
 };
 use aruna_net::{NetConfig, NetHandle};
 use aruna_operations::create_metadata_document::{
-    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+    CreateMetadataDocumentConfig, CreateMetadataDocumentError, CreateMetadataDocumentOperation,
+    CreateMetadataDocumentPayload,
 };
 use aruna_operations::delete_metadata_document::DeleteMetadataDocumentOperation;
 use aruna_operations::driver::{DriverContext, drive};
@@ -56,6 +57,80 @@ struct TestContext {
     actor: Actor,
     config: RealmConfigDocument,
     context: Arc<DriverContext>,
+}
+
+#[tokio::test]
+async fn lost_response_retries() -> Result<(), Box<dyn std::error::Error>> {
+    let test = build_context_without_net().await?;
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
+    let config = CreateMetadataDocumentConfig {
+        actor: test.actor.clone(),
+        group_id,
+        document_id,
+        document_path: "datasets/lost-response".to_string(),
+        public: true,
+        payload: CreateMetadataDocumentPayload::Scaffold {
+            name: "Lost Response".to_string(),
+            description: "Retry before asynchronous projection".to_string(),
+            date_published: "2026-01-01".to_string(),
+            license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+        },
+    };
+
+    // Drive only the durable create operation, then discard its response. The
+    // public wrapper has not scheduled projection, so the registry remains empty.
+    let accepted = drive(
+        CreateMetadataDocumentOperation::new(config.clone()),
+        test.context.as_ref(),
+    )
+    .await?;
+    assert!(
+        drive(
+            ListMetadataDocumentsOperation::new(group_id),
+            test.context.as_ref(),
+        )
+        .await?
+        .is_empty()
+    );
+
+    let retried = drive(
+        CreateMetadataDocumentOperation::new(config.clone()),
+        test.context.as_ref(),
+    )
+    .await?;
+
+    assert_eq!(retried, accepted);
+    let group_error = drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            group_id: Ulid::r#gen(),
+            ..config.clone()
+        }),
+        test.context.as_ref(),
+    )
+    .await
+    .expect_err("an accepted document id cannot move groups");
+    assert_eq!(
+        group_error,
+        CreateMetadataDocumentError::DocumentAlreadyExists
+    );
+    let path_error = drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            document_path: "datasets/other".to_string(),
+            ..config
+        }),
+        test.context.as_ref(),
+    )
+    .await
+    .expect_err("an accepted document id cannot change path");
+    assert_eq!(
+        path_error,
+        CreateMetadataDocumentError::DocumentAlreadyExists
+    );
+    let events = read_create_events(&test, document_id).await?;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_id, accepted.event_id);
+    Ok(())
 }
 
 impl TestContext {

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -17,7 +17,7 @@ use aruna_core::storage_entries::{
     metadata_pending_projection_key, metadata_registry_key, metadata_registry_write_entries,
 };
 use aruna_core::structs::{
-    Actor, MetadataRegistryRecord, RealmConfigDocument, RealmId, RealmNodeKind,
+    Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind,
 };
 use aruna_net::{NetConfig, NetHandle};
 use aruna_operations::create_metadata_document::{
@@ -244,7 +244,9 @@ async fn generated_metadata_create_foreground_storage_effect_count_is_reduced()
         .requests_total;
 
     assert_eq!(created.record.document_id, document_id);
-    assert_eq!(after - before, 1);
+    // Realm config read (bucket choice) plus the event append; a generated id
+    // still skips the existing-document read a client-supplied id needs.
+    assert_eq!(after - before, 2);
     Ok(())
 }
 
@@ -270,6 +272,7 @@ async fn metadata_event_log_replay_repairs_wal_only_create()
             document_path,
             document_id,
         ),
+        placement: PlacementRef::NIL,
         holder_node_ids: vec![test.actor.node_id],
         created_at_ms: 1,
         updated_at_ms: 1,
@@ -658,6 +661,7 @@ fn build_create_event(
             document_path,
             document_id,
         ),
+        placement: PlacementRef::NIL,
         holder_node_ids: vec![test.actor.node_id],
         created_at_ms: 1,
         updated_at_ms: 1,

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -1,22 +1,20 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
     DOCUMENT_SYNC_OUTBOX_KEYSPACE, METADATA_DOCUMENT_INDEX_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE,
     METADATA_HOLDERS_KEYSPACE, METADATA_INDEX_KEYSPACE, METADATA_MATERIALIZATION_JOB_KEYSPACE,
-    METADATA_PENDING_PROJECTION_KEYSPACE, REALM_CONFIG_KEYSPACE, SYNC_PLACEMENT_KEYSPACE,
+    METADATA_PENDING_PROJECTION_KEYSPACE, REALM_CONFIG_KEYSPACE,
 };
 use aruna_core::metadata::{
     MetadataCreateEventPayload, MetadataCreateEventRecord, MetadataGraphLifecycleRecord,
 };
 use aruna_core::storage_entries::{
-    document_placement_key, metadata_create_event_and_pending_projection_write_entries,
-    metadata_create_event_write_entry, metadata_document_key, metadata_event_log_prefix,
-    metadata_graph_lifecycle_write_entry, metadata_pending_projection_key, metadata_registry_key,
-    metadata_registry_write_entries,
+    metadata_create_event_and_pending_projection_write_entries, metadata_create_event_write_entry,
+    metadata_document_key, metadata_event_log_prefix, metadata_graph_lifecycle_write_entry,
+    metadata_pending_projection_key, metadata_registry_key, metadata_registry_write_entries,
 };
 use aruna_core::structs::{
     Actor, MetadataRegistryRecord, RealmConfigDocument, RealmId, RealmNodeKind,
@@ -108,17 +106,6 @@ async fn metadata_crud_roundtrip_uses_craqle_backend() -> Result<(), Box<dyn std
 
     let replayed = replay_metadata_event_log(test.context.as_ref()).await?;
     assert_eq!(replayed, 1);
-    let lifecycle_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    assert!(
-        read_storage_value(
-            &test,
-            SYNC_PLACEMENT_KEYSPACE,
-            document_placement_key(test.actor.realm_id, &lifecycle_target),
-        )
-        .await?
-        .is_some(),
-        "local projection must retain lifecycle placement inventory"
-    );
     let materialized = process_metadata_materialization_batch(test.context.as_ref()).await?;
     assert_eq!(materialized.processed, 1);
 
@@ -200,17 +187,6 @@ async fn metadata_crud_roundtrip_uses_craqle_backend() -> Result<(), Box<dyn std
         test.context.as_ref(),
     )
     .await?;
-
-    assert!(
-        read_storage_value(
-            &test,
-            SYNC_PLACEMENT_KEYSPACE,
-            document_placement_key(test.actor.realm_id, &lifecycle_target),
-        )
-        .await?
-        .is_none(),
-        "metadata deletion must remove lifecycle placement inventory"
-    );
 
     let deleted = drive(
         GetMetadataDocumentOperation::new(group_id, document_id),

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -272,9 +272,9 @@ async fn generated_metadata_create_foreground_storage_effect_count_is_reduced()
         .requests_total;
 
     assert_eq!(created.record.document_id, document_id);
-    // Realm config read (bucket choice) plus the event append; a generated id
-    // still skips the existing-document read a client-supplied id needs.
-    assert_eq!(after - before, 2);
+    // Transaction start, realm config read, atomic event/fence write, and commit;
+    // a generated id still skips the existing-document read a client-supplied id needs.
+    assert_eq!(after - before, 4);
     Ok(())
 }
 

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::StorageEffect;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
@@ -36,6 +37,9 @@ use aruna_operations::metadata::projector::{
     project_metadata_create_events, replay_metadata_event_log,
     schedule_pending_metadata_projection_drain,
 };
+use aruna_operations::placement::{
+    PlacementResolutionContext, choose_origin_bucket, strategy_for_target, subject_bytes,
+};
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_operations::update_metadata_document::{
     UpdateMetadataDocumentConfig, UpdateMetadataDocumentMutation, UpdateMetadataDocumentOperation,
@@ -50,7 +54,31 @@ struct TestContext {
     _storage_dir: TempDir,
     _metadata_dir: TempDir,
     actor: Actor,
+    config: RealmConfigDocument,
     context: Arc<DriverContext>,
+}
+
+impl TestContext {
+    // The bucket the create operation would have chosen on this node.
+    fn placement(&self, group_id: Ulid, document_id: Ulid, document_path: &str) -> PlacementRef {
+        let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+        let (strategy, _) = strategy_for_target(
+            &self.config,
+            &target,
+            PlacementResolutionContext {
+                group_id: Some(group_id),
+                metadata_path: Some(document_path),
+            },
+        )
+        .expect("metadata strategy resolves");
+        choose_origin_bucket(
+            &self.config,
+            strategy,
+            self.actor.node_id,
+            &subject_bytes(&target),
+        )
+        .expect("origin holds a bucket")
+    }
 }
 
 #[tokio::test]
@@ -259,6 +287,7 @@ async fn metadata_event_log_replay_repairs_wal_only_create()
     let document_path = "datasets/replay-repair";
     let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
     let event_id = Ulid::r#gen();
+    let placement = test.placement(group_id, document_id, document_path);
     let record = MetadataRegistryRecord {
         realm_id: test.actor.realm_id,
         group_id,
@@ -272,7 +301,7 @@ async fn metadata_event_log_replay_repairs_wal_only_create()
             document_path,
             document_id,
         ),
-        placement: PlacementRef::NIL,
+        placement,
         holder_node_ids: vec![test.actor.node_id],
         created_at_ms: 1,
         updated_at_ms: 1,
@@ -648,6 +677,7 @@ fn build_create_event(
 ) -> (MetadataRegistryRecord, MetadataCreateEventRecord) {
     let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
     let event_id = Ulid::r#gen();
+    let placement = test.placement(group_id, document_id, document_path);
     let record = MetadataRegistryRecord {
         realm_id: test.actor.realm_id,
         group_id,
@@ -661,7 +691,7 @@ fn build_create_event(
             document_path,
             document_id,
         ),
-        placement: PlacementRef::NIL,
+        placement,
         holder_node_ids: vec![test.actor.node_id],
         created_at_ms: 1,
         updated_at_ms: 1,
@@ -948,7 +978,7 @@ async fn build_context() -> Result<TestContext, Box<dyn std::error::Error>> {
         user_id: aruna_core::UserId::local(Ulid::r#gen(), RealmId([5u8; 32])),
         realm_id: RealmId([5u8; 32]),
     };
-    seed_realm_config(&storage_handle, &actor).await?;
+    let config = seed_realm_config(&storage_handle, &actor).await?;
     let context = Arc::new(DriverContext {
         storage_handle,
         net_handle: Some(net_handle),
@@ -960,6 +990,7 @@ async fn build_context() -> Result<TestContext, Box<dyn std::error::Error>> {
         _storage_dir: storage_dir,
         _metadata_dir: metadata_dir,
         actor,
+        config,
         context,
     })
 }
@@ -984,7 +1015,7 @@ async fn build_context_without_net() -> Result<TestContext, Box<dyn std::error::
         user_id: aruna_core::UserId::local(Ulid::r#gen(), realm_id),
         realm_id,
     };
-    seed_realm_config(&storage_handle, &actor).await?;
+    let config = seed_realm_config(&storage_handle, &actor).await?;
     let context = Arc::new(DriverContext {
         storage_handle,
         net_handle: None,
@@ -996,6 +1027,7 @@ async fn build_context_without_net() -> Result<TestContext, Box<dyn std::error::
         _storage_dir: storage_dir,
         _metadata_dir: metadata_dir,
         actor,
+        config,
         context,
     })
 }
@@ -1003,7 +1035,7 @@ async fn build_context_without_net() -> Result<TestContext, Box<dyn std::error::
 async fn seed_realm_config(
     storage: &aruna_storage::StorageHandle,
     actor: &Actor,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
     let mut config = RealmConfigDocument::new(actor.realm_id, Vec::new(), 3);
     config.seed_default_placement();
     config.ensure_node(actor.node_id, RealmNodeKind::Server);
@@ -1016,7 +1048,7 @@ async fn seed_realm_config(
         })
         .await
     {
-        Event::Storage(StorageEvent::WriteResult { .. }) => Ok(()),
+        Event::Storage(StorageEvent::WriteResult { .. }) => Ok(config),
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
         other => Err(format!("unexpected realm config write event: {other:?}").into()),
     }

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -13,6 +13,7 @@ use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{API_STATE_KEYSPACE, AUTH_KEYSPACE, REALM_CONFIG_KEYSPACE};
+use aruna_core::metadata::MetadataError;
 use aruna_core::structs::{
     Actor, MetadataRegistryRecord, PlacementRef, RealmAuthorizationDocument, RealmConfigDocument,
     RealmId, RealmNodeKind, TokenClaims,
@@ -29,10 +30,15 @@ use aruna_operations::document_sync_outbox::{
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_metadata_document::load_metadata_record_by_document;
 use aruna_operations::incoming::initialize_net_incoming;
-use aruna_operations::metadata::forward::create_metadata_document_routed;
+use aruna_operations::metadata::forward::{
+    MetadataWriteError, create_metadata_document_routed, update_metadata_document_routed,
+};
 use aruna_operations::metadata::{MetadataAuthToken, MetadataHandle};
 use aruna_operations::placement::resolve_shard_holders;
 use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_operations::update_metadata_document::{
+    UpdateMetadataDocumentError, UpdateMetadataDocumentMutation,
+};
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use ed25519_dalek::SigningKey;
@@ -101,6 +107,48 @@ async fn user_node_forwards_create() -> Result<(), Box<dyn std::error::Error>> {
         }
         sleep(Duration::from_millis(50)).await;
     }
+
+    shutdown(nodes).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarded_invalid_terminal() -> Result<(), Box<dyn std::error::Error>> {
+    let realm = Realm::new();
+    let (nodes, config) = build_realm(&realm, 3, 1).await?;
+    let user_node = nodes.last().expect("user node");
+    let group_id = seed_group(&realm, &nodes).await?;
+    let document_id = Ulid::r#gen();
+    let record = drive_forwarded_create(&realm, user_node, group_id, document_id).await?;
+    let holders = resolve_shard_holders(&config, &record.placement);
+    wait_for_record_on_holders(&nodes, &holders, document_id).await?;
+
+    let error = update_metadata_document_routed(
+        &user_node.context,
+        Actor {
+            node_id: user_node.net.node_id(),
+            user_id: realm.user_id,
+            realm_id: realm.realm_id,
+        },
+        &record,
+        None,
+        UpdateMetadataDocumentMutation::UpsertDataEntity {
+            jsonld: "{}".to_string(),
+        },
+        Some(realm.bearer_token()),
+    )
+    .await
+    .expect_err("invalid forwarded update must fail");
+
+    assert!(
+        matches!(
+            &error,
+            MetadataWriteError::Update(UpdateMetadataDocumentError::MetadataError(
+                MetadataError::InvalidInput(_)
+            ))
+        ),
+        "unexpected forwarded update error: {error:?}"
+    );
 
     shutdown(nodes).await;
     Ok(())

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -49,7 +49,10 @@ use tempfile::TempDir;
 use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(30);
+// Every wait below polls to a condition; the ceiling only bounds a genuine
+// hang, so it carries generous headroom for a loaded CI runner where forwarded
+// writes and holder convergence are thread-starved and slow.
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
 
 struct TestNode {
     _temp_dir: TempDir,

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -260,6 +260,51 @@ async fn forwarded_create_is_idempotent() -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
+#[tokio::test]
+async fn create_replay_rejects() -> Result<(), Box<dyn std::error::Error>> {
+    let realm = Realm::new();
+    let (nodes, config) = build_realm(&realm, 3, 1).await?;
+    let user_node = nodes.last().expect("user node");
+    let first_group = seed_group(&realm, &nodes).await?;
+    let other_group = seed_group(&realm, &nodes).await?;
+    let document_id = Ulid::r#gen();
+
+    let created = drive_forwarded_create(&realm, user_node, first_group, document_id).await?;
+    let holders = resolve_shard_holders(&config, &created.placement);
+    wait_for_record_on_holders(&nodes, &holders, document_id).await?;
+
+    let group_error = drive_forwarded_create_at(
+        &realm,
+        user_node,
+        other_group,
+        document_id,
+        "datasets/forwarded",
+    )
+    .await
+    .expect_err("a document id cannot replay a record from another group");
+    assert!(matches!(
+        group_error.downcast_ref::<MetadataWriteError>(),
+        Some(MetadataWriteError::Undeliverable(_))
+    ));
+
+    let path_error = drive_forwarded_create_at(
+        &realm,
+        user_node,
+        first_group,
+        document_id,
+        "datasets/other",
+    )
+    .await
+    .expect_err("a document id cannot replay a record from another path");
+    assert!(matches!(
+        path_error.downcast_ref::<MetadataWriteError>(),
+        Some(MetadataWriteError::Undeliverable(_))
+    ));
+
+    shutdown(nodes).await;
+    Ok(())
+}
+
 fn forged_delete_change(placement: PlacementRef, actor: NodeId) -> DocumentSyncChange {
     DocumentSyncChange {
         base: None,
@@ -547,6 +592,16 @@ async fn drive_forwarded_create(
     group_id: Ulid,
     document_id: Ulid,
 ) -> Result<MetadataRegistryRecord, Box<dyn std::error::Error>> {
+    drive_forwarded_create_at(realm, node, group_id, document_id, "datasets/forwarded").await
+}
+
+async fn drive_forwarded_create_at(
+    realm: &Realm,
+    node: &TestNode,
+    group_id: Ulid,
+    document_id: Ulid,
+    document_path: &str,
+) -> Result<MetadataRegistryRecord, Box<dyn std::error::Error>> {
     let created = create_metadata_document_routed(
         CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
             actor: Actor {
@@ -556,7 +611,7 @@ async fn drive_forwarded_create(
             },
             group_id,
             document_id,
-            document_path: "datasets/forwarded".to_string(),
+            document_path: document_path.to_string(),
             public: true,
             payload: CreateMetadataDocumentPayload::Scaffold {
                 name: "Forwarded".to_string(),

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -97,6 +97,67 @@ async fn user_node_forwards_create() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// A group created on a User-kind node is never silently lost.
+///
+/// A User node holds no bucket of any group, so its admin-operation outbox
+/// records can never publish from here. They also cannot be relayed: receivers
+/// authenticate an admin event by requiring its signed publisher to be its
+/// `origin_node_id`, so a holder publishing on the emitter's behalf is rejected
+/// realm-wide (`validate_replicated_admin_event`). The record therefore stays in
+/// the outbox, retried and loud, instead of being deleted after the caller was
+/// told the group exists. Creating groups from a User node needs a signed-origin
+/// admin relay in the net layer; until then this test pins the invariant that
+/// matters — the write is never thrown away.
+#[tokio::test]
+async fn user_node_group_survives() -> Result<(), Box<dyn std::error::Error>> {
+    let realm = Realm::new();
+    let (nodes, _config) = build_realm(&realm, 3, 1).await?;
+    let user_node = nodes.last().expect("user node");
+
+    let (group, _auth) = drive(
+        CreateGroupOperation::new(CreateGroupConfig {
+            actor: Actor {
+                node_id: user_node.net.node_id(),
+                user_id: realm.user_id,
+                realm_id: realm.realm_id,
+            },
+            display_name: "group from a user node".to_string(),
+            owner_cap: None,
+        }),
+        user_node.context.as_ref(),
+    )
+    .await?;
+
+    // Give the drain time to run: it must not have deleted the records.
+    sleep(Duration::from_secs(2)).await;
+    assert!(read_group_auth(user_node, group.group_id).await?.is_some());
+    assert!(
+        outbox_len(user_node).await? > 0,
+        "the user node's unpublishable admin records must be retained, not dropped"
+    );
+
+    shutdown(nodes).await;
+    Ok(())
+}
+
+async fn outbox_len(node: &TestNode) -> Result<usize, Box<dyn std::error::Error>> {
+    match node
+        .context
+        .storage_handle
+        .send_storage_effect(aruna_core::effects::StorageEffect::Iter {
+            key_space: aruna_core::keyspaces::DOCUMENT_SYNC_OUTBOX_KEYSPACE.to_string(),
+            prefix: None,
+            start: None,
+            limit: 64,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::IterResult { values, .. }) => Ok(values.len()),
+        other => Err(format!("unexpected outbox iter event: {other:?}").into()),
+    }
+}
+
 /// Re-forwarding a create that already applied returns the existing record.
 ///
 /// A forward whose response is lost is retried, possibly against a different
@@ -253,20 +314,27 @@ async fn seed_group(realm: &Realm, nodes: &[TestNode]) -> Result<Ulid, Box<dyn s
     )
     .await?;
 
+    wait_for_group(nodes, group.group_id).await?;
+    Ok(group.group_id)
+}
+
+/// Waits for the group's authorization document — what the permission check
+/// reads — on every sync-eligible node. A User node is never a sync target, so it
+/// never receives the group it may itself have created.
+async fn wait_for_group(
+    nodes: &[TestNode],
+    group_id: Ulid,
+) -> Result<(), Box<dyn std::error::Error>> {
     let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
     loop {
         let mut pending = false;
-        for node in nodes {
-            // A user node is not a sync target, so it never receives the group.
-            if !node.sync_eligible {
-                continue;
-            }
-            if read_group_auth(node, group.group_id).await?.is_none() {
+        for node in nodes.iter().filter(|node| node.sync_eligible) {
+            if read_group_auth(node, group_id).await?.is_none() {
                 pending = true;
             }
         }
         if !pending {
-            return Ok(group.group_id);
+            return Ok(());
         }
         if Instant::now() >= deadline {
             return Err("the group's authorization document never reached every holder".into());

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -2,20 +2,29 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use aruna_core::NodeId;
 use aruna_core::UserId;
 use aruna_core::auth::TRUSTED_REALMS_LIST_KEY;
+use aruna_core::document::{
+    DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncOutboxEvent, DocumentSyncRevision,
+    DocumentSyncTarget,
+};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{API_STATE_KEYSPACE, AUTH_KEYSPACE, REALM_CONFIG_KEYSPACE};
 use aruna_core::structs::{
-    Actor, MetadataRegistryRecord, RealmAuthorizationDocument, RealmConfigDocument, RealmId,
-    RealmNodeKind, TokenClaims,
+    Actor, MetadataRegistryRecord, PlacementRef, RealmAuthorizationDocument, RealmConfigDocument,
+    RealmId, RealmNodeKind, TokenClaims,
 };
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
 use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
+use aruna_operations::document_sync_outbox::{
+    new_outbox_record, outbox_key, read_outbox_record, schedule_outbox_drain_effect,
+    write_outbox_effect,
 };
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_metadata_document::load_metadata_record_by_document;
@@ -100,14 +109,13 @@ async fn user_node_forwards_create() -> Result<(), Box<dyn std::error::Error>> {
 /// A group created on a User-kind node is never silently lost.
 ///
 /// A User node holds no bucket of any group, so its admin-operation outbox
-/// records can never publish from here. They also cannot be relayed: receivers
-/// authenticate an admin event by requiring its signed publisher to be its
-/// `origin_node_id`, so a holder publishing on the emitter's behalf is rejected
-/// realm-wide (`validate_replicated_admin_event`). The record therefore stays in
-/// the outbox, retried and loud, instead of being deleted after the caller was
-/// told the group exists. Creating groups from a User node needs a signed-origin
-/// admin relay in the net layer; until then this test pins the invariant that
-/// matters — the write is never thrown away.
+/// records can never publish from here. There is no outbox relay to hand them to
+/// a holder either: a peer-relayed publish carries no proof it was
+/// permission-checked, so the tokenless relay was removed. The record therefore
+/// stays in the outbox, retried and loud, instead of being deleted after the
+/// caller was told the group exists. Creating groups from a User node needs a
+/// signed-origin admin path in the net layer; until then this test pins the
+/// invariant that matters — the write is never thrown away.
 #[tokio::test]
 async fn user_node_group_survives() -> Result<(), Box<dyn std::error::Error>> {
     let realm = Realm::new();
@@ -158,22 +166,41 @@ async fn outbox_len(node: &TestNode) -> Result<usize, Box<dyn std::error::Error>
     }
 }
 
-/// Re-forwarding a create that already applied returns the existing record.
+/// Re-forwarding a create that already applied returns the existing record,
+/// even when the retry lands on a different holder.
 ///
-/// A forward whose response is lost is retried, possibly against a different
-/// holder. Every holder of the document's blind-hashed bucket stamps that same
-/// bucket, and a holder that already has the document replays it instead of
-/// creating a second one, so a retry cannot fork one document across two topics.
+/// The forward always offers the create to the bucket's rank-0 holder first, so
+/// a plain second attempt would just hit that same holder again. Taking rank-0
+/// down after the first create forces the retry onto a co-holder that never
+/// created the document itself but received it by sync; it must replay the record
+/// rather than fork a second one onto another topic. Node count is beside the
+/// point — skipping rank-0 is what makes the holder differ — so this stays at the
+/// minimum realm that leaves a holder to fail over to.
 #[tokio::test]
 async fn forwarded_create_is_idempotent() -> Result<(), Box<dyn std::error::Error>> {
     let realm = Realm::new();
-    let (nodes, _config) = build_realm(&realm, 3, 1).await?;
+    let (nodes, config) = build_realm(&realm, 3, 1).await?;
     let user_node = nodes.last().expect("user node");
 
     let group_id = seed_group(&realm, &nodes).await?;
     let document_id = Ulid::r#gen();
 
     let first = drive_forwarded_create(&realm, user_node, group_id, document_id).await?;
+    let holders = resolve_shard_holders(&config, &first.placement);
+    assert_eq!(holders.len(), 3);
+
+    // Every holder must carry the row before the retry, so a co-holder that never
+    // created the document can still replay it.
+    wait_for_record_on_holders(&nodes, &holders, document_id).await?;
+
+    // Rank-0 answered the first forward; taking it down routes the retry to a
+    // different holder.
+    let rank0 = nodes
+        .iter()
+        .find(|node| node.net.node_id() == holders[0])
+        .expect("rank-0 holder is a node");
+    rank0.net.shutdown().await;
+
     let second = drive_forwarded_create(&realm, user_node, group_id, document_id).await?;
 
     assert_eq!(second.document_id, first.document_id);
@@ -185,14 +212,57 @@ async fn forwarded_create_is_idempotent() -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
-/// A node holding no bucket of a document can still resolve it.
+fn forged_delete_change(placement: PlacementRef, actor: NodeId) -> DocumentSyncChange {
+    DocumentSyncChange {
+        base: None,
+        current: DocumentSyncRevision {
+            generation: 1,
+            event_id: Ulid::r#gen(),
+            actor,
+            updated_at_ms: 1,
+        },
+        kind: DocumentSyncChangeKind::Delete,
+        placement,
+    }
+}
+
+async fn wait_for_record_on_holders(
+    nodes: &[TestNode],
+    holders: &[NodeId],
+    document_id: Ulid,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        let mut pending = false;
+        for node in nodes
+            .iter()
+            .filter(|node| holders.contains(&node.net.node_id()))
+        {
+            if registry_record(node, document_id).await?.is_none() {
+                pending = true;
+            }
+        }
+        if !pending {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("the create never reached every holder".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// A node holding no bucket of a document can resolve it, and cannot be tricked
+/// into relaying a forged delete for it.
 ///
 /// Five nodes at replication factor three leaves two nodes outside every
 /// document's bucket. Registry rows are the only thing that tells such a node the
 /// document exists at all, and they ride the registry class's own everywhere-bound
 /// topic rather than the document's capped bucket. Without them a read through a
 /// non-holder 404s forever and an update through it cannot even load the record it
-/// needs in order to forward.
+/// needs in order to forward. The same non-holder must never publish a delete for
+/// that bucket: the tokenless outbox relay is gone, so a forged delete it plants
+/// in its own outbox stays there, unpublished, and the document survives.
 #[tokio::test]
 async fn nonholder_resolves_document() -> Result<(), Box<dyn std::error::Error>> {
     let realm = Realm::new();
@@ -245,6 +315,56 @@ async fn nonholder_resolves_document() -> Result<(), Box<dyn std::error::Error>>
             }
             None => sleep(Duration::from_millis(50)).await,
         }
+    }
+
+    // Plant a delete for the document's bucket into the non-holder's outbox: a
+    // record it can never publish and that the removed relay used to hand to a
+    // holder to publish under the holder's signature.
+    let forged = new_outbox_record(
+        outsider.net.node_id(),
+        DocumentSyncTarget::MetadataDocumentLifecycle { document_id },
+        Vec::new(),
+        DocumentSyncOutboxEvent::Delete {
+            change: forged_delete_change(created.placement, outsider.net.node_id()),
+        },
+        created.placement,
+        false,
+    );
+    let key = outbox_key(&forged).to_vec();
+    match outsider
+        .context
+        .storage_handle
+        .send_effect(write_outbox_effect(&forged)?)
+        .await
+    {
+        Event::Storage(StorageEvent::WriteResult { .. }) => {}
+        other => return Err(format!("unexpected forged outbox write event: {other:?}").into()),
+    }
+    outsider
+        .context
+        .task_handle
+        .as_ref()
+        .expect("task handle")
+        .send_effect(schedule_outbox_drain_effect())
+        .await;
+    sleep(Duration::from_secs(2)).await;
+
+    // Neither relayed nor deleted: the forged record is still in the outbox.
+    assert_eq!(
+        read_outbox_record(&outsider.context.storage_handle, &key).await?,
+        Some(forged),
+        "the forged delete must stay in the non-holder's outbox, unpublished"
+    );
+    // And the document survives on every holder: the forged delete never reached a
+    // topic.
+    for node in nodes
+        .iter()
+        .filter(|node| holders.contains(&node.net.node_id()))
+    {
+        assert!(
+            registry_record(node, document_id).await?.is_some(),
+            "a forged delete from a non-holder must not remove the document"
+        );
     }
 
     shutdown(nodes).await;

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -1,0 +1,516 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aruna_core::UserId;
+use aruna_core::auth::TRUSTED_REALMS_LIST_KEY;
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::{API_STATE_KEYSPACE, AUTH_KEYSPACE, REALM_CONFIG_KEYSPACE};
+use aruna_core::structs::{
+    Actor, MetadataRegistryRecord, RealmAuthorizationDocument, RealmConfigDocument, RealmId,
+    RealmNodeKind, TokenClaims,
+};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_metadata_document::load_metadata_record_by_document;
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::metadata::forward::create_metadata_document_routed;
+use aruna_operations::metadata::{MetadataAuthToken, MetadataHandle};
+use aruna_operations::placement::resolve_shard_holders;
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use ed25519_dalek::SigningKey;
+use ed25519_dalek::pkcs8::EncodePrivateKey;
+use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use tempfile::TempDir;
+use tokio::time::{Instant, sleep};
+use ulid::Ulid;
+
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct TestNode {
+    _temp_dir: TempDir,
+    net: NetHandle,
+    context: Arc<DriverContext>,
+    sync_eligible: bool,
+}
+
+/// A create from a User-kind node lands on a holder, over the wire.
+///
+/// User nodes are never sync-eligible, so they hold no bucket and can publish
+/// nothing: every write they take must be forwarded. That makes them the case the
+/// forwarding path exists for, and the case a sync-eligibility gate on the receive
+/// side would reject. The holder applies the create under the caller's own bearer
+/// token and re-runs the same permission check the origin's HTTP handler would.
+#[tokio::test]
+async fn user_node_forwards_create() -> Result<(), Box<dyn std::error::Error>> {
+    let realm = Realm::new();
+    let (nodes, config) = build_realm(&realm, 3, 1).await?;
+    let user_node = nodes.last().expect("user node");
+
+    let group_id = seed_group(&realm, &nodes).await?;
+    let document_id = Ulid::r#gen();
+    let created = drive_forwarded_create(&realm, user_node, group_id, document_id).await?;
+
+    // The user node holds nothing, so the record it got back was written by a
+    // holder, not locally: the holder set must exclude the forwarder.
+    let holders = resolve_shard_holders(&config, &created.placement);
+    assert!(!holders.contains(&user_node.net.node_id()));
+    assert!(!holders.is_empty());
+
+    // Whichever holder answered the forward publishes the create onto the bucket's
+    // topic, so it reaches every holder of that bucket.
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        let mut pending = false;
+        for node in nodes
+            .iter()
+            .filter(|node| holders.contains(&node.net.node_id()))
+        {
+            match registry_record(node, document_id).await? {
+                Some(stored) => {
+                    assert_eq!(stored.document_id, document_id);
+                    assert_eq!(stored.group_id, group_id);
+                    assert_eq!(stored.placement, created.placement);
+                }
+                None => pending = true,
+            }
+        }
+        if !pending {
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err("the forwarded create never reached every holder".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    shutdown(nodes).await;
+    Ok(())
+}
+
+/// Re-forwarding a create that already applied returns the existing record.
+///
+/// A forward whose response is lost is retried, possibly against a different
+/// holder. Every holder of the document's blind-hashed bucket stamps that same
+/// bucket, and a holder that already has the document replays it instead of
+/// creating a second one, so a retry cannot fork one document across two topics.
+#[tokio::test]
+async fn forwarded_create_is_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+    let realm = Realm::new();
+    let (nodes, _config) = build_realm(&realm, 3, 1).await?;
+    let user_node = nodes.last().expect("user node");
+
+    let group_id = seed_group(&realm, &nodes).await?;
+    let document_id = Ulid::r#gen();
+
+    let first = drive_forwarded_create(&realm, user_node, group_id, document_id).await?;
+    let second = drive_forwarded_create(&realm, user_node, group_id, document_id).await?;
+
+    assert_eq!(second.document_id, first.document_id);
+    assert_eq!(second.placement, first.placement);
+    assert_eq!(second.last_event_id, first.last_event_id);
+    assert_eq!(second.created_at_ms, first.created_at_ms);
+
+    shutdown(nodes).await;
+    Ok(())
+}
+
+/// A node holding no bucket of a document can still resolve it.
+///
+/// Five nodes at replication factor three leaves two nodes outside every
+/// document's bucket. Registry rows are the only thing that tells such a node the
+/// document exists at all, and they ride the registry class's own everywhere-bound
+/// topic rather than the document's capped bucket. Without them a read through a
+/// non-holder 404s forever and an update through it cannot even load the record it
+/// needs in order to forward.
+#[tokio::test]
+async fn nonholder_resolves_document() -> Result<(), Box<dyn std::error::Error>> {
+    let realm = Realm::new();
+    let (nodes, config) = build_realm(&realm, 5, 0).await?;
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
+
+    let created = drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: realm.user_id,
+                realm_id: realm.realm_id,
+            },
+            group_id,
+            document_id,
+            document_path: "datasets/nonholder".to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Non Holder".to_string(),
+                description: "Resolvable from outside its bucket".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?
+    .record;
+
+    let holders = resolve_shard_holders(&config, &created.placement);
+    assert_eq!(holders.len(), 3);
+    let outsider = nodes
+        .iter()
+        .find(|node| !holders.contains(&node.net.node_id()))
+        .expect("replica 3 of 5 nodes leaves a non-holder");
+
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        match registry_record(outsider, document_id).await? {
+            Some(record) => {
+                assert_eq!(record.document_id, document_id);
+                assert_eq!(record.placement, created.placement);
+                // The point of the row: the non-holder can route to the holders.
+                assert_eq!(resolve_shard_holders(&config, &record.placement), holders);
+                break;
+            }
+            None if Instant::now() >= deadline => {
+                return Err("the registry row never reached a non-holder".into());
+            }
+            None => sleep(Duration::from_millis(50)).await,
+        }
+    }
+
+    shutdown(nodes).await;
+    Ok(())
+}
+
+/// A realm whose id is its token-signing key, so tests can mint bearer tokens the
+/// forwarded-write path validates exactly as it validates a real caller's.
+struct Realm {
+    signing_key: SigningKey,
+    realm_id: RealmId,
+    user_id: UserId,
+}
+
+impl Realm {
+    fn new() -> Self {
+        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
+        Self {
+            realm_id,
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
+            signing_key,
+        }
+    }
+
+    fn bearer_token(&self) -> MetadataAuthToken {
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let claims = TokenClaims {
+            sub: self.user_id.to_string(),
+            iss: self.realm_id.to_string(),
+            iat: now,
+            exp: now + 600,
+            jti: Ulid::r#gen().to_string(),
+            restrictions: None,
+            issuer_pubkey: None,
+            delegation_signature: None,
+        };
+        let key_pem = self
+            .signing_key
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("realm key encodes");
+        let token = encode(
+            &Header::new(Algorithm::EdDSA),
+            &claims,
+            &EncodingKey::from_ed_pem(key_pem.as_bytes()).expect("realm key is an ed25519 key"),
+        )
+        .expect("token signs");
+        MetadataAuthToken::bearer(token).expect("token is within the length bound")
+    }
+}
+
+/// A group owned by the realm's user, replicated to every node. The holder of a
+/// forwarded write re-runs the caller's permission check against this group's
+/// authorization document, read from its own `AUTH_KEYSPACE`.
+async fn seed_group(realm: &Realm, nodes: &[TestNode]) -> Result<Ulid, Box<dyn std::error::Error>> {
+    let (group, _auth) = drive(
+        CreateGroupOperation::new(CreateGroupConfig {
+            actor: Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: realm.user_id,
+                realm_id: realm.realm_id,
+            },
+            display_name: "forwarding group".to_string(),
+            owner_cap: None,
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?;
+
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        let mut pending = false;
+        for node in nodes {
+            // A user node is not a sync target, so it never receives the group.
+            if !node.sync_eligible {
+                continue;
+            }
+            if read_group_auth(node, group.group_id).await?.is_none() {
+                pending = true;
+            }
+        }
+        if !pending {
+            return Ok(group.group_id);
+        }
+        if Instant::now() >= deadline {
+            return Err("the group's authorization document never reached every holder".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn registry_record(
+    node: &TestNode,
+    document_id: Ulid,
+) -> Result<Option<MetadataRegistryRecord>, Box<dyn std::error::Error>> {
+    load_metadata_record_by_document(node.context.as_ref(), document_id)
+        .await
+        .map_err(|error| format!("metadata registry read failed: {error:?}").into())
+}
+
+async fn read_group_auth(
+    node: &TestNode,
+    group_id: Ulid,
+) -> Result<Option<Vec<u8>>, Box<dyn std::error::Error>> {
+    match node
+        .context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: AUTH_KEYSPACE.to_string(),
+            key: group_id.to_bytes().into(),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => {
+            Ok(value.map(|bytes| bytes.to_vec()))
+        }
+        other => Err(format!("unexpected group auth read event: {other:?}").into()),
+    }
+}
+
+async fn drive_forwarded_create(
+    realm: &Realm,
+    node: &TestNode,
+    group_id: Ulid,
+    document_id: Ulid,
+) -> Result<MetadataRegistryRecord, Box<dyn std::error::Error>> {
+    let created = create_metadata_document_routed(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: node.net.node_id(),
+                user_id: realm.user_id,
+                realm_id: realm.realm_id,
+            },
+            group_id,
+            document_id,
+            document_path: "datasets/forwarded".to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Forwarded".to_string(),
+                description: "Placed by a holder".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        node.context.clone(),
+        Some(realm.bearer_token()),
+    )
+    .await?;
+    Ok(created.record)
+}
+
+async fn build_realm(
+    realm: &Realm,
+    servers: usize,
+    users: usize,
+) -> Result<(Vec<TestNode>, RealmConfigDocument), Box<dyn std::error::Error>> {
+    let mut nodes = Vec::with_capacity(servers + users);
+    for index in 0..(servers + users) {
+        nodes.push(spawn_node(realm.realm_id, index < servers).await?);
+    }
+
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+
+    let config = install_realm_config(realm, &nodes).await?;
+    Ok((nodes, config))
+}
+
+async fn spawn_node(
+    realm_id: RealmId,
+    sync_eligible: bool,
+) -> Result<TestNode, Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+    let metadata_handle = MetadataHandle::new(
+        temp_dir.path().join("metadata"),
+        net.node_id(),
+        storage.clone(),
+        Some(net.clone()),
+        Some(net.document_sync_node()),
+        Some(net.document_sync_database()),
+    )?;
+
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: Some(metadata_handle),
+        task_handle: Some(task_handle.clone()),
+    });
+
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle).await;
+
+    Ok(TestNode {
+        _temp_dir: temp_dir,
+        net,
+        context,
+        sync_eligible,
+    })
+}
+
+async fn install_realm_config(
+    realm: &Realm,
+    nodes: &[TestNode],
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
+    let realm_id = realm.realm_id;
+    let mut config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+    config.seed_default_placement();
+    for node in nodes {
+        let kind = if node.sync_eligible {
+            RealmNodeKind::Management
+        } else {
+            RealmNodeKind::User
+        };
+        config.ensure_node(node.net.node_id(), kind);
+    }
+
+    let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+    let trusted = HashSet::from([realm_id]);
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: UserId::nil(realm_id),
+            realm_id,
+        };
+        write(
+            node,
+            REALM_CONFIG_KEYSPACE,
+            realm_id.as_bytes().to_vec(),
+            config.to_bytes(&actor)?,
+        )
+        .await?;
+        // The realm authorization document the permission check reads first, and
+        // the trusted-realm list the forwarded caller's bearer token validates
+        // against: both are per-node local state in production too.
+        write(
+            node,
+            AUTH_KEYSPACE,
+            realm_id.as_bytes().to_vec(),
+            realm_auth.to_bytes(&actor)?,
+        )
+        .await?;
+        write(
+            node,
+            API_STATE_KEYSPACE,
+            TRUSTED_REALMS_LIST_KEY.to_vec(),
+            postcard::to_allocvec(&trusted)?,
+        )
+        .await?;
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+
+    for _ in 0..5 {
+        for node in nodes {
+            aruna_operations::startup::restore_shard_subscriptions(
+                &node.context,
+                node.net.node_id(),
+                realm_id,
+            )
+            .await;
+        }
+        let mut retry = false;
+        for node in nodes {
+            retry |= aruna_operations::process_placements::process_shard_placements(
+                &node.context,
+                realm_id,
+                node.net.node_id(),
+            )
+            .await
+            .retry_scheduled;
+        }
+        if !retry {
+            break;
+        }
+    }
+
+    Ok(config)
+}
+
+async fn write(
+    node: &TestNode,
+    key_space: &str,
+    key: Vec<u8>,
+    value: Vec<u8>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match node
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Write {
+            key_space: key_space.to_string(),
+            key: key.into(),
+            value: value.into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::WriteResult { .. }) => Ok(()),
+        other => Err(format!("unexpected write event in `{key_space}`: {other:?}").into()),
+    }
+}
+
+async fn shutdown(nodes: Vec<TestNode>) {
+    for node in nodes {
+        node.net.shutdown().await;
+    }
+}

--- a/operations/tests/metadata_materialization_recovery.rs
+++ b/operations/tests/metadata_materialization_recovery.rs
@@ -14,7 +14,7 @@ use aruna_core::storage_entries::{
     metadata_create_event_write_entry, metadata_materialization_job_write_entry,
     metadata_materialization_status_key, metadata_materialization_status_write_entry,
 };
-use aruna_core::structs::{Actor, MetadataRegistryRecord, RealmId};
+use aruna_core::structs::{Actor, MetadataRegistryRecord, PlacementRef, RealmId};
 use aruna_operations::driver::DriverContext;
 use aruna_operations::metadata::MetadataHandle;
 use aruna_operations::metadata::materialization_queue::{
@@ -236,6 +236,7 @@ fn create_event_with_payload(
             &document_path,
             document_id,
         ),
+        placement: PlacementRef::NIL,
         holder_node_ids: vec![test.actor.node_id],
         created_at_ms: 1,
         updated_at_ms: 1,

--- a/operations/tests/metadata_propagation_tail.rs
+++ b/operations/tests/metadata_propagation_tail.rs
@@ -587,10 +587,10 @@ async fn install_realm_config(nodes: &[TestNode], realm_id: &RealmId) -> Result<
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             *realm_id,
             node.net.node_id(),

--- a/operations/tests/metadata_propagation_tail.rs
+++ b/operations/tests/metadata_propagation_tail.rs
@@ -587,6 +587,16 @@ async fn install_realm_config(nodes: &[TestNode], realm_id: &RealmId) -> Result<
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
     Ok(())
 }
 

--- a/operations/tests/metadata_query_concurrency.rs
+++ b/operations/tests/metadata_query_concurrency.rs
@@ -13,7 +13,7 @@ use aruna_core::metadata::{
 };
 use aruna_core::storage_entries::{metadata_graph_lifecycle_write_entry, metadata_registry_key};
 use aruna_core::structs::{
-    Actor, AuthContext, Group, GroupAuthorizationDocument, MetadataRegistryRecord,
+    Actor, AuthContext, Group, GroupAuthorizationDocument, MetadataRegistryRecord, PlacementRef,
     RealmAuthorizationDocument, RealmId,
 };
 use aruna_core::types::{GroupId, Key, Value};
@@ -85,6 +85,7 @@ fn registry_record(
         graph_iri: graph_iri.unwrap_or_else(|| MetadataRegistryRecord::graph_iri_for(document_id)),
         public: true,
         permission_path: format!("/realm/g/{group_id}/meta/datasets/doc-{index:05}@{document_id}"),
+        placement: PlacementRef::NIL,
         holder_node_ids: Vec::new(),
         created_at_ms: 0,
         updated_at_ms: 0,
@@ -300,6 +301,7 @@ fn visibility_record(group_id: GroupId, path: &str, public: bool) -> MetadataReg
             path,
             document_id,
         ),
+        placement: PlacementRef::NIL,
         holder_node_ids: Vec::new(),
         created_at_ms: 0,
         updated_at_ms: 0,

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -24,7 +24,7 @@ use aruna_core::storage_entries::{
 };
 use aruna_core::structs::{
     Actor, MetadataRegistryRecord, NodePlacementEntry, PlacementRef, RealmConfigDocument, RealmId,
-    RealmNodeKind,
+    RealmNodeKind, shard_for_subject,
 };
 use aruna_core::util::unix_timestamp_millis;
 use aruna_core::{DocumentSyncEffect, DocumentSyncNetEvent};
@@ -49,7 +49,8 @@ use aruna_operations::mutate_realm_placement::{
     MutateRealmPlacementConfig, MutateRealmPlacementOperation, RealmPlacementMutation,
 };
 use aruna_operations::placement::{
-    PlacementResolutionContext, plan_target_placement, resolve_shard_holders,
+    PlacementResolutionContext, choose_origin_bucket, held_buckets, resolve_shard_holders,
+    strategy_for_target, subject_bytes,
 };
 use aruna_operations::sync_placement::sort_node_ids;
 use aruna_operations::task_incoming::initialize_task_incoming;
@@ -131,7 +132,6 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
     let group_id = Ulid::r#gen();
     let document_id = Ulid::r#gen();
     let document_path = "datasets/replan-holder-refresh";
-    let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
 
     let created = drive(
         CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
@@ -169,14 +169,11 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
         nodes[0].context.as_ref(),
     )
     .await?;
-    let placement_context = PlacementResolutionContext {
-        group_id: Some(group_id),
-        metadata_path: Some(document_path),
-    };
-    let mut initial_holders = plan_target_placement(&initial_config, &target, placement_context)
-        .expect("metadata lifecycle placement resolves")
-        .holders;
+    // The bucket was chosen by the origin at create; holders derive from it.
+    let placement = created.placement;
+    let mut initial_holders = resolve_shard_holders(&initial_config, &placement);
     sort_node_ids(&mut initial_holders);
+    assert!(initial_holders.contains(&nodes[0].net.node_id()));
     wait_for_persisted_holder_set(
         &nodes,
         &initial_holders,
@@ -228,10 +225,7 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
         nodes[0].context.as_ref(),
     )
     .await?;
-    let plan = plan_target_placement(&updated_config, &target, placement_context)
-        .expect("updated metadata lifecycle placement resolves");
-    let placement = plan.placement;
-    let mut final_holders = plan.holders;
+    let mut final_holders = resolve_shard_holders(&updated_config, &placement);
     sort_node_ids(&mut final_holders);
     let replacement = final_holders
         .iter()
@@ -261,6 +255,71 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
         refreshed_event.payload,
         MetadataCreateEventPayload::UpsertDataEntity { .. }
     ));
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+// The document id hashes into a bucket the origin does not hold: before the
+// bucket was chosen at create, the origin could never join that bucket's topic
+// and the create never replicated.
+#[tokio::test]
+async fn origin_off_hash_converges() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([47u8; 32]);
+    let (nodes, config) = build_realm_nodes(&realm_id, 4).await?;
+    let group_id = Ulid::r#gen();
+    let document_path = "datasets/off-hash-origin";
+    let origin = nodes[0].net.node_id();
+
+    let context = PlacementResolutionContext {
+        group_id: Some(group_id),
+        metadata_path: Some(document_path),
+    };
+    let sample = DocumentSyncTarget::MetadataDocumentLifecycle {
+        document_id: Ulid::r#gen(),
+    };
+    let (strategy, _) =
+        strategy_for_target(&config, &sample, context).expect("metadata strategy resolves");
+    let held = held_buckets(&config, strategy, origin);
+    assert!(!held.is_empty() && held.len() < strategy.shard_count as usize);
+
+    let hashed_shard =
+        |document_id: Ulid| shard_for_subject(&document_id.to_bytes(), strategy.shard_count);
+    let mut document_id = Ulid::r#gen();
+    while held.contains(&hashed_shard(document_id)) {
+        document_id = Ulid::r#gen();
+    }
+
+    let created = drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: origin,
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
+                realm_id,
+            },
+            group_id,
+            document_id,
+            document_path: document_path.to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Off Hash Origin".to_string(),
+                description: "Created on a node outside the hashed bucket".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?
+    .record;
+
+    assert!(!held.contains(&hashed_shard(document_id)));
+    assert!(held.contains(&created.placement.shard));
+
+    let mut holders = resolve_shard_holders(&config, &created.placement);
+    sort_node_ids(&mut holders);
+    assert!(holders.contains(&origin));
+    wait_for_persisted_holder_set(&nodes, &holders, group_id, document_id, &holders).await?;
 
     shutdown_nodes(nodes).await;
     Ok(())
@@ -390,7 +449,7 @@ async fn batched_metadata_create_projection_materializes_many_documents()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([43u8; 32]);
     let nodes = vec![spawn_node(realm_id).await?];
-    install_realm_config(&nodes, &realm_id).await?;
+    let config = install_realm_config(&nodes, &realm_id).await?;
     let node = &nodes[0];
     let group_id = Ulid::r#gen();
     let mut events = Vec::new();
@@ -400,6 +459,23 @@ async fn batched_metadata_create_projection_materializes_many_documents()
         let now = unix_timestamp_millis().saturating_add(index.into());
         let document_path = format!("datasets/batch-{index}");
         let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
+        let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+        let (strategy, _) = strategy_for_target(
+            &config,
+            &target,
+            PlacementResolutionContext {
+                group_id: Some(group_id),
+                metadata_path: Some(document_path.as_str()),
+            },
+        )
+        .expect("metadata strategy resolves");
+        let placement = choose_origin_bucket(
+            &config,
+            strategy,
+            node.net.node_id(),
+            &subject_bytes(&target),
+        )
+        .expect("origin holds a bucket");
         let record = MetadataRegistryRecord {
             realm_id,
             group_id,
@@ -413,7 +489,7 @@ async fn batched_metadata_create_projection_materializes_many_documents()
                 &document_path,
                 document_id,
             ),
-            placement: PlacementRef::NIL,
+            placement,
             holder_node_ids: vec![node.net.node_id()],
             created_at_ms: now,
             updated_at_ms: now,
@@ -476,6 +552,12 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
     let document_path = "datasets/reordered-delete";
     let event_id = Ulid::r#gen();
     let graph_iri = MetadataRegistryRecord::graph_iri_for(document_id);
+    let lifecycle_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+    let placement = aruna_operations::placement::placement_ref_for_target(
+        &realm_config,
+        &lifecycle_target,
+        Default::default(),
+    );
     let record = MetadataRegistryRecord {
         realm_id,
         group_id,
@@ -489,7 +571,7 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
             document_path,
             document_id,
         ),
-        placement: PlacementRef::NIL,
+        placement,
         holder_node_ids: vec![nodes[0].net.node_id(), nodes[1].net.node_id()],
         created_at_ms: 1,
         updated_at_ms: 1,
@@ -518,17 +600,10 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
             deleted_after_event_id: event_id,
         },
     };
-    // All records of this document share a subject and so one shard topic.
-    // The placement comes from the installed realm config, so the shard
-    // topic's genesis exists (created eagerly by its rank-0 holder during
-    // install); the publisher below only joins it, never creates it.
-    let lifecycle_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    let placement = aruna_operations::placement::placement_ref_for_target(
-        &realm_config,
-        &lifecycle_target,
-        Default::default(),
-    );
-    assert_ne!(placement, aruna_core::structs::PlacementRef::NIL);
+    // All records of this document ride the bucket stamped on the record, so
+    // one shard topic. Its genesis exists (created eagerly by its rank-0 holder
+    // during install); the publisher below only joins it, never creates it.
+    assert_ne!(placement, PlacementRef::NIL);
     let shard_topic_of = |target: &DocumentSyncTarget| target.sync_topic_id(realm_id, &placement);
     // Make sure the publisher knows the shard topic before publishing onto it:
     // sync_document_topics bootstraps the genesis from the co-holder when

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -132,7 +132,7 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
     let document_path = "datasets/replan-holder-refresh";
     let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
 
-    drive(
+    let created = drive(
         CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
             actor: Actor {
                 node_id: nodes[0].net.node_id(),
@@ -152,10 +152,15 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
         }),
         nodes[0].context.as_ref(),
     )
-    .await?;
-    assert_eq!(
-        replay_metadata_event_log(nodes[0].context.as_ref()).await?,
-        1
+    .await?
+    .record;
+    // See metadata_creation_replicates_to_all_three_holders: the projection
+    // count races the async drain, the logged event is the stable invariant.
+    assert!(replay_metadata_event_log(nodes[0].context.as_ref()).await? <= 1);
+    assert!(
+        read_metadata_event_log_value(&nodes[0], document_id, created.last_event_id)
+            .await?
+            .is_some()
     );
 
     let initial_config = drive(

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -246,10 +246,11 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
         wait_for_persisted_update(replacement_node, group_id, document_id, latest_update_id)
             .await?;
     assert_eq!(registry.last_event_id, latest_update_id);
+    // The registry row rides the everywhere-bound registry class, so it can land
+    // on the replacement before the document's own bucket topic delivers the
+    // event: the row is a routing pointer, not evidence the content arrived.
     let refreshed_event =
-        read_metadata_event_log_value(replacement_node, document_id, latest_update_id)
-            .await?
-            .expect("replacement persisted refreshed lifecycle event");
+        wait_for_event_log_value(replacement_node, document_id, latest_update_id).await?;
     let refreshed_event: MetadataCreateEventRecord = postcard::from_bytes(&refreshed_event)?;
     assert!(matches!(
         refreshed_event.payload,
@@ -954,6 +955,27 @@ async fn read_persisted_holder_set(
         }
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
         other => Err(format!("unexpected metadata index read event: {other:?}").into()),
+    }
+}
+
+async fn wait_for_event_log_value(
+    node: &TestNode,
+    document_id: Ulid,
+    event_id: Ulid,
+) -> Result<aruna_core::types::Value, Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        if let Some(value) = read_metadata_event_log_value(node, document_id, event_id).await? {
+            return Ok(value);
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "node={} never persisted metadata event {event_id} of document {document_id}",
+                node.net.node_id()
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(50)).await;
     }
 }
 

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -63,7 +63,10 @@ use tempfile::TempDir;
 use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(30);
+// Every wait below polls to a condition; the ceiling only bounds a genuine
+// hang, so it carries generous headroom for a loaded CI runner where gossip and
+// anti-entropy across the holders are thread-starved and slow.
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
 
 struct TestNode {
     _temp_dir: TempDir,

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -71,7 +71,7 @@ struct TestNode {
 async fn metadata_creation_replicates_to_all_three_holders()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([41u8; 32]);
-    let nodes = build_realm_nodes(&realm_id, 3).await?;
+    let (nodes, _config) = build_realm_nodes(&realm_id, 3).await?;
     let group_id = Ulid::r#gen();
     let document_id = Ulid::r#gen();
 
@@ -106,9 +106,14 @@ async fn metadata_creation_replicates_to_all_three_holders()
     .record;
 
     assert_eq!(created.holder_node_ids, vec![nodes[0].net.node_id()]);
-    assert_eq!(
-        replay_metadata_event_log(nodes[0].context.as_ref()).await?,
-        1
+    // Replay is idempotent: it projects the logged create event unless the
+    // async drain (and the holders' expansion round trip) already did, so the
+    // stable invariant is the logged event itself, not the projection count.
+    assert!(replay_metadata_event_log(nodes[0].context.as_ref()).await? <= 1);
+    assert!(
+        read_metadata_event_log_value(&nodes[0], document_id, created.last_event_id)
+            .await?
+            .is_some()
     );
 
     wait_for_metadata_convergence(&nodes, group_id, document_id, &created.graph_iri).await?;
@@ -263,7 +268,7 @@ async fn metadata_replan_refreshes_replacement_holder_indexes()
 async fn metadata_updates_and_deletes_apply_to_local_holder()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([42u8; 32]);
-    let nodes = build_realm_nodes(&realm_id, 3).await?;
+    let (nodes, _config) = build_realm_nodes(&realm_id, 3).await?;
     let group_id = Ulid::r#gen();
     let document_id = Ulid::r#gen();
 
@@ -289,9 +294,13 @@ async fn metadata_updates_and_deletes_apply_to_local_holder()
     )
     .await?;
 
-    assert_eq!(
-        replay_metadata_event_log(nodes[0].context.as_ref()).await?,
-        1
+    // See metadata_creation_replicates_to_all_three_holders: the projection
+    // count races the async drain, the logged event is the stable invariant.
+    assert!(replay_metadata_event_log(nodes[0].context.as_ref()).await? <= 1);
+    assert!(
+        read_metadata_event_log_value(&nodes[0], document_id, created.record.last_event_id)
+            .await?
+            .is_some()
     );
 
     wait_for_metadata_state(
@@ -458,7 +467,7 @@ async fn batched_metadata_create_projection_materializes_many_documents()
 async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([44u8; 32]);
-    let nodes = build_realm_nodes(&realm_id, 2).await?;
+    let (nodes, realm_config) = build_realm_nodes(&realm_id, 2).await?;
     let group_id = Ulid::r#gen();
     let document_id = Ulid::r#gen();
     let document_path = "datasets/reordered-delete";
@@ -505,25 +514,53 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
             deleted_after_event_id: event_id,
         },
     };
+    // All records of this document share a subject and so one bucket topic.
+    // The placement comes from the installed realm config, so the bucket
+    // topic's genesis exists (created eagerly by its rank-0 holder during
+    // install); the publisher below only joins it, never creates it.
     let lifecycle_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+    let placement = aruna_operations::placement::placement_ref_for_target(
+        &realm_config,
+        &lifecycle_target,
+        None,
+    );
+    assert_ne!(placement, aruna_core::structs::PlacementRef::NIL);
+    let bucket_topic = |target: &DocumentSyncTarget| target.sync_topic_id(realm_id, &placement);
+    // Make sure the publisher knows the bucket topic before publishing onto it:
+    // sync_document_topics bootstraps the genesis from the co-holder when
+    // rank-0 was the other node (the singular sync never bootstraps).
+    nodes[0]
+        .net
+        .sync_document_topics(
+            vec![bucket_topic(&lifecycle_target)],
+            vec![nodes[1].net.node_id()],
+        )
+        .await;
+    assert!(
+        nodes[0]
+            .net
+            .document_sync_topic_exists(bucket_topic(&lifecycle_target))?,
+        "bucket topic genesis unavailable on both nodes after install"
+    );
     publish_document_to_peer(
         &nodes[0],
         delete_event_id,
         lifecycle_target.clone(),
         postcard::to_allocvec(&lifecycle)?,
         nodes[1].net.node_id(),
+        placement,
     )
     .await?;
     nodes[1]
         .net
         .sync_document_topic_with_peers(
-            lifecycle_target.sync_topic_id(),
+            bucket_topic(&lifecycle_target),
             vec![nodes[0].net.node_id()],
         )
         .await?;
     let delete_result = nodes[1]
         .net
-        .reconcile_document_sync_topics(vec![lifecycle_target.sync_topic_id()])
+        .reconcile_document_sync_topics(vec![bucket_topic(&lifecycle_target)])
         .await?;
     assert_eq!(delete_result.metadata_create_events.len(), 0);
 
@@ -537,15 +574,16 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
         stale_target.clone(),
         postcard::to_allocvec(&create_event)?,
         nodes[1].net.node_id(),
+        placement,
     )
     .await?;
     nodes[1]
         .net
-        .sync_document_topic_with_peers(stale_target.sync_topic_id(), vec![nodes[0].net.node_id()])
+        .sync_document_topic_with_peers(bucket_topic(&stale_target), vec![nodes[0].net.node_id()])
         .await?;
     let stale_result = nodes[1]
         .net
-        .reconcile_document_sync_topics(vec![stale_target.sync_topic_id()])
+        .reconcile_document_sync_topics(vec![bucket_topic(&stale_target)])
         .await?;
 
     assert!(stale_result.metadata_create_events.is_empty());
@@ -567,7 +605,7 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
 async fn build_realm_nodes(
     realm_id: &RealmId,
     count: usize,
-) -> Result<Vec<TestNode>, Box<dyn std::error::Error>> {
+) -> Result<(Vec<TestNode>, RealmConfigDocument), Box<dyn std::error::Error>> {
     let mut nodes = Vec::with_capacity(count);
     for _ in 0..count {
         nodes.push(spawn_node(*realm_id).await?);
@@ -599,8 +637,8 @@ async fn build_realm_nodes(
     }
 
     wait_for_realm_node_convergence(&nodes, realm_id).await?;
-    install_realm_config(&nodes, realm_id).await?;
-    Ok(nodes)
+    let config = install_realm_config(&nodes, realm_id).await?;
+    Ok((nodes, config))
 }
 
 async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
@@ -648,7 +686,7 @@ async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::E
 async fn install_realm_config(
     nodes: &[TestNode],
     realm_id: &RealmId,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
     let mut config = RealmConfigDocument::default_for_realm(*realm_id, Vec::new());
     config.seed_default_placement();
     for node in nodes {
@@ -678,8 +716,18 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
 
-    Ok(())
+    Ok(config)
 }
 
 async fn publish_document_to_peer(
@@ -688,6 +736,7 @@ async fn publish_document_to_peer(
     target: DocumentSyncTarget,
     bytes: Vec<u8>,
     peer: aruna_core::NodeId,
+    placement: aruna_core::structs::PlacementRef,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match node
         .net
@@ -696,7 +745,12 @@ async fn publish_document_to_peer(
                 documents: vec![DocumentSyncPublish::Upsert {
                     event_id,
                     target: target.clone(),
-                    change: document_change_for_publish(node.net.node_id(), &target, &bytes)?,
+                    change: document_change_for_publish(
+                        node.net.node_id(),
+                        &target,
+                        &bytes,
+                        placement,
+                    )?,
                     bytes,
                     allow_genesis: true,
                 }],
@@ -719,6 +773,7 @@ fn document_change_for_publish(
     node_id: aruna_core::NodeId,
     target: &DocumentSyncTarget,
     bytes: &[u8],
+    placement: aruna_core::structs::PlacementRef,
 ) -> Result<DocumentSyncChange, Box<dyn std::error::Error>> {
     match target {
         DocumentSyncTarget::MetadataDocumentLifecycle { document_id } => {
@@ -727,9 +782,7 @@ fn document_change_for_publish(
                 return Err("metadata document lifecycle target mismatch".into());
             }
             Ok(metadata_document_lifecycle_revision_change(
-                &lifecycle,
-                node_id,
-                aruna_core::structs::PlacementRef::NIL,
+                &lifecycle, node_id, placement,
             ))
         }
         DocumentSyncTarget::MetadataCreateEvent {
@@ -749,7 +802,7 @@ fn document_change_for_publish(
                     updated_at_ms: record.occurred_at_ms,
                 },
                 kind: DocumentSyncChangeKind::Upsert,
-                placement: aruna_core::structs::PlacementRef::NIL,
+                placement,
             })
         }
         _ => Err("unsupported test publish target".into()),

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -522,7 +522,7 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
     let placement = aruna_operations::placement::placement_ref_for_target(
         &realm_config,
         &lifecycle_target,
-        None,
+        Default::default(),
     );
     assert_ne!(placement, aruna_core::structs::PlacementRef::NIL);
     let shard_topic_of = |target: &DocumentSyncTarget| target.sync_topic_id(realm_id, &placement);

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -23,7 +23,8 @@ use aruna_core::storage_entries::{
     metadata_event_log_key, metadata_registry_key,
 };
 use aruna_core::structs::{
-    Actor, MetadataRegistryRecord, NodePlacementEntry, RealmConfigDocument, RealmId, RealmNodeKind,
+    Actor, MetadataRegistryRecord, NodePlacementEntry, PlacementRef, RealmConfigDocument, RealmId,
+    RealmNodeKind,
 };
 use aruna_core::util::unix_timestamp_millis;
 use aruna_core::{DocumentSyncEffect, DocumentSyncNetEvent};
@@ -412,6 +413,7 @@ async fn batched_metadata_create_projection_materializes_many_documents()
                 &document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![node.net.node_id()],
             created_at_ms: now,
             updated_at_ms: now,
@@ -487,6 +489,7 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
             document_path,
             document_id,
         ),
+        placement: PlacementRef::NIL,
         holder_node_ids: vec![nodes[0].net.node_id(), nodes[1].net.node_id()],
         created_at_ms: 1,
         updated_at_ms: 1,

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -601,20 +601,11 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
         },
     };
     // All records of this document ride the bucket stamped on the record, so
-    // one shard topic. Its genesis exists (created eagerly by its rank-0 holder
-    // during install); the publisher below only joins it, never creates it.
+    // one shard topic. Its genesis exists on both nodes after install with no
+    // manual bootstrap: rank-0 created it, and the other holder pulled it in
+    // its own placement pass. The publisher below only joins it, never creates.
     assert_ne!(placement, PlacementRef::NIL);
     let shard_topic_of = |target: &DocumentSyncTarget| target.sync_topic_id(realm_id, &placement);
-    // Make sure the publisher knows the shard topic before publishing onto it:
-    // sync_document_topics bootstraps the genesis from the co-holder when
-    // rank-0 was the other node (the singular sync never bootstraps).
-    nodes[0]
-        .net
-        .sync_document_topics(
-            vec![shard_topic_of(&lifecycle_target)],
-            vec![nodes[1].net.node_id()],
-        )
-        .await;
     assert!(
         nodes[0]
             .net

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -125,7 +125,7 @@ async fn metadata_creation_replicates_to_all_three_holders()
 async fn metadata_replan_refreshes_replacement_holder_indexes()
 -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([46u8; 32]);
-    let nodes = build_realm_nodes(&realm_id, 4).await?;
+    let (nodes, _config) = build_realm_nodes(&realm_id, 4).await?;
     let group_id = Ulid::r#gen();
     let document_id = Ulid::r#gen();
     let document_path = "datasets/replan-holder-refresh";

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -47,7 +47,9 @@ use aruna_operations::metadata::projector::{
 use aruna_operations::mutate_realm_placement::{
     MutateRealmPlacementConfig, MutateRealmPlacementOperation, RealmPlacementMutation,
 };
-use aruna_operations::placement::{PlacementResolutionContext, plan_target_placement};
+use aruna_operations::placement::{
+    PlacementResolutionContext, plan_target_placement, resolve_shard_holders,
+};
 use aruna_operations::sync_placement::sort_node_ids;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_operations::update_metadata_document::{
@@ -122,8 +124,7 @@ async fn metadata_creation_replicates_to_all_three_holders()
 }
 
 #[tokio::test]
-async fn metadata_replan_refreshes_replacement_holder_indexes()
--> Result<(), Box<dyn std::error::Error>> {
+async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([46u8; 32]);
     let (nodes, _config) = build_realm_nodes(&realm_id, 4).await?;
     let group_id = Ulid::r#gen();
@@ -221,9 +222,10 @@ async fn metadata_replan_refreshes_replacement_holder_indexes()
         nodes[0].context.as_ref(),
     )
     .await?;
-    let mut final_holders = plan_target_placement(&updated_config, &target, placement_context)
-        .expect("updated metadata lifecycle placement resolves")
-        .holders;
+    let plan = plan_target_placement(&updated_config, &target, placement_context)
+        .expect("updated metadata lifecycle placement resolves");
+    let placement = plan.placement;
+    let mut final_holders = plan.holders;
     sort_node_ids(&mut final_holders);
     let replacement = final_holders
         .iter()
@@ -231,24 +233,18 @@ async fn metadata_replan_refreshes_replacement_holder_indexes()
         .find(|node_id| !initial_holders.contains(node_id))
         .expect("replan selects a replacement holder");
 
-    wait_for_persisted_holder_set(
-        &nodes,
-        &final_holders,
-        group_id,
-        document_id,
-        &final_holders,
-    )
-    .await?;
+    let live_holders = resolve_shard_holders(&updated_config, &placement);
+    assert!(live_holders.contains(&replacement));
+    assert!(!live_holders.contains(&obsolete));
+
     let replacement_node = nodes
         .iter()
         .find(|node| node.net.node_id() == replacement)
         .expect("replacement fixture node exists");
-    let (registry, holders) = read_persisted_holder_set(replacement_node, group_id, document_id)
-        .await?
-        .expect("replacement persisted metadata indexes");
-    assert!(same_holder_set(&registry.holder_node_ids, &final_holders));
-    assert!(same_holder_set(&holders, &final_holders));
-    assert!(!holders.contains(&obsolete));
+    // holder_node_ids is an event-time stamp; freshness is the shard guarantee (#395).
+    let registry =
+        wait_for_persisted_update(replacement_node, group_id, document_id, latest_update_id)
+            .await?;
     assert_eq!(registry.last_event_id, latest_update_id);
     let refreshed_event =
         read_metadata_event_log_value(replacement_node, document_id, latest_update_id)
@@ -865,6 +861,31 @@ async fn read_persisted_holder_set(
         }
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
         other => Err(format!("unexpected metadata index read event: {other:?}").into()),
+    }
+}
+
+async fn wait_for_persisted_update(
+    node: &TestNode,
+    group_id: Ulid,
+    document_id: Ulid,
+    expected_event_id: Ulid,
+) -> Result<MetadataRegistryRecord, Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        let last = match read_persisted_holder_set(node, group_id, document_id).await? {
+            Some((registry, _)) if registry.last_event_id == expected_event_id => {
+                return Ok(registry);
+            }
+            Some((registry, _)) => format!("last_event_id={}", registry.last_event_id),
+            None => "missing".to_string(),
+        };
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "replacement did not converge to update {expected_event_id}: {last}"
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(50)).await;
     }
 }
 

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -514,8 +514,8 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
             deleted_after_event_id: event_id,
         },
     };
-    // All records of this document share a subject and so one bucket topic.
-    // The placement comes from the installed realm config, so the bucket
+    // All records of this document share a subject and so one shard topic.
+    // The placement comes from the installed realm config, so the shard
     // topic's genesis exists (created eagerly by its rank-0 holder during
     // install); the publisher below only joins it, never creates it.
     let lifecycle_target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
@@ -525,22 +525,22 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
         None,
     );
     assert_ne!(placement, aruna_core::structs::PlacementRef::NIL);
-    let bucket_topic = |target: &DocumentSyncTarget| target.sync_topic_id(realm_id, &placement);
-    // Make sure the publisher knows the bucket topic before publishing onto it:
+    let shard_topic_of = |target: &DocumentSyncTarget| target.sync_topic_id(realm_id, &placement);
+    // Make sure the publisher knows the shard topic before publishing onto it:
     // sync_document_topics bootstraps the genesis from the co-holder when
     // rank-0 was the other node (the singular sync never bootstraps).
     nodes[0]
         .net
         .sync_document_topics(
-            vec![bucket_topic(&lifecycle_target)],
+            vec![shard_topic_of(&lifecycle_target)],
             vec![nodes[1].net.node_id()],
         )
         .await;
     assert!(
         nodes[0]
             .net
-            .document_sync_topic_exists(bucket_topic(&lifecycle_target))?,
-        "bucket topic genesis unavailable on both nodes after install"
+            .document_sync_topic_exists(shard_topic_of(&lifecycle_target))?,
+        "shard topic genesis unavailable on both nodes after install"
     );
     publish_document_to_peer(
         &nodes[0],
@@ -554,13 +554,13 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
     nodes[1]
         .net
         .sync_document_topic_with_peers(
-            bucket_topic(&lifecycle_target),
+            shard_topic_of(&lifecycle_target),
             vec![nodes[0].net.node_id()],
         )
         .await?;
     let delete_result = nodes[1]
         .net
-        .reconcile_document_sync_topics(vec![bucket_topic(&lifecycle_target)])
+        .reconcile_document_sync_topics(vec![shard_topic_of(&lifecycle_target)])
         .await?;
     assert_eq!(delete_result.metadata_create_events.len(), 0);
 
@@ -579,11 +579,11 @@ async fn metadata_delete_wins_when_stale_create_arrives_after_tombstone()
     .await?;
     nodes[1]
         .net
-        .sync_document_topic_with_peers(bucket_topic(&stale_target), vec![nodes[0].net.node_id()])
+        .sync_document_topic_with_peers(shard_topic_of(&stale_target), vec![nodes[0].net.node_id()])
         .await?;
     let stale_result = nodes[1]
         .net
-        .reconcile_document_sync_topics(vec![bucket_topic(&stale_target)])
+        .reconcile_document_sync_topics(vec![shard_topic_of(&stale_target)])
         .await?;
 
     assert!(stale_result.metadata_create_events.is_empty());
@@ -716,10 +716,10 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             *realm_id,
             node.net.node_id(),

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -795,15 +795,34 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the shard's rank-0 holder eagerly creates each
-    // shard topic genesis (mirrors the production realm-config apply path).
-    for node in nodes {
-        aruna_operations::process_placements::process_shard_placements(
-            &node.context,
-            *realm_id,
-            node.net.node_id(),
-        )
-        .await;
+    // Startup hook, exactly as the binary runs it after loading the config: it
+    // joins the shared realm topics (RealmConfig among them, so a later placement
+    // change actually reaches the other nodes) and reconciles the held shard
+    // topics. A node whose rank-0 co-holder has not created a genesis yet leaves
+    // it for the next pass, so run until quiescent instead of waiting out the
+    // production retry timer.
+    for _ in 0..3 {
+        for node in nodes {
+            aruna_operations::startup::restore_shard_subscriptions(
+                &node.context,
+                node.net.node_id(),
+                *realm_id,
+            )
+            .await;
+        }
+        let mut retry = false;
+        for node in nodes {
+            retry |= aruna_operations::process_placements::process_shard_placements(
+                &node.context,
+                *realm_id,
+                node.net.node_id(),
+            )
+            .await
+            .retry_scheduled;
+        }
+        if !retry {
+            break;
+        }
     }
 
     Ok(config)

--- a/operations/tests/metadata_throughput.rs
+++ b/operations/tests/metadata_throughput.rs
@@ -684,6 +684,16 @@ async fn install_realm_config(nodes: &[TestNode], realm_id: &RealmId) -> Result<
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
     Ok(())
 }
 

--- a/operations/tests/metadata_throughput.rs
+++ b/operations/tests/metadata_throughput.rs
@@ -684,10 +684,10 @@ async fn install_realm_config(nodes: &[TestNode], realm_id: &RealmId) -> Result<
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             *realm_id,
             node.net.node_id(),

--- a/operations/tests/notification_delivery.rs
+++ b/operations/tests/notification_delivery.rs
@@ -558,6 +558,16 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
     Ok(())
 }
 

--- a/operations/tests/notification_delivery.rs
+++ b/operations/tests/notification_delivery.rs
@@ -558,10 +558,10 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             realm_id,
             node.net.node_id(),

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -688,6 +688,8 @@ async fn seed_realm_config_sync_topic(
     config: &RealmConfigDocument,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = DocumentSyncTarget::RealmConfig { realm_id };
+    let placement = aruna_operations::placement::placement_ref_for_target(config, &target, None);
+    let topic = target.sync_topic_id(realm_id, &placement);
     let actor = Actor {
         node_id: nodes[1].net.node_id(),
         user_id: aruna_core::UserId::nil(realm_id),
@@ -713,6 +715,7 @@ async fn seed_realm_config_sync_topic(
                 documents: vec![DocumentSyncPublish::AdminOperation {
                     target: target.clone(),
                     event: Box::new(event),
+                    placement,
                     allow_genesis: true,
                 }],
                 peers: Vec::new(),
@@ -730,7 +733,7 @@ async fn seed_realm_config_sync_topic(
         .net
         .send_effect(Effect::Net(NetEffect::DocumentSync(
             DocumentSyncEffect::SyncDocuments {
-                targets: vec![target],
+                topics: vec![topic],
                 peers: Vec::new(),
             },
         )))

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -669,6 +669,16 @@ async fn install_realm_config(
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
     seed_realm_config_sync_topic(nodes, realm_id, &config).await?;
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
     Ok(())
 }
 

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -351,7 +351,7 @@ fn assert_weighted_distinct_resolution(nodes: &[TestNode], config: &RealmConfigD
     let mut baseline_hot_wins = 0usize;
     for counter in 0u64..2_000 {
         let subject = blake3::hash(&counter.to_le_bytes());
-        let holders = resolve_holders(&view, strategy, subject.as_bytes(), 0, None);
+        let holders = resolve_holders(&view, strategy, subject.as_bytes(), None);
         let locations: std::collections::HashSet<_> = holders
             .iter()
             .map(|holder| {
@@ -366,9 +366,8 @@ fn assert_weighted_distinct_resolution(nodes: &[TestNode], config: &RealmConfigD
         assert_eq!(holders.len(), 2);
         assert_eq!(locations.len(), 2);
         hot_wins += usize::from(holders[0] == hot_node);
-        baseline_hot_wins += usize::from(
-            resolve_holders(&view, &baseline, subject.as_bytes(), 0, None)[0] == hot_node,
-        );
+        baseline_hot_wins +=
+            usize::from(resolve_holders(&view, &baseline, subject.as_bytes(), None)[0] == hot_node);
     }
     assert!(
         hot_wins > baseline_hot_wins + 400,
@@ -414,13 +413,13 @@ fn assert_resolve_holders_identical(configs: &[RealmConfigDocument]) {
 
     for counter in 0u64..100 {
         let subject = *blake3::hash(&counter.to_le_bytes()).as_bytes();
-        let reference = resolve_holders(&views[0], &strategy, &subject, 0, None);
+        let reference = resolve_holders(&views[0], &strategy, &subject, None);
         assert!(
             !reference.is_empty(),
             "empty holder set for subject {counter}"
         );
         for view in &views[1..] {
-            let holders = resolve_holders(view, &strategy, &subject, 0, None);
+            let holders = resolve_holders(view, &strategy, &subject, None);
             assert_eq!(
                 holders, reference,
                 "holder set diverged for subject {counter}"

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -669,10 +669,10 @@ async fn install_realm_config(
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
     seed_realm_config_sync_topic(nodes, realm_id, &config).await?;
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             realm_id,
             node.net.node_id(),

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -9,23 +9,24 @@ use aruna_core::effects::{Effect, NetEffect, StorageEffect};
 use aruna_core::events::{Event, NetEvent, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
-use aruna_core::metadata::{MetadataCreateEventPayload, MetadataCreateEventRecord};
 use aruna_core::structs::{
     Actor, AffinityEffect, AffinityRule, LabelMatch, MetadataRegistryRecord, NodePlacementEntry,
-    NodeUrls, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind,
+    NodeUrls, RealmConfigDocument, RealmId, RealmNodeKind,
 };
 use aruna_core::{DocumentSyncEffect, DocumentSyncNetEvent};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::metadata::MetadataHandle;
 use aruna_operations::mutate_realm_placement::{
     MutateRealmPlacementConfig, MutateRealmPlacementOperation, RealmPlacementMutation,
 };
 use aruna_operations::node_info::{read_node_info_document, seed_node_info_document};
-use aruna_operations::placement::{
-    PlacementResolutionContext, build_view, plan_target_placement, resolve_holders,
-};
+use aruna_operations::placement::{build_view, resolve_holders, resolve_shard_holders};
 use aruna_operations::replicate_documents::{
     ReplicateDocumentsConfig, ReplicateDocumentsOperation,
 };
@@ -55,32 +56,6 @@ async fn placement_policy_converges_and_replans_completed_inventory()
     let actor = test_actor(&nodes[0], realm_id);
     let group_id = Ulid::from_bytes([71; 16]);
     let document_id = Ulid::from_bytes([72; 16]);
-    let event_id = Ulid::from_bytes([73; 16]);
-    let target = DocumentSyncTarget::MetadataCreateEvent {
-        document_id,
-        event_id,
-    };
-    write_metadata_create_event(
-        &nodes[0],
-        realm_id,
-        group_id,
-        document_id,
-        event_id,
-        &target,
-    )
-    .await?;
-
-    drive(
-        ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
-            realm_id,
-            local_node_id: nodes[0].net.node_id(),
-            excluded_peers: Vec::new(),
-            documents: vec![target.clone()],
-            allow_genesis: true,
-        }),
-        nodes[0].context.as_ref(),
-    )
-    .await?;
 
     let initial_config = drive(
         GetRealmConfigOperation::new(realm_id),
@@ -88,15 +63,20 @@ async fn placement_policy_converges_and_replans_completed_inventory()
     )
     .await?;
     assert_weighted_distinct_resolution(&nodes, &initial_config);
-    let initial_plan = plan_target_placement(
-        &initial_config,
-        &target,
-        PlacementResolutionContext::default(),
-    )
-    .expect("default placement strategy should plan the document");
-    assert_eq!(initial_plan.desired_count, 2);
-    let mut expected_initial = initial_plan.holders;
+
+    // The create-receiving node chooses the document's bucket out of the ones
+    // it holds; every record of the document rides that bucket.
+    let created = create_metadata_document(&nodes[0], realm_id, group_id, document_id).await?;
+    let placement = created.placement;
+    let target = DocumentSyncTarget::MetadataCreateEvent {
+        document_id,
+        event_id: created.last_event_id,
+    };
+
+    let mut expected_initial = resolve_shard_holders(&initial_config, &placement);
     sort_node_ids(&mut expected_initial);
+    assert_eq!(expected_initial.len(), 2);
+    assert!(expected_initial.contains(&nodes[0].net.node_id()));
     wait_for_document_on_holders(&nodes, &expected_initial, &target).await?;
 
     let obsolete = expected_initial[0];
@@ -136,14 +116,8 @@ async fn placement_policy_converges_and_replans_completed_inventory()
     let configs = wait_for_policy_convergence(&nodes, realm_id, obsolete, 3).await?;
     assert_placement_state_identical(&configs);
     assert_resolve_holders_identical(&configs);
-    let final_plan =
-        plan_target_placement(&configs[0], &target, PlacementResolutionContext::default())
-            .expect("updated placement strategy should plan the document");
-    assert_eq!(
-        final_plan.placement.strategy_id,
-        expanded_strategy.strategy_id
-    );
-    let mut expected_final = final_plan.holders;
+    assert_eq!(placement.strategy_id, expanded_strategy.strategy_id);
+    let mut expected_final = resolve_shard_holders(&configs[0], &placement);
     sort_node_ids(&mut expected_final);
     assert_eq!(expected_final.len(), 3);
     assert!(!expected_final.contains(&obsolete));
@@ -244,60 +218,34 @@ fn test_actor(node: &TestNode, realm_id: RealmId) -> Actor {
     }
 }
 
-async fn write_metadata_create_event(
+async fn create_metadata_document(
     node: &TestNode,
     realm_id: RealmId,
     group_id: Ulid,
     document_id: Ulid,
-    event_id: Ulid,
-    target: &DocumentSyncTarget,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let document_path = "datasets/issue-261";
-    let record = MetadataCreateEventRecord {
-        event_id,
-        record: MetadataRegistryRecord {
-            realm_id,
+) -> Result<MetadataRegistryRecord, Box<dyn std::error::Error>> {
+    Ok(drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: node.net.node_id(),
+                user_id: aruna_core::UserId::local(Ulid::from_bytes([74; 16]), realm_id),
+                realm_id,
+            },
             group_id,
             document_id,
-            document_path: document_path.to_string(),
-            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+            document_path: "datasets/issue-261".to_string(),
             public: false,
-            permission_path: MetadataRegistryRecord::permission_path_for(
-                &realm_id,
-                group_id,
-                document_path,
-                document_id,
-            ),
-            placement: PlacementRef::NIL,
-            holder_node_ids: vec![node.net.node_id()],
-            created_at_ms: 1,
-            updated_at_ms: 1,
-            last_event_id: event_id,
-        },
-        user_id: aruna_core::UserId::local(Ulid::from_bytes([74; 16]), realm_id),
-        node_id: node.net.node_id(),
-        payload: MetadataCreateEventPayload::Scaffold {
-            name: "Issue 261 placement".to_string(),
-            description: "Integration placement fixture".to_string(),
-            date_published: "2026-07-10".to_string(),
-            license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
-        },
-        occurred_at_ms: 1,
-    };
-    match node
-        .context
-        .storage_handle
-        .send_effect(Effect::Storage(StorageEffect::Write {
-            key_space: target.storage_keyspace().to_string(),
-            key: target.storage_key(),
-            value: postcard::to_allocvec(&record)?.into(),
-            txn_id: None,
-        }))
-        .await
-    {
-        Event::Storage(StorageEvent::WriteResult { .. }) => Ok(()),
-        other => Err(format!("unexpected metadata create-event write: {other:?}").into()),
-    }
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Issue 261 placement".to_string(),
+                description: "Integration placement fixture".to_string(),
+                date_published: "2026-07-10".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        node.context.as_ref(),
+    )
+    .await?
+    .record)
 }
 
 async fn wait_for_document_on_holders(
@@ -524,12 +472,20 @@ async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::E
     )
     .await?;
     let task_handle = TaskHandle::new();
+    let metadata_handle = MetadataHandle::new(
+        temp_dir.path().join("metadata"),
+        net.node_id(),
+        storage.clone(),
+        Some(net.clone()),
+        Some(net.document_sync_node()),
+        Some(net.document_sync_database()),
+    )?;
 
     let context = Arc::new(DriverContext {
         storage_handle: storage,
         net_handle: Some(net.clone()),
         blob_handle: None,
-        metadata_handle: None,
+        metadata_handle: Some(metadata_handle),
         task_handle: Some(task_handle.clone()),
     });
 

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -12,7 +12,7 @@ use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
 use aruna_core::metadata::{MetadataCreateEventPayload, MetadataCreateEventRecord};
 use aruna_core::structs::{
     Actor, AffinityEffect, AffinityRule, LabelMatch, MetadataRegistryRecord, NodePlacementEntry,
-    NodeUrls, RealmConfigDocument, RealmId, RealmNodeKind,
+    NodeUrls, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind,
 };
 use aruna_core::{DocumentSyncEffect, DocumentSyncNetEvent};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
@@ -268,6 +268,7 @@ async fn write_metadata_create_event(
                 document_path,
                 document_id,
             ),
+            placement: PlacementRef::NIL,
             holder_node_ids: vec![node.net.node_id()],
             created_at_ms: 1,
             updated_at_ms: 1,

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use aruna_core::admin_document_reducer::AdminDocumentReducerState;
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
-use aruna_core::document::{DocumentSyncPublish, DocumentSyncTarget, PendingDocumentPlacement};
+use aruna_core::document::{DocumentSyncPublish, DocumentSyncTarget};
 use aruna_core::effects::{Effect, NetEffect, StorageEffect};
 use aruna_core::events::{Event, NetEvent, StorageEvent};
 use aruna_core::handle::Handle;
@@ -29,7 +29,6 @@ use aruna_operations::placement::{
 use aruna_operations::replicate_documents::{
     ReplicateDocumentsConfig, ReplicateDocumentsOperation,
 };
-use aruna_operations::sync_placement::{decode_placement, placement_key};
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
@@ -89,20 +88,18 @@ async fn placement_policy_converges_and_replans_completed_inventory()
     )
     .await?;
     assert_weighted_distinct_resolution(&nodes, &initial_config);
-    let mut expected_initial = plan_target_placement(
+    let initial_plan = plan_target_placement(
         &initial_config,
         &target,
         PlacementResolutionContext::default(),
     )
-    .expect("default placement strategy should plan the document")
-    .holders;
+    .expect("default placement strategy should plan the document");
+    assert_eq!(initial_plan.desired_count, 2);
+    let mut expected_initial = initial_plan.holders;
     sort_node_ids(&mut expected_initial);
-    let initial = wait_for_placement(&nodes[0], realm_id, &target, |record| {
-        record.desired_holder_count == 2 && record.selected_holders == expected_initial
-    })
-    .await?;
+    wait_for_document_on_holders(&nodes, &expected_initial, &target).await?;
 
-    let obsolete = initial.selected_holders[0];
+    let obsolete = expected_initial[0];
     let old_entry = initial_config
         .placement_entry(obsolete)
         .expect("selected holder should have a placement entry");
@@ -139,37 +136,24 @@ async fn placement_policy_converges_and_replans_completed_inventory()
     let configs = wait_for_policy_convergence(&nodes, realm_id, obsolete, 3).await?;
     assert_placement_state_identical(&configs);
     assert_resolve_holders_identical(&configs);
-    let mut expected_final =
+    let final_plan =
         plan_target_placement(&configs[0], &target, PlacementResolutionContext::default())
-            .expect("updated placement strategy should plan the document")
-            .holders;
+            .expect("updated placement strategy should plan the document");
+    assert_eq!(
+        final_plan.placement.strategy_id,
+        expanded_strategy.strategy_id
+    );
+    let mut expected_final = final_plan.holders;
     sort_node_ids(&mut expected_final);
     assert_eq!(expected_final.len(), 3);
     assert!(!expected_final.contains(&obsolete));
-
-    let final_record = wait_for_placement(&nodes[0], realm_id, &target, |record| {
-        record.desired_holder_count == 3 && record.selected_holders == expected_final
-    })
-    .await?;
-    assert_eq!(
-        final_record.placement.strategy_id,
-        expanded_strategy.strategy_id
-    );
-    assert!(!final_record.selected_holders.contains(&obsolete));
     assert!(
-        final_record
-            .selected_holders
+        expected_final
             .iter()
-            .any(|holder| !initial.selected_holders.contains(holder)),
+            .any(|holder| !expected_initial.contains(holder)),
         "policy change should add replacement/top-up holders"
     );
-    for holder in &final_record.selected_holders {
-        let node = nodes
-            .iter()
-            .find(|node| node.net.node_id() == *holder)
-            .expect("final holder should be a fixture node");
-        wait_for_document(node, &target).await?;
-    }
+    wait_for_document_on_holders(&nodes, &expected_final, &target).await?;
 
     shutdown_nodes(nodes).await;
     Ok(())
@@ -315,59 +299,19 @@ async fn write_metadata_create_event(
     }
 }
 
-async fn read_placement(
-    node: &TestNode,
-    realm_id: RealmId,
+async fn wait_for_document_on_holders(
+    nodes: &[TestNode],
+    holders: &[aruna_core::NodeId],
     target: &DocumentSyncTarget,
-) -> Result<Option<PendingDocumentPlacement>, Box<dyn std::error::Error>> {
-    match node
-        .context
-        .storage_handle
-        .send_effect(Effect::Storage(StorageEffect::Read {
-            key_space: aruna_core::keyspaces::SYNC_PLACEMENT_KEYSPACE.to_string(),
-            key: placement_key(realm_id, target),
-            txn_id: None,
-        }))
-        .await
-    {
-        Event::Storage(StorageEvent::ReadResult { value, .. }) => Ok(value
-            .map(|value| decode_placement(value.as_ref()))
-            .transpose()?),
-        other => Err(format!("unexpected placement read event: {other:?}").into()),
+) -> Result<(), Box<dyn std::error::Error>> {
+    for holder in holders {
+        let node = nodes
+            .iter()
+            .find(|node| node.net.node_id() == *holder)
+            .expect("holder should be a fixture node");
+        wait_for_document(node, target).await?;
     }
-}
-
-async fn wait_for_placement(
-    node: &TestNode,
-    realm_id: RealmId,
-    target: &DocumentSyncTarget,
-    predicate: impl Fn(&PendingDocumentPlacement) -> bool,
-) -> Result<PendingDocumentPlacement, Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    let mut last_record = None;
-    loop {
-        if let Some(record) = read_placement(node, realm_id, target).await? {
-            if predicate(&record) {
-                return Ok(record);
-            }
-            last_record = Some(record);
-        }
-        if Instant::now() >= deadline {
-            let config = drive(
-                GetRealmConfigOperation::new(realm_id),
-                node.context.as_ref(),
-            )
-            .await?;
-            let active_strategy = config
-                .default_strategy_id
-                .and_then(|strategy_id| config.strategy(&strategy_id));
-            return Err(format!(
-                "placement inventory did not reach the expected state; active strategy: {active_strategy:?}; last record: {last_record:?}"
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+    Ok(())
 }
 
 async fn wait_for_document(
@@ -688,7 +632,8 @@ async fn seed_realm_config_sync_topic(
     config: &RealmConfigDocument,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let target = DocumentSyncTarget::RealmConfig { realm_id };
-    let placement = aruna_operations::placement::placement_ref_for_target(config, &target, None);
+    let placement =
+        aruna_operations::placement::placement_ref_for_target(config, &target, Default::default());
     let topic = target.sync_topic_id(realm_id, &placement);
     let actor = Actor {
         node_id: nodes[1].net.node_id(),

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -11,10 +11,10 @@ use aruna_core::keyspaces::{
 };
 use aruna_core::structs::{
     Actor, GroupAuthorizationDocument, NOTIFICATION_WATCH_PER_USER_CAP, NotificationClass,
-    NotificationKind, NotificationRecord, RealmAuthorizationDocument, RealmConfigDocument, RealmId,
-    RealmNodeKind, WatchEvent, WatchEventDetail, WatchEventKind, WatchEventMask,
-    WatchInterestDigest, WatchSubscription, data_watch_resource_path, watch_interest_node_key,
-    watch_notification_id,
+    NotificationKind, NotificationRecord, PlacementRef, RealmAuthorizationDocument,
+    RealmConfigDocument, RealmId, RealmNodeKind, WatchEvent, WatchEventDetail, WatchEventKind,
+    WatchEventMask, WatchInterestDigest, WatchSubscription, data_watch_resource_path,
+    watch_interest_node_key, watch_notification_id,
 };
 use aruna_core::util::unix_timestamp_millis;
 use aruna_core::{DocumentSyncEffect, NodeId, UserId};
@@ -438,10 +438,11 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
         .net
         .send_effect(Effect::Net(NetEffect::DocumentSync(
             DocumentSyncEffect::SyncDocument {
-                target: DocumentSyncTarget::WatchInterest {
+                topic: DocumentSyncTarget::WatchInterest {
                     realm_id,
                     node_id: old_holder,
-                },
+                }
+                .sync_topic_id(realm_id, &PlacementRef::NIL),
                 peers: vec![old_holder],
             },
         )))

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -44,7 +44,10 @@ use tokio::time::Instant;
 use tokio::time::sleep;
 use ulid::Ulid;
 
-const POLL_TIMEOUT: Duration = Duration::from_secs(60);
+// Positive delivery waits poll to a condition; the ceiling only bounds a genuine
+// hang, so it carries generous headroom for a loaded CI runner where multi-node
+// watch delivery is thread-starved and slow.
+const POLL_TIMEOUT: Duration = Duration::from_secs(180);
 const LIST_LIMIT: usize = LIST_NOTIFICATIONS_MAX_LIMIT;
 // Interest publication is debounced by 2s, so a few seconds comfortably bounds
 // the window an erroneous delivery would need to land in for negative assertions.

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -777,10 +777,10 @@ async fn install_config_document(
         }
         node.net.refresh_realm_peers_from_document(config).await?;
     }
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             realm_id,
             node.net.node_id(),

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -777,6 +777,16 @@ async fn install_config_document(
         }
         node.net.refresh_realm_peers_from_document(config).await?;
     }
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
     Ok(())
 }
 

--- a/operations/tests/restart_traffic.rs
+++ b/operations/tests/restart_traffic.rs
@@ -1,0 +1,470 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aruna_core::UserId;
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{Actor, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::types::GroupId;
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::announce_realm_presence::{
+    AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
+};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_metadata_document::GetMetadataDocumentOperation;
+use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::metadata::MetadataHandle;
+use aruna_operations::metadata::projector::project_metadata_create_events_from_log;
+use aruna_operations::startup::{SHARED_RESTORE_TOPIC_COUNT, restore_shard_subscriptions};
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use ulid::Ulid;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+const SETUP_TIMEOUT: Duration = Duration::from_secs(30);
+const PROJECTION_BATCH: usize = 32;
+const SEED_DOCUMENTS: usize = 500;
+
+struct TestNode {
+    _temp_dir: Option<TempDir>,
+    net: NetHandle,
+    task_handle: TaskHandle,
+    context: Arc<DriverContext>,
+}
+
+// A restart re-announces one topic per held shard plus the fixed shared topics —
+// never one per stored document — and a fresh write still converges to the
+// restarted node afterwards.
+#[test]
+fn restart_reannounces_held_shard_topics_not_documents() -> Result<(), BoxError> {
+    let runtime = make_runtime()?;
+    let result = runtime.block_on(restart_traffic_body());
+    runtime.shutdown_timeout(Duration::from_secs(10));
+    result
+}
+
+async fn restart_traffic_body() -> Result<(), BoxError> {
+    let realm_id = RealmId([126u8; 32]);
+    let node2_dir = tempfile::tempdir()?;
+    let secret = iroh::SecretKey::from_bytes(&[7u8; 32]);
+
+    let aux = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()?;
+
+    let mut nodes = Vec::with_capacity(3);
+    nodes.push(spawn_node(realm_id).await?);
+    nodes.push(spawn_node(realm_id).await?);
+    let dir2 = node2_dir.path().to_path_buf();
+    let secret2 = secret.clone();
+    let node2 = aux
+        .handle()
+        .spawn(async move { spawn_node_with(realm_id, Some(secret2), dir2).await })
+        .await??;
+    nodes.push(node2);
+
+    wire_peers(&nodes).await;
+    for (index, node) in nodes.iter().enumerate() {
+        let op = AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+            realm_id,
+            node_id: node.net.node_id(),
+            schedule_refresh: true,
+        });
+        if index == 2 {
+            let ctx = node.context.clone();
+            aux.handle()
+                .spawn(async move {
+                    drive(op, ctx.as_ref())
+                        .await
+                        .map_err(|error| format!("announce failed: {error:?}"))
+                })
+                .await??;
+        } else {
+            drive(op, node.context.as_ref()).await?;
+        }
+    }
+    wait_for_realm_node_convergence(&nodes, &realm_id).await?;
+    install_realm_config(&nodes, &realm_id).await?;
+
+    // Seed ~500 documents across shards from node 0.
+    let group_id = Ulid::r#gen();
+    let targets0 = vec![(nodes[0].net.node_id(), nodes[0].context.clone())];
+    let created = run_writer(realm_id, group_id, SEED_DOCUMENTS, targets0).await?;
+    // Wait until the restarting node holds real shard state (a recent sample is
+    // visible), so the restore has something it could wrongly re-announce.
+    let sample: Vec<(GroupId, Ulid)> = created
+        .iter()
+        .rev()
+        .take(40)
+        .map(|(group_id, document_id)| (*group_id, *document_id))
+        .collect();
+    wait_for_visibility(
+        std::slice::from_ref(&nodes[2].context),
+        &sample,
+        Duration::from_millis(200),
+        Duration::from_secs(60),
+    )
+    .await?;
+    println!("seeded {} docs, node 2 caught up", created.len());
+
+    // Restart node 2's whole stack.
+    let node2 = nodes.pop().expect("node 2 present");
+    node2.net.clear_inbound_handler();
+    node2.task_handle.clear_inbound_handler().await;
+    node2.net.shutdown().await;
+    drop(node2);
+    tokio::task::spawn_blocking(move || aux.shutdown_timeout(Duration::from_secs(10))).await?;
+    println!("node 2 shut down");
+
+    let node2 = respawn_with_retry(realm_id, secret, node2_dir.path()).await?;
+    for other in &nodes {
+        node2.net.add_peer_addr(other.net.endpoint_addr()).await;
+        other.net.add_peer_addr(node2.net.endpoint_addr()).await;
+    }
+    drive(
+        AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+            realm_id,
+            node_id: node2.net.node_id(),
+            schedule_refresh: true,
+        }),
+        node2.context.as_ref(),
+    )
+    .await?;
+
+    // (a) The startup restore touches O(held shards) topics, not O(documents).
+    let summary = restore_shard_subscriptions(&node2.context, node2.net.node_id(), realm_id).await;
+    println!(
+        "restore summary: held_shards={} shard_topics={} shared_topics={} total={}",
+        summary.held_shards,
+        summary.shard_topics,
+        summary.shared_topics,
+        summary.total_topics()
+    );
+    assert!(summary.held_shards > 0, "node 2 must hold shards");
+    assert!(
+        summary.total_topics() <= summary.held_shards + SHARED_RESTORE_TOPIC_COUNT,
+        "restore announced {} topics, more than held_shards {} + shared {}",
+        summary.total_topics(),
+        summary.held_shards,
+        SHARED_RESTORE_TOPIC_COUNT
+    );
+    assert!(
+        summary.total_topics() < created.len(),
+        "restore announced {} topics, not fewer than the {} seeded documents",
+        summary.total_topics(),
+        created.len()
+    );
+
+    // (b) A fresh write after the restart converges to all nodes.
+    nodes.push(node2);
+    let fresh = run_writer(realm_id, group_id, 1, {
+        vec![(nodes[0].net.node_id(), nodes[0].context.clone())]
+    })
+    .await?;
+    let contexts: Vec<Arc<DriverContext>> = nodes.iter().map(|node| node.context.clone()).collect();
+    wait_for_visibility(
+        &contexts,
+        &fresh,
+        Duration::from_millis(200),
+        Duration::from_secs(60),
+    )
+    .await?;
+    println!("fresh write converged to all nodes after restart");
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+fn make_runtime() -> Result<tokio::runtime::Runtime, BoxError> {
+    Ok(tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?)
+}
+
+async fn run_writer(
+    realm_id: RealmId,
+    group_id: GroupId,
+    count: usize,
+    targets: Vec<(aruna_core::NodeId, Arc<DriverContext>)>,
+) -> Result<Vec<(GroupId, Ulid)>, BoxError> {
+    let mut batches: Vec<Vec<(Ulid, Ulid)>> = targets.iter().map(|_| Vec::new()).collect();
+    let mut pending = 0usize;
+    let mut created = Vec::with_capacity(count);
+
+    for index in 0..count {
+        let slot = index % targets.len();
+        let (node_id, context) = &targets[slot];
+        let document_id = Ulid::r#gen();
+        let result = drive(
+            CreateMetadataDocumentOperation::new_for_generated_document_id(
+                CreateMetadataDocumentConfig {
+                    actor: Actor {
+                        node_id: *node_id,
+                        user_id: UserId::local(Ulid::r#gen(), realm_id),
+                        realm_id,
+                    },
+                    group_id,
+                    document_id,
+                    document_path: format!("datasets/restart-{index}"),
+                    public: true,
+                    payload: CreateMetadataDocumentPayload::Scaffold {
+                        name: format!("Restart Dataset {index}"),
+                        description: "Restart traffic document".to_string(),
+                        date_published: "2026-07-07".to_string(),
+                        license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+                    },
+                },
+            ),
+            context.as_ref(),
+        )
+        .await
+        .map_err(|error| format!("create failed index={index}: {error:?}"))?;
+
+        batches[slot].push((result.record.document_id, result.record.last_event_id));
+        created.push((group_id, result.record.document_id));
+        pending += 1;
+        if pending >= PROJECTION_BATCH {
+            flush_projection_batches(&targets, &mut batches).await?;
+            pending = 0;
+        }
+    }
+    flush_projection_batches(&targets, &mut batches).await?;
+    Ok(created)
+}
+
+async fn flush_projection_batches(
+    targets: &[(aruna_core::NodeId, Arc<DriverContext>)],
+    batches: &mut [Vec<(Ulid, Ulid)>],
+) -> Result<(), BoxError> {
+    for (slot, batch) in batches.iter_mut().enumerate() {
+        if batch.is_empty() {
+            continue;
+        }
+        let drained: Vec<(Ulid, Ulid)> = std::mem::take(batch);
+        project_metadata_create_events_from_log(targets[slot].1.as_ref(), drained)
+            .await
+            .map_err(|error| format!("projection failed: {error:?}"))?;
+    }
+    Ok(())
+}
+
+async fn wait_for_visibility(
+    contexts: &[Arc<DriverContext>],
+    pairs: &[(GroupId, Ulid)],
+    poll_interval: Duration,
+    timeout: Duration,
+) -> Result<(), BoxError> {
+    let t0 = Instant::now();
+    let mut remaining: Vec<Vec<(GroupId, Ulid)>> =
+        contexts.iter().map(|_| pairs.to_vec()).collect();
+
+    loop {
+        for (context, missing) in contexts.iter().zip(remaining.iter_mut()) {
+            let mut still_missing = Vec::new();
+            for &(group_id, document_id) in missing.iter() {
+                if drive(
+                    GetMetadataDocumentOperation::new(group_id, document_id),
+                    context.as_ref(),
+                )
+                .await
+                .is_err()
+                {
+                    still_missing.push((group_id, document_id));
+                }
+            }
+            *missing = still_missing;
+        }
+        if remaining.iter().all(Vec::is_empty) {
+            return Ok(());
+        }
+        if t0.elapsed() > timeout {
+            let counts: Vec<usize> = remaining.iter().map(Vec::len).collect();
+            return Err(format!("visibility timeout; missing per node: {counts:?}").into());
+        }
+        sleep(poll_interval).await;
+    }
+}
+
+async fn spawn_node(realm_id: RealmId) -> Result<TestNode, BoxError> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut node = spawn_node_with(realm_id, None, temp_dir.path().to_path_buf()).await?;
+    node._temp_dir = Some(temp_dir);
+    Ok(node)
+}
+
+async fn spawn_node_with(
+    realm_id: RealmId,
+    secret_key: Option<iroh::SecretKey>,
+    dir: PathBuf,
+) -> Result<TestNode, BoxError> {
+    let fjall_dir = dir.join("fjall");
+    std::fs::create_dir_all(&fjall_dir)?;
+    let storage = FjallStorage::open(fjall_dir.to_str().ok_or("invalid storage path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            secret_key,
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            document_sync_storage_path: Some(dir.join("document-sync")),
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+    let metadata_handle = MetadataHandle::new(
+        dir.join("metadata"),
+        net.node_id(),
+        storage.clone(),
+        Some(net.clone()),
+        Some(net.document_sync_node()),
+        Some(net.document_sync_database()),
+    )?;
+
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: Some(metadata_handle),
+        task_handle: Some(task_handle.clone()),
+    });
+
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle.clone()).await;
+
+    Ok(TestNode {
+        _temp_dir: None,
+        net,
+        task_handle,
+        context,
+    })
+}
+
+async fn respawn_with_retry(
+    realm_id: RealmId,
+    secret_key: iroh::SecretKey,
+    dir: &Path,
+) -> Result<TestNode, BoxError> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        match spawn_node_with(realm_id, Some(secret_key.clone()), dir.to_path_buf()).await {
+            Ok(node) => return Ok(node),
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(format!("respawn failed after retries: {error}").into());
+                }
+                sleep(Duration::from_millis(250)).await;
+            }
+        }
+    }
+}
+
+async fn wire_peers(nodes: &[TestNode]) {
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+}
+
+async fn install_realm_config(nodes: &[TestNode], realm_id: &RealmId) -> Result<(), BoxError> {
+    let mut config = RealmConfigDocument::default_for_realm(*realm_id, Vec::new());
+    config.seed_default_placement();
+    for node in nodes {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: UserId::nil(*realm_id),
+            realm_id: *realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+    for node in nodes {
+        aruna_operations::process_placements::process_shard_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
+    Ok(())
+}
+
+async fn wait_for_realm_node_convergence(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<(), BoxError> {
+    let expected: std::collections::HashSet<_> =
+        nodes.iter().map(|node| node.net.node_id()).collect();
+    let deadline = Instant::now() + SETUP_TIMEOUT;
+
+    loop {
+        let mut converged = true;
+        for node in nodes {
+            match drive(
+                GetRealmNodesOperation::new(*realm_id),
+                node.context.as_ref(),
+            )
+            .await
+            {
+                Ok(realm_nodes) if realm_nodes == expected => {}
+                _ => {
+                    converged = false;
+                    break;
+                }
+            }
+        }
+        if converged {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("realm nodes did not converge".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn shutdown_nodes(nodes: Vec<TestNode>) {
+    for node in nodes {
+        node.net.shutdown().await;
+    }
+}

--- a/operations/tests/restart_traffic.rs
+++ b/operations/tests/restart_traffic.rs
@@ -32,7 +32,11 @@ use ulid::Ulid;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-const SETUP_TIMEOUT: Duration = Duration::from_secs(30);
+// Realm-node and document convergence poll to a condition; the ceilings only
+// bound a genuine hang, so they carry generous headroom for a loaded CI runner
+// where anti-entropy across three nodes is thread-starved and slow.
+const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
 const PROJECTION_BATCH: usize = 32;
 const SEED_DOCUMENTS: usize = 500;
 
@@ -59,10 +63,7 @@ async fn restart_traffic_body() -> Result<(), BoxError> {
     let node2_dir = tempfile::tempdir()?;
     let secret = iroh::SecretKey::from_bytes(&[7u8; 32]);
 
-    let aux = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .enable_all()
-        .build()?;
+    let aux = AuxRuntime::new()?;
 
     let mut nodes = Vec::with_capacity(3);
     nodes.push(spawn_node(realm_id).await?);
@@ -114,7 +115,7 @@ async fn restart_traffic_body() -> Result<(), BoxError> {
         std::slice::from_ref(&nodes[2].context),
         &sample,
         Duration::from_millis(200),
-        Duration::from_secs(60),
+        CONVERGENCE_TIMEOUT,
     )
     .await?;
     println!("seeded {} docs, node 2 caught up", created.len());
@@ -125,7 +126,7 @@ async fn restart_traffic_body() -> Result<(), BoxError> {
     node2.task_handle.clear_inbound_handler().await;
     node2.net.shutdown().await;
     drop(node2);
-    tokio::task::spawn_blocking(move || aux.shutdown_timeout(Duration::from_secs(10))).await?;
+    aux.shutdown().await;
     println!("node 2 shut down");
 
     let node2 = respawn_with_retry(realm_id, secret, node2_dir.path()).await?;
@@ -178,7 +179,7 @@ async fn restart_traffic_body() -> Result<(), BoxError> {
         &contexts,
         &fresh,
         Duration::from_millis(200),
-        Duration::from_secs(60),
+        CONVERGENCE_TIMEOUT,
     )
     .await?;
     println!("fresh write converged to all nodes after restart");
@@ -191,6 +192,48 @@ fn make_runtime() -> Result<tokio::runtime::Runtime, BoxError> {
     Ok(tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?)
+}
+
+// Owns the auxiliary node-2 runtime and always tears it down off the async
+// context. Shutting a runtime down by dropping it inside an async task panics;
+// routing every drop through `spawn_blocking` means an early `?` return yields
+// the real error instead of that masking panic.
+struct AuxRuntime(Option<tokio::runtime::Runtime>);
+
+impl AuxRuntime {
+    fn new() -> Result<Self, BoxError> {
+        Ok(Self(Some(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()?,
+        )))
+    }
+
+    fn handle(&self) -> tokio::runtime::Handle {
+        self.0
+            .as_ref()
+            .expect("aux runtime present")
+            .handle()
+            .clone()
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(runtime) = self.0.take() {
+            let _ = tokio::task::spawn_blocking(move || {
+                runtime.shutdown_timeout(Duration::from_secs(10))
+            })
+            .await;
+        }
+    }
+}
+
+impl Drop for AuxRuntime {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.0.take() {
+            tokio::task::spawn_blocking(move || runtime.shutdown_timeout(Duration::from_secs(10)));
+        }
+    }
 }
 
 async fn run_writer(

--- a/operations/tests/shard_genesis_confirmation.rs
+++ b/operations/tests/shard_genesis_confirmation.rs
@@ -93,6 +93,62 @@ async fn unreachable_co_holder_withholds_then_creates_on_retry()
     Ok(())
 }
 
+// A co-holder that HAS the topic but has not yet admitted the prober silently
+// omits its summary (irokle refuses the Open). A never-member rank-0 holder must
+// read that as possibly-existing and withhold, not mint a forking genesis; once
+// the co-holder's member top-up admits it, it adopts the existing genesis.
+#[tokio::test]
+async fn never_member_rank0_adopts_existing_genesis_after_top_up()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([152u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 2).await?;
+    let config = install_realm_config(&nodes, realm_id).await?;
+    mesh_nodes(&nodes).await;
+
+    let (rank0, co_holder) = (&nodes[0], &nodes[1]);
+    let placement = rank0_shard_of(&config, rank0.net.node_id(), co_holder.net.node_id());
+    let topic = shard_topic_id(realm_id, &placement);
+
+    // The co-holder holds the genesis with only itself as a member (passing its
+    // own id leaves an empty sync-peer set), so it refuses the rank-0 holder's
+    // probe and its summary is silently omitted.
+    co_holder
+        .net
+        .ensure_document_sync_topics(&[topic], vec![co_holder.net.node_id()])?;
+    assert!(
+        co_holder
+            .net
+            .document_sync_topic_exists(topic)
+            .unwrap_or(false),
+        "the co-holder must hold the genesis before the probe"
+    );
+
+    process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+    assert!(
+        !rank0.net.document_sync_topic_exists(topic).unwrap_or(false),
+        "a refused (held-but-not-a-member) probe must withhold creation, not fork a genesis"
+    );
+
+    // The co-holder's member top-up admits the rank-0 holder.
+    process_shard_placements(&co_holder.context, realm_id, co_holder.net.node_id()).await;
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+        if rank0.net.document_sync_topic_exists(topic).unwrap_or(false) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the rank-0 holder never adopted the existing genesis after the top-up"
+        );
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
 fn rank0_shard_of(config: &RealmConfigDocument, rank0: NodeId, co_holder: NodeId) -> PlacementRef {
     for strategy in &config.strategies {
         for shard in 0..strategy.shard_count {

--- a/operations/tests/shard_genesis_confirmation.rs
+++ b/operations/tests/shard_genesis_confirmation.rs
@@ -7,13 +7,15 @@ use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
-use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::structs::{
+    Actor, PlacementOverride, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind,
+};
 use aruna_core::task::{TaskEffect, TaskKey};
 use aruna_core::{NodeId, UserId};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::driver::DriverContext;
 use aruna_operations::incoming::initialize_net_incoming;
-use aruna_operations::placement::resolve_shard_holders;
+use aruna_operations::placement::{resolve_shard_holders, shard_subject_bytes};
 use aruna_operations::process_placements::process_shard_placements;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
@@ -206,6 +208,124 @@ async fn never_member_rank0_adopts_existing_genesis_after_top_up()
     Ok(())
 }
 
+// A node admitted to the realm after the buckets already exist becomes a holder
+// of buckets whose genesis lives on a co-holder, and it cannot add itself to a
+// topic it does not have. An incumbent that can reach it pushes the genesis, but
+// nothing guarantees one does: the incumbents here have no route to the newcomer
+// when they admit it (which is what a partitioned member, or the shard's origin
+// drained out of the holder set, looks like), so their pushes never land. The
+// newcomer's own config-apply pass must then pull its held-but-unknown topics,
+// or it stays passive forever and the buckets it now holds never reach it.
+//
+// Rank-0 is pinned away from the newcomer on every bucket, so a pass that skips
+// its missing member topics dials nobody at all: the incumbents then never learn
+// its address and can never push, which is what makes the pull the only path.
+#[tokio::test]
+async fn new_holder_pulls_topics() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([154u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 3).await?;
+    let (incumbents, newcomer_nodes) = nodes.split_at(2);
+    let newcomer_node = &newcomer_nodes[0];
+    mesh_nodes(incumbents).await;
+
+    let mut config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+    config.seed_default_placement();
+    for node in incumbents {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+    config.placement_overrides = pin_rank0_everywhere(&config, incumbents[0].net.node_id());
+    write_realm_config(&nodes, realm_id, &config).await?;
+    for node in incumbents {
+        process_shard_placements(&node.context, realm_id, node.net.node_id()).await;
+    }
+
+    let newcomer = newcomer_node.net.node_id();
+    config.ensure_node(newcomer, RealmNodeKind::Management);
+    write_realm_config(&nodes, realm_id, &config).await?;
+    // The incumbents' own config-apply pass: it admits the newcomer to every
+    // bucket's membership (a local control op), which is all a holder can do for
+    // another. They have no address for it, so nothing is pushed.
+    for node in incumbents {
+        process_shard_placements(&node.context, realm_id, node.net.node_id()).await;
+    }
+
+    let held = member_shard_topics(&config, realm_id, newcomer);
+    assert!(
+        !held.is_empty(),
+        "the newcomer must hold non-rank-0 buckets"
+    );
+    for node in incumbents {
+        newcomer_node
+            .net
+            .add_peer_addr(node.net.endpoint_addr())
+            .await;
+    }
+    for topic in &held {
+        assert!(
+            !newcomer_node.net.document_sync_topic_exists(*topic)?,
+            "the newcomer must start without the genesis of {topic}"
+        );
+    }
+
+    process_shard_placements(&newcomer_node.context, realm_id, newcomer).await;
+
+    for topic in &held {
+        assert!(
+            newcomer_node.net.document_sync_topic_exists(*topic)?,
+            "newly held bucket topic {topic} was not pulled from a co-holder"
+        );
+    }
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+/// Pins `rank0` first on every bucket of every strategy, so no other holder is
+/// ever a bucket's rank-0 and none of them probes a co-holder for a genesis.
+fn pin_rank0_everywhere(config: &RealmConfigDocument, rank0: NodeId) -> Vec<PlacementOverride> {
+    let mut overrides = Vec::new();
+    for strategy in &config.strategies {
+        for shard in 0..strategy.shard_count {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard,
+            };
+            overrides.push(PlacementOverride {
+                subject: shard_subject_bytes(&placement),
+                pinned: vec![rank0],
+                excluded: Vec::new(),
+                strategy_id: None,
+            });
+        }
+    }
+    overrides
+}
+
+/// Shard topics `node_id` holds without being their rank-0 holder: the genesis
+/// is a co-holder's to create, so these are the topics a holder can only pull.
+fn member_shard_topics(
+    config: &RealmConfigDocument,
+    realm_id: RealmId,
+    node_id: NodeId,
+) -> Vec<::irokle::TopicId> {
+    let mut topics = Vec::new();
+    for strategy in &config.strategies {
+        for shard in 0..strategy.shard_count {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard,
+            };
+            let holders = resolve_shard_holders(config, &placement);
+            if holders.contains(&node_id) && holders.first() != Some(&node_id) {
+                topics.push(shard_topic_id(realm_id, &placement));
+            }
+        }
+    }
+    topics
+}
+
 fn rank0_shard_of(config: &RealmConfigDocument, rank0: NodeId, co_holder: NodeId) -> PlacementRef {
     for strategy in &config.strategies {
         for shard in 0..strategy.shard_count {
@@ -305,8 +425,17 @@ async fn install_realm_config(
     for node in nodes {
         config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
     }
-    // Installs the config without running the placement reconciler, so each test
-    // drives genesis creation explicitly.
+    write_realm_config(nodes, realm_id, &config).await?;
+    Ok(config)
+}
+
+/// Installs `config` on every node without running the placement reconciler, so
+/// each test drives genesis creation explicitly.
+async fn write_realm_config(
+    nodes: &[TestNode],
+    realm_id: RealmId,
+    config: &RealmConfigDocument,
+) -> Result<(), Box<dyn std::error::Error>> {
     for node in nodes {
         let actor = Actor {
             node_id: node.net.node_id(),
@@ -328,9 +457,9 @@ async fn install_realm_config(
             Event::Storage(StorageEvent::WriteResult { .. }) => {}
             other => return Err(format!("unexpected realm config write event: {other:?}").into()),
         }
-        node.net.refresh_realm_peers_from_document(&config).await?;
+        node.net.refresh_realm_peers_from_document(config).await?;
     }
-    Ok(config)
+    Ok(())
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/shard_genesis_confirmation.rs
+++ b/operations/tests/shard_genesis_confirmation.rs
@@ -7,6 +7,7 @@ use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
 use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::task::{TaskEffect, TaskKey};
 use aruna_core::{NodeId, UserId};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::driver::DriverContext;
@@ -54,8 +55,11 @@ async fn reachable_topicless_co_holder_lets_rank0_create_the_genesis()
     Ok(())
 }
 
-// An unreachable co-holder might hold a genesis, so creation is withheld; once
-// the co-holder is reachable again, the retry creates it.
+// An unreachable co-holder might hold a genesis, so creation is withheld — and,
+// crucially, withholding schedules a SyncPlacements retry so a returning
+// co-holder re-runs the reconciler on its own (no placement record exists to
+// drive it). The retry is driven here through the real task handler rather than
+// by re-running the reconciler by hand, which is what masked the liveness gap.
 #[tokio::test]
 async fn unreachable_co_holder_withholds_then_creates_on_retry()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -68,17 +72,24 @@ async fn unreachable_co_holder_withholds_then_creates_on_retry()
     let placement = rank0_shard_of(&config, rank0.net.node_id(), co_holder.net.node_id());
     let topic = shard_topic_id(realm_id, &placement);
 
-    process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+    let outcome = process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
     assert!(
         !rank0.net.document_sync_topic_exists(topic).unwrap_or(false),
         "an unreachable co-holder must withhold genesis creation (a fork would be permanent)"
     );
+    assert!(
+        outcome.retry_scheduled,
+        "withholding must schedule a SyncPlacements retry so a returning co-holder re-runs the reconciler"
+    );
 
-    // The co-holder returns.
+    // The co-holder returns; the scheduled retry is fired immediately (instead of
+    // after the 30s production delay) through the task handler. The test never
+    // calls process_shard_placements itself past this point — convergence proves
+    // the armed retry, not a hand-driven loop, re-creates the genesis.
     mesh_nodes(&nodes).await;
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
-        process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+        fire_sync_placements_retry(rank0, realm_id).await;
         if rank0.net.document_sync_topic_exists(topic).unwrap_or(false) {
             break;
         }
@@ -91,6 +102,23 @@ async fn unreachable_co_holder_withholds_then_creates_on_retry()
 
     shutdown_nodes(nodes).await;
     Ok(())
+}
+
+// Fires the SyncPlacements timer now (compressing the 30s production retry), so
+// the task handler re-runs the reconciler through its real dispatch path.
+async fn fire_sync_placements_retry(node: &TestNode, realm_id: RealmId) {
+    let Some(task_handle) = node.context.task_handle.as_ref() else {
+        return;
+    };
+    let _ = task_handle
+        .send_effect(Effect::Task(TaskEffect::ResetTimer {
+            key: TaskKey::SyncPlacements {
+                realm_id,
+                node_id: node.net.node_id(),
+            },
+            after: Duration::ZERO,
+        }))
+        .await;
 }
 
 // A co-holder that HAS the topic but has not yet admitted the prober silently

--- a/operations/tests/shard_genesis_confirmation.rs
+++ b/operations/tests/shard_genesis_confirmation.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -17,6 +18,8 @@ use aruna_operations::process_placements::process_shard_placements;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
+use irokle::oplog::Oplog;
+use irokle::{ReplicationPolicy, TopicGenesis};
 use tempfile::TempDir;
 use tokio::time::sleep;
 
@@ -24,6 +27,32 @@ struct TestNode {
     _temp_dir: TempDir,
     net: NetHandle,
     context: Arc<DriverContext>,
+}
+
+// If the final ensure/create step fails after the topic was selected for
+// ensuring, no pending placement record exists yet. The reconciler must still
+// report retry-worthy work so the missing/invalid genesis path is retried.
+#[tokio::test]
+async fn rank0_topic_ensure_failure_schedules_retry() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([153u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 2).await?;
+    let config = install_realm_config(&nodes, realm_id).await?;
+    mesh_nodes(&nodes).await;
+
+    let (rank0, co_holder) = (&nodes[0], &nodes[1]);
+    let placement = rank0_shard_of(&config, rank0.net.node_id(), co_holder.net.node_id());
+    let topic = shard_topic_id(realm_id, &placement);
+    seed_wrong_event_type_topic(&rank0.net, topic)?;
+
+    let outcome = process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+
+    assert!(
+        outcome.retry_scheduled,
+        "failed topic ensure must schedule a placement retry"
+    );
+
+    shutdown_nodes(nodes).await;
+    Ok(())
 }
 
 // A reachable, topic-less co-holder is positive confirmation that no genesis
@@ -192,6 +221,22 @@ fn rank0_shard_of(config: &RealmConfigDocument, rank0: NodeId, co_holder: NodeId
         }
     }
     panic!("no shard has {rank0} as rank-0 with {co_holder} as a co-holder");
+}
+
+fn seed_wrong_event_type_topic(
+    net: &NetHandle,
+    topic: ::irokle::TopicId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let node = net.document_sync_node();
+    let actor_id = irokle::actor_id_for(topic, node.peer_id());
+    let genesis = TopicGenesis {
+        event_type_id: "aruna.test.wrong".to_string(),
+        initial_peers: BTreeSet::new(),
+        replication_policy: ReplicationPolicy::all(),
+    };
+    let oplog = Oplog::with_storage(node.storage().clone());
+    oplog.create_topic_genesis(topic, actor_id, genesis, node.signer())?;
+    Ok(())
 }
 
 async fn build_realm_nodes(

--- a/operations/tests/shard_genesis_confirmation.rs
+++ b/operations/tests/shard_genesis_confirmation.rs
@@ -1,0 +1,211 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aruna_core::document::shard_topic_id;
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::{NodeId, UserId};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::driver::DriverContext;
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::placement::resolve_shard_holders;
+use aruna_operations::process_placements::process_shard_placements;
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+struct TestNode {
+    _temp_dir: TempDir,
+    net: NetHandle,
+    context: Arc<DriverContext>,
+}
+
+// A reachable, topic-less co-holder is positive confirmation that no genesis
+// exists: the rank-0 holder creates one.
+#[tokio::test]
+async fn reachable_topicless_co_holder_lets_rank0_create_the_genesis()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([150u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 2).await?;
+    let config = install_realm_config(&nodes, realm_id).await?;
+    mesh_nodes(&nodes).await;
+
+    let (rank0, co_holder) = (&nodes[0], &nodes[1]);
+    let placement = rank0_shard_of(&config, rank0.net.node_id(), co_holder.net.node_id());
+    let topic = shard_topic_id(realm_id, &placement);
+    assert!(
+        !rank0.net.document_sync_topic_exists(topic).unwrap_or(false),
+        "no genesis exists before the placement reconciler runs"
+    );
+
+    process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+
+    assert!(
+        rank0.net.document_sync_topic_exists(topic).unwrap_or(false),
+        "an all-reached-none-know probe must let the rank-0 holder create the genesis"
+    );
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+// An unreachable co-holder might hold a genesis, so creation is withheld; once
+// the co-holder is reachable again, the retry creates it.
+#[tokio::test]
+async fn unreachable_co_holder_withholds_then_creates_on_retry()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([151u8; 32]);
+    let nodes = build_realm_nodes(&realm_id, 2).await?;
+    let config = install_realm_config(&nodes, realm_id).await?;
+    // Deliberately NOT meshed: the rank-0 holder has no path to the co-holder.
+
+    let (rank0, co_holder) = (&nodes[0], &nodes[1]);
+    let placement = rank0_shard_of(&config, rank0.net.node_id(), co_holder.net.node_id());
+    let topic = shard_topic_id(realm_id, &placement);
+
+    process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+    assert!(
+        !rank0.net.document_sync_topic_exists(topic).unwrap_or(false),
+        "an unreachable co-holder must withhold genesis creation (a fork would be permanent)"
+    );
+
+    // The co-holder returns.
+    mesh_nodes(&nodes).await;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        process_shard_placements(&rank0.context, realm_id, rank0.net.node_id()).await;
+        if rank0.net.document_sync_topic_exists(topic).unwrap_or(false) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "genesis was not created after the co-holder became reachable"
+        );
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+fn rank0_shard_of(config: &RealmConfigDocument, rank0: NodeId, co_holder: NodeId) -> PlacementRef {
+    for strategy in &config.strategies {
+        for shard in 0..strategy.shard_count {
+            let placement = PlacementRef {
+                strategy_id: strategy.strategy_id,
+                epoch: 0,
+                shard,
+            };
+            let holders = resolve_shard_holders(config, &placement);
+            if holders.first() == Some(&rank0) && holders.contains(&co_holder) {
+                return placement;
+            }
+        }
+    }
+    panic!("no shard has {rank0} as rank-0 with {co_holder} as a co-holder");
+}
+
+async fn build_realm_nodes(
+    realm_id: &RealmId,
+    count: usize,
+) -> Result<Vec<TestNode>, Box<dyn std::error::Error>> {
+    let mut nodes = Vec::with_capacity(count);
+    for _ in 0..count {
+        nodes.push(spawn_node(*realm_id).await?);
+    }
+    Ok(nodes)
+}
+
+async fn mesh_nodes(nodes: &[TestNode]) {
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+}
+
+async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: None,
+        task_handle: Some(task_handle.clone()),
+    });
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle).await;
+    Ok(TestNode {
+        _temp_dir: temp_dir,
+        net,
+        context,
+    })
+}
+
+async fn install_realm_config(
+    nodes: &[TestNode],
+    realm_id: RealmId,
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
+    let mut config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+    config.seed_default_placement();
+    for node in nodes {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+    // Installs the config without running the placement reconciler, so each test
+    // drives genesis creation explicitly.
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: UserId::nil(realm_id),
+            realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+    Ok(config)
+}
+
+async fn shutdown_nodes(nodes: Vec<TestNode>) {
+    for node in nodes {
+        node.net.shutdown().await;
+    }
+}

--- a/operations/tests/shard_manifest.rs
+++ b/operations/tests/shard_manifest.rs
@@ -19,7 +19,7 @@ use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::incoming::initialize_net_incoming;
 use aruna_operations::metadata::MetadataHandle;
-use aruna_operations::placement::placement_ref_for_target;
+use aruna_operations::placement::resolve_shard_holders;
 use aruna_operations::shard::assemble_shard_manifest;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
@@ -69,12 +69,13 @@ async fn document_manifest_row_lands_on_origin_and_receiver_with_matching_digest
     let document_id = created.record.document_id;
 
     let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    let placement = placement_ref_for_target(&config, &target, Default::default());
+    let placement = created.record.placement;
     assert_ne!(
         placement,
         PlacementRef::NIL,
         "document must resolve a shard"
     );
+    assert!(resolve_shard_holders(&config, &placement).contains(&nodes[0].net.node_id()));
 
     // The receiver only writes its manifest row once the lifecycle syncs and
     // applies, so poll node B until the document appears.

--- a/operations/tests/shard_manifest.rs
+++ b/operations/tests/shard_manifest.rs
@@ -1,0 +1,296 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aruna_core::document::{DocumentSyncTarget, ShardManifest};
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::{NodeId, UserId};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::announce_realm_presence::{
+    AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
+};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::metadata::MetadataHandle;
+use aruna_operations::placement::placement_ref_for_target;
+use aruna_operations::shard::assemble_shard_manifest;
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use ulid::Ulid;
+
+struct TestNode {
+    _temp_dir: TempDir,
+    net: NetHandle,
+    context: Arc<DriverContext>,
+}
+
+// A metadata document created on node A must leave a manifest row on the origin
+// AND on the receiver that syncs it, and both holders' assembled shard manifests
+// must agree on the entry set and the topic digest.
+#[tokio::test]
+async fn document_manifest_row_lands_on_origin_and_receiver_with_matching_digest()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([120u8; 32]);
+    let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
+
+    let created = drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
+                realm_id,
+            },
+            group_id,
+            document_id,
+            document_path: "datasets/manifest-canary".to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Manifest Canary".to_string(),
+                description: "manifest maintenance test".to_string(),
+                date_published: "2026-07-07".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?;
+    let document_id = created.record.document_id;
+
+    let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+    let placement = placement_ref_for_target(&config, &target, None);
+    assert_ne!(
+        placement,
+        PlacementRef::NIL,
+        "document must resolve a shard"
+    );
+
+    // The receiver only writes its manifest row once the lifecycle syncs and
+    // applies, so poll node B until the document appears.
+    let receiver = wait_for_manifest_entry(&nodes[1], realm_id, placement, &target).await?;
+    let origin = assemble_shard_manifest(nodes[0].context.as_ref(), realm_id, placement).await?;
+
+    assert!(
+        manifest_contains(&origin, &target),
+        "origin manifest missing the document"
+    );
+    assert!(
+        manifest_contains(&receiver, &target),
+        "receiver manifest missing the document"
+    );
+    // Same shard, converged topic ⇒ identical digest across holders.
+    assert_eq!(
+        origin.digest, receiver.digest,
+        "co-holder shard digests must agree"
+    );
+    // The lifecycle revision the origin recorded is the one the receiver applied.
+    let origin_revision = manifest_revision(&origin, &target);
+    let receiver_revision = manifest_revision(&receiver, &target);
+    assert_eq!(origin_revision, receiver_revision);
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+fn manifest_contains(manifest: &ShardManifest, target: &DocumentSyncTarget) -> bool {
+    manifest.entries.iter().any(|entry| &entry.target == target)
+}
+
+fn manifest_revision(
+    manifest: &ShardManifest,
+    target: &DocumentSyncTarget,
+) -> aruna_core::document::DocumentSyncRevision {
+    manifest
+        .entries
+        .iter()
+        .find(|entry| &entry.target == target)
+        .map(|entry| entry.revision)
+        .expect("manifest entry present")
+}
+
+async fn wait_for_manifest_entry(
+    node: &TestNode,
+    realm_id: RealmId,
+    placement: PlacementRef,
+    target: &DocumentSyncTarget,
+) -> Result<ShardManifest, Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let manifest = assemble_shard_manifest(node.context.as_ref(), realm_id, placement).await?;
+        if manifest_contains(&manifest, target) {
+            return Ok(manifest);
+        }
+        if Instant::now() >= deadline {
+            return Err("timed out waiting for receiver manifest entry".into());
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn build_realm_nodes(
+    realm_id: &RealmId,
+    count: usize,
+) -> Result<(Vec<TestNode>, RealmConfigDocument), Box<dyn std::error::Error>> {
+    let mut nodes = Vec::with_capacity(count);
+    for _ in 0..count {
+        nodes.push(spawn_node(*realm_id).await?);
+    }
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+    for node in &nodes {
+        drive(
+            AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+                realm_id: *realm_id,
+                node_id: node.net.node_id(),
+                schedule_refresh: true,
+            }),
+            node.context.as_ref(),
+        )
+        .await?;
+    }
+    wait_for_realm_node_convergence(&nodes, realm_id).await?;
+    let config = install_realm_config(&nodes, realm_id).await?;
+    Ok((nodes, config))
+}
+
+async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+    let metadata_handle = MetadataHandle::new(
+        temp_dir.path().join("metadata"),
+        net.node_id(),
+        storage.clone(),
+        Some(net.clone()),
+        Some(net.document_sync_node()),
+        Some(net.document_sync_database()),
+    )?;
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: Some(metadata_handle),
+        task_handle: Some(task_handle.clone()),
+    });
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle).await;
+    Ok(TestNode {
+        _temp_dir: temp_dir,
+        net,
+        context,
+    })
+}
+
+async fn install_realm_config(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
+    let mut config = RealmConfigDocument::default_for_realm(*realm_id, Vec::new());
+    config.seed_default_placement();
+    for node in nodes {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: UserId::nil(*realm_id),
+            realm_id: *realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+    for node in nodes {
+        aruna_operations::process_placements::process_shard_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
+    Ok(config)
+}
+
+async fn wait_for_realm_node_convergence(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let expected: std::collections::HashSet<NodeId> =
+        nodes.iter().map(|node| node.net.node_id()).collect();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let mut converged = true;
+        for node in nodes {
+            match drive(
+                GetRealmNodesOperation::new(*realm_id),
+                node.context.as_ref(),
+            )
+            .await
+            {
+                Ok(realm_nodes) if realm_nodes == expected => {}
+                _ => {
+                    converged = false;
+                    break;
+                }
+            }
+        }
+        if converged {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("realm nodes did not converge".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn shutdown_nodes(nodes: Vec<TestNode>) {
+    for node in nodes {
+        node.net.shutdown().await;
+    }
+}

--- a/operations/tests/shard_manifest.rs
+++ b/operations/tests/shard_manifest.rs
@@ -69,7 +69,7 @@ async fn document_manifest_row_lands_on_origin_and_receiver_with_matching_digest
     let document_id = created.record.document_id;
 
     let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    let placement = placement_ref_for_target(&config, &target, None);
+    let placement = placement_ref_for_target(&config, &target, Default::default());
     assert_ne!(
         placement,
         PlacementRef::NIL,

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -1,0 +1,323 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aruna_core::document::{DocumentSyncTarget, ShardManifest, ShardManifestEntry};
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::{NodeId, UserId};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::announce_realm_presence::{
+    AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
+};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::metadata::MetadataHandle;
+use aruna_operations::placement::placement_ref_for_target;
+use aruna_operations::shard::assemble_shard_manifest;
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use ulid::Ulid;
+
+struct TestNode {
+    _temp_dir: TempDir,
+    net: NetHandle,
+    context: Arc<DriverContext>,
+}
+
+// Two holders write documents of one shard, interleaved from both sides. Once
+// the shard drains and reconciles, both nodes must assemble byte-identical
+// manifests: same entry set, same digest.
+#[tokio::test]
+async fn interleaved_writes_to_one_shard_converge_on_both_holders()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([125u8; 32]);
+    let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
+    let group_id = Ulid::r#gen();
+
+    // Pick one shard and gather several document ids that all hash into it.
+    let strategy = config.strategies.first().expect("a strategy").clone();
+    let target_shard = shard_of(&config, Ulid::r#gen());
+    let placement = PlacementRef {
+        strategy_id: strategy.strategy_id,
+        epoch: 0,
+        shard: target_shard,
+    };
+    let document_ids = document_ids_in_shard(&config, target_shard, 6);
+
+    // Interleave the creates across the two holders.
+    for (index, document_id) in document_ids.iter().enumerate() {
+        let node = &nodes[index % 2];
+        create_document(node, realm_id, group_id, *document_id, index).await?;
+    }
+
+    // Both holders must converge to the same entry set and digest.
+    wait_for_manifest_agreement(
+        &nodes[0],
+        &nodes[1],
+        realm_id,
+        placement,
+        document_ids.len(),
+    )
+    .await?;
+
+    let left = assemble_shard_manifest(nodes[0].context.as_ref(), realm_id, placement).await?;
+    let right = assemble_shard_manifest(nodes[1].context.as_ref(), realm_id, placement).await?;
+    assert_eq!(left.entries.len(), document_ids.len());
+    assert_eq!(sorted_entries(&left), sorted_entries(&right));
+    assert_eq!(left.digest, right.digest);
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+fn shard_of(config: &RealmConfigDocument, document_id: Ulid) -> u32 {
+    let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+    placement_ref_for_target(config, &target, None).shard
+}
+
+fn document_ids_in_shard(config: &RealmConfigDocument, shard: u32, count: usize) -> Vec<Ulid> {
+    let mut ids = Vec::with_capacity(count);
+    while ids.len() < count {
+        let candidate = Ulid::r#gen();
+        if shard_of(config, candidate) == shard {
+            ids.push(candidate);
+        }
+    }
+    ids
+}
+
+fn sorted_entries(manifest: &ShardManifest) -> Vec<ShardManifestEntry> {
+    let mut entries = manifest.entries.clone();
+    entries.sort_by_key(|entry| postcard::to_allocvec(&entry.target).unwrap());
+    entries
+}
+
+async fn create_document(
+    node: &TestNode,
+    realm_id: RealmId,
+    group_id: Ulid,
+    document_id: Ulid,
+    index: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: node.net.node_id(),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
+                realm_id,
+            },
+            group_id,
+            document_id,
+            document_path: format!("datasets/converge-{index}"),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: format!("Converge {index}"),
+                description: "convergence test".to_string(),
+                date_published: "2026-07-07".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        node.context.as_ref(),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn wait_for_manifest_agreement(
+    left: &TestNode,
+    right: &TestNode,
+    realm_id: RealmId,
+    placement: PlacementRef,
+    expected: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let left_manifest =
+            assemble_shard_manifest(left.context.as_ref(), realm_id, placement).await?;
+        let right_manifest =
+            assemble_shard_manifest(right.context.as_ref(), realm_id, placement).await?;
+        if left_manifest.entries.len() == expected
+            && right_manifest.entries.len() == expected
+            && left_manifest.digest == right_manifest.digest
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "manifests did not converge: left={} right={} digest_eq={}",
+                left_manifest.entries.len(),
+                right_manifest.entries.len(),
+                left_manifest.digest == right_manifest.digest
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(150)).await;
+    }
+}
+
+async fn build_realm_nodes(
+    realm_id: &RealmId,
+    count: usize,
+) -> Result<(Vec<TestNode>, RealmConfigDocument), Box<dyn std::error::Error>> {
+    let mut nodes = Vec::with_capacity(count);
+    for _ in 0..count {
+        nodes.push(spawn_node(*realm_id).await?);
+    }
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+    for node in &nodes {
+        drive(
+            AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+                realm_id: *realm_id,
+                node_id: node.net.node_id(),
+                schedule_refresh: true,
+            }),
+            node.context.as_ref(),
+        )
+        .await?;
+    }
+    wait_for_realm_node_convergence(&nodes, realm_id).await?;
+    let config = install_realm_config(&nodes, realm_id).await?;
+    Ok((nodes, config))
+}
+
+async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+    let metadata_handle = MetadataHandle::new(
+        temp_dir.path().join("metadata"),
+        net.node_id(),
+        storage.clone(),
+        Some(net.clone()),
+        Some(net.document_sync_node()),
+        Some(net.document_sync_database()),
+    )?;
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: Some(metadata_handle),
+        task_handle: Some(task_handle.clone()),
+    });
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle).await;
+    Ok(TestNode {
+        _temp_dir: temp_dir,
+        net,
+        context,
+    })
+}
+
+async fn install_realm_config(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
+    let mut config = RealmConfigDocument::default_for_realm(*realm_id, Vec::new());
+    config.seed_default_placement();
+    for node in nodes {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: UserId::nil(*realm_id),
+            realm_id: *realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+    for node in nodes {
+        aruna_operations::process_placements::process_shard_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
+    Ok(config)
+}
+
+async fn wait_for_realm_node_convergence(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let expected: std::collections::HashSet<NodeId> =
+        nodes.iter().map(|node| node.net.node_id()).collect();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let mut converged = true;
+        for node in nodes {
+            match drive(
+                GetRealmNodesOperation::new(*realm_id),
+                node.context.as_ref(),
+            )
+            .await
+            {
+                Ok(realm_nodes) if realm_nodes == expected => {}
+                _ => {
+                    converged = false;
+                    break;
+                }
+            }
+        }
+        if converged {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("realm nodes did not converge".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn shutdown_nodes(nodes: Vec<TestNode>) {
+    for node in nodes {
+        node.net.shutdown().await;
+    }
+}

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -33,6 +33,12 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 use ulid::Ulid;
 
+// Realm-node and manifest convergence poll to a condition; the ceilings only
+// bound a genuine hang, so they carry generous headroom for a loaded CI runner
+// where anti-entropy across the holders is thread-starved and slow.
+const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
+
 struct TestNode {
     _temp_dir: TempDir,
     net: NetHandle,
@@ -101,7 +107,7 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
     )
     .await?;
 
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
     loop {
         let left = assemble_shard_manifest(nodes[0].context.as_ref(), realm_id, placement).await?;
         let right = assemble_shard_manifest(nodes[1].context.as_ref(), realm_id, placement).await?;
@@ -221,7 +227,7 @@ async fn wait_for_manifest_agreement(
     placement: PlacementRef,
     expected: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
     loop {
         let left_manifest =
             assemble_shard_manifest(left.context.as_ref(), realm_id, placement).await?;
@@ -370,7 +376,7 @@ async fn wait_for_realm_node_convergence(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let expected: std::collections::HashSet<NodeId> =
         nodes.iter().map(|node| node.net.node_id()).collect();
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + SETUP_TIMEOUT;
     loop {
         let mut converged = true;
         for node in nodes {

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -15,6 +15,7 @@ use aruna_operations::announce_realm_presence::{
 use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
 };
+use aruna_operations::delete_metadata_document::DeleteMetadataDocumentOperation;
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::incoming::initialize_net_incoming;
@@ -75,6 +76,63 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
     assert_eq!(left.entries.len(), document_ids.len());
     assert_eq!(sorted_entries(&left), sorted_entries(&right));
     assert_eq!(left.digest, right.digest);
+
+    // Delete one document and assert the tombstone converges byte-identically.
+    // Receivers must stamp the ORIGIN's actor into the delete tombstone's
+    // manifest row (not their own local node id), or the entry sets diverge
+    // across holders even though the topic digests agree.
+    let deleted_id = document_ids[0];
+    let deleted_target = DocumentSyncTarget::MetadataDocumentLifecycle {
+        document_id: deleted_id,
+    };
+    drive(
+        DeleteMetadataDocumentOperation::new(
+            Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
+                realm_id,
+            },
+            group_id,
+            deleted_id,
+        ),
+        nodes[0].context.as_ref(),
+    )
+    .await?;
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let left = assemble_shard_manifest(nodes[0].context.as_ref(), realm_id, placement).await?;
+        let right = assemble_shard_manifest(nodes[1].context.as_ref(), realm_id, placement).await?;
+        let left_tomb = left
+            .entries
+            .iter()
+            .find(|entry| entry.target == deleted_target)
+            .map(|entry| entry.revision);
+        let right_tomb = right
+            .entries
+            .iter()
+            .find(|entry| entry.target == deleted_target)
+            .map(|entry| entry.revision);
+        if left_tomb.is_some() && left_tomb == right_tomb {
+            // Both holders now carry the same tombstone row: the whole entry set
+            // (tombstone included) and the digest must be identical.
+            assert_eq!(
+                left.entries.len(),
+                document_ids.len(),
+                "the delete keeps a tombstone row"
+            );
+            assert_eq!(sorted_entries(&left), sorted_entries(&right));
+            assert_eq!(left.digest, right.digest);
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "delete tombstone did not converge across holders: left={left_tomb:?} right={right_tomb:?}"
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(150)).await;
+    }
 
     shutdown_nodes(nodes).await;
     Ok(())

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -6,7 +6,9 @@ use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
-use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::structs::{
+    Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind,
+};
 use aruna_core::{NodeId, UserId};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::announce_realm_presence::{
@@ -20,7 +22,9 @@ use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::incoming::initialize_net_incoming;
 use aruna_operations::metadata::MetadataHandle;
-use aruna_operations::placement::{choose_origin_bucket, strategy_for_target, subject_bytes};
+use aruna_operations::placement::{
+    PlacementResolutionContext, choose_origin_bucket, meta_bucket_subject, strategy_for_target,
+};
 use aruna_operations::shard::assemble_shard_manifest;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
@@ -44,17 +48,14 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
     let realm_id = RealmId([125u8; 32]);
     let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
     let group_id = Ulid::r#gen();
-
-    // Pick one shard and gather several document ids both holders choose it for.
-    let strategy = config.strategies.first().expect("a strategy").clone();
     let holders = [nodes[0].net.node_id(), nodes[1].net.node_id()];
-    let target_shard = shard_of(&config, holders[0], Ulid::r#gen());
-    let placement = PlacementRef {
-        strategy_id: strategy.strategy_id,
-        epoch: 0,
-        shard: target_shard,
-    };
-    let document_ids = document_ids_in_shard(&config, &holders, target_shard, 6);
+
+    // The bucket is chosen from the canonical path (6.3.6), so documents sharing
+    // one path land in one bucket. Both holders hold every bucket over two nodes
+    // and choose from the same subject, so their choice is the shared shard this
+    // test needs.
+    let placement = shared_path_bucket(&config, &holders, realm_id, group_id);
+    let document_ids: Vec<Ulid> = (0..6).map(|_| Ulid::r#gen()).collect();
 
     // Interleave the creates across the two holders.
     for (index, document_id) in document_ids.iter().enumerate() {
@@ -139,32 +140,41 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
     Ok(())
 }
 
-fn shard_of(config: &RealmConfigDocument, origin: NodeId, document_id: Ulid) -> u32 {
-    let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    let (strategy, _) =
-        strategy_for_target(config, &target, Default::default()).expect("strategy resolves");
-    choose_origin_bucket(config, strategy, origin, &subject_bytes(&target))
-        .expect("origin holds a bucket")
-        .shard
-}
+const CONVERGE_PATH: &str = "datasets/converge";
 
-fn document_ids_in_shard(
+/// The bucket every document on [`CONVERGE_PATH`] lands in. The subject is the
+/// canonical `(realm, group, path)` (6.3.6), and both holders hold every bucket
+/// (RF over two nodes), so their origin-bucket choice is identical.
+fn shared_path_bucket(
     config: &RealmConfigDocument,
-    origins: &[NodeId],
-    shard: u32,
-    count: usize,
-) -> Vec<Ulid> {
-    let mut ids = Vec::with_capacity(count);
-    while ids.len() < count {
-        let candidate = Ulid::r#gen();
-        if origins
-            .iter()
-            .all(|origin| shard_of(config, *origin, candidate) == shard)
-        {
-            ids.push(candidate);
-        }
+    holders: &[NodeId],
+    realm_id: RealmId,
+    group_id: Ulid,
+) -> PlacementRef {
+    let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+        document_id: Ulid::nil(),
+    };
+    let path = MetadataRegistryRecord::normalize_document_path(CONVERGE_PATH);
+    let (strategy, _) = strategy_for_target(
+        config,
+        &target,
+        PlacementResolutionContext {
+            group_id: Some(group_id),
+            metadata_path: Some(&path),
+        },
+    )
+    .expect("strategy resolves");
+    let subject = meta_bucket_subject(realm_id, group_id, &path);
+    let placement = choose_origin_bucket(config, strategy, holders[0], &subject)
+        .expect("origin holds a bucket");
+    for holder in holders {
+        assert_eq!(
+            choose_origin_bucket(config, strategy, *holder, &subject).map(|bucket| bucket.shard),
+            Some(placement.shard),
+            "both holders choose the same bucket for the shared path"
+        );
     }
-    ids
+    placement
 }
 
 fn sorted_entries(manifest: &ShardManifest) -> Vec<ShardManifestEntry> {
@@ -189,7 +199,7 @@ async fn create_document(
             },
             group_id,
             document_id,
-            document_path: format!("datasets/converge-{index}"),
+            document_path: CONVERGE_PATH.to_string(),
             public: true,
             payload: CreateMetadataDocumentPayload::Scaffold {
                 name: format!("Converge {index}"),

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -20,7 +20,7 @@ use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::incoming::initialize_net_incoming;
 use aruna_operations::metadata::MetadataHandle;
-use aruna_operations::placement::placement_ref_for_target;
+use aruna_operations::placement::{choose_origin_bucket, strategy_for_target, subject_bytes};
 use aruna_operations::shard::assemble_shard_manifest;
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
@@ -45,15 +45,16 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
     let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
     let group_id = Ulid::r#gen();
 
-    // Pick one shard and gather several document ids that all hash into it.
+    // Pick one shard and gather several document ids both holders choose it for.
     let strategy = config.strategies.first().expect("a strategy").clone();
-    let target_shard = shard_of(&config, Ulid::r#gen());
+    let holders = [nodes[0].net.node_id(), nodes[1].net.node_id()];
+    let target_shard = shard_of(&config, holders[0], Ulid::r#gen());
     let placement = PlacementRef {
         strategy_id: strategy.strategy_id,
         epoch: 0,
         shard: target_shard,
     };
-    let document_ids = document_ids_in_shard(&config, target_shard, 6);
+    let document_ids = document_ids_in_shard(&config, &holders, target_shard, 6);
 
     // Interleave the creates across the two holders.
     for (index, document_id) in document_ids.iter().enumerate() {
@@ -138,16 +139,28 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
     Ok(())
 }
 
-fn shard_of(config: &RealmConfigDocument, document_id: Ulid) -> u32 {
+fn shard_of(config: &RealmConfigDocument, origin: NodeId, document_id: Ulid) -> u32 {
     let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    placement_ref_for_target(config, &target, Default::default()).shard
+    let (strategy, _) =
+        strategy_for_target(config, &target, Default::default()).expect("strategy resolves");
+    choose_origin_bucket(config, strategy, origin, &subject_bytes(&target))
+        .expect("origin holds a bucket")
+        .shard
 }
 
-fn document_ids_in_shard(config: &RealmConfigDocument, shard: u32, count: usize) -> Vec<Ulid> {
+fn document_ids_in_shard(
+    config: &RealmConfigDocument,
+    origins: &[NodeId],
+    shard: u32,
+    count: usize,
+) -> Vec<Ulid> {
     let mut ids = Vec::with_capacity(count);
     while ids.len() < count {
         let candidate = Ulid::r#gen();
-        if shard_of(config, candidate) == shard {
+        if origins
+            .iter()
+            .all(|origin| shard_of(config, *origin, candidate) == shard)
+        {
             ids.push(candidate);
         }
     }

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -140,7 +140,7 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
 
 fn shard_of(config: &RealmConfigDocument, document_id: Ulid) -> u32 {
     let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    placement_ref_for_target(config, &target, None).shard
+    placement_ref_for_target(config, &target, Default::default()).shard
 }
 
 fn document_ids_in_shard(config: &RealmConfigDocument, shard: u32, count: usize) -> Vec<Ulid> {

--- a/operations/tests/shard_manifest_protocol.rs
+++ b/operations/tests/shard_manifest_protocol.rs
@@ -21,7 +21,6 @@ use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::incoming::initialize_net_incoming;
 use aruna_operations::metadata::MetadataHandle;
-use aruna_operations::placement::placement_ref_for_target;
 use aruna_operations::shard::assemble_shard_manifest;
 use aruna_operations::shard::client::fetch_shard_manifest;
 use aruna_operations::shard::verify::{is_shard_verified, verify_held_shards};
@@ -126,7 +125,7 @@ async fn manifest_request_rejected_from_sync_eligible_non_holder()
 #[tokio::test]
 async fn new_holder_verifies_shard_against_co_holder() -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([124u8; 32]);
-    let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
+    let (nodes, _config) = build_realm_nodes(&realm_id, 2).await?;
     let group_id = Ulid::r#gen();
 
     let created = drive(
@@ -153,7 +152,7 @@ async fn new_holder_verifies_shard_against_co_holder() -> Result<(), Box<dyn std
     let target = DocumentSyncTarget::MetadataDocumentLifecycle {
         document_id: created.record.document_id,
     };
-    let placement = placement_ref_for_target(&config, &target, Default::default());
+    let placement = created.record.placement;
 
     // Wait until node B (the co-holder) has synced the document into its shard.
     wait_for_manifest_entry(&nodes[1], realm_id, placement, &target).await?;

--- a/operations/tests/shard_manifest_protocol.rs
+++ b/operations/tests/shard_manifest_protocol.rs
@@ -92,6 +92,38 @@ async fn manifest_request_rejected_for_non_held_shard() -> Result<(), Box<dyn st
 }
 
 #[tokio::test]
+async fn manifest_request_rejected_from_sync_eligible_non_holder()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([127u8; 32]);
+    let (nodes, config) = build_realm_nodes(&realm_id, 4).await?;
+    let responder = nodes[0].net.node_id();
+    let (placement, non_holder, holder) = placement_with_non_holder_requester(&config, &nodes);
+
+    let non_holder_node = nodes
+        .iter()
+        .find(|node| node.net.node_id() == non_holder)
+        .expect("non-holder node exists");
+    let error = fetch_shard_manifest(&non_holder_node.net, responder, realm_id, placement)
+        .await
+        .expect_err("sync-eligible non-holder peer must be rejected");
+    assert!(
+        error.contains("is not a holder"),
+        "unexpected reject: {error}"
+    );
+
+    let holder_node = nodes
+        .iter()
+        .find(|node| node.net.node_id() == holder)
+        .expect("holder node exists");
+    let manifest = fetch_shard_manifest(&holder_node.net, responder, realm_id, placement).await?;
+    assert_eq!(manifest.holder, responder);
+    assert_eq!(manifest.placement, placement);
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn new_holder_verifies_shard_against_co_holder() -> Result<(), Box<dyn std::error::Error>> {
     let realm_id = RealmId([124u8; 32]);
     let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
@@ -277,6 +309,39 @@ fn any_held_placement(config: &RealmConfigDocument, node_id: NodeId) -> Placemen
         }
     }
     panic!("node holds no shard");
+}
+
+fn placement_with_non_holder_requester(
+    config: &RealmConfigDocument,
+    nodes: &[TestNode],
+) -> (PlacementRef, NodeId, NodeId) {
+    let responder = nodes[0].net.node_id();
+    let strategy = config.strategies.first().expect("a strategy");
+    for shard in 0..strategy.shard_count {
+        let placement = PlacementRef {
+            strategy_id: strategy.strategy_id,
+            epoch: 0,
+            shard,
+        };
+        let holders = aruna_operations::placement::resolve_shard_holders(config, &placement);
+        if !holders.contains(&responder) {
+            continue;
+        }
+        let Some(non_holder) = nodes
+            .iter()
+            .map(|node| node.net.node_id())
+            .find(|node_id| *node_id != responder && !holders.contains(node_id))
+        else {
+            continue;
+        };
+        let holder = holders
+            .iter()
+            .copied()
+            .find(|node_id| *node_id != responder)
+            .expect("responder has a co-holder");
+        return (placement, non_holder, holder);
+    }
+    panic!("no shard found with a holder responder and sync-eligible non-holder requester");
 }
 
 async fn wait_for_manifest_entry(

--- a/operations/tests/shard_manifest_protocol.rs
+++ b/operations/tests/shard_manifest_protocol.rs
@@ -1,0 +1,344 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aruna_core::document::{DocumentSyncTarget, ShardManifest};
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::{NodeId, UserId};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::announce_realm_presence::{
+    AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
+};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::metadata::MetadataHandle;
+use aruna_operations::placement::placement_ref_for_target;
+use aruna_operations::shard::assemble_shard_manifest;
+use aruna_operations::shard::client::fetch_shard_manifest;
+use aruna_operations::shard::verify::{is_shard_verified, verify_held_shards};
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use ulid::Ulid;
+
+struct TestNode {
+    _temp_dir: TempDir,
+    net: NetHandle,
+    context: Arc<DriverContext>,
+}
+
+#[tokio::test]
+async fn manifest_request_rejected_from_non_realm_peer() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([121u8; 32]);
+    let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
+    // An outsider node that is not in the realm config at all.
+    let outsider = spawn_node(realm_id).await?;
+    outsider
+        .net
+        .add_peer_addr(nodes[0].net.endpoint_addr())
+        .await;
+    nodes[0]
+        .net
+        .add_peer_addr(outsider.net.endpoint_addr())
+        .await;
+
+    let placement = any_held_placement(&config, nodes[0].net.node_id());
+    let error = fetch_shard_manifest(&outsider.net, nodes[0].net.node_id(), realm_id, placement)
+        .await
+        .expect_err("non-realm peer must be rejected");
+    assert!(
+        error.contains("not a sync-eligible node"),
+        "unexpected reject: {error}"
+    );
+
+    outsider.net.shutdown().await;
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn manifest_request_rejected_for_non_held_shard() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([123u8; 32]);
+    let (nodes, _config) = build_realm_nodes(&realm_id, 2).await?;
+
+    // A placement whose strategy the config does not know resolves to no holders,
+    // so the responder never holds it.
+    let bogus = PlacementRef {
+        strategy_id: Ulid::from_bytes([0xAB; 16]),
+        epoch: 0,
+        shard: 1,
+    };
+    let error = fetch_shard_manifest(&nodes[1].net, nodes[0].net.node_id(), realm_id, bogus)
+        .await
+        .expect_err("non-held shard must be rejected");
+    assert!(
+        error.contains("does not hold shard"),
+        "unexpected reject: {error}"
+    );
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn new_holder_verifies_shard_against_co_holder() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([124u8; 32]);
+    let (nodes, config) = build_realm_nodes(&realm_id, 2).await?;
+    let group_id = Ulid::r#gen();
+
+    let created = drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
+                realm_id,
+            },
+            group_id,
+            document_id: Ulid::r#gen(),
+            document_path: "datasets/verify-canary".to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Verify Canary".to_string(),
+                description: "verification test".to_string(),
+                date_published: "2026-07-07".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?;
+    let target = DocumentSyncTarget::MetadataDocumentLifecycle {
+        document_id: created.record.document_id,
+    };
+    let placement = placement_ref_for_target(&config, &target, None);
+
+    // Wait until node B (the co-holder) has synced the document into its shard.
+    wait_for_manifest_entry(&nodes[1], realm_id, placement, &target).await?;
+
+    // Before verification, node B has no marker for that shard.
+    assert!(!is_shard_verified(nodes[1].context.as_ref(), realm_id, &placement).await);
+
+    // Node B fetches node A's manifest directly and sees the same document.
+    let remote =
+        fetch_shard_manifest(&nodes[1].net, nodes[0].net.node_id(), realm_id, placement).await?;
+    assert!(remote.entries.iter().any(|entry| entry.target == target));
+
+    let summary = verify_held_shards(&nodes[1].context, nodes[1].net.node_id(), realm_id).await;
+    assert!(
+        summary.newly_verified > 0,
+        "expected at least one shard verified, got {summary:?}"
+    );
+    assert!(
+        is_shard_verified(nodes[1].context.as_ref(), realm_id, &placement).await,
+        "the document's shard must be verified"
+    );
+
+    // A second pass finds every held shard already verified (idempotent, cheap).
+    let second = verify_held_shards(&nodes[1].context, nodes[1].net.node_id(), realm_id).await;
+    assert_eq!(second.newly_verified, 0);
+    assert_eq!(second.already_verified, second.held);
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+fn any_held_placement(config: &RealmConfigDocument, node_id: NodeId) -> PlacementRef {
+    let strategy = config.strategies.first().expect("a strategy");
+    for shard in 0..strategy.shard_count {
+        let placement = PlacementRef {
+            strategy_id: strategy.strategy_id,
+            epoch: 0,
+            shard,
+        };
+        if aruna_operations::placement::resolve_shard_holders(config, &placement).contains(&node_id)
+        {
+            return placement;
+        }
+    }
+    panic!("node holds no shard");
+}
+
+async fn wait_for_manifest_entry(
+    node: &TestNode,
+    realm_id: RealmId,
+    placement: PlacementRef,
+    target: &DocumentSyncTarget,
+) -> Result<ShardManifest, Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let manifest = assemble_shard_manifest(node.context.as_ref(), realm_id, placement).await?;
+        if manifest.entries.iter().any(|entry| &entry.target == target) {
+            return Ok(manifest);
+        }
+        if Instant::now() >= deadline {
+            return Err("timed out waiting for manifest entry".into());
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn build_realm_nodes(
+    realm_id: &RealmId,
+    count: usize,
+) -> Result<(Vec<TestNode>, RealmConfigDocument), Box<dyn std::error::Error>> {
+    let mut nodes = Vec::with_capacity(count);
+    for _ in 0..count {
+        nodes.push(spawn_node(*realm_id).await?);
+    }
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+    for node in &nodes {
+        drive(
+            AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+                realm_id: *realm_id,
+                node_id: node.net.node_id(),
+                schedule_refresh: true,
+            }),
+            node.context.as_ref(),
+        )
+        .await?;
+    }
+    wait_for_realm_node_convergence(&nodes, realm_id).await?;
+    let config = install_realm_config(&nodes, realm_id).await?;
+    Ok((nodes, config))
+}
+
+async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+    let metadata_handle = MetadataHandle::new(
+        temp_dir.path().join("metadata"),
+        net.node_id(),
+        storage.clone(),
+        Some(net.clone()),
+        Some(net.document_sync_node()),
+        Some(net.document_sync_database()),
+    )?;
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: Some(metadata_handle),
+        task_handle: Some(task_handle.clone()),
+    });
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle).await;
+    Ok(TestNode {
+        _temp_dir: temp_dir,
+        net,
+        context,
+    })
+}
+
+async fn install_realm_config(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
+    let mut config = RealmConfigDocument::default_for_realm(*realm_id, Vec::new());
+    config.seed_default_placement();
+    for node in nodes {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: UserId::nil(*realm_id),
+            realm_id: *realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+    for node in nodes {
+        aruna_operations::process_placements::process_shard_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
+    Ok(config)
+}
+
+async fn wait_for_realm_node_convergence(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let expected: std::collections::HashSet<NodeId> =
+        nodes.iter().map(|node| node.net.node_id()).collect();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let mut converged = true;
+        for node in nodes {
+            match drive(
+                GetRealmNodesOperation::new(*realm_id),
+                node.context.as_ref(),
+            )
+            .await
+            {
+                Ok(realm_nodes) if realm_nodes == expected => {}
+                _ => {
+                    converged = false;
+                    break;
+                }
+            }
+        }
+        if converged {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("realm nodes did not converge".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn shutdown_nodes(nodes: Vec<TestNode>) {
+    for node in nodes {
+        node.net.shutdown().await;
+    }
+}

--- a/operations/tests/shard_manifest_protocol.rs
+++ b/operations/tests/shard_manifest_protocol.rs
@@ -153,7 +153,7 @@ async fn new_holder_verifies_shard_against_co_holder() -> Result<(), Box<dyn std
     let target = DocumentSyncTarget::MetadataDocumentLifecycle {
         document_id: created.record.document_id,
     };
-    let placement = placement_ref_for_target(&config, &target, None);
+    let placement = placement_ref_for_target(&config, &target, Default::default());
 
     // Wait until node B (the co-holder) has synced the document into its shard.
     wait_for_manifest_entry(&nodes[1], realm_id, placement, &target).await?;

--- a/operations/tests/shard_manifest_protocol.rs
+++ b/operations/tests/shard_manifest_protocol.rs
@@ -6,7 +6,9 @@ use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
-use aruna_core::structs::{Actor, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::structs::{
+    Actor, PlacementRef, PlacementStrategy, RealmConfigDocument, RealmId, RealmNodeKind,
+};
 use aruna_core::{NodeId, UserId};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::announce_realm_presence::{
@@ -149,6 +151,116 @@ async fn new_holder_verifies_shard_against_co_holder() -> Result<(), Box<dyn std
 
     shutdown_nodes(nodes).await;
     Ok(())
+}
+
+// Two genesis-less holders compute the SAME (non-zero) empty fingerprint, so
+// their digests match — exactly the condition that would falsely certify
+// convergence. Verification must still refuse to mark the shard verified,
+// because neither has a local genesis.
+#[tokio::test]
+async fn co_holders_with_no_genesis_do_not_verify_on_matching_empty_digest()
+-> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([126u8; 32]);
+    let nodes = build_meshed_nodes(realm_id, 2).await?;
+    let config = install_config_without_placements(&nodes, realm_id, 2).await?;
+
+    let placement = any_held_placement(&config, nodes[1].net.node_id());
+    let left = assemble_shard_manifest(nodes[0].context.as_ref(), realm_id, placement).await?;
+    let right = assemble_shard_manifest(nodes[1].context.as_ref(), realm_id, placement).await?;
+    assert_eq!(
+        left.digest, right.digest,
+        "genesis-less holders share the empty fingerprint"
+    );
+    assert!(
+        !nodes[1]
+            .net
+            .document_sync_topic_exists(aruna_core::document::shard_topic_id(realm_id, &placement))
+            .unwrap_or(false),
+        "no local genesis exists for the shard"
+    );
+
+    let summary = verify_held_shards(&nodes[1].context, nodes[1].net.node_id(), realm_id).await;
+    assert_eq!(
+        summary.newly_verified, 0,
+        "a matching empty digest must not verify a genesis-less shard: {summary:?}"
+    );
+    assert!(
+        !is_shard_verified(nodes[1].context.as_ref(), realm_id, &placement).await,
+        "a genesis-less shard must stay unverified"
+    );
+
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+async fn build_meshed_nodes(
+    realm_id: RealmId,
+    count: usize,
+) -> Result<Vec<TestNode>, Box<dyn std::error::Error>> {
+    let mut nodes = Vec::with_capacity(count);
+    for _ in 0..count {
+        nodes.push(spawn_node(realm_id).await?);
+    }
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            nodes[i]
+                .net
+                .add_peer_addr(nodes[j].net.endpoint_addr())
+                .await;
+            nodes[j]
+                .net
+                .add_peer_addr(nodes[i].net.endpoint_addr())
+                .await;
+        }
+    }
+    Ok(nodes)
+}
+
+// Installs a small-shard realm config (every node holds every shard) but does
+// not run the placement reconciler, so no shard topic genesis exists.
+async fn install_config_without_placements(
+    nodes: &[TestNode],
+    realm_id: RealmId,
+    shard_count: u32,
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
+    let mut config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+    let strategy = PlacementStrategy {
+        strategy_id: Ulid::r#gen(),
+        name: "default".to_string(),
+        replica_count: None,
+        distinct_locations: false,
+        affinity: Vec::new(),
+        shard_count,
+    };
+    config.default_strategy_id = Some(strategy.strategy_id);
+    config.strategies = vec![strategy];
+    for node in nodes {
+        config.ensure_node(node.net.node_id(), RealmNodeKind::Management);
+    }
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.net.node_id(),
+            user_id: UserId::nil(realm_id),
+            realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+    Ok(config)
 }
 
 fn any_held_placement(config: &RealmConfigDocument, node_id: NodeId) -> PlacementRef {

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -494,10 +494,10 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
-    // Config apply hook: the bucket's rank-0 holder eagerly creates each
-    // bucket topic genesis (mirrors the production realm-config apply path).
+    // Config apply hook: the shard's rank-0 holder eagerly creates each
+    // shard topic genesis (mirrors the production realm-config apply path).
     for node in nodes {
-        aruna_operations::process_placements::process_bucket_placements(
+        aruna_operations::process_placements::process_shard_placements(
             &node.context,
             *realm_id,
             node.net.node_id(),

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -494,6 +494,16 @@ async fn install_realm_config(
         }
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
+    // Config apply hook: the bucket's rank-0 holder eagerly creates each
+    // bucket topic genesis (mirrors the production realm-config apply path).
+    for node in nodes {
+        aruna_operations::process_placements::process_bucket_placements(
+            &node.context,
+            *realm_id,
+            node.net.node_id(),
+        )
+        .await;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Closes #262

Adds the shard-based sync partition layer on top of placement.

- Documents are grouped into shards (the sync partition unit; "shard" avoids collision with S3 buckets), each with a per-(strategy, shard) topic, manifest, and digest-based anti-entropy.
- Shard-topic genesis is single-origin by rank uniqueness: only the resolver's rank-0 holder of a (strategy, epoch, shard) creates the topic genesis; other nodes join-only. Outbox records whose shard-topic genesis hasn't arrived are deferred until it does, avoiding split-brain from concurrent first-writers.
- Bucket assignment and topic derivation are wired through document sync, onboarding, metadata, and the admin outbox; node-info and onboarding-placement invariants from the placement core are preserved.

Depends on #261 (merged).
