### PR TITLE
[fix] Authorize resource watches on the holder

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -343,22 +343,28 @@ pub fn bearer_token(headers: &HeaderMap) -> Option<&str> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedArunaBearerTokenCarrier {
     token: String,
+    expires_at_secs: u64,
 }
 
 impl ValidatedArunaBearerTokenCarrier {
-    fn new(token: impl Into<String>) -> Self {
+    fn new(token: impl Into<String>, expires_at_secs: u64) -> Self {
         Self {
             token: token.into(),
+            expires_at_secs,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn new_for_test(token: impl Into<String>) -> Self {
-        Self::new(token)
+        Self::new(token, u64::MAX)
     }
 
     pub fn as_str(&self) -> &str {
         &self.token
+    }
+
+    pub fn expires_at_secs(&self) -> u64 {
+        self.expires_at_secs
     }
 }
 
@@ -396,13 +402,17 @@ async fn extract_auth_context_and_bearer_token(
         Ok(claims) => claims,
         Err(_) => return (None, None),
     };
+    let expires_at_secs = claims.exp;
     let auth_context: AuthContext = match claims.try_into() {
         Ok(auth_context) => auth_context,
         Err(_) => return (None, None),
     };
     (
         Some(auth_context),
-        Some(ValidatedArunaBearerTokenCarrier::new(token)),
+        Some(ValidatedArunaBearerTokenCarrier::new(
+            token,
+            expires_at_secs,
+        )),
     )
 }
 

--- a/api/src/ops.rs
+++ b/api/src/ops.rs
@@ -108,6 +108,12 @@ impl OpsState {
     ) -> Arc<Self> {
         register_storage_source(&metrics, ctx.clone()).await;
         register_queue_metrics(&metrics, ctx.clone()).await;
+        if let Some(net_handle) = &ctx.net_handle {
+            net_handle
+                .notification_watch_metrics()
+                .register(&metrics)
+                .await;
+        }
         Arc::new(Self {
             ctx,
             metrics,

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -188,7 +188,7 @@ fn map_watch_dispatch_error(error: WatchDispatchError, operation: &str) -> Serve
         }
         // A holder-side denial answers exactly as the create-time check does, so
         // an unreadable path never separates into a distinct existence signal.
-        WatchDispatchError::Unauthorized => ServerError::Forbidden,
+        WatchDispatchError::Unauthorized(_) => ServerError::Forbidden,
         WatchDispatchError::Internal(reason) => ServerError::InternalError(reason),
         WatchDispatchError::Remote(reason) => {
             warn!(operation, reason = %reason, "notification holder proxy failed");
@@ -818,8 +818,8 @@ pub async fn create_watch(
     )
     .await
     .map_err(|error| {
-        if matches!(error, WatchDispatchError::Unauthorized) {
-            record_watch_creation_denial(&state, WatchAuthorizationMetricReason::PermissionDenied);
+        if let WatchDispatchError::Unauthorized(reason) = &error {
+            record_watch_creation_denial(&state, *reason);
         }
         map_watch_dispatch_error(error, "create_watch")
     })?;

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -14,7 +14,8 @@ use aruna_operations::driver::DriverContext;
 use aruna_operations::notifications::dispatch::{
     InboxWakeReceiver, NotificationDispatchError, WatchDispatchError, create_watch_for_user,
     delete_watch_for_user, list_notifications_for_user, list_watches_for_user, mark_read_for_user,
-    resolve_inbox_holder_for_user, subscribe_inbox_wakes, unread_count_for_user,
+    record_watch_creation_denial_metric, resolve_inbox_holder_for_user, subscribe_inbox_wakes,
+    unread_count_for_user,
 };
 use aruna_operations::notifications::list::LIST_NOTIFICATIONS_MAX_LIMIT;
 use aruna_operations::notifications::mark_read::MARK_READ_MAX_IDS;
@@ -212,11 +213,7 @@ fn watch_response(subscription: &WatchSubscription) -> WatchResponse {
 }
 
 fn record_watch_creation_denial(state: &ServerState, reason: WatchAuthorizationMetricReason) {
-    if let Some(net_handle) = state.get_ctx().net_handle.as_ref() {
-        net_handle
-            .notification_watch_metrics()
-            .record_creation_denial(reason);
-    }
+    record_watch_creation_denial_metric(state.get_ctx().as_ref(), reason);
     warn!(
         parent: None,
         reason = reason.as_str(),

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -1,11 +1,11 @@
-use crate::auth::{ensure_permission, require_realm_auth};
+use crate::auth::require_realm_auth;
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
 use aruna_core::NodeId;
 use aruna_core::UserId;
 use aruna_core::structs::{
     AuthContext, NOTIFICATION_WATCH_MAX_PREFIX_LEN, NotificationClass, NotificationKind,
-    NotificationRecord, Permission, WatchEventKind, WatchEventMask, WatchSubscription,
+    NotificationRecord, WatchEventKind, WatchEventMask, WatchSubscription,
 };
 use aruna_operations::driver::DriverContext;
 use aruna_operations::notifications::dispatch::{
@@ -15,7 +15,9 @@ use aruna_operations::notifications::dispatch::{
 };
 use aruna_operations::notifications::list::LIST_NOTIFICATIONS_MAX_LIMIT;
 use aruna_operations::notifications::mark_read::MARK_READ_MAX_IDS;
-use aruna_operations::notifications::watch::authorization::watch_permission_path;
+use aruna_operations::notifications::watch::authorization::{
+    is_watch_authorized, watch_permission_path,
+};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -319,15 +321,32 @@ fn notification_response(record: &NotificationRecord) -> NotificationResponse {
     response
 }
 
+/// Creation shares the exact authorization result delivery and enumeration use,
+/// so a watch cannot be created on anything they would later refuse. A prefix
+/// with no canonical resource identity is a malformed request; everything else a
+/// caller may not read answers Forbidden, whether or not it exists.
 async fn authorize_watch(
     state: &ServerState,
     auth: &AuthContext,
     path_prefix: &str,
     event_mask: WatchEventMask,
 ) -> ServerResult<()> {
-    let permission_path = watch_permission_path(state.get_realm_id(), path_prefix, event_mask)
-        .ok_or(ServerError::BadRequest)?;
-    ensure_permission(state, auth, permission_path, Permission::READ).await
+    if watch_permission_path(state.get_realm_id(), path_prefix, event_mask).is_none() {
+        return Err(ServerError::BadRequest);
+    }
+    match is_watch_authorized(
+        &state.get_ctx(),
+        state.get_realm_id(),
+        auth.user_id,
+        path_prefix,
+        event_mask,
+    )
+    .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(ServerError::Forbidden),
+        Err(error) => Err(ServerError::InternalError(error)),
+    }
 }
 
 #[utoipa::path(
@@ -1570,6 +1589,50 @@ mod tests {
         .expect("bucket reader may create a watch");
         assert_eq!(status, StatusCode::CREATED);
         assert_eq!(created.path_prefix, path_prefix);
+    }
+
+    // A group that does not exist and a group the caller may not read answer
+    // identically, so creating a watch is never an existence oracle.
+    #[tokio::test]
+    async fn missing_group_forbidden() {
+        let realm_id = realm_id(18);
+        let holder = node(18);
+        let (_dir, state) = build_state(realm_id, holder).await;
+        install_local_holder_config(&state, realm_id, holder).await;
+        let caller = UserId::new(Ulid::r#gen(), realm_id);
+        let existing_group = Ulid::r#gen();
+        install_group_authorization(
+            &state,
+            realm_id,
+            existing_group,
+            UserId::new(Ulid::r#gen(), realm_id),
+            &[],
+        )
+        .await;
+
+        let missing = create_watch(
+            State(state.clone()),
+            Extension(Some(auth_for(caller, realm_id))),
+            Json(CreateWatchRequest {
+                path_prefix: format!("meta/{}/datasets", Ulid::r#gen()),
+                events: vec!["metadata_created".to_string()],
+            }),
+        )
+        .await
+        .expect_err("a watch on a group that does not exist must be refused");
+        assert!(matches!(missing, ServerError::Forbidden));
+
+        let unreadable = create_watch(
+            State(state),
+            Extension(Some(auth_for(caller, realm_id))),
+            Json(CreateWatchRequest {
+                path_prefix: format!("meta/{existing_group}/datasets"),
+                events: vec!["metadata_created".to_string()],
+            }),
+        )
+        .await
+        .expect_err("a watch on an existing unreadable group must be refused");
+        assert!(matches!(unreadable, ServerError::Forbidden));
     }
 
     #[tokio::test]

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -1,11 +1,13 @@
-use crate::auth::require_realm_auth;
+use crate::auth::{ValidatedArunaBearerTokenCarrier, require_realm_auth};
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
 use aruna_core::NodeId;
 use aruna_core::UserId;
+use aruna_core::auth::bearer_token_hash;
 use aruna_core::structs::{
     AuthContext, NOTIFICATION_WATCH_MAX_PREFIX_LEN, NotificationClass, NotificationKind,
-    NotificationRecord, WatchEventKind, WatchEventMask, WatchSubscription,
+    NotificationRecord, WatchAuthorizationBinding, WatchEventKind, WatchEventMask,
+    WatchSubscription,
 };
 use aruna_operations::driver::DriverContext;
 use aruna_operations::notifications::dispatch::{
@@ -330,6 +332,7 @@ async fn authorize_watch(
     auth: &AuthContext,
     path_prefix: &str,
     event_mask: WatchEventMask,
+    authorization: &WatchAuthorizationBinding,
 ) -> ServerResult<()> {
     if watch_permission_path(state.get_realm_id(), path_prefix, event_mask).is_none() {
         return Err(ServerError::BadRequest);
@@ -340,6 +343,7 @@ async fn authorize_watch(
         auth.user_id,
         path_prefix,
         event_mask,
+        authorization,
     )
     .await
     {
@@ -735,9 +739,11 @@ pub async fn list_watches(
 pub async fn create_watch(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
+    Extension(bearer_token): Extension<Option<ValidatedArunaBearerTokenCarrier>>,
     Json(request): Json<CreateWatchRequest>,
 ) -> ServerResult<(StatusCode, Json<WatchResponse>)> {
-    let auth = require_unrestricted_realm_auth(&state, auth)?;
+    let auth = require_realm_auth(&state, auth)?;
+    let bearer_token = bearer_token.ok_or(ServerError::Unauthorized)?;
     if request.path_prefix.is_empty()
         || request.path_prefix.starts_with('/')
         || request.path_prefix.len() > NOTIFICATION_WATCH_MAX_PREFIX_LEN
@@ -750,9 +756,21 @@ pub async fn create_watch(
         let kind = WatchEventKind::from_name(name).ok_or(ServerError::BadRequest)?;
         event_mask.insert(kind);
     }
+    let authorization = WatchAuthorizationBinding {
+        token_hash: bearer_token_hash(bearer_token.as_str()),
+        expires_at_secs: bearer_token.expires_at_secs(),
+        path_restrictions: auth.path_restrictions.clone(),
+    };
     // A remote holder receives only the durable subscription, not this request's
     // AuthContext. Authorize the immutable canonical identity before dispatch.
-    authorize_watch(&state, &auth, &request.path_prefix, event_mask).await?;
+    authorize_watch(
+        &state,
+        &auth,
+        &request.path_prefix,
+        event_mask,
+        &authorization,
+    )
+    .await?;
 
     let subscription = create_watch_for_user(
         &state.get_ctx(),
@@ -760,6 +778,7 @@ pub async fn create_watch(
         auth.user_id,
         request.path_prefix,
         event_mask,
+        authorization,
     )
     .await
     .map_err(|error| map_watch_dispatch_error(error, "create_watch"))?;
@@ -999,6 +1018,12 @@ mod tests {
             realm_id,
             path_restrictions: None,
         }
+    }
+
+    fn bearer() -> Extension<Option<ValidatedArunaBearerTokenCarrier>> {
+        Extension(Some(ValidatedArunaBearerTokenCarrier::new_for_test(
+            "notification-watch-test-token",
+        )))
     }
 
     #[tokio::test]
@@ -1478,6 +1503,7 @@ mod tests {
         let (status, created) = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: path_prefix.clone(),
                 events: vec!["data_uploaded".to_string()],
@@ -1528,6 +1554,7 @@ mod tests {
         let error = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(unauthorized, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: path_prefix.clone(),
                 events: vec!["metadata_created".to_string()],
@@ -1540,6 +1567,7 @@ mod tests {
         let (status, created) = create_watch(
             State(state),
             Extension(Some(auth_for(authorized, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: path_prefix.clone(),
                 events: vec!["metadata_created".to_string()],
@@ -1568,6 +1596,7 @@ mod tests {
         let error = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(unauthorized, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: path_prefix.clone(),
                 events: vec!["data_uploaded".to_string()],
@@ -1580,6 +1609,7 @@ mod tests {
         let (status, created) = create_watch(
             State(state),
             Extension(Some(auth_for(authorized, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: path_prefix.clone(),
                 events: vec!["data_uploaded".to_string()],
@@ -1613,6 +1643,7 @@ mod tests {
         let missing = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(caller, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: format!("meta/{}/datasets", Ulid::r#gen()),
                 events: vec!["metadata_created".to_string()],
@@ -1625,6 +1656,7 @@ mod tests {
         let unreadable = create_watch(
             State(state),
             Extension(Some(auth_for(caller, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: format!("meta/{existing_group}/datasets"),
                 events: vec!["metadata_created".to_string()],
@@ -1648,6 +1680,7 @@ mod tests {
         let error = create_watch(
             State(state),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix,
                 events,
@@ -1667,6 +1700,7 @@ mod tests {
         let empty_prefix = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: String::new(),
                 events: vec!["metadata_created".to_string()],
@@ -1679,6 +1713,7 @@ mod tests {
         let leading_slash = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: "/bucket".to_string(),
                 events: vec!["metadata_created".to_string()],
@@ -1691,6 +1726,7 @@ mod tests {
         let empty_events = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: "bucket".to_string(),
                 events: Vec::new(),
@@ -1703,6 +1739,7 @@ mod tests {
         let unknown_event = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: "bucket".to_string(),
                 events: vec!["not_an_event".to_string()],
@@ -1715,6 +1752,7 @@ mod tests {
         let unscoped_data = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: "reports".to_string(),
                 events: vec!["data_uploaded".to_string()],
@@ -1728,6 +1766,7 @@ mod tests {
         let unscoped_metadata = create_watch(
             State(state.clone()),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: format!("meta/{group_id}"),
                 events: vec!["metadata_created".to_string()],
@@ -1740,6 +1779,7 @@ mod tests {
         let noncanonical_metadata = create_watch(
             State(state),
             Extension(Some(auth_for(user_id, realm_id))),
+            bearer(),
             Json(CreateWatchRequest {
                 path_prefix: format!("meta/{group_id}/datasets/proteomics/"),
                 events: vec!["metadata_created".to_string()],
@@ -1766,13 +1806,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watch_endpoints_reject_path_restricted_token() {
+    async fn watch_creation_honors_path_restricted_token() {
         let realm_id = realm_id(9);
-        let (_dir, state) = build_state(realm_id, node(9)).await;
+        let holder = node(9);
+        let (_dir, state) = build_state(realm_id, holder).await;
+        install_local_holder_config(&state, realm_id, holder).await;
         let user_id = UserId::new(Ulid::r#gen(), realm_id);
+        let group_id = Ulid::r#gen();
+        install_group_authorization(&state, realm_id, group_id, user_id, &[]).await;
         let mut auth = auth_for(user_id, realm_id);
         auth.path_restrictions = Some(vec![PathRestriction {
-            pattern: "/bucket/**".to_string(),
+            pattern: format!("/{realm_id}/g/{group_id}/data/{holder}/bucket/allowed/**"),
             permission: Permission::READ,
         }]);
 
@@ -1781,16 +1825,29 @@ mod tests {
             .expect_err("delegated token must be rejected");
         assert!(matches!(list_err, ServerError::Forbidden));
 
-        let create_err = create_watch(
+        let _ = create_watch(
             State(state.clone()),
             Extension(Some(auth.clone())),
+            bearer(),
             Json(CreateWatchRequest {
-                path_prefix: "bucket".to_string(),
-                events: vec!["metadata_created".to_string()],
+                path_prefix: data_watch_resource_path(group_id, holder, "bucket", "allowed/"),
+                events: vec!["data_uploaded".to_string()],
             }),
         )
         .await
-        .expect_err("delegated token must be rejected");
+        .expect("delegated token may watch its allowed prefix");
+
+        let create_err = create_watch(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            bearer(),
+            Json(CreateWatchRequest {
+                path_prefix: data_watch_resource_path(group_id, holder, "bucket", "private/"),
+                events: vec!["data_uploaded".to_string()],
+            }),
+        )
+        .await
+        .expect_err("delegated token must not watch outside its prefix");
         assert!(matches!(create_err, ServerError::Forbidden));
 
         let delete_err = delete_watch(

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -795,6 +795,7 @@ pub async fn create_watch(
         token_hash: bearer_token_hash(bearer_token.as_str()),
         expires_at_secs: bearer_token.expires_at_secs(),
         path_restrictions: auth.path_restrictions.clone(),
+        watch_path_prefix: request.path_prefix.clone(),
     };
     // A remote holder receives only the durable subscription, not this request's
     // AuthContext. Authorize the immutable canonical identity before dispatch.

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -4,6 +4,7 @@ use crate::server_state::ServerState;
 use aruna_core::NodeId;
 use aruna_core::UserId;
 use aruna_core::auth::bearer_token_hash;
+use aruna_core::metrics::WatchAuthorizationMetricReason;
 use aruna_core::structs::{
     AuthContext, NOTIFICATION_WATCH_MAX_PREFIX_LEN, NotificationClass, NotificationKind,
     NotificationRecord, WatchAuthorizationBinding, WatchEventKind, WatchEventMask,
@@ -18,7 +19,7 @@ use aruna_operations::notifications::dispatch::{
 use aruna_operations::notifications::list::LIST_NOTIFICATIONS_MAX_LIMIT;
 use aruna_operations::notifications::mark_read::MARK_READ_MAX_IDS;
 use aruna_operations::notifications::watch::authorization::{
-    is_watch_authorized, watch_permission_path,
+    WatchAuthorization, evaluate_watch_authorization, watch_permission_path,
 };
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -210,6 +211,19 @@ fn watch_response(subscription: &WatchSubscription) -> WatchResponse {
     }
 }
 
+fn record_watch_creation_denial(state: &ServerState, reason: WatchAuthorizationMetricReason) {
+    if let Some(net_handle) = state.get_ctx().net_handle.as_ref() {
+        net_handle
+            .notification_watch_metrics()
+            .record_creation_denial(reason);
+    }
+    warn!(
+        parent: None,
+        reason = reason.as_str(),
+        "Notification watch creation denied"
+    );
+}
+
 /// Watch subscriptions cannot retain token-only path restrictions on their
 /// holder, so path-restricted (delegated) tokens must not reach notification
 /// endpoints even though create performs a resource permission check.
@@ -335,9 +349,10 @@ async fn authorize_watch(
     authorization: &WatchAuthorizationBinding,
 ) -> ServerResult<()> {
     if watch_permission_path(state.get_realm_id(), path_prefix, event_mask).is_none() {
+        record_watch_creation_denial(state, WatchAuthorizationMetricReason::InvalidResource);
         return Err(ServerError::BadRequest);
     }
-    match is_watch_authorized(
+    match evaluate_watch_authorization(
         &state.get_ctx(),
         state.get_realm_id(),
         auth.user_id,
@@ -347,9 +362,25 @@ async fn authorize_watch(
     )
     .await
     {
-        Ok(true) => Ok(()),
-        Ok(false) => Err(ServerError::Forbidden),
-        Err(error) => Err(ServerError::InternalError(error)),
+        Ok(WatchAuthorization::Authorized) => Ok(()),
+        Ok(WatchAuthorization::Denied(reason)) => {
+            record_watch_creation_denial(state, reason.metric_reason());
+            Err(ServerError::Forbidden)
+        }
+        Ok(WatchAuthorization::Unavailable(_)) => {
+            record_watch_creation_denial(
+                state,
+                WatchAuthorizationMetricReason::AuthorizationUnavailable,
+            );
+            Err(ServerError::Forbidden)
+        }
+        Err(error) => {
+            record_watch_creation_denial(
+                state,
+                WatchAuthorizationMetricReason::AuthorizationUnavailable,
+            );
+            Err(ServerError::InternalError(error))
+        }
     }
 }
 
@@ -749,11 +780,15 @@ pub async fn create_watch(
         || request.path_prefix.len() > NOTIFICATION_WATCH_MAX_PREFIX_LEN
         || request.events.is_empty()
     {
+        record_watch_creation_denial(&state, WatchAuthorizationMetricReason::InvalidResource);
         return Err(ServerError::BadRequest);
     }
     let mut event_mask = WatchEventMask::empty();
     for name in &request.events {
-        let kind = WatchEventKind::from_name(name).ok_or(ServerError::BadRequest)?;
+        let Some(kind) = WatchEventKind::from_name(name) else {
+            record_watch_creation_denial(&state, WatchAuthorizationMetricReason::InvalidResource);
+            return Err(ServerError::BadRequest);
+        };
         event_mask.insert(kind);
     }
     let authorization = WatchAuthorizationBinding {
@@ -781,7 +816,12 @@ pub async fn create_watch(
         authorization,
     )
     .await
-    .map_err(|error| map_watch_dispatch_error(error, "create_watch"))?;
+    .map_err(|error| {
+        if matches!(error, WatchDispatchError::Unauthorized) {
+            record_watch_creation_denial(&state, WatchAuthorizationMetricReason::PermissionDenied);
+        }
+        map_watch_dispatch_error(error, "create_watch")
+    })?;
 
     Ok((StatusCode::CREATED, Json(watch_response(&subscription))))
 }
@@ -829,6 +869,7 @@ mod tests {
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{AUTH_KEYSPACE, REALM_CONFIG_KEYSPACE};
+    use aruna_core::metrics::NodeMetrics;
     use aruna_core::structs::{
         Actor, GroupAuthorizationDocument, NodeCapabilities, PathRestriction, Permission,
         RealmAuthorizationDocument, RealmConfigDocument, RealmId, RealmNodeKind,
@@ -1542,8 +1583,10 @@ mod tests {
     #[tokio::test]
     async fn create_watch_requires_metadata_group_read_permission() {
         let realm_id = realm_id(15);
-        let holder = node(15);
-        let (_dir, state) = build_state(realm_id, holder).await;
+        let (_dir, state, net) = build_state_with_net(realm_id, [15u8; 32]).await;
+        let holder = net.node_id();
+        let metrics = NodeMetrics::new();
+        net.notification_watch_metrics().register(&metrics).await;
         install_local_holder_config(&state, realm_id, holder).await;
         let authorized = UserId::new(Ulid::r#gen(), realm_id);
         let unauthorized = UserId::new(Ulid::r#gen(), realm_id);
@@ -1563,6 +1606,9 @@ mod tests {
         .await
         .expect_err("user without metadata READ must be rejected");
         assert!(matches!(error, ServerError::Forbidden));
+        assert!(metrics.render().await.contains(
+            "aruna_notification_watch_creation_denials_total{reason=\"permission_denied\"} 1"
+        ));
 
         let (status, created) = create_watch(
             State(state),

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -181,6 +181,9 @@ fn map_watch_dispatch_error(error: WatchDispatchError, operation: &str) -> Serve
         WatchDispatchError::CapExceeded => {
             ServerError::Conflict("notification watch subscription cap reached".to_string())
         }
+        // A holder-side denial answers exactly as the create-time check does, so
+        // an unreadable path never separates into a distinct existence signal.
+        WatchDispatchError::Unauthorized => ServerError::Forbidden,
         WatchDispatchError::Internal(reason) => ServerError::InternalError(reason),
         WatchDispatchError::Remote(reason) => {
             warn!(operation, reason = %reason, "notification holder proxy failed");

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -83,6 +83,20 @@ impl WatchAuthorizationMetricReason {
             Self::InvalidState => "invalid_state",
         }
     }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "invalid_resource" => Self::InvalidResource,
+            "invalid_owner" => Self::InvalidOwner,
+            "token_restricted" => Self::TokenRestricted,
+            "token_expired" => Self::TokenExpired,
+            "token_revoked" => Self::TokenRevoked,
+            "permission_denied" => Self::PermissionDenied,
+            "authorization_unavailable" => Self::AuthorizationUnavailable,
+            "invalid_state" => Self::InvalidState,
+            _ => return None,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
@@ -358,6 +372,10 @@ mod tests {
 
     #[tokio::test]
     async fn notification_watch_metrics_use_bounded_reason_labels() {
+        assert_eq!(
+            WatchAuthorizationMetricReason::parse("token_revoked"),
+            Some(WatchAuthorizationMetricReason::TokenRevoked)
+        );
         let metrics = NodeMetrics::new();
         let watch_metrics = NotificationWatchMetrics::default();
         watch_metrics.register(&metrics).await;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -58,6 +58,79 @@ pub struct RouteLabels {
     pub op: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WatchAuthorizationMetricReason {
+    InvalidResource,
+    InvalidOwner,
+    TokenRestricted,
+    TokenExpired,
+    TokenRevoked,
+    PermissionDenied,
+    AuthorizationUnavailable,
+    InvalidState,
+}
+
+impl WatchAuthorizationMetricReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidResource => "invalid_resource",
+            Self::InvalidOwner => "invalid_owner",
+            Self::TokenRestricted => "token_restricted",
+            Self::TokenExpired => "token_expired",
+            Self::TokenRevoked => "token_revoked",
+            Self::PermissionDenied => "permission_denied",
+            Self::AuthorizationUnavailable => "authorization_unavailable",
+            Self::InvalidState => "invalid_state",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct WatchAuthorizationLabels {
+    reason: &'static str,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NotificationWatchMetrics {
+    creation_denials: Family<WatchAuthorizationLabels, Counter>,
+    delivery_suppressions: Family<WatchAuthorizationLabels, Counter>,
+}
+
+impl NotificationWatchMetrics {
+    pub fn record_creation_denial(&self, reason: WatchAuthorizationMetricReason) {
+        self.creation_denials
+            .get_or_create(&WatchAuthorizationLabels {
+                reason: reason.as_str(),
+            })
+            .inc();
+    }
+
+    pub fn record_delivery_suppression(&self, reason: WatchAuthorizationMetricReason) {
+        self.delivery_suppressions
+            .get_or_create(&WatchAuthorizationLabels {
+                reason: reason.as_str(),
+            })
+            .inc();
+    }
+
+    pub async fn register(&self, metrics: &NodeMetrics) {
+        metrics
+            .register(
+                "notification_watch_creation_denials",
+                "Notification watch creation denials",
+                self.creation_denials.clone(),
+            )
+            .await;
+        metrics
+            .register(
+                "notification_watch_delivery_suppressions",
+                "Notification watch delivery suppressions",
+                self.delivery_suppressions.clone(),
+            )
+            .await;
+    }
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct BuildInfoLabels {
     version: String,
@@ -281,5 +354,22 @@ mod tests {
         assert!(metrics.render().await.contains("aruna_refreshes 1"));
         assert!(metrics.render().await.contains("aruna_refreshes 2"));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn notification_watch_metrics_use_bounded_reason_labels() {
+        let metrics = NodeMetrics::new();
+        let watch_metrics = NotificationWatchMetrics::default();
+        watch_metrics.register(&metrics).await;
+        watch_metrics.record_creation_denial(WatchAuthorizationMetricReason::PermissionDenied);
+        watch_metrics.record_delivery_suppression(WatchAuthorizationMetricReason::TokenRestricted);
+
+        let body = metrics.render().await;
+        assert!(body.contains(
+            "aruna_notification_watch_creation_denials_total{reason=\"permission_denied\"} 1"
+        ));
+        assert!(body.contains(
+            "aruna_notification_watch_delivery_suppressions_total{reason=\"token_restricted\"} 1"
+        ));
     }
 }

--- a/core/src/structs/notification.rs
+++ b/core/src/structs/notification.rs
@@ -4,7 +4,7 @@ use ulid::Ulid;
 
 use crate::NodeId;
 use crate::errors::ConversionError;
-use crate::structs::RealmId;
+use crate::structs::{RealmId, WatchAuthorizationBinding};
 use crate::types::{GroupId, Key, UserId};
 
 pub const NOTIFICATION_DIRECT_TTL_MS: u64 = 90 * 24 * 60 * 60 * 1000;
@@ -98,6 +98,7 @@ pub struct NotificationRecord {
     pub kind: NotificationKind,
     pub created_at_ms: u64,
     pub read_at_ms: Option<u64>,
+    pub watch_authorization: Option<WatchAuthorizationBinding>,
 }
 
 impl NotificationRecord {
@@ -114,6 +115,7 @@ impl NotificationRecord {
             kind,
             created_at_ms,
             read_at_ms: None,
+            watch_authorization: None,
         }
     }
 

--- a/core/src/structs/notification.rs
+++ b/core/src/structs/notification.rs
@@ -1,4 +1,5 @@
 use byteview::ByteView;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
@@ -101,7 +102,35 @@ pub struct NotificationRecord {
     pub watch_authorization: Option<WatchAuthorizationBinding>,
 }
 
+type LegacyNotificationRecord = (
+    Ulid,
+    UserId,
+    NotificationClass,
+    NotificationKind,
+    u64,
+    Option<u64>,
+);
+
+fn from_exact_bytes<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, postcard::Error> {
+    match postcard::take_from_bytes(bytes)? {
+        (record, []) => Ok(record),
+        _ => Err(postcard::Error::SerdeDeCustom),
+    }
+}
+
 impl NotificationRecord {
+    fn from_legacy(record: LegacyNotificationRecord) -> Self {
+        Self {
+            notification_id: record.0,
+            recipient: record.1,
+            class: record.2,
+            kind: record.3,
+            created_at_ms: record.4,
+            read_at_ms: record.5,
+            watch_authorization: None,
+        }
+    }
+
     pub fn new(
         recipient: UserId,
         class: NotificationClass,
@@ -128,7 +157,9 @@ impl NotificationRecord {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
-        Ok(postcard::from_bytes(bytes)?)
+        from_exact_bytes(bytes)
+            .or_else(|_| from_exact_bytes(bytes).map(Self::from_legacy))
+            .map_err(Into::into)
     }
 }
 
@@ -158,6 +189,19 @@ pub enum ResourceEvent {
 pub struct NotificationOutboxRecord {
     pub outbox_id: Ulid,
     pub record: NotificationRecord,
+}
+
+impl NotificationOutboxRecord {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConversionError> {
+        from_exact_bytes(bytes)
+            .or_else(|_| {
+                from_exact_bytes::<(Ulid, LegacyNotificationRecord)>(bytes).map(|record| Self {
+                    outbox_id: record.0,
+                    record: NotificationRecord::from_legacy(record.1),
+                })
+            })
+            .map_err(Into::into)
+    }
 }
 
 pub fn invert_timestamp_ms(timestamp_ms: u64) -> u64 {
@@ -247,6 +291,35 @@ mod tests {
             group_id: Ulid::r#gen(),
             actor_user_id: user(1, actor),
         }
+    }
+
+    #[test]
+    fn notification_record_decodes_legacy_schema() {
+        let recipient = user(1, 2);
+        let notification_id = Ulid::r#gen();
+        let legacy = (
+            notification_id,
+            recipient,
+            NotificationClass::Direct,
+            added(3),
+            1234,
+            None::<u64>,
+        );
+        let legacy_bytes = postcard::to_allocvec(&legacy).unwrap();
+        let decoded = NotificationRecord::from_bytes(&legacy_bytes)
+            .expect("legacy notification record decodes");
+        assert_eq!(decoded.notification_id, notification_id);
+        assert_eq!(decoded.recipient, recipient);
+        assert_eq!(decoded.watch_authorization, None);
+        assert!(NotificationRecord::from_bytes(&[legacy_bytes, vec![2]].concat()).is_err());
+
+        let outbox_id = Ulid::r#gen();
+        let outbox = (outbox_id, legacy);
+        let decoded =
+            NotificationOutboxRecord::from_bytes(&postcard::to_allocvec(&outbox).unwrap())
+                .expect("legacy notification outbox record decodes");
+        assert_eq!(decoded.outbox_id, outbox_id);
+        assert_eq!(decoded.record.watch_authorization, None);
     }
 
     #[test]

--- a/core/src/structs/notification_watch.rs
+++ b/core/src/structs/notification_watch.rs
@@ -7,7 +7,7 @@ use ulid::Ulid;
 
 use crate::NodeId;
 use crate::errors::ConversionError;
-use crate::structs::{NotificationKind, RealmId};
+use crate::structs::{NotificationKind, PathRestriction, RealmId};
 use crate::types::{GroupId, Key, UserId};
 
 pub const NOTIFICATION_WATCH_PER_USER_CAP: usize = 50;
@@ -233,12 +233,43 @@ pub fn watch_notification_id(event_id: Ulid, watch_id: Ulid) -> Ulid {
 /// Durable watch subscription row on the owner's inbox-holder node. Placed and
 /// proxied exactly like a notification inbox record.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatchAuthorizationBinding {
+    pub token_hash: String,
+    pub expires_at_secs: u64,
+    pub path_restrictions: Option<Vec<PathRestriction>>,
+}
+
+impl WatchAuthorizationBinding {
+    pub fn is_valid(&self) -> bool {
+        self.expires_at_secs > 0
+            && self.token_hash.len() == 64
+            && self.token_hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && self
+                .path_restrictions
+                .iter()
+                .flatten()
+                .all(|restriction| globset::Glob::new(&restriction.pattern).is_ok())
+    }
+}
+
+impl Default for WatchAuthorizationBinding {
+    fn default() -> Self {
+        Self {
+            token_hash: blake3::hash(b"internal-watch").to_hex().to_string(),
+            expires_at_secs: u64::MAX,
+            path_restrictions: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WatchSubscription {
     pub watch_id: Ulid,
     pub owner: UserId,
     pub path_prefix: String,
     pub event_mask: WatchEventMask,
     pub created_at_ms: u64,
+    pub authorization: WatchAuthorizationBinding,
 }
 
 impl WatchSubscription {
@@ -248,12 +279,29 @@ impl WatchSubscription {
         event_mask: WatchEventMask,
         created_at_ms: u64,
     ) -> Self {
+        Self::new_with_authorization(
+            owner,
+            path_prefix,
+            event_mask,
+            created_at_ms,
+            WatchAuthorizationBinding::default(),
+        )
+    }
+
+    pub fn new_with_authorization(
+        owner: UserId,
+        path_prefix: String,
+        event_mask: WatchEventMask,
+        created_at_ms: u64,
+        authorization: WatchAuthorizationBinding,
+    ) -> Self {
         Self {
             watch_id: Ulid::r#gen(),
             owner,
             path_prefix,
             event_mask,
             created_at_ms,
+            authorization,
         }
     }
 

--- a/core/src/structs/notification_watch.rs
+++ b/core/src/structs/notification_watch.rs
@@ -237,6 +237,7 @@ pub struct WatchAuthorizationBinding {
     pub token_hash: String,
     pub expires_at_secs: u64,
     pub path_restrictions: Option<Vec<PathRestriction>>,
+    pub watch_path_prefix: String,
 }
 
 impl WatchAuthorizationBinding {
@@ -261,6 +262,7 @@ impl Default for WatchAuthorizationBinding {
             token_hash: blake3::hash(b"internal-watch").to_hex().to_string(),
             expires_at_secs: u64::MAX,
             path_restrictions: None,
+            watch_path_prefix: String::new(),
         }
     }
 }
@@ -296,8 +298,9 @@ impl WatchSubscription {
         path_prefix: String,
         event_mask: WatchEventMask,
         created_at_ms: u64,
-        authorization: WatchAuthorizationBinding,
+        mut authorization: WatchAuthorizationBinding,
     ) -> Self {
+        authorization.watch_path_prefix = path_prefix.clone();
         Self {
             watch_id: Ulid::r#gen(),
             owner,

--- a/core/src/structs/notification_watch.rs
+++ b/core/src/structs/notification_watch.rs
@@ -243,7 +243,10 @@ impl WatchAuthorizationBinding {
     pub fn is_valid(&self) -> bool {
         self.expires_at_secs > 0
             && self.token_hash.len() == 64
-            && self.token_hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && self
+                .token_hash
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
             && self
                 .path_restrictions
                 .iter()
@@ -787,6 +790,14 @@ mod tests {
             watch_notification_id(event_id, watch_id),
             watch_notification_id(Ulid::from_bytes([9u8; 16]), watch_id)
         );
+    }
+
+    #[test]
+    fn watch_authorization_hash_must_be_canonical() {
+        let mut binding = WatchAuthorizationBinding::default();
+        assert!(binding.is_valid());
+        binding.token_hash.make_ascii_uppercase();
+        assert!(!binding.is_valid());
     }
 
     #[test]

--- a/core/src/structs/notification_watch.rs
+++ b/core/src/structs/notification_watch.rs
@@ -291,11 +291,11 @@ pub fn parse_watch_subscription_key(key: &[u8]) -> Result<(UserId, Ulid), Conver
 
 /// Keys in the watch-interest keyspace. Per-node digests use fixed-length keys
 /// so their prefixes are unambiguous: `n/` + realm id + node id (realm first so
-/// all nodes' digests for one realm form a single scan range). Local-only dirty
-/// markers use a text prefix (`dirty/`) that never collides with the binary
-/// digest prefix.
+/// all nodes' digests for one realm form a single scan range). Local-only
+/// markers use text prefixes that never collide with the binary digest prefix.
 pub const WATCH_INTEREST_NODE_PREFIX: &[u8] = b"n/";
 pub const WATCH_INTEREST_DIRTY_PREFIX: &[u8] = b"dirty/";
+const WATCH_INTEREST_PENDING_PREFIX: &[u8] = b"pending/";
 
 /// One coalesced interest entry: the union of every subscription a node holds
 /// for a realm that shares this path prefix.
@@ -386,6 +386,13 @@ pub fn watch_interest_key_node_id(key: &[u8]) -> Option<NodeId> {
 pub fn watch_interest_dirty_key(realm_id: RealmId) -> Vec<u8> {
     let mut key = Vec::with_capacity(WATCH_INTEREST_DIRTY_PREFIX.len() + 32);
     key.extend_from_slice(WATCH_INTEREST_DIRTY_PREFIX);
+    key.extend_from_slice(realm_id.as_bytes());
+    key
+}
+
+pub fn watch_interest_pending_key(realm_id: RealmId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(WATCH_INTEREST_PENDING_PREFIX.len() + 32);
+    key.extend_from_slice(WATCH_INTEREST_PENDING_PREFIX);
     key.extend_from_slice(realm_id.as_bytes());
     key
 }

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -28,6 +28,7 @@ use aruna_core::events::{DhtEntry, Event, NetError as CoreNetError, NetEvent, St
 use aruna_core::handle::Handle;
 use aruna_core::id::NodeId;
 use aruna_core::keys::realm_endpoint_key;
+use aruna_core::metrics::NotificationWatchMetrics;
 use aruna_core::structs::{
     ConnectionAddressState, ConnectionAddressStatus, ConnectionMonitorState, NetState,
     NetworkDiagnosticsState, PeerConnectionState, PeerConnectionStatus, ProtocolConnectionState,
@@ -394,6 +395,7 @@ struct NetInner {
     relay_method: RelayMethod,
     realm_peers: Arc<RwLock<Vec<NodeId>>>,
     watch_interest: Arc<RwLock<WatchInterestTable>>,
+    notification_watch_metrics: NotificationWatchMetrics,
     notification_wakes: broadcast::Sender<UserId>,
     dht_signed_authorized_nodes: Arc<RwLock<Vec<NodeId>>>,
     dht: Arc<DhtHandle>,
@@ -790,6 +792,7 @@ impl NetHandle {
             relay_method,
             realm_peers,
             watch_interest,
+            notification_watch_metrics: NotificationWatchMetrics::default(),
             notification_wakes,
             dht_signed_authorized_nodes,
             dht,
@@ -1032,6 +1035,10 @@ impl NetHandle {
     /// events against this table without any per-event storage read.
     pub fn watch_interest_snapshot(&self) -> WatchInterestTable {
         self.inner.watch_interest.read().clone()
+    }
+
+    pub fn notification_watch_metrics(&self) -> &NotificationWatchMetrics {
+        &self.inner.notification_watch_metrics
     }
 
     /// Replaces the whole watch interest cache (startup and full rebuilds).

--- a/operations/src/incoming.rs
+++ b/operations/src/incoming.rs
@@ -14,6 +14,7 @@ use crate::metadata::projector::{
 use crate::metadata::prune_queue::process_metadata_graph_tombstones;
 use crate::notifications::watch::interest::refresh_watch_interest_for_targets;
 use crate::process_placements::process_shard_placements;
+use crate::queue_backoff::queue_retry_after_ms;
 use crate::replication::incoming_version_replication::IncomingVersionReplicationOperation;
 use crate::replication::protocol::VersionReplicationMessage;
 use crate::usage_stats::refresh_realm_usage_summary_for_targets;
@@ -82,6 +83,7 @@ impl DocumentSyncReconcileCoalescer {
         }
         let coalescer = self.clone();
         tokio::spawn(async move {
+            let mut failures = 0u32;
             loop {
                 let batch: Vec<irokle::TopicId> = {
                     let mut state = coalescer
@@ -96,9 +98,29 @@ impl DocumentSyncReconcileCoalescer {
                     state.queued_since = None;
                     std::mem::take(&mut state.queued).into_iter().collect()
                 };
-                reconcile_inbound_document_sync_topics(&context, batch).await;
+                if reconcile_inbound_document_sync_topics(&context, batch.clone()).await {
+                    failures = 0;
+                } else {
+                    coalescer.trigger(context.clone(), batch);
+                    let retry_after = Duration::from_millis(queue_retry_after_ms(failures));
+                    failures = failures.saturating_add(1);
+                    sleep(retry_after).await;
+                }
             }
         });
+    }
+
+    fn trigger_all(self: &Arc<Self>, context: Arc<DriverContext>) {
+        let Some(net_handle) = context.net_handle.as_ref() else {
+            return;
+        };
+        let Ok(topics) = net_handle.document_sync_node().list_topics() else {
+            return;
+        };
+        self.trigger(
+            context,
+            topics.into_iter().map(|topic| topic.topic_id).collect(),
+        );
     }
 
     fn lag_snapshot(&self) -> (usize, bool, u64) {
@@ -144,9 +166,9 @@ fn spawn_reconcile_queue_gauge(coalescer: Weak<DocumentSyncReconcileCoalescer>) 
 async fn reconcile_inbound_document_sync_topics(
     context: &Arc<DriverContext>,
     topics: Vec<irokle::TopicId>,
-) {
+) -> bool {
     let Some(net_handle) = context.net_handle.clone() else {
-        return;
+        return true;
     };
     let run_started = Instant::now();
     let topic_count = topics.len();
@@ -154,14 +176,14 @@ async fn reconcile_inbound_document_sync_topics(
         Ok(targets) => targets,
         Err(err) => {
             error!(error = ?err, "Failed to reconcile inbound document sync topics");
-            return;
+            return false;
         }
     };
     let reconcile_elapsed = run_started.elapsed();
     let applied = targets.applied();
     debug!(applied, "Reconciled inbound document sync events");
     if applied == 0 {
-        return;
+        return true;
     }
     let metadata_graph_tombstones = targets.metadata_graph_tombstones.clone();
     let realm_config_changed = targets
@@ -188,6 +210,7 @@ async fn reconcile_inbound_document_sync_topics(
         total_ms = duration_ms(run_started.elapsed()),
         "Inbound document sync reconcile summary"
     );
+    true
 }
 
 pub fn initialize_net_incoming(context: Arc<DriverContext>) {
@@ -196,10 +219,15 @@ pub fn initialize_net_incoming(context: Arc<DriverContext>) {
         return;
     };
     let metadata_handle = context.metadata_handle.clone();
+    let inbound_handler = Arc::new(OperationsInboundHandler::new(context.clone()));
 
-    net_handle.set_inbound_handler(Arc::new(OperationsInboundHandler::new(context)));
+    net_handle.set_inbound_handler(inbound_handler.clone());
     if let Some(metadata_handle) = metadata_handle {
-        schedule_periodic_metadata_document_sync_maintenance(metadata_handle);
+        schedule_periodic_metadata_document_sync_maintenance(
+            context,
+            Arc::downgrade(&inbound_handler.document_sync_reconcile),
+            metadata_handle,
+        );
     }
 }
 
@@ -291,7 +319,11 @@ impl InboundEventHandler for OperationsInboundHandler {
                             self.document_sync_reconcile
                                 .trigger(self.context.clone(), touched_topics);
                         }
-                        Err(err) => error!(error = ?err, "Failed to process inbound document sync stream"),
+                        Err(err) => {
+                            error!(error = ?err, "Failed to process inbound document sync stream");
+                            self.document_sync_reconcile
+                                .trigger_all(self.context.clone());
+                        }
                     }
                 }
                 Alpn::Metadata => {
@@ -463,7 +495,11 @@ async fn schedule_projection_retry(context: &DriverContext) {
     }
 }
 
-fn schedule_periodic_metadata_document_sync_maintenance(metadata_handle: MetadataHandle) {
+fn schedule_periodic_metadata_document_sync_maintenance(
+    context: Arc<DriverContext>,
+    coalescer: Weak<DocumentSyncReconcileCoalescer>,
+    metadata_handle: MetadataHandle,
+) {
     let jitter = Duration::from_secs(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -474,6 +510,10 @@ fn schedule_periodic_metadata_document_sync_maintenance(metadata_handle: Metadat
         let mut cycle = 0usize;
         loop {
             sleep(METADATA_DOCUMENT_SYNC_MAINTENANCE_INTERVAL + jitter).await;
+            let Some(coalescer) = coalescer.upgrade() else {
+                return;
+            };
+            coalescer.trigger_all(context.clone());
             cycle = cycle.saturating_add(1);
             run_metadata_document_sync_maintenance(&metadata_handle, "periodic", cycle).await;
         }

--- a/operations/src/notifications/client.rs
+++ b/operations/src/notifications/client.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 use aruna_core::NodeId;
 use aruna_core::alpn::Alpn;
-use aruna_core::structs::{NotificationRecord, WatchEvent, WatchEventMask, WatchSubscription};
+use aruna_core::structs::{
+    NotificationRecord, WatchAuthorizationBinding, WatchEvent, WatchEventMask, WatchSubscription,
+};
 use aruna_core::types::UserId;
 use aruna_net::NetHandle;
 use aruna_net::streams::BiStream;
@@ -124,6 +126,7 @@ pub async fn create_watch_remote(
     owner: UserId,
     path_prefix: String,
     event_mask: WatchEventMask,
+    authorization: WatchAuthorizationBinding,
 ) -> Result<WatchSubscription, String> {
     match send_notification_request(
         net_handle,
@@ -132,6 +135,7 @@ pub async fn create_watch_remote(
             owner,
             path_prefix,
             event_mask,
+            authorization,
         },
     )
     .await?

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -273,23 +273,15 @@ pub async fn mark_read_for_user(
 ) -> Result<u32, NotificationDispatchError> {
     let holder = resolve_holder(context, recipient).await?;
     if holder == local_node_id {
-        let output = drive(
-            MarkReadOperation::new(MarkReadInput {
-                recipient,
-                ids,
-                up_to_ms,
-                now_ms: unix_timestamp_millis(),
-            }),
-            context,
-        )
-        .await
-        .map_err(|error| NotificationDispatchError::Internal(error.to_string()))?;
-        if output.marked > 0
+        let marked = mark_read_on_holder(context, recipient, ids, up_to_ms)
+            .await
+            .map_err(NotificationDispatchError::Internal)?;
+        if marked > 0
             && let Some(net_handle) = context.net_handle.as_ref()
         {
             net_handle.notify_inbox_activity(recipient);
         }
-        Ok(output.marked as u32)
+        Ok(marked)
     } else {
         let net_handle = context
             .net_handle
@@ -298,6 +290,57 @@ pub async fn mark_read_for_user(
         mark_read_remote(net_handle, holder, recipient, ids, up_to_ms)
             .await
             .map_err(NotificationDispatchError::Remote)
+    }
+}
+
+pub(crate) async fn mark_read_on_holder(
+    context: &DriverContext,
+    recipient: UserId,
+    mut ids: Vec<Ulid>,
+    up_to_ms: Option<u64>,
+) -> Result<u32, String> {
+    if ids.len() > crate::notifications::mark_read::MARK_READ_MAX_IDS {
+        return Err("mark read id count exceeds cap".to_string());
+    }
+    if ids.is_empty() && up_to_ms.is_none() {
+        return Ok(0);
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    let mut cursor = None;
+    let mut marked = 0u32;
+    let now_ms = unix_timestamp_millis();
+    loop {
+        let (records, next_cursor) =
+            list_notifications_on_holder(context, recipient, cursor, LIST_NOTIFICATIONS_MAX_LIMIT)
+                .await?;
+        let visible_ids: Vec<_> = records
+            .into_iter()
+            .filter(|record| {
+                record.read_at_ms.is_none()
+                    && (ids.binary_search(&record.notification_id).is_ok()
+                        || up_to_ms.is_some_and(|limit| record.created_at_ms <= limit))
+            })
+            .map(|record| record.notification_id)
+            .collect();
+        for chunk in visible_ids.chunks(crate::notifications::mark_read::MARK_READ_MAX_IDS) {
+            marked += drive(
+                MarkReadOperation::new(MarkReadInput {
+                    recipient,
+                    ids: chunk.to_vec(),
+                    up_to_ms: None,
+                    now_ms,
+                }),
+                context,
+            )
+            .await
+            .map_err(|error| error.to_string())?
+            .marked as u32;
+        }
+        match next_cursor {
+            Some(next) => cursor = Some(next),
+            None => return Ok(marked),
+        }
     }
 }
 

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -16,10 +16,11 @@ use crate::notifications::list::{ListNotificationsInput, ListNotificationsOperat
 use crate::notifications::mark_read::{MarkReadInput, MarkReadOperation};
 use crate::notifications::placement::resolve_inbox_holder;
 use crate::notifications::unread::{UnreadCountInput, UnreadCountOperation};
+use crate::notifications::watch::authorization::list_authorized_watch_subscriptions;
 use crate::notifications::watch::interest::schedule_watch_interest_publish;
 use crate::notifications::watch::subscriptions::{
-    WATCH_SUBSCRIPTION_CAP_REACHED, WatchSubscriptionError, create_replicated_watch_subscription,
-    delete_replicated_watch_subscription, list_watch_subscriptions,
+    WATCH_SUBSCRIPTION_CAP_REACHED, WATCH_SUBSCRIPTION_UNAUTHORIZED, WatchSubscriptionError,
+    create_replicated_watch_subscription, delete_replicated_watch_subscription,
 };
 
 /// Outcome of serving a user's inbox read op through the resolved holder.
@@ -36,13 +37,16 @@ pub enum NotificationDispatchError {
 }
 
 /// Watch CRUD dispatch outcome. Distinguishes the per-user cap so the REST layer
-/// can answer 409 instead of a generic proxy failure.
+/// can answer 409, and an unauthorized watched path so it can answer 403, instead
+/// of a generic proxy failure.
 #[derive(Debug, Error)]
 pub enum WatchDispatchError {
     #[error("no inbox holder is currently available")]
     Unavailable,
     #[error("notification watch subscription cap reached")]
     CapExceeded,
+    #[error("{WATCH_SUBSCRIPTION_UNAUTHORIZED}")]
+    Unauthorized,
     #[error("holder proxy failed: {0}")]
     Remote(String),
     #[error("{0}")]
@@ -216,6 +220,7 @@ pub async fn create_watch_for_user(
         .await
         .map_err(|error| match error {
             WatchSubscriptionError::CapExceeded => WatchDispatchError::CapExceeded,
+            WatchSubscriptionError::Unauthorized => WatchDispatchError::Unauthorized,
             other => WatchDispatchError::Internal(other.to_string()),
         })?;
         schedule_watch_interest_publish(context).await;
@@ -230,6 +235,8 @@ pub async fn create_watch_for_user(
             .map_err(|reason| {
                 if reason == WATCH_SUBSCRIPTION_CAP_REACHED {
                     WatchDispatchError::CapExceeded
+                } else if reason == WATCH_SUBSCRIPTION_UNAUTHORIZED {
+                    WatchDispatchError::Unauthorized
                 } else {
                     WatchDispatchError::Remote(reason)
                 }
@@ -274,9 +281,9 @@ pub async fn list_watches_for_user(
 ) -> Result<Vec<WatchSubscription>, WatchDispatchError> {
     let holder = resolve_holder(context, owner).await?;
     if holder == local_node_id {
-        list_watch_subscriptions(&context.storage_handle, owner)
+        list_authorized_watch_subscriptions(context, owner)
             .await
-            .map_err(|error| WatchDispatchError::Internal(error.to_string()))
+            .map_err(WatchDispatchError::Internal)
     } else {
         let net_handle = context
             .net_handle

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -1,5 +1,7 @@
 use aruna_core::NodeId;
-use aruna_core::structs::{NotificationRecord, WatchEventMask, WatchSubscription};
+use aruna_core::structs::{
+    NotificationKind, NotificationRecord, WatchEventKind, WatchEventMask, WatchSubscription,
+};
 use aruna_core::types::UserId;
 use aruna_core::util::unix_timestamp_millis;
 use thiserror::Error;
@@ -12,11 +14,15 @@ use crate::notifications::client::{
     create_watch_remote, delete_watch_remote, list_remote, list_watches_remote, mark_read_remote,
     unread_count_remote,
 };
-use crate::notifications::list::{ListNotificationsInput, ListNotificationsOperation};
+use crate::notifications::list::{
+    LIST_NOTIFICATIONS_MAX_LIMIT, ListNotificationsInput, ListNotificationsOperation,
+};
 use crate::notifications::mark_read::{MarkReadInput, MarkReadOperation};
 use crate::notifications::placement::resolve_inbox_holder;
 use crate::notifications::unread::{UnreadCountInput, UnreadCountOperation};
-use crate::notifications::watch::authorization::list_authorized_watch_subscriptions;
+use crate::notifications::watch::authorization::{
+    is_watch_authorized, list_authorized_watch_subscriptions,
+};
 use crate::notifications::watch::interest::schedule_watch_interest_publish;
 use crate::notifications::watch::subscriptions::{
     WATCH_SUBSCRIPTION_CAP_REACHED, WATCH_SUBSCRIPTION_UNAUTHORIZED, WatchSubscriptionError,
@@ -116,17 +122,9 @@ pub async fn list_notifications_for_user(
 ) -> Result<(Vec<NotificationRecord>, Option<Vec<u8>>), NotificationDispatchError> {
     let holder = resolve_holder(context, recipient).await?;
     if holder == local_node_id {
-        let output = drive(
-            ListNotificationsOperation::new(ListNotificationsInput {
-                recipient,
-                cursor,
-                limit,
-            }),
-            context,
-        )
-        .await
-        .map_err(|error| NotificationDispatchError::Internal(error.to_string()))?;
-        Ok((output.records, output.next_cursor))
+        list_notifications_on_holder(context, recipient, cursor, limit)
+            .await
+            .map_err(NotificationDispatchError::Internal)
     } else {
         let net_handle = context
             .net_handle
@@ -135,6 +133,62 @@ pub async fn list_notifications_for_user(
         list_remote(net_handle, holder, recipient, cursor, limit as u32)
             .await
             .map_err(NotificationDispatchError::Remote)
+    }
+}
+
+/// Reauthorizes persisted resource-watch records at the inbox-holder boundary.
+/// Suppressed rows do not consume the caller's page, so revocation cannot hide
+/// older ordinary notifications behind a page of stale watch records.
+pub(crate) async fn list_notifications_on_holder(
+    context: &DriverContext,
+    recipient: UserId,
+    mut cursor: Option<Vec<u8>>,
+    limit: usize,
+) -> Result<(Vec<NotificationRecord>, Option<Vec<u8>>), String> {
+    let limit = limit.clamp(1, LIST_NOTIFICATIONS_MAX_LIMIT);
+    let mut records = Vec::with_capacity(limit);
+
+    loop {
+        let output = drive(
+            ListNotificationsOperation::new(ListNotificationsInput {
+                recipient,
+                cursor,
+                limit: limit - records.len(),
+            }),
+            context,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+
+        for record in output.records {
+            let watch = match &record.kind {
+                NotificationKind::MetadataCreated { path, .. } => Some((
+                    path.as_str(),
+                    WatchEventMask::from_kinds([WatchEventKind::MetadataCreated]),
+                )),
+                NotificationKind::DataUploaded { path, .. } => Some((
+                    path.as_str(),
+                    WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+                )),
+                _ => None,
+            };
+            let visible = match watch {
+                None => true,
+                Some((path, event_mask)) => {
+                    is_watch_authorized(context, recipient.realm_id, recipient, path, event_mask)
+                        .await
+                        .unwrap_or(false)
+                }
+            };
+            if visible {
+                records.push(record);
+            }
+        }
+
+        if records.len() == limit || output.next_cursor.is_none() {
+            return Ok((records, output.next_cursor));
+        }
+        cursor = output.next_cursor;
     }
 }
 

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -136,6 +136,30 @@ pub async fn list_notifications_for_user(
     }
 }
 
+async fn notification_is_visible(
+    context: &DriverContext,
+    recipient: UserId,
+    record: &NotificationRecord,
+) -> Result<bool, String> {
+    let watch = match &record.kind {
+        NotificationKind::MetadataCreated { path, .. } => Some((
+            path.as_str(),
+            WatchEventMask::from_kinds([WatchEventKind::MetadataCreated]),
+        )),
+        NotificationKind::DataUploaded { path, .. } => Some((
+            path.as_str(),
+            WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+        )),
+        _ => None,
+    };
+    match watch {
+        None => Ok(true),
+        Some((path, event_mask)) => {
+            is_watch_authorized(context, recipient.realm_id, recipient, path, event_mask).await
+        }
+    }
+}
+
 /// Reauthorizes persisted resource-watch records at the inbox-holder boundary.
 /// Suppressed rows do not consume the caller's page, so revocation cannot hide
 /// older ordinary notifications behind a page of stale watch records.
@@ -161,26 +185,7 @@ pub(crate) async fn list_notifications_on_holder(
         .map_err(|error| error.to_string())?;
 
         for record in output.records {
-            let watch = match &record.kind {
-                NotificationKind::MetadataCreated { path, .. } => Some((
-                    path.as_str(),
-                    WatchEventMask::from_kinds([WatchEventKind::MetadataCreated]),
-                )),
-                NotificationKind::DataUploaded { path, .. } => Some((
-                    path.as_str(),
-                    WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
-                )),
-                _ => None,
-            };
-            let visible = match watch {
-                None => true,
-                Some((path, event_mask)) => {
-                    is_watch_authorized(context, recipient.realm_id, recipient, path, event_mask)
-                        .await
-                        .unwrap_or(false)
-                }
-            };
-            if visible {
+            if notification_is_visible(context, recipient, &record).await? {
                 records.push(record);
             }
         }

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -87,6 +87,17 @@ pub async fn resolve_inbox_holder_for_user(
 /// names the net handle's channel type directly.
 pub type InboxWakeReceiver = broadcast::Receiver<UserId>;
 
+pub fn record_watch_creation_denial_metric(
+    context: &DriverContext,
+    reason: WatchAuthorizationMetricReason,
+) {
+    if let Some(net_handle) = context.net_handle.as_ref() {
+        net_handle
+            .notification_watch_metrics()
+            .record_creation_denial(reason);
+    }
+}
+
 /// Subscribes to local inbox-delivery wakes. `Unavailable` when the node runs
 /// without a net handle, matching the other dispatch paths.
 pub fn subscribe_inbox_wakes(

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -1,4 +1,5 @@
 use aruna_core::NodeId;
+use aruna_core::metrics::WatchAuthorizationMetricReason;
 use aruna_core::structs::{
     NotificationClass, NotificationKind, NotificationRecord, WatchAuthorizationBinding,
     WatchEventMask, WatchSubscription,
@@ -53,8 +54,8 @@ pub enum WatchDispatchError {
     Unavailable,
     #[error("notification watch subscription cap reached")]
     CapExceeded,
-    #[error("{WATCH_SUBSCRIPTION_UNAUTHORIZED}")]
-    Unauthorized,
+    #[error("{WATCH_SUBSCRIPTION_UNAUTHORIZED}: {}", .0.as_str())]
+    Unauthorized(WatchAuthorizationMetricReason),
     #[error("holder proxy failed: {0}")]
     Remote(String),
     #[error("{0}")]
@@ -366,7 +367,9 @@ pub async fn create_watch_for_user(
         .await
         .map_err(|error| match error {
             WatchSubscriptionError::CapExceeded => WatchDispatchError::CapExceeded,
-            WatchSubscriptionError::Unauthorized => WatchDispatchError::Unauthorized,
+            WatchSubscriptionError::Unauthorized(reason) => {
+                WatchDispatchError::Unauthorized(reason)
+            }
             other => WatchDispatchError::Internal(other.to_string()),
         })?;
         schedule_watch_interest_publish(context).await;
@@ -388,8 +391,12 @@ pub async fn create_watch_for_user(
         .map_err(|reason| {
             if reason == WATCH_SUBSCRIPTION_CAP_REACHED {
                 WatchDispatchError::CapExceeded
-            } else if reason == WATCH_SUBSCRIPTION_UNAUTHORIZED {
-                WatchDispatchError::Unauthorized
+            } else if let Some(reason) = reason
+                .strip_prefix(WATCH_SUBSCRIPTION_UNAUTHORIZED)
+                .and_then(|value| value.strip_prefix(": "))
+                .and_then(WatchAuthorizationMetricReason::parse)
+            {
+                WatchDispatchError::Unauthorized(reason)
             } else {
                 WatchDispatchError::Remote(reason)
             }

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -1,6 +1,7 @@
 use aruna_core::NodeId;
 use aruna_core::structs::{
-    NotificationKind, NotificationRecord, WatchEventKind, WatchEventMask, WatchSubscription,
+    NotificationKind, NotificationRecord, WatchAuthorizationBinding, WatchEventKind,
+    WatchEventMask, WatchSubscription,
 };
 use aruna_core::types::UserId;
 use aruna_core::util::unix_timestamp_millis;
@@ -155,7 +156,15 @@ async fn notification_is_visible(
     match watch {
         None => Ok(true),
         Some((path, event_mask)) => {
-            is_watch_authorized(context, recipient.realm_id, recipient, path, event_mask).await
+            is_watch_authorized(
+                context,
+                recipient.realm_id,
+                recipient,
+                path,
+                event_mask,
+                &WatchAuthorizationBinding::default(),
+            )
+            .await
         }
     }
 }
@@ -303,6 +312,7 @@ pub async fn create_watch_for_user(
     owner: UserId,
     path_prefix: String,
     event_mask: WatchEventMask,
+    authorization: WatchAuthorizationBinding,
 ) -> Result<WatchSubscription, WatchDispatchError> {
     let holder = resolve_holder(context, owner).await?;
     if holder == local_node_id {
@@ -312,6 +322,7 @@ pub async fn create_watch_for_user(
             owner,
             path_prefix,
             event_mask,
+            authorization.clone(),
             unix_timestamp_millis(),
         )
         .await
@@ -327,17 +338,24 @@ pub async fn create_watch_for_user(
             .net_handle
             .as_ref()
             .ok_or(WatchDispatchError::Unavailable)?;
-        create_watch_remote(net_handle, holder, owner, path_prefix, event_mask)
-            .await
-            .map_err(|reason| {
-                if reason == WATCH_SUBSCRIPTION_CAP_REACHED {
-                    WatchDispatchError::CapExceeded
-                } else if reason == WATCH_SUBSCRIPTION_UNAUTHORIZED {
-                    WatchDispatchError::Unauthorized
-                } else {
-                    WatchDispatchError::Remote(reason)
-                }
-            })
+        create_watch_remote(
+            net_handle,
+            holder,
+            owner,
+            path_prefix,
+            event_mask,
+            authorization,
+        )
+        .await
+        .map_err(|reason| {
+            if reason == WATCH_SUBSCRIPTION_CAP_REACHED {
+                WatchDispatchError::CapExceeded
+            } else if reason == WATCH_SUBSCRIPTION_UNAUTHORIZED {
+                WatchDispatchError::Unauthorized
+            } else {
+                WatchDispatchError::Remote(reason)
+            }
+        })
     }
 }
 

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -19,7 +19,7 @@ use crate::notifications::list::{
 };
 use crate::notifications::mark_read::{MarkReadInput, MarkReadOperation};
 use crate::notifications::placement::resolve_inbox_holder;
-use crate::notifications::unread::{UnreadCountInput, UnreadCountOperation};
+use crate::notifications::unread::{UNREAD_COUNT_CAP, UNREAD_SCAN_MAX_ROWS};
 use crate::notifications::watch::authorization::{
     is_watch_authorized, list_authorized_watch_subscriptions,
 };
@@ -197,6 +197,48 @@ pub(crate) async fn list_notifications_on_holder(
     }
 }
 
+pub(crate) async fn unread_count_on_holder(
+    context: &DriverContext,
+    recipient: UserId,
+) -> Result<(u32, bool), String> {
+    let mut cursor = None;
+    let mut count = 0usize;
+    let mut examined = 0usize;
+
+    loop {
+        let output = drive(
+            ListNotificationsOperation::new(ListNotificationsInput {
+                recipient,
+                cursor,
+                limit: UNREAD_COUNT_CAP.min(UNREAD_SCAN_MAX_ROWS - examined),
+            }),
+            context,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        examined += output.records.len();
+
+        for record in output.records {
+            if record.read_at_ms.is_none()
+                && notification_is_visible(context, recipient, &record).await?
+            {
+                if count == UNREAD_COUNT_CAP {
+                    return Ok((count as u32, true));
+                }
+                count += 1;
+            }
+        }
+
+        if examined >= UNREAD_SCAN_MAX_ROWS && output.next_cursor.is_some() {
+            return Ok((count as u32, true));
+        }
+        match output.next_cursor {
+            Some(next) => cursor = Some(next),
+            None => return Ok((count as u32, false)),
+        }
+    }
+}
+
 pub async fn unread_count_for_user(
     context: &DriverContext,
     local_node_id: NodeId,
@@ -204,13 +246,9 @@ pub async fn unread_count_for_user(
 ) -> Result<(u32, bool), NotificationDispatchError> {
     let holder = resolve_holder(context, recipient).await?;
     if holder == local_node_id {
-        let output = drive(
-            UnreadCountOperation::new(UnreadCountInput { recipient }),
-            context,
-        )
-        .await
-        .map_err(|error| NotificationDispatchError::Internal(error.to_string()))?;
-        Ok((output.count as u32, output.capped))
+        unread_count_on_holder(context, recipient)
+            .await
+            .map_err(NotificationDispatchError::Internal)
     } else {
         let net_handle = context
             .net_handle

--- a/operations/src/notifications/dispatch.rs
+++ b/operations/src/notifications/dispatch.rs
@@ -1,6 +1,6 @@
 use aruna_core::NodeId;
 use aruna_core::structs::{
-    NotificationKind, NotificationRecord, WatchAuthorizationBinding, WatchEventKind,
+    NotificationClass, NotificationKind, NotificationRecord, WatchAuthorizationBinding,
     WatchEventMask, WatchSubscription,
 };
 use aruna_core::types::UserId;
@@ -22,7 +22,8 @@ use crate::notifications::mark_read::{MarkReadInput, MarkReadOperation};
 use crate::notifications::placement::resolve_inbox_holder;
 use crate::notifications::unread::{UNREAD_COUNT_CAP, UNREAD_SCAN_MAX_ROWS};
 use crate::notifications::watch::authorization::{
-    is_watch_authorized, list_authorized_watch_subscriptions,
+    WatchAuthorization, evaluate_watch_notification_authorization,
+    list_authorized_watch_subscriptions,
 };
 use crate::notifications::watch::interest::schedule_watch_interest_publish;
 use crate::notifications::watch::subscriptions::{
@@ -142,30 +143,24 @@ async fn notification_is_visible(
     recipient: UserId,
     record: &NotificationRecord,
 ) -> Result<bool, String> {
-    let watch = match &record.kind {
-        NotificationKind::MetadataCreated { path, .. } => Some((
-            path.as_str(),
-            WatchEventMask::from_kinds([WatchEventKind::MetadataCreated]),
-        )),
-        NotificationKind::DataUploaded { path, .. } => Some((
-            path.as_str(),
-            WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
-        )),
-        _ => None,
+    if !matches!(
+        record.kind,
+        NotificationKind::MetadataCreated { .. } | NotificationKind::DataUploaded { .. }
+    ) {
+        return Ok(record.watch_authorization.is_none());
+    }
+    let Some(authorization) = record.watch_authorization.as_ref() else {
+        return Ok(false);
     };
-    match watch {
-        None => Ok(true),
-        Some((path, event_mask)) => {
-            is_watch_authorized(
-                context,
-                recipient.realm_id,
-                recipient,
-                path,
-                event_mask,
-                &WatchAuthorizationBinding::default(),
-            )
-            .await
-        }
+    if record.class != NotificationClass::Transient || record.recipient != recipient {
+        return Ok(false);
+    }
+    match evaluate_watch_notification_authorization(context, recipient, &record.kind, authorization)
+        .await?
+    {
+        WatchAuthorization::Authorized => Ok(true),
+        WatchAuthorization::Denied(_) => Ok(false),
+        WatchAuthorization::Unavailable(error) => Err(error),
     }
 }
 

--- a/operations/src/notifications/inbox.rs
+++ b/operations/src/notifications/inbox.rs
@@ -7,7 +7,8 @@ use aruna_core::structs::{NotificationRecord, notification_inbox_key};
 use aruna_core::types::{Key, KeySpace, TxnId, UserId, Value};
 use aruna_storage::StorageHandle;
 
-enum UpsertFailure {
+#[derive(Debug)]
+pub(crate) enum UpsertFailure {
     Conflict,
     Fatal(String),
 }
@@ -74,6 +75,35 @@ async fn upsert_once(
         }
     };
 
+    let outcome = match upsert_inbox_records_in_transaction(storage, records, txn_id).await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            abort_txn(storage, txn_id).await;
+            return Err(error);
+        }
+    };
+    if outcome.written == 0 {
+        abort_txn(storage, txn_id).await;
+        return Ok(outcome);
+    }
+
+    match storage
+        .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
+        .await
+    {
+        Event::Storage(StorageEvent::TransactionCommitted { .. }) => Ok(outcome),
+        Event::Storage(StorageEvent::Error { error }) => Err(classify(error)),
+        other => Err(UpsertFailure::Fatal(format!(
+            "unexpected storage event: {other:?}"
+        ))),
+    }
+}
+
+pub(crate) async fn upsert_inbox_records_in_transaction(
+    storage: &StorageHandle,
+    records: &[NotificationRecord],
+    txn_id: TxnId,
+) -> Result<InboxWriteOutcome, UpsertFailure> {
     let reads: Vec<(KeySpace, Key)> = records
         .iter()
         .map(|record| {
@@ -96,11 +126,8 @@ async fn upsert_once(
         .await
     {
         Event::Storage(StorageEvent::BatchReadResult { values }) => values,
-        Event::Storage(StorageEvent::Error { error }) => {
-            return Err(abort_and_classify(storage, txn_id, error).await);
-        }
+        Event::Storage(StorageEvent::Error { error }) => return Err(classify(error)),
         other => {
-            abort_txn(storage, txn_id).await;
             return Err(UpsertFailure::Fatal(format!(
                 "unexpected storage event: {other:?}"
             )));
@@ -122,14 +149,12 @@ async fn upsert_once(
                 }
             }
             Err(error) => {
-                abort_txn(storage, txn_id).await;
                 return Err(UpsertFailure::Fatal(error.to_string()));
             }
         }
     }
 
     if writes.is_empty() {
-        abort_txn(storage, txn_id).await;
         return Ok(InboxWriteOutcome::default());
     }
 
@@ -141,27 +166,15 @@ async fn upsert_once(
         .await
     {
         Event::Storage(StorageEvent::BatchWriteResult { .. }) => {}
-        Event::Storage(StorageEvent::Error { error }) => {
-            return Err(abort_and_classify(storage, txn_id, error).await);
-        }
+        Event::Storage(StorageEvent::Error { error }) => return Err(classify(error)),
         other => {
-            abort_txn(storage, txn_id).await;
             return Err(UpsertFailure::Fatal(format!(
                 "unexpected storage event: {other:?}"
             )));
         }
     }
 
-    match storage
-        .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
-        .await
-    {
-        Event::Storage(StorageEvent::TransactionCommitted { .. }) => Ok(outcome),
-        Event::Storage(StorageEvent::Error { error }) => Err(classify(error)),
-        other => Err(UpsertFailure::Fatal(format!(
-            "unexpected storage event: {other:?}"
-        ))),
-    }
+    Ok(outcome)
 }
 
 fn classify(error: StorageError) -> UpsertFailure {
@@ -176,15 +189,6 @@ async fn abort_txn(storage: &StorageHandle, txn_id: TxnId) {
     let _ = storage
         .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
         .await;
-}
-
-async fn abort_and_classify(
-    storage: &StorageHandle,
-    txn_id: TxnId,
-    error: StorageError,
-) -> UpsertFailure {
-    abort_txn(storage, txn_id).await;
-    classify(error)
 }
 
 #[cfg(test)]

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -18,13 +18,12 @@ use crate::driver::{DriverContext, drive};
 use crate::notifications::client::{
     close_stream, drain_request_stream, read_message, write_message,
 };
-use crate::notifications::dispatch::list_notifications_on_holder;
+use crate::notifications::dispatch::{list_notifications_on_holder, unread_count_on_holder};
 use crate::notifications::inbox::upsert_inbox_records_reporting;
 use crate::notifications::mark_read::{MARK_READ_MAX_IDS, MarkReadInput, MarkReadOperation};
 use crate::notifications::outbox::NOTIFICATION_OUTBOX_DRAIN_BATCH_SIZE;
 use crate::notifications::placement::resolve_inbox_holder;
 use crate::notifications::protocol::{NotificationTransportMessage, notification_message_kind};
-use crate::notifications::unread::{UnreadCountInput, UnreadCountOperation};
 use crate::notifications::watch::authorization::list_authorized_watch_subscriptions;
 use crate::notifications::watch::expand::expand_watch_events;
 use crate::notifications::watch::interest::{
@@ -130,17 +129,11 @@ async fn build_response(
             {
                 return NotificationTransportMessage::Reject(reason);
             }
-            match drive(
-                UnreadCountOperation::new(UnreadCountInput { recipient }),
-                context,
-            )
-            .await
-            {
-                Ok(output) => NotificationTransportMessage::UnreadCountResult {
-                    count: output.count as u32,
-                    capped: output.capped,
-                },
-                Err(error) => NotificationTransportMessage::Reject(error.to_string()),
+            match unread_count_on_holder(context, recipient).await {
+                Ok((count, capped)) => {
+                    NotificationTransportMessage::UnreadCountResult { count, capped }
+                }
+                Err(error) => NotificationTransportMessage::Reject(error),
             }
         }
         NotificationTransportMessage::MarkRead {
@@ -1288,6 +1281,12 @@ mod tests {
                 .len(),
             3
         );
+        assert_eq!(
+            unread_count_remote(&a.net, b.net.node_id(), recipient)
+                .await
+                .expect("authorized unread count"),
+            (3, false)
+        );
         let (first_page, retry_cursor) = list_remote(&a.net, b.net.node_id(), recipient, None, 1)
             .await
             .expect("first authorized page");
@@ -1300,6 +1299,13 @@ mod tests {
             .expect("list after revocation");
         assert_eq!(listed, vec![direct]);
         assert_eq!(next_cursor, None);
+        assert_eq!(
+            unread_count_remote(&a.net, b.net.node_id(), recipient)
+                .await
+                .expect("unread count after revocation"),
+            (1, false)
+        );
+
         assert!(matches!(
             b.context
                 .storage_handle

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -383,6 +383,14 @@ fn validate_inbound_watch_event(
 }
 
 fn validate_inbound_record(record: &NotificationRecord, now_ms: u64) -> Result<(), String> {
+    if record.watch_authorization.is_some()
+        || matches!(
+            record.kind,
+            NotificationKind::MetadataCreated { .. } | NotificationKind::DataUploaded { .. }
+        )
+    {
+        return Err("resource watch records must use watch event delivery".to_string());
+    }
     if record.read_at_ms.is_some() {
         return Err("delivered notification records must be unread".to_string());
     }
@@ -1088,7 +1096,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn batch_with_invalid_watch_actor_is_rejected_without_partial_write() {
+    async fn generic_batch_rejects_watch_records_without_partial_write() {
         let (a, b, recipient) = delivery_pair(83).await;
         let valid = record(recipient, 1);
         let mut invalid = record(recipient, 2);
@@ -1101,14 +1109,14 @@ mod tests {
             bucket: "bucket".to_string(),
             key: "object".to_string(),
             size_bytes: 0,
-            actor_user_id: UserId::nil(recipient.realm_id),
+            actor_user_id: recipient,
         };
 
         let error = deliver_remote(&a.net, b.net.node_id(), vec![valid, invalid])
             .await
-            .expect_err("batch containing invalid watch actor must be rejected");
+            .expect_err("generic batch containing watch data must be rejected");
         assert!(
-            error.contains("empty actor_user_id"),
+            error.contains("must use watch event delivery"),
             "unexpected reject reason: {error}"
         );
         assert!(read_inbox(&b).await.is_empty());

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -18,8 +18,8 @@ use crate::driver::{DriverContext, drive};
 use crate::notifications::client::{
     close_stream, drain_request_stream, read_message, write_message,
 };
+use crate::notifications::dispatch::list_notifications_on_holder;
 use crate::notifications::inbox::upsert_inbox_records_reporting;
-use crate::notifications::list::{ListNotificationsInput, ListNotificationsOperation};
 use crate::notifications::mark_read::{MARK_READ_MAX_IDS, MarkReadInput, MarkReadOperation};
 use crate::notifications::outbox::NOTIFICATION_OUTBOX_DRAIN_BATCH_SIZE;
 use crate::notifications::placement::resolve_inbox_holder;
@@ -116,21 +116,12 @@ async fn build_response(
             {
                 return NotificationTransportMessage::Reject(reason);
             }
-            match drive(
-                ListNotificationsOperation::new(ListNotificationsInput {
-                    recipient,
-                    cursor,
-                    limit: limit as usize,
-                }),
-                context,
-            )
-            .await
-            {
-                Ok(output) => NotificationTransportMessage::ListResult {
-                    records: output.records,
-                    next_cursor: output.next_cursor,
+            match list_notifications_on_holder(context, recipient, cursor, limit as usize).await {
+                Ok((records, next_cursor)) => NotificationTransportMessage::ListResult {
+                    records,
+                    next_cursor,
                 },
-                Err(error) => NotificationTransportMessage::Reject(error.to_string()),
+                Err(error) => NotificationTransportMessage::Reject(error),
             }
         }
         NotificationTransportMessage::UnreadCount { recipient } => {
@@ -852,6 +843,24 @@ mod tests {
         )
     }
 
+    fn watch_record(recipient: UserId, seed: u8) -> NotificationRecord {
+        let key = format!("object-{seed}");
+        NotificationRecord::new(
+            recipient,
+            NotificationClass::Transient,
+            NotificationKind::DataUploaded {
+                path: data_path(&key),
+                group_id: data_group_id(),
+                node_id: data_node_id(),
+                bucket: "bucket".to_string(),
+                key,
+                size_bytes: seed as u64,
+                actor_user_id: recipient,
+            },
+            1_700_000_000_000 + seed as u64,
+        )
+    }
+
     async fn delivery_pair(realm_seed: u8) -> (Node, Node, UserId) {
         let realm_id = RealmId::from_bytes([realm_seed; 32]);
         let a = spawn(realm_id, [realm_seed; 32]).await;
@@ -1243,6 +1252,51 @@ mod tests {
                 1_700_000_000_000 + 1,
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn rpc_list_skips_revoked_watch_records_without_consuming_page() {
+        let realm_id = RealmId::from_bytes([83u8; 32]);
+        let a = spawn(realm_id, [83u8; 32]).await;
+        let b = spawn(realm_id, [84u8; 32]).await;
+        connect(&a, &b).await;
+        let config = install_config(
+            &b,
+            realm_id,
+            &[
+                (a.net.node_id(), RealmNodeKind::Server),
+                (b.net.node_id(), RealmNodeKind::Server),
+            ],
+        )
+        .await;
+        let recipient = recipient_for_holder(&config, b.net.node_id(), realm_id);
+        install_watch_authorization(&b, realm_id, recipient, &[]).await;
+        let direct = record(recipient, 1);
+        seed_inbox(
+            &b,
+            &[
+                direct.clone(),
+                watch_record(recipient, 2),
+                watch_record(recipient, 3),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            list_remote(&a.net, b.net.node_id(), recipient, None, 10)
+                .await
+                .expect("authorized list")
+                .0
+                .len(),
+            3
+        );
+        install_watch_authorization(&b, realm_id, UserId::new(Ulid::r#gen(), realm_id), &[]).await;
+
+        let (listed, next_cursor) = list_remote(&a.net, b.net.node_id(), recipient, None, 1)
+            .await
+            .expect("list after revocation");
+        assert_eq!(listed, vec![direct]);
+        assert_eq!(next_cursor, None);
     }
 
     #[tokio::test]

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -642,8 +642,10 @@ mod tests {
     use crate::notifications::watch::subscriptions::{
         WATCH_SUBSCRIPTION_UNAUTHORIZED, create_watch_subscription, list_watch_subscriptions,
     };
+    use aruna_core::auth::TOKEN_REVOCATION_LIST_KEY;
     use aruna_core::keyspaces::{
-        AUTH_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE, NOTIFICATION_WATCH_INTEREST_KEYSPACE,
+        API_STATE_KEYSPACE, AUTH_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE,
+        NOTIFICATION_WATCH_INTEREST_KEYSPACE,
     };
     use aruna_core::structs::{
         Actor, GroupAuthorizationDocument, NotificationClass, NotificationKind, NotificationRecord,
@@ -654,6 +656,7 @@ mod tests {
     use aruna_core::types::UserId;
     use aruna_net::{DiscoveryMethod, NetConfig, RelayMethod};
     use aruna_storage::FjallStorage;
+    use std::collections::HashSet;
     use std::sync::Arc;
     use std::time::Duration;
     use tempfile::TempDir;
@@ -841,7 +844,7 @@ mod tests {
 
     fn watch_record(recipient: UserId, seed: u8) -> NotificationRecord {
         let key = format!("object-{seed}");
-        NotificationRecord::new(
+        let mut record = NotificationRecord::new(
             recipient,
             NotificationClass::Transient,
             NotificationKind::DataUploaded {
@@ -854,7 +857,9 @@ mod tests {
                 actor_user_id: recipient,
             },
             1_700_000_000_000 + seed as u64,
-        )
+        );
+        record.watch_authorization = Some(WatchAuthorizationBinding::default());
+        record
     }
 
     async fn delivery_pair(realm_seed: u8) -> (Node, Node, UserId) {
@@ -1337,6 +1342,61 @@ mod tests {
                 .expect("same cursor retries after authorization recovers")
                 .0,
             vec![watch_two]
+        );
+    }
+
+    #[tokio::test]
+    async fn rpc_list_hides_watch_record_after_token_revocation() {
+        let realm_id = RealmId::from_bytes([82u8; 32]);
+        let a = spawn(realm_id, [82u8; 32]).await;
+        let b = spawn(realm_id, [83u8; 32]).await;
+        connect(&a, &b).await;
+        let config = install_config(
+            &b,
+            realm_id,
+            &[
+                (a.net.node_id(), RealmNodeKind::Server),
+                (b.net.node_id(), RealmNodeKind::Server),
+            ],
+        )
+        .await;
+        let recipient = recipient_for_holder(&config, b.net.node_id(), realm_id);
+        install_watch_authorization(&b, realm_id, recipient, &[]).await;
+        let direct = record(recipient, 1);
+        let watch = watch_record(recipient, 2);
+        seed_inbox(&b, &[direct.clone(), watch.clone()]).await;
+
+        let revoked = HashSet::from([watch
+            .watch_authorization
+            .as_ref()
+            .expect("watch binding")
+            .token_hash
+            .clone()]);
+        assert!(matches!(
+            b.context
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: API_STATE_KEYSPACE.to_string(),
+                    key: TOKEN_REVOCATION_LIST_KEY.into(),
+                    value: postcard::to_allocvec(&revoked).unwrap().into(),
+                    txn_id: None,
+                })
+                .await,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+
+        assert_eq!(
+            list_remote(&a.net, b.net.node_id(), recipient, None, 10)
+                .await
+                .expect("list after token revocation")
+                .0,
+            vec![direct]
+        );
+        assert_eq!(
+            unread_count_remote(&a.net, b.net.node_id(), recipient)
+                .await
+                .expect("unread count after token revocation"),
+            (1, false)
         );
     }
 

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -1625,7 +1625,7 @@ mod tests {
     }
 
     // Enumeration shares the delivery authorization result: once READ is revoked
-    // the watch stops being listed, though the stored row itself survives.
+    // only an opaque cleanup id remains visible for the stored row.
     #[tokio::test]
     async fn revoked_watch_unlisted() {
         let realm_id = RealmId::from_bytes([84u8; 32]);
@@ -1657,19 +1657,21 @@ mod tests {
             list_watches_remote(&a.net, b.net.node_id(), owner)
                 .await
                 .expect("list succeeds"),
-            vec![created]
+            vec![created.clone()]
         );
 
         // Re-owning the group drops the original owner's READ.
         install_watch_authorization(&b, realm_id, UserId::new(Ulid::r#gen(), realm_id), &[]).await;
 
-        assert!(
-            list_watches_remote(&a.net, b.net.node_id(), owner)
-                .await
-                .expect("list after revocation succeeds")
-                .is_empty(),
-            "a watch whose READ was revoked must not be enumerable"
-        );
+        let listed = list_watches_remote(&a.net, b.net.node_id(), owner)
+            .await
+            .expect("list after revocation succeeds");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].watch_id, created.watch_id);
+        assert_eq!(listed[0].owner, owner);
+        assert!(listed[0].path_prefix.is_empty());
+        assert!(listed[0].event_mask.is_empty());
+        assert_eq!(listed[0].created_at_ms, 0);
         assert_eq!(
             list_watch_subscriptions(&b.context.storage_handle, owner)
                 .await
@@ -1677,6 +1679,15 @@ mod tests {
                 .len(),
             1,
             "the row is filtered at the surface, not silently deleted"
+        );
+        delete_watch_remote(&a.net, b.net.node_id(), owner, listed[0].watch_id)
+            .await
+            .expect("redacted watch remains deletable");
+        assert!(
+            list_watch_subscriptions(&b.context.storage_handle, owner)
+                .await
+                .expect("list after delete succeeds")
+                .is_empty()
         );
     }
 

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -1775,7 +1775,10 @@ mod tests {
         )
         .await
         .expect_err("an owner without READ must be refused by the holder");
-        assert_eq!(error, WATCH_SUBSCRIPTION_UNAUTHORIZED);
+        assert_eq!(
+            error,
+            format!("{WATCH_SUBSCRIPTION_UNAUTHORIZED}: permission_denied")
+        );
         assert!(
             list_watch_subscriptions(&b.context.storage_handle, owner)
                 .await

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -14,13 +14,15 @@ use aruna_net::streams::BiStream;
 use byteview::ByteView;
 use tracing::{debug, warn};
 
-use crate::driver::{DriverContext, drive};
+use crate::driver::DriverContext;
 use crate::notifications::client::{
     close_stream, drain_request_stream, read_message, write_message,
 };
-use crate::notifications::dispatch::{list_notifications_on_holder, unread_count_on_holder};
+use crate::notifications::dispatch::{
+    list_notifications_on_holder, mark_read_on_holder, unread_count_on_holder,
+};
 use crate::notifications::inbox::upsert_inbox_records_reporting;
-use crate::notifications::mark_read::{MARK_READ_MAX_IDS, MarkReadInput, MarkReadOperation};
+use crate::notifications::mark_read::MARK_READ_MAX_IDS;
 use crate::notifications::outbox::NOTIFICATION_OUTBOX_DRAIN_BATCH_SIZE;
 use crate::notifications::placement::resolve_inbox_holder;
 use crate::notifications::protocol::{NotificationTransportMessage, notification_message_kind};
@@ -152,26 +154,14 @@ async fn build_response(
             {
                 return NotificationTransportMessage::Reject(reason);
             }
-            match drive(
-                MarkReadOperation::new(MarkReadInput {
-                    recipient,
-                    ids,
-                    up_to_ms,
-                    now_ms: unix_timestamp_millis(),
-                }),
-                context,
-            )
-            .await
-            {
-                Ok(output) => {
-                    if output.marked > 0 {
+            match mark_read_on_holder(context, recipient, ids, up_to_ms).await {
+                Ok(marked) => {
+                    if marked > 0 {
                         net_handle.notify_inbox_activity(recipient);
                     }
-                    NotificationTransportMessage::MarkReadResult {
-                        marked: output.marked as u32,
-                    }
+                    NotificationTransportMessage::MarkReadResult { marked }
                 }
-                Err(error) => NotificationTransportMessage::Reject(error.to_string()),
+                Err(error) => NotificationTransportMessage::Reject(error),
             }
         }
         NotificationTransportMessage::CreateWatch {
@@ -1405,6 +1395,27 @@ mod tests {
                 .await
                 .expect("unread count after token revocation"),
             (1, false)
+        );
+        assert_eq!(
+            mark_read_remote(
+                &a.net,
+                b.net.node_id(),
+                recipient,
+                vec![watch.notification_id],
+                None,
+            )
+            .await
+            .expect("mark revoked watch record"),
+            0
+        );
+        assert!(
+            read_inbox(&b)
+                .await
+                .into_iter()
+                .find(|record| record.notification_id == watch.notification_id)
+                .expect("stored watch record")
+                .read_at_ms
+                .is_none()
         );
     }
 

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -25,13 +25,13 @@ use crate::notifications::outbox::NOTIFICATION_OUTBOX_DRAIN_BATCH_SIZE;
 use crate::notifications::placement::resolve_inbox_holder;
 use crate::notifications::protocol::{NotificationTransportMessage, notification_message_kind};
 use crate::notifications::unread::{UnreadCountInput, UnreadCountOperation};
+use crate::notifications::watch::authorization::list_authorized_watch_subscriptions;
 use crate::notifications::watch::expand::expand_watch_events;
 use crate::notifications::watch::interest::{
     mark_watch_interest_dirty, schedule_watch_interest_publish,
 };
 use crate::notifications::watch::subscriptions::{
     create_replicated_watch_subscription, delete_replicated_watch_subscription,
-    list_watch_subscriptions,
 };
 
 const NOTIFICATION_MAX_FUTURE_SKEW_MS: u64 = 5 * 60 * 1000;
@@ -245,9 +245,9 @@ async fn build_response(
                 return NotificationTransportMessage::Reject(reason);
             }
 
-            match list_watch_subscriptions(&context.storage_handle, owner).await {
+            match list_authorized_watch_subscriptions(context, owner).await {
                 Ok(subscriptions) => NotificationTransportMessage::WatchList { subscriptions },
-                Err(error) => NotificationTransportMessage::Reject(error.to_string()),
+                Err(error) => NotificationTransportMessage::Reject(error),
             }
         }
         NotificationTransportMessage::DeliverWatchEvents { events } => {
@@ -653,7 +653,9 @@ mod tests {
         unread_count_remote,
     };
     use crate::notifications::inbox::upsert_inbox_records;
-    use crate::notifications::watch::subscriptions::create_watch_subscription;
+    use crate::notifications::watch::subscriptions::{
+        WATCH_SUBSCRIPTION_UNAUTHORIZED, create_watch_subscription, list_watch_subscriptions,
+    };
     use aruna_core::keyspaces::{
         AUTH_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE, NOTIFICATION_WATCH_INTEREST_KEYSPACE,
     };
@@ -1446,6 +1448,7 @@ mod tests {
         .await;
 
         let owner = recipient_for_holder(&config, b.net.node_id(), realm_id);
+        install_watch_authorization(&b, realm_id, owner, &[]).await;
         let mask = WatchEventMask::from_kinds([WatchEventKind::DataUploaded]);
         let prefix = data_path("prefix");
         let created = create_watch_remote(&a.net, b.net.node_id(), owner, prefix.clone(), mask)
@@ -1522,6 +1525,104 @@ mod tests {
                 .await
                 .expect("list succeeds")
                 .is_empty()
+        );
+    }
+
+    // The holder persists and replicates the subscription, so a proxying peer's
+    // assertion is not authority to watch: an owner without READ is refused there
+    // too, and nothing durable is written.
+    #[tokio::test]
+    async fn create_requires_read() {
+        let realm_id = RealmId::from_bytes([86u8; 32]);
+        let a = spawn(realm_id, [86u8; 32]).await;
+        let b = spawn(realm_id, [87u8; 32]).await;
+        connect(&a, &b).await;
+        let config = install_config(
+            &b,
+            realm_id,
+            &[
+                (a.net.node_id(), RealmNodeKind::Server),
+                (b.net.node_id(), RealmNodeKind::Server),
+            ],
+        )
+        .await;
+
+        let owner = recipient_for_holder(&config, b.net.node_id(), realm_id);
+        // The watched group exists and is readable, just not by `owner`.
+        install_watch_authorization(&b, realm_id, UserId::new(Ulid::r#gen(), realm_id), &[]).await;
+
+        let error = create_watch_remote(
+            &a.net,
+            b.net.node_id(),
+            owner,
+            data_path("prefix"),
+            WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+        )
+        .await
+        .expect_err("an owner without READ must be refused by the holder");
+        assert_eq!(error, WATCH_SUBSCRIPTION_UNAUTHORIZED);
+        assert!(
+            list_watch_subscriptions(&b.context.storage_handle, owner)
+                .await
+                .expect("list succeeds")
+                .is_empty(),
+            "an unauthorized create must not persist watch state"
+        );
+    }
+
+    // Enumeration shares the delivery authorization result: once READ is revoked
+    // the watch stops being listed, though the stored row itself survives.
+    #[tokio::test]
+    async fn revoked_watch_unlisted() {
+        let realm_id = RealmId::from_bytes([84u8; 32]);
+        let a = spawn(realm_id, [84u8; 32]).await;
+        let b = spawn(realm_id, [85u8; 32]).await;
+        connect(&a, &b).await;
+        let config = install_config(
+            &b,
+            realm_id,
+            &[
+                (a.net.node_id(), RealmNodeKind::Server),
+                (b.net.node_id(), RealmNodeKind::Server),
+            ],
+        )
+        .await;
+
+        let owner = recipient_for_holder(&config, b.net.node_id(), realm_id);
+        install_watch_authorization(&b, realm_id, owner, &[]).await;
+        let created = create_watch_remote(
+            &a.net,
+            b.net.node_id(),
+            owner,
+            data_path("prefix"),
+            WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+        )
+        .await
+        .expect("authorized create succeeds");
+        assert_eq!(
+            list_watches_remote(&a.net, b.net.node_id(), owner)
+                .await
+                .expect("list succeeds"),
+            vec![created]
+        );
+
+        // Re-owning the group drops the original owner's READ.
+        install_watch_authorization(&b, realm_id, UserId::new(Ulid::r#gen(), realm_id), &[]).await;
+
+        assert!(
+            list_watches_remote(&a.net, b.net.node_id(), owner)
+                .await
+                .expect("list after revocation succeeds")
+                .is_empty(),
+            "a watch whose READ was revoked must not be enumerable"
+        );
+        assert_eq!(
+            list_watch_subscriptions(&b.context.storage_handle, owner)
+                .await
+                .expect("stored row survives")
+                .len(),
+            1,
+            "the row is filtered at the surface, not silently deleted"
         );
     }
 

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -647,9 +647,9 @@ mod tests {
     };
     use aruna_core::structs::{
         Actor, GroupAuthorizationDocument, NotificationClass, NotificationKind, NotificationRecord,
-        RealmAuthorizationDocument, RealmNodeKind, WatchAuthorizationBinding, WatchEvent,
-        WatchEventDetail, WatchEventKind, WatchEventMask, data_watch_resource_path,
-        watch_interest_dirty_key,
+        PathRestriction, Permission, RealmAuthorizationDocument, RealmNodeKind,
+        WatchAuthorizationBinding, WatchEvent, WatchEventDetail, WatchEventKind, WatchEventMask,
+        blob_object_permission_path, data_watch_resource_path, watch_interest_dirty_key,
     };
     use aruna_core::types::UserId;
     use aruna_net::{DiscoveryMethod, NetConfig, RelayMethod};
@@ -856,7 +856,9 @@ mod tests {
             },
             1_700_000_000_000 + seed as u64,
         );
-        record.watch_authorization = Some(WatchAuthorizationBinding::default());
+        let mut authorization = WatchAuthorizationBinding::default();
+        authorization.watch_path_prefix = data_path("");
+        record.watch_authorization = Some(authorization);
         record
     }
 
@@ -1416,6 +1418,36 @@ mod tests {
                 .expect("stored watch record")
                 .read_at_ms
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn rpc_list_requires_original_watch_prefix() {
+        let (a, b, recipient) = delivery_pair(80).await;
+        install_watch_authorization(&b, recipient.realm_id, recipient, &[]).await;
+        let mut watch = watch_record(recipient, 2);
+        watch
+            .watch_authorization
+            .as_mut()
+            .unwrap()
+            .path_restrictions = Some(vec![PathRestriction {
+            pattern: blob_object_permission_path(
+                recipient.realm_id,
+                data_group_id(),
+                data_node_id(),
+                "bucket",
+                "object-2",
+            ),
+            permission: Permission::READ,
+        }]);
+        seed_inbox(&b, &[watch.clone()]).await;
+
+        assert!(
+            list_remote(&a.net, b.net.node_id(), recipient, None, 10)
+                .await
+                .expect("list with unreadable watch prefix")
+                .0
+                .is_empty()
         );
     }
 

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -178,6 +178,7 @@ async fn build_response(
             owner,
             path_prefix,
             event_mask,
+            authorization,
         } => {
             if let Err(reason) = verify_recipient_local_holder(&owner, &realm_config, local_node_id)
             {
@@ -190,6 +191,7 @@ async fn build_response(
                 owner,
                 path_prefix,
                 event_mask,
+                authorization,
                 unix_timestamp_millis(),
             )
             .await
@@ -645,8 +647,9 @@ mod tests {
     };
     use aruna_core::structs::{
         Actor, GroupAuthorizationDocument, NotificationClass, NotificationKind, NotificationRecord,
-        RealmAuthorizationDocument, RealmNodeKind, WatchEvent, WatchEventDetail, WatchEventKind,
-        WatchEventMask, data_watch_resource_path, watch_interest_dirty_key,
+        RealmAuthorizationDocument, RealmNodeKind, WatchAuthorizationBinding, WatchEvent,
+        WatchEventDetail, WatchEventKind, WatchEventMask, data_watch_resource_path,
+        watch_interest_dirty_key,
     };
     use aruna_core::types::UserId;
     use aruna_net::{DiscoveryMethod, NetConfig, RelayMethod};
@@ -1543,9 +1546,16 @@ mod tests {
         install_watch_authorization(&b, realm_id, owner, &[]).await;
         let mask = WatchEventMask::from_kinds([WatchEventKind::DataUploaded]);
         let prefix = data_path("prefix");
-        let created = create_watch_remote(&a.net, b.net.node_id(), owner, prefix.clone(), mask)
-            .await
-            .expect("create succeeds");
+        let created = create_watch_remote(
+            &a.net,
+            b.net.node_id(),
+            owner,
+            prefix.clone(),
+            mask,
+            WatchAuthorizationBinding::default(),
+        )
+        .await
+        .expect("create succeeds");
         assert_eq!(created.owner, owner);
         assert_eq!(created.path_prefix, prefix);
         assert_eq!(created.event_mask, mask);
@@ -1589,6 +1599,7 @@ mod tests {
             owner,
             data_path(""),
             WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+            WatchAuthorizationBinding::default(),
         )
         .await
         .expect_err("create on non-holder must be rejected");
@@ -1649,6 +1660,7 @@ mod tests {
             owner,
             data_path("prefix"),
             WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+            WatchAuthorizationBinding::default(),
         )
         .await
         .expect_err("an owner without READ must be refused by the holder");
@@ -1688,6 +1700,7 @@ mod tests {
             owner,
             data_path("prefix"),
             WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+            WatchAuthorizationBinding::default(),
         )
         .await
         .expect("authorized create succeeds");
@@ -2094,6 +2107,7 @@ mod tests {
             owner,
             "bucket".to_string(),
             WatchEventMask::from_kinds([WatchEventKind::MetadataCreated]),
+            WatchAuthorizationBinding::default(),
         )
         .await
         .expect_err("non-eligible peer must be rejected");

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -1272,13 +1272,11 @@ mod tests {
         let recipient = recipient_for_holder(&config, b.net.node_id(), realm_id);
         install_watch_authorization(&b, realm_id, recipient, &[]).await;
         let direct = record(recipient, 1);
+        let watch_two = watch_record(recipient, 2);
+        let watch_three = watch_record(recipient, 3);
         seed_inbox(
             &b,
-            &[
-                direct.clone(),
-                watch_record(recipient, 2),
-                watch_record(recipient, 3),
-            ],
+            &[direct.clone(), watch_two.clone(), watch_three.clone()],
         )
         .await;
 
@@ -1290,6 +1288,11 @@ mod tests {
                 .len(),
             3
         );
+        let (first_page, retry_cursor) = list_remote(&a.net, b.net.node_id(), recipient, None, 1)
+            .await
+            .expect("first authorized page");
+        assert_eq!(first_page, vec![watch_three]);
+        let retry_cursor = retry_cursor.expect("cursor after first authorized page");
         install_watch_authorization(&b, realm_id, UserId::new(Ulid::r#gen(), realm_id), &[]).await;
 
         let (listed, next_cursor) = list_remote(&a.net, b.net.node_id(), recipient, None, 1)
@@ -1297,6 +1300,35 @@ mod tests {
             .expect("list after revocation");
         assert_eq!(listed, vec![direct]);
         assert_eq!(next_cursor, None);
+        assert!(matches!(
+            b.context
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: AUTH_KEYSPACE.to_string(),
+                    key: data_group_id().to_bytes().to_vec().into(),
+                    value: vec![0xff].into(),
+                    txn_id: None,
+                })
+                .await,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+        list_remote(
+            &a.net,
+            b.net.node_id(),
+            recipient,
+            Some(retry_cursor.clone()),
+            1,
+        )
+        .await
+        .expect_err("authorization decode failure must reject the page");
+        install_watch_authorization(&b, realm_id, recipient, &[]).await;
+        assert_eq!(
+            list_remote(&a.net, b.net.node_id(), recipient, Some(retry_cursor), 1,)
+                .await
+                .expect("same cursor retries after authorization recovers")
+                .0,
+            vec![watch_two]
+        );
     }
 
     #[tokio::test]

--- a/operations/src/notifications/incoming.rs
+++ b/operations/src/notifications/incoming.rs
@@ -856,8 +856,10 @@ mod tests {
             },
             1_700_000_000_000 + seed as u64,
         );
-        let mut authorization = WatchAuthorizationBinding::default();
-        authorization.watch_path_prefix = data_path("");
+        let authorization = WatchAuthorizationBinding {
+            watch_path_prefix: data_path(""),
+            ..Default::default()
+        };
         record.watch_authorization = Some(authorization);
         record
     }

--- a/operations/src/notifications/list.rs
+++ b/operations/src/notifications/list.rs
@@ -11,7 +11,6 @@ use aruna_core::types::{Effects, Key, UserId, Value};
 use byteview::ByteView;
 use smallvec::smallvec;
 use thiserror::Error;
-use tracing::warn;
 
 pub const LIST_NOTIFICATIONS_MAX_LIMIT: usize = 200;
 
@@ -106,15 +105,22 @@ impl ListNotificationsOperation {
     fn collect(&mut self, values: Vec<(Key, Value)>) -> Result<Effects, ListNotificationsError> {
         let mut records = Vec::with_capacity(values.len());
         for (key, value) in values {
-            let (recipient, _, _) = parse_notification_inbox_key(&key)?;
-            if recipient != self.input.recipient {
-                warn!(
-                    ?recipient,
-                    "Skipping notification row with foreign recipient"
-                );
-                continue;
+            let (recipient, created_at_ms, notification_id) = parse_notification_inbox_key(&key)?;
+            let record = NotificationRecord::from_bytes(&value)?;
+            if recipient != self.input.recipient
+                || (recipient, created_at_ms, notification_id)
+                    != (
+                        record.recipient,
+                        record.created_at_ms,
+                        record.notification_id,
+                    )
+            {
+                return Err(ConversionError::FromStrError(
+                    "notification inbox key does not match payload identity".to_string(),
+                )
+                .into());
             }
-            records.push(NotificationRecord::from_bytes(&value)?);
+            records.push(record);
         }
 
         let next_cursor = if records.len() > self.input.limit {
@@ -197,7 +203,9 @@ mod tests {
     use crate::driver::{DriverContext, drive};
     use crate::notifications::inbox::upsert_inbox_records;
     use aruna_core::keyspaces::NOTIFICATION_INBOX_KEYSPACE;
-    use aruna_core::structs::{NotificationClass, NotificationKind, RealmId};
+    use aruna_core::structs::{
+        NotificationClass, NotificationKind, RealmId, notification_inbox_key,
+    };
     use aruna_storage::storage::{FjallStorage, StorageHandle};
     use tempfile::{TempDir, tempdir};
     use ulid::Ulid;
@@ -401,6 +409,44 @@ mod tests {
         )
         .await;
         assert_eq!(result, Err(ListNotificationsError::InvalidCursor));
+    }
+
+    #[tokio::test]
+    async fn list_rejects_key_payload_identity_mismatch() {
+        let (_tempdir, context) = context_with_storage();
+        let recipient = user(1, 1);
+        let original = record(recipient, 10);
+        let mut mismatched = original.clone();
+        mismatched.notification_id = Ulid::r#gen();
+        assert!(matches!(
+            context
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: NOTIFICATION_INBOX_KEYSPACE.to_string(),
+                    key: notification_inbox_key(
+                        recipient,
+                        original.created_at_ms,
+                        original.notification_id,
+                    ),
+                    value: mismatched.to_bytes().unwrap().into(),
+                    txn_id: None,
+                })
+                .await,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+
+        assert!(matches!(
+            drive(
+                ListNotificationsOperation::new(ListNotificationsInput {
+                    recipient,
+                    cursor: None,
+                    limit: 10,
+                }),
+                &context,
+            )
+            .await,
+            Err(ListNotificationsError::ConversionError(_))
+        ));
     }
 
     #[test]

--- a/operations/src/notifications/mark_read.rs
+++ b/operations/src/notifications/mark_read.rs
@@ -4,7 +4,10 @@ use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::NOTIFICATION_INBOX_KEYSPACE;
 use aruna_core::operation::Operation;
 use aruna_core::storage_entries::notification_inbox_update_entry;
-use aruna_core::structs::{NotificationRecord, invert_timestamp_ms, notification_inbox_prefix};
+use aruna_core::structs::{
+    NotificationRecord, invert_timestamp_ms, notification_inbox_prefix,
+    parse_notification_inbox_key,
+};
 use aruna_core::types::{Effects, Key, KeySpace, UserId, Value};
 use byteview::ByteView;
 use smallvec::smallvec;
@@ -134,11 +137,31 @@ impl MarkReadOperation {
         };
 
         let mut writes: Vec<(KeySpace, Key, Value)> = Vec::new();
-        for (_, value) in values {
+        for (key, value) in values {
+            let (recipient, created_at_ms, notification_id) =
+                match parse_notification_inbox_key(&key) {
+                    Ok(identity) => identity,
+                    Err(error) => return self.fail(error.into()),
+                };
             let mut record = match NotificationRecord::from_bytes(&value) {
                 Ok(record) => record,
                 Err(error) => return self.fail(error.into()),
             };
+            if recipient != self.input.recipient
+                || (recipient, created_at_ms, notification_id)
+                    != (
+                        record.recipient,
+                        record.created_at_ms,
+                        record.notification_id,
+                    )
+            {
+                return self.fail(
+                    ConversionError::FromStrError(
+                        "notification inbox key does not match payload identity".to_string(),
+                    )
+                    .into(),
+                );
+            }
             let by_id = self
                 .input
                 .ids
@@ -257,7 +280,9 @@ mod tests {
     use crate::driver::{DriverContext, drive};
     use crate::notifications::inbox::upsert_inbox_records;
     use aruna_core::keyspaces::NOTIFICATION_INBOX_PRUNE_INDEX_KEYSPACE;
-    use aruna_core::structs::{NotificationClass, NotificationKind, RealmId};
+    use aruna_core::structs::{
+        NotificationClass, NotificationKind, RealmId, notification_inbox_key,
+    };
     use aruna_storage::storage::{FjallStorage, StorageHandle};
     use tempfile::{TempDir, tempdir};
 
@@ -538,6 +563,45 @@ mod tests {
         assert_eq!(alice_stored[0].read_at_ms, Some(5));
         let bob_stored = read_all(&context.storage_handle, bob).await;
         assert_eq!(bob_stored[0].read_at_ms, None);
+    }
+
+    #[tokio::test]
+    async fn mark_rejects_key_payload_identity_mismatch() {
+        let (_tempdir, context) = context_with_storage();
+        let recipient = user(1, 1);
+        let original = record(recipient, 10);
+        let mut mismatched = original.clone();
+        mismatched.created_at_ms = 20;
+        assert!(matches!(
+            context
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: NOTIFICATION_INBOX_KEYSPACE.to_string(),
+                    key: notification_inbox_key(
+                        recipient,
+                        original.created_at_ms,
+                        original.notification_id,
+                    ),
+                    value: mismatched.to_bytes().unwrap().into(),
+                    txn_id: None,
+                })
+                .await,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+
+        assert!(matches!(
+            drive(
+                MarkReadOperation::new(MarkReadInput {
+                    recipient,
+                    ids: vec![original.notification_id],
+                    up_to_ms: None,
+                    now_ms: 30,
+                }),
+                &context,
+            )
+            .await,
+            Err(MarkReadError::ConversionError(_))
+        ));
     }
 
     #[tokio::test]

--- a/operations/src/notifications/outbox.rs
+++ b/operations/src/notifications/outbox.rs
@@ -60,7 +60,7 @@ pub async fn read_notification_outbox_batch(
             let next_start_after = page.last().map(|(key, _)| key.to_vec());
             let mut records = Vec::with_capacity(page.len());
             for (key, value) in page {
-                match postcard::from_bytes(&value) {
+                match NotificationOutboxRecord::from_bytes(&value) {
                     Ok(record) => records.push((key.to_vec(), record)),
                     Err(error) => {
                         let key = key.to_vec();

--- a/operations/src/notifications/protocol.rs
+++ b/operations/src/notifications/protocol.rs
@@ -1,4 +1,6 @@
-use aruna_core::structs::{NotificationRecord, WatchEvent, WatchEventMask, WatchSubscription};
+use aruna_core::structs::{
+    NotificationRecord, WatchAuthorizationBinding, WatchEvent, WatchEventMask, WatchSubscription,
+};
 use aruna_core::types::UserId;
 use aruna_net::streams::BiStream;
 use serde::{Deserialize, Serialize};
@@ -44,6 +46,7 @@ pub enum NotificationTransportMessage {
         owner: UserId,
         path_prefix: String,
         event_mask: WatchEventMask,
+        authorization: WatchAuthorizationBinding,
     },
     WatchCreated {
         subscription: WatchSubscription,

--- a/operations/src/notifications/routing.rs
+++ b/operations/src/notifications/routing.rs
@@ -143,6 +143,7 @@ pub fn route_watch_event(
             kind: event.notification_kind(),
             created_at_ms: event.occurred_at_ms,
             read_at_ms: None,
+            watch_authorization: Some(subscription.authorization.clone()),
         });
     }
     records

--- a/operations/src/notifications/routing.rs
+++ b/operations/src/notifications/routing.rs
@@ -413,6 +413,14 @@ mod tests {
         assert_eq!(records[0].recipient, owner);
         assert_eq!(records[0].class, NotificationClass::Transient);
         assert_eq!(records[0].created_at_ms, 5_000);
+        assert_eq!(
+            records[0]
+                .watch_authorization
+                .as_ref()
+                .unwrap()
+                .watch_path_prefix,
+            subs[0].path_prefix
+        );
         assert!(matches!(
             records[0].kind,
             NotificationKind::DataUploaded { .. }

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -8,8 +8,10 @@ use aruna_core::errors::AuthorizationError;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::API_STATE_KEYSPACE;
 use aruna_core::structs::{
-    AuthContext, MetadataRegistryRecord, Permission, RealmId, WatchAuthorizationBinding,
-    WatchEventMask, WatchSubscription, blob_object_permission_path, parse_data_watch_resource_path,
+    AuthContext, MetadataRegistryRecord, NotificationKind, Permission, RealmId,
+    WatchAuthorizationBinding, WatchEvent, WatchEventDetail, WatchEventKind, WatchEventMask,
+    WatchSubscription, blob_object_permission_path, data_watch_resource_path,
+    parse_data_watch_resource_path,
 };
 use aruna_core::types::UserId;
 use aruna_core::util::unix_timestamp_secs;
@@ -28,9 +30,18 @@ pub struct AuthorizedWatchSubscriptions {
     pub check_failed: bool,
 }
 
-enum WatchAuthorization {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WatchAuthorizationDenial {
+    InvalidState,
+    TokenExpired,
+    TokenRevoked,
+    TokenRestricted,
+    PermissionDenied,
+}
+
+pub enum WatchAuthorization {
     Authorized,
-    Denied,
+    Denied(WatchAuthorizationDenial),
     Unavailable(String),
 }
 
@@ -44,7 +55,8 @@ pub fn watch_permission_path(
             let remainder = path_prefix.strip_prefix("meta/")?;
             let (raw_group_id, document_path_prefix) = remainder.split_once('/')?;
             let group_id = Ulid::from_str(raw_group_id).ok()?;
-            if group_id.is_nil()
+            if document_path_prefix.is_empty()
+                || group_id.is_nil()
                 || raw_group_id != group_id.to_string()
                 || MetadataRegistryRecord::normalize_document_path(document_path_prefix)
                     != document_path_prefix
@@ -105,22 +117,46 @@ async fn evaluate_watch_authorization(
     authorization: &WatchAuthorizationBinding,
 ) -> Result<WatchAuthorization, String> {
     let Some(permission_path) = watch_permission_path(realm_id, path_prefix, event_mask) else {
-        return Ok(WatchAuthorization::Denied);
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::InvalidState,
+        ));
     };
-    if owner.is_nil()
-        || owner.realm_id != realm_id
-        || !authorization.is_valid()
-        || unix_timestamp_secs() > authorization.expires_at_secs
-        || token_is_revoked(context, &authorization.token_hash).await?
-    {
-        return Ok(WatchAuthorization::Denied);
+    evaluate_permission_path(context, realm_id, owner, permission_path, authorization).await
+}
+
+async fn evaluate_permission_path(
+    context: &DriverContext,
+    realm_id: RealmId,
+    owner: UserId,
+    permission_path: String,
+    authorization: &WatchAuthorizationBinding,
+) -> Result<WatchAuthorization, String> {
+    if owner.is_nil() || owner.realm_id != realm_id || !authorization.is_valid() {
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::InvalidState,
+        ));
+    }
+    if unix_timestamp_secs() > authorization.expires_at_secs {
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::TokenExpired,
+        ));
+    }
+    if token_is_revoked(context, &authorization.token_hash).await? {
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::TokenRevoked,
+        ));
+    }
+    if !token_restrictions_allow(authorization, &permission_path)? {
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::TokenRestricted,
+        ));
     }
     match drive(
         CheckPermissionsOperation::new(CheckPermissionsConfig {
             auth_context: AuthContext {
                 user_id: owner,
                 realm_id,
-                path_restrictions: authorization.path_restrictions.clone(),
+                path_restrictions: None,
             },
             path: permission_path,
             required_permission: Permission::READ,
@@ -130,7 +166,9 @@ async fn evaluate_watch_authorization(
     .await
     {
         Ok(true) => Ok(WatchAuthorization::Authorized),
-        Ok(false) => Ok(WatchAuthorization::Denied),
+        Ok(false) => Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::PermissionDenied,
+        )),
         // A path whose realm, group or authorization state is absent is simply
         // unreadable. Answering it exactly as a denied role keeps a watch from
         // separating "does not exist" from "you may not read it", which is the
@@ -144,6 +182,175 @@ async fn evaluate_watch_authorization(
         ) => Ok(WatchAuthorization::Unavailable(error.to_string())),
         Err(error) => Err(error.to_string()),
     }
+}
+
+fn token_restrictions_allow(
+    authorization: &WatchAuthorizationBinding,
+    permission_path: &str,
+) -> Result<bool, String> {
+    let Some(restrictions) = authorization.path_restrictions.as_ref() else {
+        return Ok(true);
+    };
+    let mut allowed = false;
+    for restriction in restrictions {
+        if globset::Glob::new(&restriction.pattern)
+            .map_err(|error| error.to_string())?
+            .compile_matcher()
+            .is_match(permission_path)
+        {
+            match restriction.permission {
+                Permission::DENY => return Ok(false),
+                Permission::READ | Permission::WRITE => allowed = true,
+            }
+        }
+    }
+    Ok(allowed)
+}
+
+pub async fn evaluate_watch_event_authorization(
+    context: &DriverContext,
+    owner: UserId,
+    authorization: &WatchAuthorizationBinding,
+    event: &WatchEvent,
+) -> Result<WatchAuthorization, String> {
+    let Some(permission_path) = watch_event_permission_path(event) else {
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::InvalidState,
+        ));
+    };
+    evaluate_permission_path(
+        context,
+        event.realm_id,
+        owner,
+        permission_path,
+        authorization,
+    )
+    .await
+}
+
+pub async fn evaluate_watch_notification_authorization(
+    context: &DriverContext,
+    recipient: UserId,
+    kind: &NotificationKind,
+    authorization: &WatchAuthorizationBinding,
+) -> Result<WatchAuthorization, String> {
+    let Some(permission_path) = watch_notification_permission_path(recipient.realm_id, kind) else {
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::InvalidState,
+        ));
+    };
+    evaluate_permission_path(
+        context,
+        recipient.realm_id,
+        recipient,
+        permission_path,
+        authorization,
+    )
+    .await
+}
+
+pub fn watch_event_permission_path(event: &WatchEvent) -> Option<String> {
+    if event.actor.is_nil() || event.actor.realm_id != event.realm_id {
+        return None;
+    }
+    match (&event.kind, &event.detail) {
+        (
+            WatchEventKind::MetadataCreated,
+            WatchEventDetail::MetadataCreated {
+                group_id,
+                document_id,
+            },
+        ) => metadata_permission_path(event.realm_id, &event.path, *group_id, *document_id),
+        (
+            WatchEventKind::DataUploaded,
+            WatchEventDetail::DataUploaded {
+                group_id,
+                node_id,
+                bucket,
+                key,
+                ..
+            },
+        ) => data_permission_path(
+            event.realm_id,
+            &event.path,
+            *group_id,
+            *node_id,
+            bucket,
+            key,
+        ),
+        _ => None,
+    }
+}
+
+fn watch_notification_permission_path(
+    realm_id: RealmId,
+    kind: &NotificationKind,
+) -> Option<String> {
+    match kind {
+        NotificationKind::MetadataCreated {
+            path,
+            group_id,
+            document_id,
+            actor_user_id,
+        } if !actor_user_id.is_nil() && actor_user_id.realm_id == realm_id => {
+            metadata_permission_path(realm_id, path, *group_id, *document_id)
+        }
+        NotificationKind::DataUploaded {
+            path,
+            group_id,
+            node_id,
+            bucket,
+            key,
+            actor_user_id,
+            ..
+        } if !actor_user_id.is_nil() && actor_user_id.realm_id == realm_id => {
+            data_permission_path(realm_id, path, *group_id, *node_id, bucket, key)
+        }
+        _ => None,
+    }
+}
+
+fn metadata_permission_path(
+    realm_id: RealmId,
+    path: &str,
+    group_id: Ulid,
+    document_id: Ulid,
+) -> Option<String> {
+    if group_id.is_nil() || document_id.is_nil() {
+        return None;
+    }
+    let document_path = path.strip_prefix(&format!("meta/{group_id}/"))?;
+    if document_path.is_empty()
+        || MetadataRegistryRecord::normalize_document_path(document_path) != document_path
+    {
+        return None;
+    }
+    Some(MetadataRegistryRecord::permission_path_for(
+        &realm_id,
+        group_id,
+        document_path,
+        document_id,
+    ))
+}
+
+fn data_permission_path(
+    realm_id: RealmId,
+    path: &str,
+    group_id: Ulid,
+    node_id: NodeId,
+    bucket: &str,
+    key: &str,
+) -> Option<String> {
+    if group_id.is_nil()
+        || bucket.is_empty()
+        || key.is_empty()
+        || path != data_watch_resource_path(group_id, node_id, bucket, key)
+    {
+        return None;
+    }
+    Some(blob_object_permission_path(
+        realm_id, group_id, node_id, bucket, key,
+    ))
 }
 
 async fn token_is_revoked(context: &DriverContext, token_hash: &str) -> Result<bool, String> {
@@ -224,7 +431,7 @@ pub async fn filter_authorized_watch_subscriptions(
         .await
         {
             Ok(WatchAuthorization::Authorized) => authorized.push(subscription),
-            Ok(WatchAuthorization::Denied) => dropped = true,
+            Ok(WatchAuthorization::Denied(_)) => dropped = true,
             Ok(WatchAuthorization::Unavailable(error)) | Err(error) => {
                 dropped = true;
                 check_failed = true;
@@ -253,7 +460,7 @@ mod tests {
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::structs::{
         Actor, GroupAuthorizationDocument, RealmAuthorizationDocument, RealmConfigDocument,
-        RealmNodeKind, WatchEventKind, data_watch_resource_path,
+        RealmNodeKind, WatchEvent, WatchEventDetail, WatchEventKind, data_watch_resource_path,
     };
     use aruna_storage::FjallStorage;
 
@@ -411,6 +618,64 @@ mod tests {
             ),
             Some(format!("/{realm_id}/g/{group_id}/meta/datasets/project"))
         );
+    }
+
+    #[test]
+    fn event_permission_paths_use_exact_resource_identity() {
+        let realm_id = RealmId([1u8; 32]);
+        let group_id = Ulid::from_bytes([2u8; 16]);
+        let document_id = Ulid::from_bytes([3u8; 16]);
+        let node_id = node(4);
+        let actor = UserId::new(Ulid::from_bytes([5u8; 16]), realm_id);
+        let data = WatchEvent {
+            event_id: Ulid::from_bytes([6u8; 16]),
+            realm_id,
+            kind: WatchEventKind::DataUploaded,
+            path: data_watch_resource_path(group_id, node_id, "bucket", "reports/a.csv"),
+            actor,
+            occurred_at_ms: 1,
+            detail: WatchEventDetail::DataUploaded {
+                group_id,
+                node_id,
+                bucket: "bucket".to_string(),
+                key: "reports/a.csv".to_string(),
+                size_bytes: 1,
+            },
+        };
+        assert_eq!(
+            watch_event_permission_path(&data),
+            Some(blob_object_permission_path(
+                realm_id,
+                group_id,
+                node_id,
+                "bucket",
+                "reports/a.csv",
+            ))
+        );
+
+        let mut metadata = WatchEvent {
+            event_id: Ulid::from_bytes([7u8; 16]),
+            realm_id,
+            kind: WatchEventKind::MetadataCreated,
+            path: format!("meta/{group_id}/datasets/project"),
+            actor,
+            occurred_at_ms: 1,
+            detail: WatchEventDetail::MetadataCreated {
+                group_id,
+                document_id,
+            },
+        };
+        assert_eq!(
+            watch_event_permission_path(&metadata),
+            Some(MetadataRegistryRecord::permission_path_for(
+                &realm_id,
+                group_id,
+                "datasets/project",
+                document_id,
+            ))
+        );
+        metadata.path.push_str("/mismatch");
+        assert!(watch_event_permission_path(&metadata).is_none());
     }
 
     #[test]

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -7,6 +7,7 @@ use aruna_core::effects::StorageEffect;
 use aruna_core::errors::AuthorizationError;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::API_STATE_KEYSPACE;
+use aruna_core::metrics::WatchAuthorizationMetricReason;
 use aruna_core::structs::{
     AuthContext, MetadataRegistryRecord, NotificationKind, Permission, RealmId,
     WatchAuthorizationBinding, WatchEvent, WatchEventDetail, WatchEventKind, WatchEventMask,
@@ -33,10 +34,24 @@ pub struct AuthorizedWatchSubscriptions {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WatchAuthorizationDenial {
     InvalidState,
+    InvalidOwner,
     TokenExpired,
     TokenRevoked,
     TokenRestricted,
     PermissionDenied,
+}
+
+impl WatchAuthorizationDenial {
+    pub const fn metric_reason(self) -> WatchAuthorizationMetricReason {
+        match self {
+            Self::InvalidState => WatchAuthorizationMetricReason::InvalidState,
+            Self::InvalidOwner => WatchAuthorizationMetricReason::InvalidOwner,
+            Self::TokenExpired => WatchAuthorizationMetricReason::TokenExpired,
+            Self::TokenRevoked => WatchAuthorizationMetricReason::TokenRevoked,
+            Self::TokenRestricted => WatchAuthorizationMetricReason::TokenRestricted,
+            Self::PermissionDenied => WatchAuthorizationMetricReason::PermissionDenied,
+        }
+    }
 }
 
 pub enum WatchAuthorization {
@@ -108,7 +123,7 @@ pub async fn is_watch_authorized(
     ))
 }
 
-async fn evaluate_watch_authorization(
+pub async fn evaluate_watch_authorization(
     context: &DriverContext,
     realm_id: RealmId,
     owner: UserId,
@@ -131,7 +146,12 @@ async fn evaluate_permission_path(
     permission_path: String,
     authorization: &WatchAuthorizationBinding,
 ) -> Result<WatchAuthorization, String> {
-    if owner.is_nil() || owner.realm_id != realm_id || !authorization.is_valid() {
+    if owner.is_nil() || owner.realm_id != realm_id {
+        return Ok(WatchAuthorization::Denied(
+            WatchAuthorizationDenial::InvalidOwner,
+        ));
+    }
+    if !authorization.is_valid() {
         return Ok(WatchAuthorization::Denied(
             WatchAuthorizationDenial::InvalidState,
         ));
@@ -386,7 +406,7 @@ pub async fn list_authorized_watch_subscriptions(
         .map_err(|error| error.to_string())?;
     let mut authorized = Vec::with_capacity(subscriptions.len());
     for mut subscription in subscriptions {
-        if !is_watch_authorized(
+        match evaluate_watch_authorization(
             context,
             owner.realm_id,
             subscription.owner,
@@ -396,9 +416,13 @@ pub async fn list_authorized_watch_subscriptions(
         )
         .await?
         {
-            subscription.path_prefix.clear();
-            subscription.event_mask = WatchEventMask::empty();
-            subscription.created_at_ms = 0;
+            WatchAuthorization::Authorized => {}
+            WatchAuthorization::Denied(_) => {
+                subscription.path_prefix.clear();
+                subscription.event_mask = WatchEventMask::empty();
+                subscription.created_at_ms = 0;
+            }
+            WatchAuthorization::Unavailable(error) => return Err(error),
         }
         authorized.push(subscription);
     }
@@ -432,14 +456,13 @@ pub async fn filter_authorized_watch_subscriptions(
         {
             Ok(WatchAuthorization::Authorized) => authorized.push(subscription),
             Ok(WatchAuthorization::Denied(_)) => dropped = true,
-            Ok(WatchAuthorization::Unavailable(error)) | Err(error) => {
+            Ok(WatchAuthorization::Unavailable(_)) | Err(_) => {
                 dropped = true;
                 check_failed = true;
                 warn!(
-                    owner = %subscription.owner,
-                    path = %subscription.path_prefix,
-                    %error,
-                    "Watch permission re-check failed closed"
+                    parent: None,
+                    reason = WatchAuthorizationMetricReason::AuthorizationUnavailable.as_str(),
+                    "Notification watch authorization check failed"
                 );
             }
         }
@@ -674,7 +697,7 @@ mod tests {
                 document_id,
             ))
         );
-        metadata.path.push_str("/mismatch");
+        metadata.path = format!("meta/{}/datasets/project", Ulid::from_bytes([8u8; 16]));
         assert!(watch_event_permission_path(&metadata).is_none());
     }
 

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -121,9 +121,9 @@ async fn evaluate_watch_authorization(
     }
 }
 
-/// Holder-side enumeration of one user's watches, filtered through the same
-/// authorization result delivery uses, so a revoked watch stops being visible as
-/// well as stopping delivery.
+/// Holder-side enumeration of one user's watches through the same authorization
+/// result delivery uses. Revoked watches retain only their opaque deletion id;
+/// protected watch details are redacted so the owner can still release quota.
 pub async fn list_authorized_watch_subscriptions(
     context: &DriverContext,
     owner: UserId,
@@ -132,8 +132,8 @@ pub async fn list_authorized_watch_subscriptions(
         .await
         .map_err(|error| error.to_string())?;
     let mut authorized = Vec::with_capacity(subscriptions.len());
-    for subscription in subscriptions {
-        if is_watch_authorized(
+    for mut subscription in subscriptions {
+        if !is_watch_authorized(
             context,
             owner.realm_id,
             subscription.owner,
@@ -142,8 +142,11 @@ pub async fn list_authorized_watch_subscriptions(
         )
         .await?
         {
-            authorized.push(subscription);
+            subscription.path_prefix.clear();
+            subscription.event_mask = WatchEventMask::empty();
+            subscription.created_at_ms = 0;
         }
+        authorized.push(subscription);
     }
     Ok(authorized)
 }

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -21,6 +21,12 @@ pub struct AuthorizedWatchSubscriptions {
     pub check_failed: bool,
 }
 
+enum WatchAuthorization {
+    Authorized,
+    Denied,
+    Unavailable(String),
+}
+
 pub fn watch_permission_path(
     realm_id: RealmId,
     path_prefix: &str,
@@ -65,11 +71,24 @@ pub async fn is_watch_authorized(
     path_prefix: &str,
     event_mask: WatchEventMask,
 ) -> Result<bool, String> {
+    Ok(matches!(
+        evaluate_watch_authorization(context, realm_id, owner, path_prefix, event_mask).await?,
+        WatchAuthorization::Authorized
+    ))
+}
+
+async fn evaluate_watch_authorization(
+    context: &DriverContext,
+    realm_id: RealmId,
+    owner: UserId,
+    path_prefix: &str,
+    event_mask: WatchEventMask,
+) -> Result<WatchAuthorization, String> {
     let Some(permission_path) = watch_permission_path(realm_id, path_prefix, event_mask) else {
-        return Ok(false);
+        return Ok(WatchAuthorization::Denied);
     };
     if owner.is_nil() || owner.realm_id != realm_id {
-        return Ok(false);
+        return Ok(WatchAuthorization::Denied);
     }
     match drive(
         CheckPermissionsOperation::new(CheckPermissionsConfig {
@@ -85,17 +104,19 @@ pub async fn is_watch_authorized(
     )
     .await
     {
-        Ok(allowed) => Ok(allowed),
+        Ok(true) => Ok(WatchAuthorization::Authorized),
+        Ok(false) => Ok(WatchAuthorization::Denied),
         // A path whose realm, group or authorization state is absent is simply
         // unreadable. Answering it exactly as a denied role keeps a watch from
         // separating "does not exist" from "you may not read it", which is the
-        // same choice the metadata surface makes.
+        // same choice the metadata surface makes. Internally, retain that the
+        // state was unavailable so interest publication leaves a retry marker.
         Err(
-            AuthorizationError::InvalidRealmId
+            error @ (AuthorizationError::InvalidRealmId
             | AuthorizationError::InvalidGroupId
             | AuthorizationError::GroupNotFound
-            | AuthorizationError::AuthDocNotFound,
-        ) => Ok(false),
+            | AuthorizationError::AuthDocNotFound),
+        ) => Ok(WatchAuthorization::Unavailable(error.to_string())),
         Err(error) => Err(error.to_string()),
     }
 }
@@ -142,7 +163,7 @@ pub async fn filter_authorized_watch_subscriptions(
     let mut check_failed = false;
 
     for subscription in subscriptions {
-        match is_watch_authorized(
+        match evaluate_watch_authorization(
             context,
             realm_id,
             subscription.owner,
@@ -151,9 +172,9 @@ pub async fn filter_authorized_watch_subscriptions(
         )
         .await
         {
-            Ok(true) => authorized.push(subscription),
-            Ok(false) => dropped = true,
-            Err(error) => {
+            Ok(WatchAuthorization::Authorized) => authorized.push(subscription),
+            Ok(WatchAuthorization::Denied) => dropped = true,
+            Ok(WatchAuthorization::Unavailable(error)) | Err(error) => {
                 dropped = true;
                 check_failed = true;
                 warn!(
@@ -180,8 +201,8 @@ mod tests {
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::structs::{
-        Actor, GroupAuthorizationDocument, RealmAuthorizationDocument, WatchEventKind,
-        data_watch_resource_path,
+        Actor, GroupAuthorizationDocument, RealmAuthorizationDocument, RealmConfigDocument,
+        RealmNodeKind, WatchEventKind, data_watch_resource_path,
     };
     use aruna_storage::FjallStorage;
 
@@ -262,6 +283,47 @@ mod tests {
             .await,
             Ok(false)
         );
+    }
+
+    #[tokio::test]
+    async fn missing_authorization_is_denied_and_marked_retryable() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let storage =
+            FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
+        let realm_id = RealmId([8u8; 32]);
+        let owner = UserId::new(Ulid::from_bytes([1u8; 16]), realm_id);
+        let group_id = Ulid::from_bytes([2u8; 16]);
+        let node_id = node(3);
+        let path = data_watch_resource_path(group_id, node_id, "bucket", "");
+        let event_mask = WatchEventMask::from_kinds([WatchEventKind::DataUploaded]);
+        let subscription = WatchSubscription::new(owner, path.clone(), event_mask, 1);
+        let mut realm_config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+        realm_config.ensure_node(node_id, RealmNodeKind::Server);
+        let context = DriverContext {
+            storage_handle: storage,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+
+        assert_eq!(
+            is_watch_authorized(&context, realm_id, owner, &path, event_mask).await,
+            Ok(false),
+            "external callers still fail closed without exposing missing state"
+        );
+        let filtered = filter_authorized_watch_subscriptions(
+            &context,
+            realm_id,
+            &realm_config,
+            node_id,
+            vec![subscription],
+        )
+        .await
+        .expect("filter succeeds");
+        assert!(filtered.subscriptions.is_empty());
+        assert!(filtered.dropped);
+        assert!(filtered.check_failed, "interest publication must retry");
     }
 
     #[test]

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -254,6 +254,36 @@ pub async fn evaluate_watch_notification_authorization(
     kind: &NotificationKind,
     authorization: &WatchAuthorizationBinding,
 ) -> Result<WatchAuthorization, String> {
+    let event_mask = match kind {
+        NotificationKind::MetadataCreated { path, .. }
+            if path.starts_with(&authorization.watch_path_prefix) =>
+        {
+            WatchEventMask::from_kinds([WatchEventKind::MetadataCreated])
+        }
+        NotificationKind::DataUploaded { path, .. }
+            if path.starts_with(&authorization.watch_path_prefix) =>
+        {
+            WatchEventMask::from_kinds([WatchEventKind::DataUploaded])
+        }
+        _ => {
+            return Ok(WatchAuthorization::Denied(
+                WatchAuthorizationDenial::InvalidState,
+            ));
+        }
+    };
+    match evaluate_watch_authorization(
+        context,
+        recipient.realm_id,
+        recipient,
+        &authorization.watch_path_prefix,
+        event_mask,
+        authorization,
+    )
+    .await?
+    {
+        WatchAuthorization::Authorized => {}
+        result => return Ok(result),
+    }
     let Some(permission_path) = watch_notification_permission_path(recipient.realm_id, kind) else {
         return Ok(WatchAuthorization::Denied(
             WatchAuthorizationDenial::InvalidState,

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -1,12 +1,19 @@
+use std::collections::HashSet;
 use std::str::FromStr;
 
 use aruna_core::NodeId;
+use aruna_core::auth::TOKEN_REVOCATION_LIST_KEY;
+use aruna_core::effects::StorageEffect;
 use aruna_core::errors::AuthorizationError;
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::API_STATE_KEYSPACE;
 use aruna_core::structs::{
-    AuthContext, MetadataRegistryRecord, Permission, RealmId, WatchEventMask, WatchSubscription,
-    blob_bucket_permission_path, parse_data_watch_resource_path,
+    AuthContext, MetadataRegistryRecord, Permission, RealmId, WatchAuthorizationBinding,
+    WatchEventMask, WatchSubscription, blob_object_permission_path, parse_data_watch_resource_path,
 };
 use aruna_core::types::UserId;
+use aruna_core::util::unix_timestamp_secs;
+use byteview::ByteView;
 use tracing::warn;
 use ulid::Ulid;
 
@@ -44,15 +51,18 @@ pub fn watch_permission_path(
             {
                 return None;
             }
-            Some(format!("/{realm_id}/g/{group_id}/meta/**"))
+            Some(format!(
+                "/{realm_id}/g/{group_id}/meta/{document_path_prefix}"
+            ))
         }
         WatchEventMask::DATA_UPLOADED => {
             let resource = parse_data_watch_resource_path(path_prefix)?;
-            Some(blob_bucket_permission_path(
+            Some(blob_object_permission_path(
                 realm_id,
                 resource.group_id,
                 resource.node_id,
                 resource.bucket,
+                resource.key_prefix,
             ))
         }
         _ => None,
@@ -70,9 +80,18 @@ pub async fn is_watch_authorized(
     owner: UserId,
     path_prefix: &str,
     event_mask: WatchEventMask,
+    authorization: &WatchAuthorizationBinding,
 ) -> Result<bool, String> {
     Ok(matches!(
-        evaluate_watch_authorization(context, realm_id, owner, path_prefix, event_mask).await?,
+        evaluate_watch_authorization(
+            context,
+            realm_id,
+            owner,
+            path_prefix,
+            event_mask,
+            authorization,
+        )
+        .await?,
         WatchAuthorization::Authorized
     ))
 }
@@ -83,11 +102,17 @@ async fn evaluate_watch_authorization(
     owner: UserId,
     path_prefix: &str,
     event_mask: WatchEventMask,
+    authorization: &WatchAuthorizationBinding,
 ) -> Result<WatchAuthorization, String> {
     let Some(permission_path) = watch_permission_path(realm_id, path_prefix, event_mask) else {
         return Ok(WatchAuthorization::Denied);
     };
-    if owner.is_nil() || owner.realm_id != realm_id {
+    if owner.is_nil()
+        || owner.realm_id != realm_id
+        || !authorization.is_valid()
+        || unix_timestamp_secs() > authorization.expires_at_secs
+        || token_is_revoked(context, &authorization.token_hash).await?
+    {
         return Ok(WatchAuthorization::Denied);
     }
     match drive(
@@ -95,7 +120,7 @@ async fn evaluate_watch_authorization(
             auth_context: AuthContext {
                 user_id: owner,
                 realm_id,
-                path_restrictions: None,
+                path_restrictions: authorization.path_restrictions.clone(),
             },
             path: permission_path,
             required_permission: Permission::READ,
@@ -121,6 +146,27 @@ async fn evaluate_watch_authorization(
     }
 }
 
+async fn token_is_revoked(context: &DriverContext, token_hash: &str) -> Result<bool, String> {
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::Read {
+            key_space: API_STATE_KEYSPACE.to_string(),
+            key: ByteView::from(TOKEN_REVOCATION_LIST_KEY),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(bytes), ..
+        }) => postcard::from_bytes::<HashSet<String>>(&bytes)
+            .map(|revoked| revoked.contains(token_hash))
+            .map_err(|error| error.to_string()),
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(false),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.to_string()),
+        other => Err(format!("unexpected storage event: {other:?}")),
+    }
+}
+
 /// Holder-side enumeration of one user's watches through the same authorization
 /// result delivery uses. Revoked watches retain only their opaque deletion id;
 /// protected watch details are redacted so the owner can still release quota.
@@ -139,6 +185,7 @@ pub async fn list_authorized_watch_subscriptions(
             subscription.owner,
             &subscription.path_prefix,
             subscription.event_mask,
+            &subscription.authorization,
         )
         .await?
         {
@@ -172,6 +219,7 @@ pub async fn filter_authorized_watch_subscriptions(
             subscription.owner,
             &subscription.path_prefix,
             subscription.event_mask,
+            &subscription.authorization,
         )
         .await
         {
@@ -282,6 +330,7 @@ mod tests {
                 UserId::nil(realm_id),
                 &prefix,
                 WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+                &WatchAuthorizationBinding::default(),
             )
             .await,
             Ok(false)
@@ -311,7 +360,15 @@ mod tests {
         };
 
         assert_eq!(
-            is_watch_authorized(&context, realm_id, owner, &path, event_mask).await,
+            is_watch_authorized(
+                &context,
+                realm_id,
+                owner,
+                &path,
+                event_mask,
+                &subscription.authorization,
+            )
+            .await,
             Ok(false),
             "external callers still fail closed without exposing missing state"
         );
@@ -342,8 +399,8 @@ mod tests {
                 &data_prefix,
                 WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
             ),
-            Some(blob_bucket_permission_path(
-                realm_id, group_id, node_id, "bucket"
+            Some(blob_object_permission_path(
+                realm_id, group_id, node_id, "bucket", "reports/"
             ))
         );
         assert_eq!(
@@ -352,7 +409,7 @@ mod tests {
                 &format!("meta/{group_id}/datasets/project"),
                 WatchEventMask::from_kinds([WatchEventKind::MetadataCreated]),
             ),
-            Some(format!("/{realm_id}/g/{group_id}/meta/**"))
+            Some(format!("/{realm_id}/g/{group_id}/meta/datasets/project"))
         );
     }
 

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -1,16 +1,19 @@
 use std::str::FromStr;
 
 use aruna_core::NodeId;
+use aruna_core::errors::AuthorizationError;
 use aruna_core::structs::{
     AuthContext, MetadataRegistryRecord, Permission, RealmId, WatchEventMask, WatchSubscription,
     blob_bucket_permission_path, parse_data_watch_resource_path,
 };
+use aruna_core::types::UserId;
 use tracing::warn;
 use ulid::Ulid;
 
 use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::driver::{DriverContext, drive};
 use crate::notifications::placement::filter_locally_held_watch_subscriptions;
+use crate::notifications::watch::subscriptions::list_watch_subscriptions;
 
 pub struct AuthorizedWatchSubscriptions {
     pub subscriptions: Vec<WatchSubscription>,
@@ -50,6 +53,80 @@ pub fn watch_permission_path(
     }
 }
 
+/// The single canonical authorization result every watch surface shares: the
+/// owner must still hold READ on the permission path derived from the watched
+/// prefix. A prefix with no canonical resource identity, and any non-user owner,
+/// is unauthorized. A check that cannot be evaluated is an error, never a grant,
+/// so callers fail closed.
+pub async fn is_watch_authorized(
+    context: &DriverContext,
+    realm_id: RealmId,
+    owner: UserId,
+    path_prefix: &str,
+    event_mask: WatchEventMask,
+) -> Result<bool, String> {
+    let Some(permission_path) = watch_permission_path(realm_id, path_prefix, event_mask) else {
+        return Ok(false);
+    };
+    if owner.is_nil() || owner.realm_id != realm_id {
+        return Ok(false);
+    }
+    match drive(
+        CheckPermissionsOperation::new(CheckPermissionsConfig {
+            auth_context: AuthContext {
+                user_id: owner,
+                realm_id,
+                path_restrictions: None,
+            },
+            path: permission_path,
+            required_permission: Permission::READ,
+        }),
+        context,
+    )
+    .await
+    {
+        Ok(allowed) => Ok(allowed),
+        // A path whose realm, group or authorization state is absent is simply
+        // unreadable. Answering it exactly as a denied role keeps a watch from
+        // separating "does not exist" from "you may not read it", which is the
+        // same choice the metadata surface makes.
+        Err(
+            AuthorizationError::InvalidRealmId
+            | AuthorizationError::InvalidGroupId
+            | AuthorizationError::GroupNotFound
+            | AuthorizationError::AuthDocNotFound,
+        ) => Ok(false),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+/// Holder-side enumeration of one user's watches, filtered through the same
+/// authorization result delivery uses, so a revoked watch stops being visible as
+/// well as stopping delivery.
+pub async fn list_authorized_watch_subscriptions(
+    context: &DriverContext,
+    owner: UserId,
+) -> Result<Vec<WatchSubscription>, String> {
+    let subscriptions = list_watch_subscriptions(&context.storage_handle, owner)
+        .await
+        .map_err(|error| error.to_string())?;
+    let mut authorized = Vec::with_capacity(subscriptions.len());
+    for subscription in subscriptions {
+        if is_watch_authorized(
+            context,
+            owner.realm_id,
+            subscription.owner,
+            &subscription.path_prefix,
+            subscription.event_mask,
+        )
+        .await?
+        {
+            authorized.push(subscription);
+        }
+    }
+    Ok(authorized)
+}
+
 pub async fn filter_authorized_watch_subscriptions(
     context: &DriverContext,
     realm_id: RealmId,
@@ -65,28 +142,12 @@ pub async fn filter_authorized_watch_subscriptions(
     let mut check_failed = false;
 
     for subscription in subscriptions {
-        let Some(permission_path) =
-            watch_permission_path(realm_id, &subscription.path_prefix, subscription.event_mask)
-        else {
-            dropped = true;
-            continue;
-        };
-        if subscription.owner.is_nil() || subscription.owner.realm_id != realm_id {
-            dropped = true;
-            continue;
-        }
-        let auth_context = AuthContext {
-            user_id: subscription.owner,
-            realm_id,
-            path_restrictions: None,
-        };
-        match drive(
-            CheckPermissionsOperation::new(CheckPermissionsConfig {
-                auth_context,
-                path: permission_path.clone(),
-                required_permission: Permission::READ,
-            }),
+        match is_watch_authorized(
             context,
+            realm_id,
+            subscription.owner,
+            &subscription.path_prefix,
+            subscription.event_mask,
         )
         .await
         {
@@ -97,7 +158,7 @@ pub async fn filter_authorized_watch_subscriptions(
                 check_failed = true;
                 warn!(
                     owner = %subscription.owner,
-                    path = %permission_path,
+                    path = %subscription.path_prefix,
                     %error,
                     "Watch permission re-check failed closed"
                 );
@@ -116,9 +177,40 @@ pub async fn filter_authorized_watch_subscriptions(
 mod tests {
     use super::*;
     use aruna_core::structs::{WatchEventKind, data_watch_resource_path};
+    use aruna_storage::FjallStorage;
 
     fn node(seed: u8) -> NodeId {
         iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    // Anonymous callers carry a nil user id and own no inbox to deliver into, so
+    // a watch stays a user-plane feature even where the watched resource is
+    // publicly readable. The nil owner is refused before any role is evaluated.
+    #[tokio::test]
+    async fn anonymous_owner_refused() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let context = DriverContext {
+            storage_handle: FjallStorage::open(dir.path().to_str().expect("temp path"))
+                .expect("storage opens"),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        };
+        let realm_id = RealmId([9u8; 32]);
+        let prefix = data_watch_resource_path(Ulid::from_bytes([4u8; 16]), node(3), "bucket", "");
+
+        assert_eq!(
+            is_watch_authorized(
+                &context,
+                realm_id,
+                UserId::nil(realm_id),
+                &prefix,
+                WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+            )
+            .await,
+            Ok(false)
+        );
     }
 
     #[test]

--- a/operations/src/notifications/watch/authorization.rs
+++ b/operations/src/notifications/watch/authorization.rs
@@ -176,29 +176,80 @@ pub async fn filter_authorized_watch_subscriptions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aruna_core::structs::{WatchEventKind, data_watch_resource_path};
+    use aruna_core::effects::StorageEffect;
+    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::keyspaces::AUTH_KEYSPACE;
+    use aruna_core::structs::{
+        Actor, GroupAuthorizationDocument, RealmAuthorizationDocument, WatchEventKind,
+        data_watch_resource_path,
+    };
     use aruna_storage::FjallStorage;
 
     fn node(seed: u8) -> NodeId {
         iroh::SecretKey::from_bytes(&[seed; 32]).public()
     }
 
-    // Anonymous callers carry a nil user id and own no inbox to deliver into, so
-    // a watch stays a user-plane feature even where the watched resource is
-    // publicly readable. The nil owner is refused before any role is evaluated.
+    // A public (Everyone) role granting READ on the watched bucket would let a
+    // nil caller through on the permission path alone. Anonymous callers own no
+    // inbox to deliver into, so the nil-owner guard must still refuse the watch
+    // before any role is evaluated, even where the resource is publicly readable.
     #[tokio::test]
     async fn anonymous_owner_refused() {
         let dir = tempfile::tempdir().expect("temp dir");
+        let storage =
+            FjallStorage::open(dir.path().to_str().expect("temp path")).expect("storage opens");
+        let realm_id = RealmId([9u8; 32]);
+        let owner = UserId::new(Ulid::from_bytes([1u8; 16]), realm_id);
+        let group_id = Ulid::from_bytes([4u8; 16]);
+        let node_id = node(3);
+
+        let actor = Actor {
+            node_id,
+            user_id: owner,
+            realm_id,
+        };
+        let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+        let mut group_auth =
+            GroupAuthorizationDocument::new_default_group_doc(owner, realm_id, group_id);
+        group_auth
+            .roles
+            .values_mut()
+            .find(|role| role.name == "viewer")
+            .expect("viewer role")
+            .assigned_users
+            .insert(UserId::nil(realm_id));
+        for (key, value) in [
+            (
+                realm_id.as_bytes().to_vec(),
+                realm_auth.to_bytes(&actor).unwrap(),
+            ),
+            (
+                group_id.to_bytes().to_vec(),
+                group_auth.to_bytes(&actor).unwrap(),
+            ),
+        ] {
+            match storage
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: AUTH_KEYSPACE.to_string(),
+                    key: key.into(),
+                    value: value.into(),
+                    txn_id: None,
+                })
+                .await
+            {
+                Event::Storage(StorageEvent::WriteResult { .. }) => {}
+                other => panic!("unexpected auth write event: {other:?}"),
+            }
+        }
+
         let context = DriverContext {
-            storage_handle: FjallStorage::open(dir.path().to_str().expect("temp path"))
-                .expect("storage opens"),
+            storage_handle: storage,
             net_handle: None,
             blob_handle: None,
             metadata_handle: None,
             task_handle: None,
         };
-        let realm_id = RealmId([9u8; 32]);
-        let prefix = data_watch_resource_path(Ulid::from_bytes([4u8; 16]), node(3), "bucket", "");
+        let prefix = data_watch_resource_path(group_id, node_id, "bucket", "");
 
         assert_eq!(
             is_watch_authorized(

--- a/operations/src/notifications/watch/emit.rs
+++ b/operations/src/notifications/watch/emit.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 use crate::driver::{DriverContext, drive};
 use crate::get_realm_config::GetRealmConfigOperation;
 use crate::notifications::client::deliver_watch_events_remote;
-use crate::notifications::watch::authorization::filter_authorized_watch_subscriptions;
+use crate::notifications::placement::filter_locally_held_watch_subscriptions;
 use crate::notifications::watch::expand::expand_watch_events;
 use crate::notifications::watch::interest::mark_watch_interest_dirty;
 use crate::notifications::watch::subscriptions::list_realm_watch_subscriptions;
@@ -100,25 +100,18 @@ async fn include_local_holder_from_subscriptions(
     let realm_config = drive(GetRealmConfigOperation::new(event.realm_id), context)
         .await
         .map_err(|error| error.to_string())?;
-    let filtered = filter_authorized_watch_subscriptions(
-        context,
-        event.realm_id,
-        &realm_config,
-        local_node_id,
-        subscriptions,
-    )
-    .await?;
+    let (subscriptions, found_stale) =
+        filter_locally_held_watch_subscriptions(subscriptions, &realm_config, local_node_id)
+            .map_err(|error| error.to_string())?;
     holders.retain(|holder| *holder != local_node_id);
-    if filtered.subscriptions.iter().any(|subscription| {
+    if subscriptions.iter().any(|subscription| {
         subscription.created_at_ms <= event.occurred_at_ms
             && subscription.event_mask.contains(event.kind)
             && event.path.starts_with(subscription.path_prefix.as_str())
     }) {
         holders.push(local_node_id);
     }
-    if filtered.dropped
-        && let Err(error) = mark_watch_interest_dirty(context, event.realm_id).await
-    {
+    if found_stale && let Err(error) = mark_watch_interest_dirty(context, event.realm_id).await {
         warn!(%error, "Failed to mark stale watch interest dirty while emitting event");
     }
     Ok(realm_config)
@@ -131,6 +124,7 @@ mod tests {
     use aruna_core::effects::StorageEffect;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{AUTH_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE};
+    use aruna_core::metrics::NodeMetrics;
     use aruna_core::structs::{
         Actor, GroupAuthorizationDocument, NotificationRecord, RealmAuthorizationDocument,
         RealmConfigDocument, RealmId, RealmNodeKind, WatchEventDetail, WatchEventKind,
@@ -294,6 +288,8 @@ mod tests {
     async fn local_subscription_matches_before_interest_publish() {
         let realm = RealmId([1u8; 32]);
         let (_dir, ctx, net) = ctx_with_net(realm, [84u8; 32]).await;
+        let metrics = NodeMetrics::new();
+        net.notification_watch_metrics().register(&metrics).await;
         let owner = UserId::new(Ulid::r#gen(), realm);
         let group_id = Ulid::from_bytes([3u8; 16]);
         let prefix = data_watch_resource_path(group_id, net.node_id(), "bucket", "");
@@ -325,6 +321,13 @@ mod tests {
             Vec::new(),
             "the local subscription has not needed a published digest"
         );
+
+        install_authorization(&ctx, realm, group_id, UserId::new(Ulid::r#gen(), realm)).await;
+        emit_resource_watch_event(&ctx, upload_event(realm, actor, &event_path)).await;
+        assert_eq!(read_inbox_rows(&ctx).await.len(), 1);
+        assert!(metrics.render().await.contains(
+            "aruna_notification_watch_delivery_suppressions_total{reason=\"permission_denied\"} 1"
+        ));
     }
 
     #[tokio::test]

--- a/operations/src/notifications/watch/expand.rs
+++ b/operations/src/notifications/watch/expand.rs
@@ -5,19 +5,22 @@ use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
     API_STATE_KEYSPACE, AUTH_KEYSPACE, NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE,
 };
+use aruna_core::metrics::WatchAuthorizationMetricReason;
 use aruna_core::structs::{
     NotificationRecord, RealmId, WatchEvent, WatchEventDetail, WatchSubscription,
     watch_subscription_key,
 };
 use aruna_core::types::{Key, KeySpace, TxnId};
+use tracing::warn;
 
 use crate::driver::DriverContext;
 use crate::notifications::inbox::{
     InboxWriteOutcome, UpsertFailure, upsert_inbox_records_in_transaction,
 };
+use crate::notifications::placement::filter_locally_held_watch_subscriptions;
 use crate::notifications::routing::route_watch_event;
 use crate::notifications::watch::authorization::{
-    WatchAuthorization, evaluate_watch_event_authorization, filter_authorized_watch_subscriptions,
+    WatchAuthorization, evaluate_watch_authorization, evaluate_watch_event_authorization,
 };
 use crate::notifications::watch::subscriptions::list_realm_watch_subscriptions;
 
@@ -70,21 +73,15 @@ async fn expand_watch_events_once(
     let subscriptions = list_realm_watch_subscriptions(&context.storage_handle, realm_id)
         .await
         .map_err(|error| UpsertFailure::Fatal(error.to_string()))?;
-    let filtered = filter_authorized_watch_subscriptions(
-        context,
-        realm_id,
-        realm_config,
-        local_node_id,
-        subscriptions,
-    )
-    .await
-    .map_err(UpsertFailure::Fatal)?;
-    if filtered.subscriptions.is_empty() {
-        return Ok((InboxWriteOutcome::default(), filtered.dropped));
+    let (subscriptions, found_stale) =
+        filter_locally_held_watch_subscriptions(subscriptions, realm_config, local_node_id)
+            .map_err(|error| UpsertFailure::Fatal(error.to_string()))?;
+    if subscriptions.is_empty() {
+        return Ok((InboxWriteOutcome::default(), found_stale));
     }
     let mut candidates = Vec::new();
     for event in events {
-        for subscription in &filtered.subscriptions {
+        for subscription in &subscriptions {
             let routed = route_watch_event(event, std::slice::from_ref(subscription));
             if !routed.is_empty() {
                 candidates.push((subscription, event, routed));
@@ -92,29 +89,29 @@ async fn expand_watch_events_once(
         }
     }
     if candidates.is_empty() {
-        return Ok((InboxWriteOutcome::default(), filtered.dropped));
+        return Ok((InboxWriteOutcome::default(), found_stale));
     }
 
     let txn_id = start_write_transaction(context).await?;
-    let outcome = match stage_watch_expansion(context, realm_id, txn_id, candidates).await {
+    let (outcome, denied) = match stage_watch_expansion(context, realm_id, txn_id, candidates).await
+    {
         Ok(outcome) => outcome,
         Err(error) => {
             abort_transaction(context, txn_id).await;
             return Err(error);
         }
     };
+    let dropped = found_stale || denied;
     if outcome.written == 0 {
         abort_transaction(context, txn_id).await;
-        return Ok((outcome, filtered.dropped));
+        return Ok((outcome, dropped));
     }
     match context
         .storage_handle
         .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
         .await
     {
-        Event::Storage(StorageEvent::TransactionCommitted { .. }) => {
-            Ok((outcome, filtered.dropped))
-        }
+        Event::Storage(StorageEvent::TransactionCommitted { .. }) => Ok((outcome, dropped)),
         Event::Storage(StorageEvent::Error { error }) => Err(classify_storage_error(error)),
         other => Err(UpsertFailure::Fatal(format!(
             "unexpected storage event: {other:?}"
@@ -127,7 +124,7 @@ async fn stage_watch_expansion(
     realm_id: RealmId,
     txn_id: TxnId,
     candidates: Vec<WatchCandidate<'_>>,
-) -> Result<InboxWriteOutcome, UpsertFailure> {
+) -> Result<(InboxWriteOutcome, bool), UpsertFailure> {
     let mut subscriptions = Vec::new();
     for (subscription, _, _) in &candidates {
         if !subscriptions
@@ -205,7 +202,32 @@ async fn stage_watch_expansion(
     }
 
     let mut records = Vec::new();
+    let mut dropped = false;
     for (subscription, event, routed) in candidates {
+        match evaluate_watch_authorization(
+            context,
+            realm_id,
+            subscription.owner,
+            &subscription.path_prefix,
+            subscription.event_mask,
+            &subscription.authorization,
+        )
+        .await
+        {
+            Ok(WatchAuthorization::Authorized) => {}
+            Ok(WatchAuthorization::Denied(reason)) => {
+                record_delivery_suppression(context, reason.metric_reason());
+                dropped = true;
+                continue;
+            }
+            Ok(WatchAuthorization::Unavailable(error)) | Err(error) => {
+                record_delivery_suppression(
+                    context,
+                    WatchAuthorizationMetricReason::AuthorizationUnavailable,
+                );
+                return Err(UpsertFailure::Fatal(error));
+            }
+        }
         match evaluate_watch_event_authorization(
             context,
             subscription.owner,
@@ -213,17 +235,26 @@ async fn stage_watch_expansion(
             event,
         )
         .await
-        .map_err(UpsertFailure::Fatal)?
         {
-            WatchAuthorization::Authorized => records.extend(routed),
-            WatchAuthorization::Denied(_) => {}
-            WatchAuthorization::Unavailable(error) => return Err(UpsertFailure::Fatal(error)),
+            Ok(WatchAuthorization::Authorized) => records.extend(routed),
+            Ok(WatchAuthorization::Denied(reason)) => {
+                record_delivery_suppression(context, reason.metric_reason());
+            }
+            Ok(WatchAuthorization::Unavailable(error)) | Err(error) => {
+                record_delivery_suppression(
+                    context,
+                    WatchAuthorizationMetricReason::AuthorizationUnavailable,
+                );
+                return Err(UpsertFailure::Fatal(error));
+            }
         }
     }
     if records.is_empty() {
-        return Ok(InboxWriteOutcome::default());
+        return Ok((InboxWriteOutcome::default(), dropped));
     }
-    upsert_inbox_records_in_transaction(&context.storage_handle, &records, txn_id).await
+    upsert_inbox_records_in_transaction(&context.storage_handle, &records, txn_id)
+        .await
+        .map(|outcome| (outcome, dropped))
 }
 
 async fn start_write_transaction(context: &DriverContext) -> Result<TxnId, UpsertFailure> {
@@ -253,6 +284,19 @@ async fn abort_transaction(context: &DriverContext, txn_id: TxnId) {
         .storage_handle
         .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
         .await;
+}
+
+fn record_delivery_suppression(context: &DriverContext, reason: WatchAuthorizationMetricReason) {
+    if let Some(net_handle) = context.net_handle.as_ref() {
+        net_handle
+            .notification_watch_metrics()
+            .record_delivery_suppression(reason);
+    }
+    warn!(
+        parent: None,
+        reason = reason.as_str(),
+        "Notification watch delivery suppressed"
+    );
 }
 
 #[cfg(test)]
@@ -536,7 +580,7 @@ mod tests {
         )
         .await
         .expect("stage authorized event");
-        assert_eq!(staged.written, 1);
+        assert_eq!(staged.0.written, 1);
 
         let replacement =
             GroupAuthorizationDocument::new_default_group_doc(replacement_owner, realm, group_id);

--- a/operations/src/notifications/watch/expand.rs
+++ b/operations/src/notifications/watch/expand.rs
@@ -1,7 +1,20 @@
-use aruna_core::structs::{RealmId, WatchEvent};
+use aruna_core::auth::TOKEN_REVOCATION_LIST_KEY;
+use aruna_core::effects::StorageEffect;
+use aruna_core::errors::StorageError;
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::{
+    API_STATE_KEYSPACE, AUTH_KEYSPACE, NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE,
+};
+use aruna_core::structs::{
+    NotificationRecord, RealmId, WatchEvent, WatchEventDetail, WatchSubscription,
+    watch_subscription_key,
+};
+use aruna_core::types::{Key, KeySpace, TxnId};
 
 use crate::driver::DriverContext;
-use crate::notifications::inbox::{InboxWriteOutcome, upsert_inbox_records_reporting};
+use crate::notifications::inbox::{
+    InboxWriteOutcome, UpsertFailure, upsert_inbox_records_in_transaction,
+};
 use crate::notifications::routing::route_watch_event;
 use crate::notifications::watch::authorization::{
     WatchAuthorization, evaluate_watch_event_authorization, filter_authorized_watch_subscriptions,
@@ -27,9 +40,36 @@ pub async fn expand_watch_events(
     if events.is_empty() {
         return Ok((InboxWriteOutcome::default(), false));
     }
+    for attempt in 0..2 {
+        match expand_watch_events_once(context, realm_id, realm_config, local_node_id, events).await
+        {
+            Ok(outcome) => return Ok(outcome),
+            Err(UpsertFailure::Conflict) if attempt == 0 => {}
+            Err(UpsertFailure::Conflict) => {
+                return Err("watch event expansion conflicted twice".to_string());
+            }
+            Err(UpsertFailure::Fatal(error)) => return Err(error),
+        }
+    }
+    unreachable!()
+}
+
+type WatchCandidate<'a> = (
+    &'a WatchSubscription,
+    &'a WatchEvent,
+    Vec<NotificationRecord>,
+);
+
+async fn expand_watch_events_once(
+    context: &DriverContext,
+    realm_id: RealmId,
+    realm_config: &aruna_core::structs::RealmConfigDocument,
+    local_node_id: aruna_core::NodeId,
+    events: &[WatchEvent],
+) -> Result<(InboxWriteOutcome, bool), UpsertFailure> {
     let subscriptions = list_realm_watch_subscriptions(&context.storage_handle, realm_id)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| UpsertFailure::Fatal(error.to_string()))?;
     let filtered = filter_authorized_watch_subscriptions(
         context,
         realm_id,
@@ -37,34 +77,182 @@ pub async fn expand_watch_events(
         local_node_id,
         subscriptions,
     )
-    .await?;
+    .await
+    .map_err(UpsertFailure::Fatal)?;
     if filtered.subscriptions.is_empty() {
         return Ok((InboxWriteOutcome::default(), filtered.dropped));
     }
-    let mut records = Vec::new();
+    let mut candidates = Vec::new();
     for event in events {
         for subscription in &filtered.subscriptions {
             let routed = route_watch_event(event, std::slice::from_ref(subscription));
-            if routed.is_empty() {
-                continue;
-            }
-            match evaluate_watch_event_authorization(
-                context,
-                subscription.owner,
-                &subscription.authorization,
-                event,
-            )
-            .await?
-            {
-                WatchAuthorization::Authorized => records.extend(routed),
-                WatchAuthorization::Denied(_) => {}
-                WatchAuthorization::Unavailable(error) => return Err(error),
+            if !routed.is_empty() {
+                candidates.push((subscription, event, routed));
             }
         }
     }
-    upsert_inbox_records_reporting(&context.storage_handle, &records)
+    if candidates.is_empty() {
+        return Ok((InboxWriteOutcome::default(), filtered.dropped));
+    }
+
+    let txn_id = start_write_transaction(context).await?;
+    let outcome = match stage_watch_expansion(context, realm_id, txn_id, candidates).await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            abort_transaction(context, txn_id).await;
+            return Err(error);
+        }
+    };
+    if outcome.written == 0 {
+        abort_transaction(context, txn_id).await;
+        return Ok((outcome, filtered.dropped));
+    }
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
         .await
-        .map(|outcome| (outcome, filtered.dropped))
+    {
+        Event::Storage(StorageEvent::TransactionCommitted { .. }) => {
+            Ok((outcome, filtered.dropped))
+        }
+        Event::Storage(StorageEvent::Error { error }) => Err(classify_storage_error(error)),
+        other => Err(UpsertFailure::Fatal(format!(
+            "unexpected storage event: {other:?}"
+        ))),
+    }
+}
+
+async fn stage_watch_expansion(
+    context: &DriverContext,
+    realm_id: RealmId,
+    txn_id: TxnId,
+    candidates: Vec<WatchCandidate<'_>>,
+) -> Result<InboxWriteOutcome, UpsertFailure> {
+    let mut subscriptions = Vec::new();
+    for (subscription, _, _) in &candidates {
+        if !subscriptions
+            .iter()
+            .any(|current: &&WatchSubscription| current.watch_id == subscription.watch_id)
+        {
+            subscriptions.push(*subscription);
+        }
+    }
+    let mut reads: Vec<(KeySpace, Key)> = subscriptions
+        .iter()
+        .map(|subscription| {
+            (
+                NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE.to_string(),
+                watch_subscription_key(subscription.owner, subscription.watch_id),
+            )
+        })
+        .collect();
+    let subscription_count = reads.len();
+    reads.push((
+        AUTH_KEYSPACE.to_string(),
+        realm_id.as_bytes().to_vec().into(),
+    ));
+    for (_, event, _) in &candidates {
+        let group_id = match &event.detail {
+            WatchEventDetail::MetadataCreated { group_id, .. }
+            | WatchEventDetail::DataUploaded { group_id, .. } => *group_id,
+        };
+        let key: Key = group_id.to_bytes().to_vec().into();
+        if !reads
+            .iter()
+            .any(|(key_space, current)| key_space == AUTH_KEYSPACE && current == &key)
+        {
+            reads.push((AUTH_KEYSPACE.to_string(), key));
+        }
+    }
+    reads.push((
+        API_STATE_KEYSPACE.to_string(),
+        TOKEN_REVOCATION_LIST_KEY.into(),
+    ));
+    let expected_count = reads.len();
+    let guarded = match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::BatchRead {
+            reads,
+            txn_id: Some(txn_id),
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchReadResult { values }) => values,
+        Event::Storage(StorageEvent::Error { error }) => {
+            return Err(classify_storage_error(error));
+        }
+        other => {
+            return Err(UpsertFailure::Fatal(format!(
+                "unexpected storage event: {other:?}"
+            )));
+        }
+    };
+    if guarded.len() != expected_count {
+        return Err(UpsertFailure::Fatal(
+            "watch authorization guard returned the wrong result count".to_string(),
+        ));
+    }
+    for (subscription, (_, stored)) in subscriptions
+        .iter()
+        .zip(guarded.into_iter().take(subscription_count))
+    {
+        let expected = subscription
+            .to_bytes()
+            .map_err(|error| UpsertFailure::Fatal(error.to_string()))?;
+        if stored.as_deref() != Some(expected.as_slice()) {
+            return Err(UpsertFailure::Conflict);
+        }
+    }
+
+    let mut records = Vec::new();
+    for (subscription, event, routed) in candidates {
+        match evaluate_watch_event_authorization(
+            context,
+            subscription.owner,
+            &subscription.authorization,
+            event,
+        )
+        .await
+        .map_err(UpsertFailure::Fatal)?
+        {
+            WatchAuthorization::Authorized => records.extend(routed),
+            WatchAuthorization::Denied(_) => {}
+            WatchAuthorization::Unavailable(error) => return Err(UpsertFailure::Fatal(error)),
+        }
+    }
+    if records.is_empty() {
+        return Ok(InboxWriteOutcome::default());
+    }
+    upsert_inbox_records_in_transaction(&context.storage_handle, &records, txn_id).await
+}
+
+async fn start_write_transaction(context: &DriverContext) -> Result<TxnId, UpsertFailure> {
+    match context
+        .storage_handle
+        .send_storage_effect(StorageEffect::StartTransaction { read: false })
+        .await
+    {
+        Event::Storage(StorageEvent::TransactionStarted { txn_id }) => Ok(txn_id),
+        Event::Storage(StorageEvent::Error { error }) => Err(classify_storage_error(error)),
+        other => Err(UpsertFailure::Fatal(format!(
+            "unexpected storage event: {other:?}"
+        ))),
+    }
+}
+
+fn classify_storage_error(error: StorageError) -> UpsertFailure {
+    if matches!(error, StorageError::TransactionConflict) {
+        UpsertFailure::Conflict
+    } else {
+        UpsertFailure::Fatal(error.to_string())
+    }
+}
+
+async fn abort_transaction(context: &DriverContext, txn_id: TxnId) {
+    let _ = context
+        .storage_handle
+        .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
+        .await;
 }
 
 #[cfg(test)]
@@ -303,7 +491,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn expansion_stops_after_bucket_read_is_revoked() {
+    async fn concurrent_revocation_prevents_watch_delivery_commit() {
         let (_dir, context) = temp_context();
         let realm = RealmId([2u8; 32]);
         let (local_node_id, config) = local_config(realm);
@@ -312,7 +500,7 @@ mod tests {
         let replacement_owner = user(realm, 3);
         let group_id = Ulid::from_bytes([4u8; 16]);
         install_authorization(&context, realm, local_node_id, group_id, owner).await;
-        create_watch_subscription(
+        let subscription = create_watch_subscription(
             &context.storage_handle,
             owner,
             data_watch_resource_path(group_id, local_node_id, "bucket", ""),
@@ -334,6 +522,22 @@ mod tests {
         .expect("first delivery");
         assert_eq!(first.0.written, 1);
 
+        let mut second_event = first_event;
+        second_event.event_id = Ulid::from_bytes([8u8; 16]);
+        let txn_id = start_write_transaction(&context)
+            .await
+            .expect("start transaction");
+        let routed = route_watch_event(&second_event, std::slice::from_ref(&subscription));
+        let staged = stage_watch_expansion(
+            &context,
+            realm,
+            txn_id,
+            vec![(&subscription, &second_event, routed)],
+        )
+        .await
+        .expect("stage authorized event");
+        assert_eq!(staged.written, 1);
+
         let replacement =
             GroupAuthorizationDocument::new_default_group_doc(replacement_owner, realm, group_id);
         let actor_record = Actor {
@@ -353,9 +557,17 @@ mod tests {
                 .await,
             Event::Storage(StorageEvent::WriteResult { .. })
         ));
+        assert!(matches!(
+            context
+                .storage_handle
+                .send_storage_effect(StorageEffect::CommitTransaction { txn_id })
+                .await,
+            Event::Storage(StorageEvent::Error {
+                error: StorageError::TransactionConflict
+            })
+        ));
+        assert_eq!(count_inbox(&context.storage_handle).await, 1);
 
-        let mut second_event = first_event;
-        second_event.event_id = Ulid::from_bytes([8u8; 16]);
         let second = expand_watch_events(&context, realm, &config, local_node_id, &[second_event])
             .await
             .expect("revoked delivery fails closed");

--- a/operations/src/notifications/watch/expand.rs
+++ b/operations/src/notifications/watch/expand.rs
@@ -3,7 +3,9 @@ use aruna_core::structs::{RealmId, WatchEvent};
 use crate::driver::DriverContext;
 use crate::notifications::inbox::{InboxWriteOutcome, upsert_inbox_records_reporting};
 use crate::notifications::routing::route_watch_event;
-use crate::notifications::watch::authorization::filter_authorized_watch_subscriptions;
+use crate::notifications::watch::authorization::{
+    WatchAuthorization, evaluate_watch_event_authorization, filter_authorized_watch_subscriptions,
+};
 use crate::notifications::watch::subscriptions::list_realm_watch_subscriptions;
 
 /// Holder-side expansion of origin watch events into inbox records. Scans every
@@ -41,7 +43,24 @@ pub async fn expand_watch_events(
     }
     let mut records = Vec::new();
     for event in events {
-        records.extend(route_watch_event(event, &filtered.subscriptions));
+        for subscription in &filtered.subscriptions {
+            let routed = route_watch_event(event, std::slice::from_ref(subscription));
+            if routed.is_empty() {
+                continue;
+            }
+            match evaluate_watch_event_authorization(
+                context,
+                subscription.owner,
+                &subscription.authorization,
+                event,
+            )
+            .await?
+            {
+                WatchAuthorization::Authorized => records.extend(routed),
+                WatchAuthorization::Denied(_) => {}
+                WatchAuthorization::Unavailable(error) => return Err(error),
+            }
+        }
     }
     upsert_inbox_records_reporting(&context.storage_handle, &records)
         .await
@@ -55,8 +74,9 @@ mod tests {
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{AUTH_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE};
     use aruna_core::structs::{
-        Actor, GroupAuthorizationDocument, RealmAuthorizationDocument, RealmConfigDocument,
-        RealmNodeKind, WatchEventDetail, WatchEventKind, WatchEventMask, data_watch_resource_path,
+        Actor, GroupAuthorizationDocument, Permission, RealmAuthorizationDocument,
+        RealmConfigDocument, RealmNodeKind, WatchEventDetail, WatchEventKind, WatchEventMask,
+        blob_object_permission_path, data_watch_resource_path,
     };
     use aruna_core::types::UserId;
     use aruna_storage::{FjallStorage, StorageHandle};
@@ -218,6 +238,67 @@ mod tests {
                 .expect("no subscriptions"),
             (InboxWriteOutcome::default(), false)
         );
+        assert_eq!(count_inbox(&context.storage_handle).await, 0);
+    }
+
+    #[tokio::test]
+    async fn exact_event_deny_suppresses_nested_object() {
+        let (_dir, context) = temp_context();
+        let realm = RealmId([4u8; 32]);
+        let (local_node_id, config) = local_config(realm);
+        let owner = user(realm, 1);
+        let actor = user(realm, 2);
+        let group_id = Ulid::from_bytes([6u8; 16]);
+        install_authorization(&context, realm, local_node_id, group_id, owner).await;
+        create_watch_subscription(
+            &context.storage_handle,
+            owner,
+            data_watch_resource_path(group_id, local_node_id, "bucket", ""),
+            WatchEventMask::from_kinds([WatchEventKind::DataUploaded]),
+            1,
+        )
+        .await
+        .expect("create");
+
+        let mut group = GroupAuthorizationDocument::new_default_group_doc(owner, realm, group_id);
+        group
+            .roles
+            .values_mut()
+            .find(|role| role.name == "admin")
+            .expect("admin role")
+            .permissions
+            .insert(
+                blob_object_permission_path(realm, group_id, local_node_id, "bucket", "object"),
+                Permission::DENY,
+            );
+        let actor_record = Actor {
+            node_id: local_node_id,
+            user_id: owner,
+            realm_id: realm,
+        };
+        assert!(matches!(
+            context
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: AUTH_KEYSPACE.to_string(),
+                    key: group_id.to_bytes().to_vec().into(),
+                    value: group.to_bytes(&actor_record).unwrap().into(),
+                    txn_id: None,
+                })
+                .await,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+
+        let outcome = expand_watch_events(
+            &context,
+            realm,
+            &config,
+            local_node_id,
+            &[upload_event(realm, actor, group_id, local_node_id)],
+        )
+        .await
+        .expect("denied event is suppressed");
+        assert_eq!(outcome.0.written, 0);
         assert_eq!(count_inbox(&context.storage_handle).await, 0);
     }
 

--- a/operations/src/notifications/watch/interest.rs
+++ b/operations/src/notifications/watch/interest.rs
@@ -7,18 +7,15 @@ use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::errors::StorageError;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
-use aruna_core::keyspaces::{
-    NOTIFICATION_WATCH_INTEREST_KEYSPACE, NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE,
-    REALM_CONFIG_KEYSPACE,
-};
+use aruna_core::keyspaces::{NOTIFICATION_WATCH_INTEREST_KEYSPACE, REALM_CONFIG_KEYSPACE};
 use aruna_core::structs::{
     RealmConfigDocument, RealmId, WATCH_INTEREST_DIRTY_PREFIX, WatchInterestDigest,
-    WatchInterestEntry, WatchInterestTable, WatchSubscription, watch_interest_dirty_key,
+    WatchInterestEntry, WatchInterestTable, watch_interest_dirty_key,
     watch_interest_dirty_realm_id, watch_interest_key_node_id, watch_interest_key_realm_id,
     watch_interest_node_key, watch_interest_node_prefix, watch_interest_realm_prefix,
 };
 use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
-use aruna_core::types::{Key, KeySpace, UserId, Value};
+use aruna_core::types::{Key, KeySpace, Value};
 use aruna_storage::StorageHandle;
 use aruna_tasks::TaskHandle;
 use byteview::ByteView;
@@ -28,6 +25,7 @@ use ulid::Ulid;
 use crate::driver::{DriverContext, drive};
 use crate::get_realm_config::GetRealmConfigOperation;
 use crate::notifications::watch::authorization::filter_authorized_watch_subscriptions;
+use crate::notifications::watch::subscriptions::list_realm_watch_subscriptions;
 use crate::replicate_documents::{ReplicateDocumentsConfig, ReplicateDocumentsOperation};
 
 /// Debounce window for the coalesced watch-interest publisher. `ShortenTimer`
@@ -251,18 +249,9 @@ async fn build_realm_digest(
     realm_id: RealmId,
     realm_config: &RealmConfigDocument,
 ) -> Result<(WatchInterestDigest, bool), String> {
-    let entries = iter_all(
-        &ctx.storage_handle,
-        NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE,
-        Some(UserId::storage_prefix(realm_id)),
-    )
-    .await?;
-    let mut subscriptions = Vec::with_capacity(entries.len());
-    for (_, value) in entries {
-        subscriptions.push(
-            WatchSubscription::from_bytes(value.as_ref()).map_err(|error| error.to_string())?,
-        );
-    }
+    let subscriptions = list_realm_watch_subscriptions(&ctx.storage_handle, realm_id)
+        .await
+        .map_err(|error| error.to_string())?;
     let filtered =
         filter_authorized_watch_subscriptions(ctx, realm_id, realm_config, node_id, subscriptions)
             .await?;
@@ -642,6 +631,7 @@ mod tests {
         Actor, GroupAuthorizationDocument, RealmAuthorizationDocument, RealmId, RealmNodeKind,
         WatchEventKind, WatchEventMask, WatchInterestEntry,
     };
+    use aruna_core::types::UserId;
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
     use aruna_storage::FjallStorage;
     use tempfile::{TempDir, tempdir};

--- a/operations/src/notifications/watch/interest.rs
+++ b/operations/src/notifications/watch/interest.rs
@@ -498,6 +498,12 @@ pub async fn refresh_watch_interest_for_targets(
             DocumentSyncTarget::WatchSubscription { owner, .. } => {
                 dirty_realms.insert(owner.realm_id);
             }
+            DocumentSyncTarget::GroupAuthorization { .. } => {
+                dirty_realms.insert(*net_handle.realm_id());
+            }
+            DocumentSyncTarget::RealmAuthorization { realm_id } => {
+                dirty_realms.insert(*realm_id);
+            }
             DocumentSyncTarget::RealmConfig { realm_id } => {
                 realms.insert(*realm_id);
                 dirty_realms.insert(*realm_id);
@@ -1101,6 +1107,65 @@ mod tests {
             vec![holder]
         );
         assert_eq!(table.nodes(realm_id).map(|nodes| nodes.len()), Some(1));
+    }
+
+    // A consumed empty digest must be re-dirtied by group authorization
+    // reconciliation so a later READ grant restores remote interest.
+    #[tokio::test]
+    async fn regrant_restores_digest() {
+        let realm_id = RealmId([6u8; 32]);
+        let (_dir, ctx, net) = ctx_with_net(realm_id, [72u8; 32]).await;
+        let node_id = net.node_id();
+        install_realm_config(&ctx, realm_id, &[node_id]).await;
+        let group_id = Ulid::r#gen();
+        let auth_owner = user(6, 3);
+        let watch_owner = user(6, 2);
+        let prefix = metadata_prefix(group_id, "a");
+        install_authorization(&ctx, realm_id, node_id, group_id, auth_owner, &[]).await;
+        create_watch_subscription(&ctx.storage_handle, watch_owner, prefix.clone(), mask(), 1)
+            .await
+            .expect("create");
+
+        assert!(
+            publish_watch_interest(&ctx, node_id)
+                .await
+                .expect("publish")
+        );
+        assert!(
+            read_digest(&ctx, realm_id, node_id)
+                .await
+                .expect("empty digest")
+                .entries
+                .is_empty()
+        );
+        assert!(read_marker(&ctx, realm_id).await.is_none());
+
+        install_authorization(
+            &ctx,
+            realm_id,
+            node_id,
+            group_id,
+            auth_owner,
+            &[watch_owner],
+        )
+        .await;
+        refresh_watch_interest_for_targets(
+            &ctx,
+            &[DocumentSyncTarget::GroupAuthorization { group_id }],
+        )
+        .await;
+
+        assert!(read_marker(&ctx, realm_id).await.is_some());
+        assert!(
+            publish_watch_interest(&ctx, node_id)
+                .await
+                .expect("republish")
+        );
+        let digest = read_digest(&ctx, realm_id, node_id)
+            .await
+            .expect("restored digest");
+        assert_eq!(digest.entries.len(), 1);
+        assert_eq!(digest.entries[0].path_prefix, prefix);
     }
 
     #[tokio::test]

--- a/operations/src/notifications/watch/interest.rs
+++ b/operations/src/notifications/watch/interest.rs
@@ -12,7 +12,8 @@ use aruna_core::structs::{
     RealmConfigDocument, RealmId, WATCH_INTEREST_DIRTY_PREFIX, WatchInterestDigest,
     WatchInterestEntry, WatchInterestTable, watch_interest_dirty_key,
     watch_interest_dirty_realm_id, watch_interest_key_node_id, watch_interest_key_realm_id,
-    watch_interest_node_key, watch_interest_node_prefix, watch_interest_realm_prefix,
+    watch_interest_node_key, watch_interest_node_prefix, watch_interest_pending_key,
+    watch_interest_realm_prefix,
 };
 use aruna_core::task::{TaskEffect, TaskEvent, TaskKey};
 use aruna_core::types::{Key, KeySpace, Value};
@@ -179,7 +180,7 @@ pub async fn publish_watch_interest(ctx: &DriverContext, node_id: NodeId) -> Res
         return Ok(false);
     }
 
-    let mut writes: Vec<(KeySpace, Key, Value)> = Vec::with_capacity(realms.len());
+    let mut writes: Vec<(KeySpace, Key, Value)> = Vec::with_capacity(realms.len() * 2);
     let mut targets: Vec<(RealmId, DocumentSyncTarget)> = Vec::with_capacity(realms.len());
     let mut authorization_retries = Vec::new();
     for realm_id in &realms {
@@ -191,11 +192,48 @@ pub async fn publish_watch_interest(ctx: &DriverContext, node_id: NodeId) -> Res
         if check_failed {
             authorization_retries.push(*realm_id);
         }
-        writes.push((
-            NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
-            Key::from(watch_interest_node_key(*realm_id, node_id)),
-            Value::from(digest.to_bytes().map_err(|e| e.to_string())?),
-        ));
+        let digest_key = Key::from(watch_interest_node_key(*realm_id, node_id));
+        let pending_key = Key::from(watch_interest_pending_key(*realm_id));
+        let digest_value = Value::from(digest.to_bytes().map_err(|e| e.to_string())?);
+        let current = match storage
+            .send_storage_effect(StorageEffect::BatchRead {
+                reads: vec![
+                    (
+                        NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
+                        digest_key.clone(),
+                    ),
+                    (
+                        NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
+                        pending_key.clone(),
+                    ),
+                ],
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::BatchReadResult { values }) => values,
+            Event::Storage(StorageEvent::Error { error }) => return Err(error.to_string()),
+            other => return Err(format!("watch interest digest read failed: {other:?}")),
+        };
+        let [(_, current_digest), (_, pending)] = current.as_slice() else {
+            return Err("watch interest digest read count mismatch".to_string());
+        };
+        let changed = current_digest.as_ref() != Some(&digest_value);
+        if !changed && pending.is_none() {
+            continue;
+        }
+        if changed {
+            writes.push((
+                NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
+                digest_key,
+                digest_value,
+            ));
+            writes.push((
+                NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
+                pending_key,
+                Value::from(Vec::new()),
+            ));
+        }
         targets.push((
             *realm_id,
             DocumentSyncTarget::WatchInterest {
@@ -205,11 +243,12 @@ pub async fn publish_watch_interest(ctx: &DriverContext, node_id: NodeId) -> Res
         ));
     }
 
-    // Persist the refreshed digests but keep the dirty markers until the
-    // documents have been durably handed to replication.
+    // Persist changed digests with pending markers, but keep the dirty markers
+    // until the documents have been durably handed to replication.
     write_documents(storage, writes).await?;
 
     // Each realm rides its own realm-scoped topic, so replicate per realm.
+    let published = !targets.is_empty();
     for (realm_id, target) in targets {
         drive(
             ReplicateDocumentsOperation::new(ReplicateDocumentsConfig {
@@ -225,6 +264,22 @@ pub async fn publish_watch_interest(ctx: &DriverContext, node_id: NodeId) -> Res
         )
         .await
         .map_err(|error| format!("watch interest replication failed: {error}"))?;
+        match storage
+            .send_storage_effect(StorageEffect::Delete {
+                key_space: NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
+                key: Key::from(watch_interest_pending_key(realm_id)),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::DeleteResult { .. }) => {}
+            Event::Storage(StorageEvent::Error { error }) => return Err(error.to_string()),
+            other => {
+                return Err(format!(
+                    "watch interest pending marker delete failed: {other:?}"
+                ));
+            }
+        }
     }
 
     // Preserve a retry generation when a permission lookup failed. The current
@@ -237,7 +292,7 @@ pub async fn publish_watch_interest(ctx: &DriverContext, node_id: NodeId) -> Res
     // those a concurrent CRUD did not re-dirty in the meantime.
     clear_consumed_markers(storage, observed_markers).await?;
 
-    Ok(true)
+    Ok(published)
 }
 
 /// Builds this node's digest for one realm from subscriptions whose owners are
@@ -267,8 +322,7 @@ async fn build_realm_digest(
     ))
 }
 
-/// Persists the refreshed digest documents. Each digest key has a single writer
-/// (this node), so a plain batch write is enough.
+/// Persists changed digests and their pending markers atomically.
 async fn write_documents(
     storage: &StorageHandle,
     writes: Vec<(KeySpace, Key, Value)>,
@@ -820,6 +874,21 @@ mod tests {
         }
     }
 
+    async fn read_pending(ctx: &DriverContext, realm_id: RealmId) -> Option<Value> {
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Read {
+                key_space: NOTIFICATION_WATCH_INTEREST_KEYSPACE.to_string(),
+                key: Key::from(watch_interest_pending_key(realm_id)),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::ReadResult { value, .. }) => value,
+            other => panic!("unexpected pending marker read event: {other:?}"),
+        }
+    }
+
     async fn read_digest(
         ctx: &DriverContext,
         realm_id: RealmId,
@@ -922,6 +991,106 @@ mod tests {
                 .await
                 .expect("republish")
         );
+    }
+
+    // An acknowledged unchanged digest consumes a fresh dirty marker without
+    // another replication handoff.
+    #[tokio::test]
+    async fn unchanged_skips_publish() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let realm_id = RealmId([7u8; 32]);
+        let node_id = node(5);
+        let owner = user(7, 2);
+        let group_id = Ulid::r#gen();
+        install_realm_config(&ctx, realm_id, &[node_id]).await;
+        install_authorization(&ctx, realm_id, node_id, group_id, owner, &[]).await;
+        create_watch_subscription(
+            &ctx.storage_handle,
+            owner,
+            metadata_prefix(group_id, "a"),
+            mask(),
+            1,
+        )
+        .await
+        .expect("create");
+
+        assert!(
+            publish_watch_interest(&ctx, node_id)
+                .await
+                .expect("publish")
+        );
+        let before = read_digest(&ctx, realm_id, node_id)
+            .await
+            .expect("digest")
+            .to_bytes()
+            .unwrap();
+        assert!(read_pending(&ctx, realm_id).await.is_none());
+
+        mark_watch_interest_dirty(&ctx, realm_id)
+            .await
+            .expect("mark dirty");
+        assert!(
+            !publish_watch_interest(&ctx, node_id)
+                .await
+                .expect("republish")
+        );
+
+        let after = read_digest(&ctx, realm_id, node_id)
+            .await
+            .expect("digest")
+            .to_bytes()
+            .unwrap();
+        assert_eq!(after, before);
+        assert!(read_marker(&ctx, realm_id).await.is_none());
+        assert!(read_pending(&ctx, realm_id).await.is_none());
+    }
+
+    // Persistent authorization unavailability retains retries while identical
+    // empty digests stop producing replicated events.
+    #[tokio::test]
+    async fn retry_stays_dirty() {
+        let temp = tempdir().unwrap();
+        let ctx = test_ctx(temp.path().to_str().unwrap());
+        let realm_id = RealmId([8u8; 32]);
+        let node_id = node(6);
+        let owner = user(8, 2);
+        let group_id = Ulid::r#gen();
+        install_realm_config(&ctx, realm_id, &[node_id]).await;
+        create_watch_subscription(
+            &ctx.storage_handle,
+            owner,
+            metadata_prefix(group_id, "a"),
+            mask(),
+            1,
+        )
+        .await
+        .expect("create");
+
+        assert!(
+            publish_watch_interest(&ctx, node_id)
+                .await
+                .expect("publish")
+        );
+        assert!(read_marker(&ctx, realm_id).await.is_some());
+        let digest = read_digest(&ctx, realm_id, node_id)
+            .await
+            .expect("empty digest");
+        assert!(digest.entries.is_empty());
+        let before = digest.to_bytes().unwrap();
+
+        assert!(
+            !publish_watch_interest(&ctx, node_id)
+                .await
+                .expect("republish")
+        );
+        let after = read_digest(&ctx, realm_id, node_id)
+            .await
+            .expect("empty digest")
+            .to_bytes()
+            .unwrap();
+        assert_eq!(after, before);
+        assert!(read_marker(&ctx, realm_id).await.is_some());
     }
 
     #[tokio::test]

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -13,7 +13,8 @@ use aruna_core::storage_entries::{
 };
 use aruna_core::structs::{
     NOTIFICATION_WATCH_MAX_PREFIX_LEN, NOTIFICATION_WATCH_PER_USER_CAP, PlacementRef, RealmId,
-    WatchEventMask, WatchSubscription, parse_watch_subscription_key, watch_subscription_prefix,
+    WatchAuthorizationBinding, WatchEventMask, WatchSubscription, parse_watch_subscription_key,
+    watch_subscription_prefix,
 };
 use aruna_core::types::{TxnId, UserId};
 use aruna_storage::StorageHandle;
@@ -79,7 +80,13 @@ pub async fn create_watch_subscription(
     event_mask: WatchEventMask,
     now_ms: u64,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
-    let subscription = validated_subscription(owner, path_prefix, event_mask, now_ms)?;
+    let subscription = validated_subscription(
+        owner,
+        path_prefix,
+        event_mask,
+        now_ms,
+        WatchAuthorizationBinding::default(),
+    )?;
     create_subscription(storage, subscription, None).await
 }
 
@@ -93,15 +100,18 @@ pub async fn create_replicated_watch_subscription(
     owner: UserId,
     path_prefix: String,
     event_mask: WatchEventMask,
+    authorization: WatchAuthorizationBinding,
     now_ms: u64,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
-    let subscription = validated_subscription(owner, path_prefix, event_mask, now_ms)?;
+    let subscription =
+        validated_subscription(owner, path_prefix, event_mask, now_ms, authorization)?;
     if !is_watch_authorized(
         context,
         owner.realm_id,
         owner,
         &subscription.path_prefix,
         subscription.event_mask,
+        &subscription.authorization,
     )
     .await
     .map_err(WatchSubscriptionError::Storage)?
@@ -120,14 +130,19 @@ fn validated_subscription(
     path_prefix: String,
     event_mask: WatchEventMask,
     now_ms: u64,
+    authorization: WatchAuthorizationBinding,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
     validate_subscription_fields(&path_prefix, event_mask)?;
+    if !authorization.is_valid() {
+        return Err(WatchSubscriptionError::Unauthorized);
+    }
 
-    Ok(WatchSubscription::new(
+    Ok(WatchSubscription::new_with_authorization(
         owner,
         path_prefix,
         event_mask,
         now_ms,
+        authorization,
     ))
 }
 
@@ -565,6 +580,11 @@ fn decode_stored_subscription(
             ))
         },
     )?;
+    if !subscription.authorization.is_valid() {
+        return Err(WatchSubscriptionError::Storage(
+            "stored watch subscription has invalid authorization binding".to_string(),
+        ));
+    }
     Ok(subscription)
 }
 
@@ -882,6 +902,7 @@ mod tests {
                 owner,
                 authorized_prefix,
                 data_mask(),
+                WatchAuthorizationBinding::default(),
                 9_999,
             )
             .await,

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -24,6 +24,7 @@ use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
 use crate::driver::DriverContext;
+use crate::notifications::watch::authorization::is_watch_authorized;
 use crate::notifications::watch::interest::watch_interest_dirty_marker_write;
 
 /// Single owner-prefix scan bound. Watches are hard-capped per user, so one page
@@ -34,8 +35,15 @@ const WATCH_SUBSCRIPTION_LIST_LIMIT: usize = 256;
 /// holder proxy to surface a 409 to the API layer.
 pub const WATCH_SUBSCRIPTION_CAP_REACHED: &str = "notification watch subscription cap reached";
 
+/// Stable reject reason for an unauthorized create; matched verbatim by the
+/// holder proxy to surface a 403 to the API layer.
+pub const WATCH_SUBSCRIPTION_UNAUTHORIZED: &str =
+    "watch subscription owner lacks READ on the watched path";
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum WatchSubscriptionError {
+    #[error("{WATCH_SUBSCRIPTION_UNAUTHORIZED}")]
+    Unauthorized,
     #[error("watch path prefix must not be empty")]
     EmptyPrefix,
     #[error("watch path prefix must not start with a slash")]
@@ -75,6 +83,10 @@ pub async fn create_watch_subscription(
     create_subscription(storage, subscription, None).await
 }
 
+/// The one holder-side create path, used by both the local API arm and the
+/// holder RPC. A proxying peer's assertion is not authority to watch, so the
+/// holder that persists and replicates the subscription re-derives the canonical
+/// permission path and checks the owner's READ itself before any durable write.
 pub async fn create_replicated_watch_subscription(
     context: &DriverContext,
     local_node_id: aruna_core::NodeId,
@@ -84,6 +96,18 @@ pub async fn create_replicated_watch_subscription(
     now_ms: u64,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
     let subscription = validated_subscription(owner, path_prefix, event_mask, now_ms)?;
+    if !is_watch_authorized(
+        context,
+        owner.realm_id,
+        owner,
+        &subscription.path_prefix,
+        subscription.event_mask,
+    )
+    .await
+    .map_err(WatchSubscriptionError::Storage)?
+    {
+        return Err(WatchSubscriptionError::Unauthorized);
+    }
     let replication = watch_upsert_replication(local_node_id, &subscription)?;
     let subscription =
         create_subscription(&context.storage_handle, subscription, Some(replication)).await?;

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -580,7 +580,9 @@ fn decode_stored_subscription(
             ))
         },
     )?;
-    if !subscription.authorization.is_valid() {
+    if !subscription.authorization.is_valid()
+        || subscription.authorization.watch_path_prefix != subscription.path_prefix
+    {
         return Err(WatchSubscriptionError::Storage(
             "stored watch subscription has invalid authorization binding".to_string(),
         ));

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -80,7 +80,7 @@ pub async fn create_watch_subscription(
     now_ms: u64,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
     let subscription = validated_subscription(owner, path_prefix, event_mask, now_ms)?;
-    create_subscription(storage, subscription, None).await
+    create_subscription(storage, subscription, None, None).await
 }
 
 /// The one holder-side create path, used by both the local API arm and the
@@ -109,8 +109,13 @@ pub async fn create_replicated_watch_subscription(
         return Err(WatchSubscriptionError::Unauthorized);
     }
     let replication = watch_upsert_replication(local_node_id, &subscription)?;
-    let subscription =
-        create_subscription(&context.storage_handle, subscription, Some(replication)).await?;
+    let subscription = create_subscription(
+        &context.storage_handle,
+        subscription,
+        Some(replication),
+        Some(context),
+    )
+    .await?;
     schedule_replication(context).await;
     Ok(subscription)
 }
@@ -153,13 +158,14 @@ async fn create_subscription(
     storage: &StorageHandle,
     subscription: WatchSubscription,
     replication: Option<WatchReplication>,
+    authorizer: Option<&DriverContext>,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
-    match create_once(storage, &subscription, replication.as_ref()).await {
+    match create_once(storage, &subscription, replication.as_ref(), authorizer).await {
         Ok(()) => Ok(subscription),
         Err(CreateFailure::Cap) => Err(WatchSubscriptionError::CapExceeded),
         Err(CreateFailure::Fatal(error)) => Err(WatchSubscriptionError::Storage(error)),
         Err(CreateFailure::Conflict) => {
-            match create_once(storage, &subscription, replication.as_ref()).await {
+            match create_once(storage, &subscription, replication.as_ref(), authorizer).await {
                 Ok(()) => Ok(subscription),
                 Err(CreateFailure::Cap) => Err(WatchSubscriptionError::CapExceeded),
                 Err(CreateFailure::Fatal(error)) => Err(WatchSubscriptionError::Storage(error)),
@@ -175,6 +181,7 @@ async fn create_once(
     storage: &StorageHandle,
     subscription: &WatchSubscription,
     replication: Option<&WatchReplication>,
+    authorizer: Option<&DriverContext>,
 ) -> Result<(), CreateFailure> {
     let txn_id = match storage
         .send_storage_effect(StorageEffect::StartTransaction { read: false })
@@ -211,8 +218,22 @@ async fn create_once(
         }
     };
     if existing.len() >= NOTIFICATION_WATCH_PER_USER_CAP {
-        abort_txn(storage, txn_id).await;
-        return Err(CreateFailure::Cap);
+        let cap_reached = match authorizer {
+            None => true,
+            Some(context) => {
+                match authorized_cap_reached(context, storage, subscription.owner, txn_id).await {
+                    Ok(reached) => reached,
+                    Err(failure) => {
+                        abort_txn(storage, txn_id).await;
+                        return Err(failure);
+                    }
+                }
+            }
+        };
+        if cap_reached {
+            abort_txn(storage, txn_id).await;
+            return Err(CreateFailure::Cap);
+        }
     }
 
     let subscription_write = match watch_subscription_write_entry(subscription) {
@@ -275,6 +296,68 @@ async fn create_once(
             "unexpected storage event: {other:?}"
         ))),
     }
+}
+
+/// Whether the owner already holds the per-user cap of subscriptions that still
+/// pass the authorization check. Consulted only once the raw row count reaches
+/// the cap, so a create below the cap adds no auth checks. Rows the owner can no
+/// longer read are excluded, so a revoked row never permanently holds a cap
+/// slot. The scan stops at the cap, bounding a rejected create.
+async fn authorized_cap_reached(
+    context: &DriverContext,
+    storage: &StorageHandle,
+    owner: UserId,
+    txn_id: TxnId,
+) -> Result<bool, CreateFailure> {
+    let mut authorized = 0usize;
+    let mut start = None;
+    loop {
+        let (values, next) = match storage
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE.to_string(),
+                prefix: Some(watch_subscription_prefix(owner)),
+                start: start.map(IterStart::After),
+                limit: NOTIFICATION_WATCH_PER_USER_CAP.saturating_add(1),
+                txn_id: Some(txn_id),
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult {
+                values,
+                next_start_after,
+            }) => (values, next_start_after),
+            Event::Storage(StorageEvent::Error { error }) => return Err(classify(error)),
+            other => {
+                return Err(CreateFailure::Fatal(format!(
+                    "unexpected storage event: {other:?}"
+                )));
+            }
+        };
+        for (_, value) in values {
+            let subscription = WatchSubscription::from_bytes(&value)
+                .map_err(|error| CreateFailure::Fatal(error.to_string()))?;
+            if is_watch_authorized(
+                context,
+                subscription.owner.realm_id,
+                subscription.owner,
+                &subscription.path_prefix,
+                subscription.event_mask,
+            )
+            .await
+            .map_err(CreateFailure::Fatal)?
+            {
+                authorized += 1;
+                if authorized >= NOTIFICATION_WATCH_PER_USER_CAP {
+                    return Ok(true);
+                }
+            }
+        }
+        match next {
+            Some(next) => start = Some(next),
+            None => break,
+        }
+    }
+    Ok(false)
 }
 
 pub async fn delete_watch_subscription(
@@ -641,7 +724,12 @@ async fn abort_and_classify(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aruna_core::structs::{RealmId, WatchEventKind};
+    use aruna_core::NodeId;
+    use aruna_core::keyspaces::AUTH_KEYSPACE;
+    use aruna_core::structs::{
+        Actor, GroupAuthorizationDocument, RealmAuthorizationDocument, RealmId, WatchEventKind,
+        data_watch_resource_path,
+    };
     use aruna_storage::FjallStorage;
     use tempfile::tempdir;
 
@@ -661,6 +749,64 @@ mod tests {
             WatchEventKind::MetadataCreated,
             WatchEventKind::DataUploaded,
         ])
+    }
+
+    fn data_mask() -> WatchEventMask {
+        WatchEventMask::from_kinds([WatchEventKind::DataUploaded])
+    }
+
+    fn node(seed: u8) -> NodeId {
+        iroh::SecretKey::from_bytes(&[seed; 32]).public()
+    }
+
+    fn test_context(storage: StorageHandle) -> DriverContext {
+        DriverContext {
+            storage_handle: storage,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        }
+    }
+
+    async fn install_auth(
+        storage: &StorageHandle,
+        realm_id: RealmId,
+        owner: UserId,
+        group_id: Ulid,
+        node_id: NodeId,
+    ) {
+        let actor = Actor {
+            node_id,
+            user_id: owner,
+            realm_id,
+        };
+        let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+        let group_auth =
+            GroupAuthorizationDocument::new_default_group_doc(owner, realm_id, group_id);
+        for (key, value) in [
+            (
+                realm_id.as_bytes().to_vec(),
+                realm_auth.to_bytes(&actor).unwrap(),
+            ),
+            (
+                group_id.to_bytes().to_vec(),
+                group_auth.to_bytes(&actor).unwrap(),
+            ),
+        ] {
+            match storage
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: AUTH_KEYSPACE.to_string(),
+                    key: key.into(),
+                    value: value.into(),
+                    txn_id: None,
+                })
+                .await
+            {
+                Event::Storage(StorageEvent::WriteResult { .. }) => {}
+                other => panic!("unexpected auth write event: {other:?}"),
+            }
+        }
     }
 
     #[tokio::test]
@@ -741,6 +887,45 @@ mod tests {
                 .len(),
             NOTIFICATION_WATCH_PER_USER_CAP
         );
+    }
+
+    // A user churned through revocations: every stored row is now unreadable.
+    // Those dead rows must not permanently occupy cap slots, so an authorized
+    // create still succeeds even though the raw row count is already at the cap.
+    #[tokio::test]
+    async fn cap_skips_unauthorized() {
+        let (_dir, storage) = temp_storage();
+        let realm_id = RealmId([7u8; 32]);
+        let owner = UserId::new(Ulid::from_bytes([1u8; 16]), realm_id);
+        let group_id = Ulid::from_bytes([2u8; 16]);
+        let node_id = node(3);
+        install_auth(&storage, realm_id, owner, group_id, node_id).await;
+
+        let dead_prefix = data_watch_resource_path(Ulid::nil(), node_id, "bucket", "");
+        for index in 0..NOTIFICATION_WATCH_PER_USER_CAP {
+            create_watch_subscription(
+                &storage,
+                owner,
+                dead_prefix.clone(),
+                data_mask(),
+                index as u64,
+            )
+            .await
+            .expect("dead row create");
+        }
+
+        let context = test_context(storage);
+        let authorized_prefix = data_watch_resource_path(group_id, node_id, "bucket", "reports/");
+        create_replicated_watch_subscription(
+            &context,
+            node_id,
+            owner,
+            authorized_prefix,
+            data_mask(),
+            9_999,
+        )
+        .await
+        .expect("authorized create despite dead rows at cap");
     }
 
     #[tokio::test]

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -13,7 +13,7 @@ use aruna_core::storage_entries::{
 };
 use aruna_core::structs::{
     NOTIFICATION_WATCH_MAX_PREFIX_LEN, NOTIFICATION_WATCH_PER_USER_CAP, PlacementRef, RealmId,
-    WatchEventMask, WatchSubscription, watch_subscription_prefix,
+    WatchEventMask, WatchSubscription, parse_watch_subscription_key, watch_subscription_prefix,
 };
 use aruna_core::types::{TxnId, UserId};
 use aruna_storage::StorageHandle;
@@ -80,7 +80,7 @@ pub async fn create_watch_subscription(
     now_ms: u64,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
     let subscription = validated_subscription(owner, path_prefix, event_mask, now_ms)?;
-    create_subscription(storage, subscription, None, None).await
+    create_subscription(storage, subscription, None).await
 }
 
 /// The one holder-side create path, used by both the local API arm and the
@@ -109,13 +109,8 @@ pub async fn create_replicated_watch_subscription(
         return Err(WatchSubscriptionError::Unauthorized);
     }
     let replication = watch_upsert_replication(local_node_id, &subscription)?;
-    let subscription = create_subscription(
-        &context.storage_handle,
-        subscription,
-        Some(replication),
-        Some(context),
-    )
-    .await?;
+    let subscription =
+        create_subscription(&context.storage_handle, subscription, Some(replication)).await?;
     schedule_replication(context).await;
     Ok(subscription)
 }
@@ -126,6 +121,20 @@ fn validated_subscription(
     event_mask: WatchEventMask,
     now_ms: u64,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
+    validate_subscription_fields(&path_prefix, event_mask)?;
+
+    Ok(WatchSubscription::new(
+        owner,
+        path_prefix,
+        event_mask,
+        now_ms,
+    ))
+}
+
+fn validate_subscription_fields(
+    path_prefix: &str,
+    event_mask: WatchEventMask,
+) -> Result<(), WatchSubscriptionError> {
     if path_prefix.is_empty() {
         return Err(WatchSubscriptionError::EmptyPrefix);
     }
@@ -146,26 +155,20 @@ fn validated_subscription(
         return Err(WatchSubscriptionError::InvalidMask);
     }
 
-    Ok(WatchSubscription::new(
-        owner,
-        path_prefix,
-        event_mask,
-        now_ms,
-    ))
+    Ok(())
 }
 
 async fn create_subscription(
     storage: &StorageHandle,
     subscription: WatchSubscription,
     replication: Option<WatchReplication>,
-    authorizer: Option<&DriverContext>,
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
-    match create_once(storage, &subscription, replication.as_ref(), authorizer).await {
+    match create_once(storage, &subscription, replication.as_ref()).await {
         Ok(()) => Ok(subscription),
         Err(CreateFailure::Cap) => Err(WatchSubscriptionError::CapExceeded),
         Err(CreateFailure::Fatal(error)) => Err(WatchSubscriptionError::Storage(error)),
         Err(CreateFailure::Conflict) => {
-            match create_once(storage, &subscription, replication.as_ref(), authorizer).await {
+            match create_once(storage, &subscription, replication.as_ref()).await {
                 Ok(()) => Ok(subscription),
                 Err(CreateFailure::Cap) => Err(WatchSubscriptionError::CapExceeded),
                 Err(CreateFailure::Fatal(error)) => Err(WatchSubscriptionError::Storage(error)),
@@ -181,7 +184,6 @@ async fn create_once(
     storage: &StorageHandle,
     subscription: &WatchSubscription,
     replication: Option<&WatchReplication>,
-    authorizer: Option<&DriverContext>,
 ) -> Result<(), CreateFailure> {
     let txn_id = match storage
         .send_storage_effect(StorageEffect::StartTransaction { read: false })
@@ -218,22 +220,8 @@ async fn create_once(
         }
     };
     if existing.len() >= NOTIFICATION_WATCH_PER_USER_CAP {
-        let cap_reached = match authorizer {
-            None => true,
-            Some(context) => {
-                match authorized_cap_reached(context, storage, subscription.owner, txn_id).await {
-                    Ok(reached) => reached,
-                    Err(failure) => {
-                        abort_txn(storage, txn_id).await;
-                        return Err(failure);
-                    }
-                }
-            }
-        };
-        if cap_reached {
-            abort_txn(storage, txn_id).await;
-            return Err(CreateFailure::Cap);
-        }
+        abort_txn(storage, txn_id).await;
+        return Err(CreateFailure::Cap);
     }
 
     let subscription_write = match watch_subscription_write_entry(subscription) {
@@ -296,68 +284,6 @@ async fn create_once(
             "unexpected storage event: {other:?}"
         ))),
     }
-}
-
-/// Whether the owner already holds the per-user cap of subscriptions that still
-/// pass the authorization check. Consulted only once the raw row count reaches
-/// the cap, so a create below the cap adds no auth checks. Rows the owner can no
-/// longer read are excluded, so a revoked row never permanently holds a cap
-/// slot. The scan stops at the cap, bounding a rejected create.
-async fn authorized_cap_reached(
-    context: &DriverContext,
-    storage: &StorageHandle,
-    owner: UserId,
-    txn_id: TxnId,
-) -> Result<bool, CreateFailure> {
-    let mut authorized = 0usize;
-    let mut start = None;
-    loop {
-        let (values, next) = match storage
-            .send_storage_effect(StorageEffect::Iter {
-                key_space: NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE.to_string(),
-                prefix: Some(watch_subscription_prefix(owner)),
-                start: start.map(IterStart::After),
-                limit: NOTIFICATION_WATCH_PER_USER_CAP.saturating_add(1),
-                txn_id: Some(txn_id),
-            })
-            .await
-        {
-            Event::Storage(StorageEvent::IterResult {
-                values,
-                next_start_after,
-            }) => (values, next_start_after),
-            Event::Storage(StorageEvent::Error { error }) => return Err(classify(error)),
-            other => {
-                return Err(CreateFailure::Fatal(format!(
-                    "unexpected storage event: {other:?}"
-                )));
-            }
-        };
-        for (_, value) in values {
-            let subscription = WatchSubscription::from_bytes(&value)
-                .map_err(|error| CreateFailure::Fatal(error.to_string()))?;
-            if is_watch_authorized(
-                context,
-                subscription.owner.realm_id,
-                subscription.owner,
-                &subscription.path_prefix,
-                subscription.event_mask,
-            )
-            .await
-            .map_err(CreateFailure::Fatal)?
-            {
-                authorized += 1;
-                if authorized >= NOTIFICATION_WATCH_PER_USER_CAP {
-                    return Ok(true);
-                }
-            }
-        }
-        match next {
-            Some(next) => start = Some(next),
-            None => break,
-        }
-    }
-    Ok(false)
 }
 
 pub async fn delete_watch_subscription(
@@ -615,6 +541,33 @@ async fn schedule_replication(context: &DriverContext) {
         .await;
 }
 
+fn decode_stored_subscription(
+    key: &[u8],
+    value: &[u8],
+) -> Result<WatchSubscription, WatchSubscriptionError> {
+    let (key_owner, key_watch_id) = parse_watch_subscription_key(key)
+        .map_err(|error| WatchSubscriptionError::Storage(error.to_string()))?;
+    let subscription = WatchSubscription::from_bytes(value)
+        .map_err(|error| WatchSubscriptionError::Storage(error.to_string()))?;
+    if key_owner.is_nil()
+        || key_watch_id.is_nil()
+        || subscription.owner != key_owner
+        || subscription.watch_id != key_watch_id
+    {
+        return Err(WatchSubscriptionError::Storage(
+            "stored watch subscription key does not match payload identity".to_string(),
+        ));
+    }
+    validate_subscription_fields(&subscription.path_prefix, subscription.event_mask).map_err(
+        |error| {
+            WatchSubscriptionError::Storage(format!(
+                "stored watch subscription violates invariants: {error}"
+            ))
+        },
+    )?;
+    Ok(subscription)
+}
+
 pub async fn list_watch_subscriptions(
     storage: &StorageHandle,
     owner: UserId,
@@ -641,11 +594,14 @@ pub async fn list_watch_subscriptions(
     };
 
     let mut subscriptions = Vec::with_capacity(values.len());
-    for (_, value) in values {
-        subscriptions.push(
-            WatchSubscription::from_bytes(&value)
-                .map_err(|error| WatchSubscriptionError::Storage(error.to_string()))?,
-        );
+    for (key, value) in values {
+        let subscription = decode_stored_subscription(&key, &value)?;
+        if subscription.owner != owner {
+            return Err(WatchSubscriptionError::Storage(
+                "stored watch subscription belongs to a different owner".to_string(),
+            ));
+        }
+        subscriptions.push(subscription);
     }
     Ok(subscriptions)
 }
@@ -684,11 +640,14 @@ pub async fn list_realm_watch_subscriptions(
                 )));
             }
         };
-        for (_, value) in values {
-            subscriptions.push(
-                WatchSubscription::from_bytes(&value)
-                    .map_err(|error| WatchSubscriptionError::Storage(error.to_string()))?,
-            );
+        for (key, value) in values {
+            let subscription = decode_stored_subscription(&key, &value)?;
+            if subscription.owner.realm_id != realm_id {
+                return Err(WatchSubscriptionError::Storage(
+                    "stored watch subscription belongs to a different realm".to_string(),
+                ));
+            }
+            subscriptions.push(subscription);
         }
         match next {
             Some(next) => start = Some(next),
@@ -889,11 +848,11 @@ mod tests {
         );
     }
 
-    // A user churned through revocations: every stored row is now unreadable.
-    // Those dead rows must not permanently occupy cap slots, so an authorized
-    // create still succeeds even though the raw row count is already at the cap.
+    // Revocation hides a watch but does not delete its replicated row. Those
+    // durable rows must keep occupying cap slots until explicit deletion, or a
+    // user can grow storage and fan-out without bound by churning permissions.
     #[tokio::test]
-    async fn cap_skips_unauthorized() {
+    async fn revoked_rows_still_count_toward_cap() {
         let (_dir, storage) = temp_storage();
         let realm_id = RealmId([7u8; 32]);
         let owner = UserId::new(Ulid::from_bytes([1u8; 16]), realm_id);
@@ -916,16 +875,65 @@ mod tests {
 
         let context = test_context(storage);
         let authorized_prefix = data_watch_resource_path(group_id, node_id, "bucket", "reports/");
-        create_replicated_watch_subscription(
-            &context,
-            node_id,
-            owner,
-            authorized_prefix,
-            data_mask(),
-            9_999,
-        )
-        .await
-        .expect("authorized create despite dead rows at cap");
+        assert_eq!(
+            create_replicated_watch_subscription(
+                &context,
+                node_id,
+                owner,
+                authorized_prefix,
+                data_mask(),
+                9_999,
+            )
+            .await,
+            Err(WatchSubscriptionError::CapExceeded)
+        );
+        assert_eq!(
+            list_watch_subscriptions(&context.storage_handle, owner)
+                .await
+                .expect("durable rows remain listable")
+                .len(),
+            NOTIFICATION_WATCH_PER_USER_CAP
+        );
+    }
+
+    #[test]
+    fn stored_rows_require_valid_key_payload_identity() {
+        let owner = user(1, 1);
+        let watch_id = Ulid::from_bytes([9u8; 16]);
+        let mut subscription = WatchSubscription::new(owner, "prefix".to_string(), mask(), 1);
+        subscription.watch_id = watch_id;
+        let bytes = subscription.to_bytes().expect("subscription encodes");
+        let key = aruna_core::structs::watch_subscription_key(owner, watch_id);
+        assert_eq!(
+            decode_stored_subscription(&key, &bytes).expect("valid row"),
+            subscription
+        );
+
+        let wrong_key = aruna_core::structs::watch_subscription_key(owner, Ulid::r#gen());
+        assert!(matches!(
+            decode_stored_subscription(&wrong_key, &bytes),
+            Err(WatchSubscriptionError::Storage(_))
+        ));
+
+        subscription.watch_id = Ulid::nil();
+        let nil_key = aruna_core::structs::watch_subscription_key(owner, Ulid::nil());
+        assert!(matches!(
+            decode_stored_subscription(
+                &nil_key,
+                &subscription.to_bytes().expect("nil row encodes")
+            ),
+            Err(WatchSubscriptionError::Storage(_))
+        ));
+
+        subscription.watch_id = watch_id;
+        subscription.path_prefix.clear();
+        assert!(matches!(
+            decode_stored_subscription(
+                &key,
+                &subscription.to_bytes().expect("invalid row encodes")
+            ),
+            Err(WatchSubscriptionError::Storage(_))
+        ));
     }
 
     #[tokio::test]

--- a/operations/src/notifications/watch/subscriptions.rs
+++ b/operations/src/notifications/watch/subscriptions.rs
@@ -7,6 +7,7 @@ use aruna_core::errors::StorageError;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE;
+use aruna_core::metrics::WatchAuthorizationMetricReason;
 use aruna_core::storage_entries::{
     document_sync_revision_write_entry, watch_subscription_delete_entry,
     watch_subscription_write_entry,
@@ -25,7 +26,9 @@ use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
 use crate::driver::DriverContext;
-use crate::notifications::watch::authorization::is_watch_authorized;
+use crate::notifications::watch::authorization::{
+    WatchAuthorization, evaluate_watch_authorization,
+};
 use crate::notifications::watch::interest::watch_interest_dirty_marker_write;
 
 /// Single owner-prefix scan bound. Watches are hard-capped per user, so one page
@@ -43,8 +46,8 @@ pub const WATCH_SUBSCRIPTION_UNAUTHORIZED: &str =
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum WatchSubscriptionError {
-    #[error("{WATCH_SUBSCRIPTION_UNAUTHORIZED}")]
-    Unauthorized,
+    #[error("{WATCH_SUBSCRIPTION_UNAUTHORIZED}: {}", .0.as_str())]
+    Unauthorized(WatchAuthorizationMetricReason),
     #[error("watch path prefix must not be empty")]
     EmptyPrefix,
     #[error("watch path prefix must not start with a slash")]
@@ -105,7 +108,7 @@ pub async fn create_replicated_watch_subscription(
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
     let subscription =
         validated_subscription(owner, path_prefix, event_mask, now_ms, authorization)?;
-    if !is_watch_authorized(
+    match evaluate_watch_authorization(
         context,
         owner.realm_id,
         owner,
@@ -116,7 +119,15 @@ pub async fn create_replicated_watch_subscription(
     .await
     .map_err(WatchSubscriptionError::Storage)?
     {
-        return Err(WatchSubscriptionError::Unauthorized);
+        WatchAuthorization::Authorized => {}
+        WatchAuthorization::Denied(reason) => {
+            return Err(WatchSubscriptionError::Unauthorized(reason.metric_reason()));
+        }
+        WatchAuthorization::Unavailable(_) => {
+            return Err(WatchSubscriptionError::Unauthorized(
+                WatchAuthorizationMetricReason::AuthorizationUnavailable,
+            ));
+        }
     }
     let replication = watch_upsert_replication(local_node_id, &subscription)?;
     let subscription =
@@ -134,7 +145,9 @@ fn validated_subscription(
 ) -> Result<WatchSubscription, WatchSubscriptionError> {
     validate_subscription_fields(&path_prefix, event_mask)?;
     if !authorization.is_valid() {
-        return Err(WatchSubscriptionError::Unauthorized);
+        return Err(WatchSubscriptionError::Unauthorized(
+            WatchAuthorizationMetricReason::InvalidState,
+        ));
     }
 
     Ok(WatchSubscription::new_with_authorization(

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -12,9 +12,9 @@ use aruna_core::keyspaces::{
 use aruna_core::structs::{
     Actor, GroupAuthorizationDocument, NOTIFICATION_WATCH_PER_USER_CAP, NotificationClass,
     NotificationKind, NotificationRecord, PlacementRef, RealmAuthorizationDocument,
-    RealmConfigDocument, RealmId, RealmNodeKind, WatchEvent, WatchEventDetail, WatchEventKind,
-    WatchEventMask, WatchInterestDigest, WatchSubscription, data_watch_resource_path,
-    watch_interest_node_key, watch_notification_id,
+    RealmConfigDocument, RealmId, RealmNodeKind, WatchAuthorizationBinding, WatchEvent,
+    WatchEventDetail, WatchEventKind, WatchEventMask, WatchInterestDigest, WatchSubscription,
+    data_watch_resource_path, watch_interest_node_key, watch_notification_id,
 };
 use aruna_core::util::unix_timestamp_millis;
 use aruna_core::{DocumentSyncEffect, NodeId, UserId};
@@ -374,6 +374,7 @@ async fn remote_create_surfaces_cap_conflict_over_the_wire()
             owner,
             data_watch_resource_path(group_id, data_node_id, "bucket", &format!("{index}/")),
             mask,
+            WatchAuthorizationBinding::default(),
         )
         .await
         .expect("remote create under cap succeeds");
@@ -385,6 +386,7 @@ async fn remote_create_surfaces_cap_conflict_over_the_wire()
         owner,
         data_watch_resource_path(group_id, data_node_id, "bucket", "overflow/"),
         mask,
+        WatchAuthorizationBinding::default(),
     )
     .await
     .expect_err("cap must be enforced over the wire");
@@ -570,6 +572,7 @@ async fn create_watch_via(
         owner,
         path_prefix.to_string(),
         event_mask,
+        WatchAuthorizationBinding::default(),
     )
     .await?)
 }

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -364,6 +364,7 @@ async fn remote_create_surfaces_cap_conflict_over_the_wire()
     let mask = WatchEventMask::from_kinds([WatchEventKind::DataUploaded]);
     let group_id = Ulid::r#gen();
     let data_node_id = nodes[1].net.node_id();
+    install_group_authorization(&nodes, realm_id, group_id, owner).await?;
 
     // Node B is not the holder, so every create proxies to node A over the wire.
     for index in 0..NOTIFICATION_WATCH_PER_USER_CAP {


### PR DESCRIPTION
Closes #350

The node that owns a watch subscription's durable state did not check whether the owner may read the path being watched.

- The holder side RPC create only verified that it was the correct inbox holder for the owner, then persisted and replicated the subscription on the calling peer's assertion. The API node authorized first, so this path was only reachable when the owner's inbox holder was a different node, but that node is the one that owns the state. Authorization now happens at the single choke point that both the local API arm and the holder RPC pass through, so no create path can skip it. Two existing tests created watches over the wire with no authorization documents installed and passed; they now install authorization and fail closed without it.
- Enumeration was never re-checked, so revoking read permission left existing watches listable. Listing now filters on current authorization. The stored row is kept and filtered at the surface rather than deleted.
- Watch creation distinguished a nonexistent group from an unreadable one, because the watch routes used the shared permission helper that maps every error to 500, while the metadata routes deliberately answer 403 for both. All watch surfaces now answer identically, so creation is not an existence oracle. Malformed prefixes still answer 400, which leaks nothing.

Anonymous watchers are refused even for publicly readable resources. A watch needs a durable per-user inbox to deliver into, and an anonymous principal has no inbox identity, so every anonymous watcher would collapse into one shared inbox key.