### PR TITLE
[fix] Restrict the public node and realm info surface

### DIFF
--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -1,3 +1,4 @@
+use crate::auth::require_realm_auth;
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
 use aruna_core::UserId;
@@ -463,7 +464,7 @@ pub async fn list_groups(
     Extension(auth): Extension<Option<AuthContext>>,
     Query(query): Query<ListGroupsQuery>,
 ) -> ServerResult<(StatusCode, Json<ListGroupsResponse>)> {
-    let auth = auth.ok_or(ServerError::Unauthorized)?;
+    let auth = require_realm_auth(&state, auth)?;
     let include_roles = parse_list_groups_include(query.include.as_deref())?;
     let limit = query.limit_or(100).clamp(1, 1_000);
     let offset = query.offset_or(0);
@@ -552,7 +553,7 @@ pub async fn get_group(
     Extension(auth): Extension<Option<AuthContext>>,
     Path(group_id): Path<String>,
 ) -> ServerResult<(StatusCode, Json<GroupInfoResponse>)> {
-    let auth = auth.ok_or(ServerError::Unauthorized)?;
+    let auth = require_realm_auth(&state, auth)?;
     let group_id = parse_group_id(&group_id)?;
     let (group, auth_doc) = load_group(&state, group_id).await?;
     let is_member = is_group_member(&auth_doc, auth.user_id);
@@ -625,7 +626,7 @@ pub async fn get_group_usage(
     Extension(auth): Extension<Option<AuthContext>>,
     Path(group_id): Path<String>,
 ) -> ServerResult<(StatusCode, Json<crate::routes::info::UsageResponse>)> {
-    let auth = auth.ok_or(ServerError::Unauthorized)?;
+    let auth = require_realm_auth(&state, auth)?;
     let group_id = parse_group_id(&group_id)?;
     let (_, auth_doc) = load_group(&state, group_id).await?;
     if !is_group_member(&auth_doc, auth.user_id) {
@@ -677,7 +678,7 @@ pub async fn list_group_members(
     Extension(auth): Extension<Option<AuthContext>>,
     Path(group_id): Path<String>,
 ) -> ServerResult<(StatusCode, Json<GroupMembersResponse>)> {
-    let auth = auth.ok_or(ServerError::Unauthorized)?;
+    let auth = require_realm_auth(&state, auth)?;
     let group_id = parse_group_id(&group_id)?;
     let (_, auth_doc) = load_group(&state, group_id).await?;
     if !is_group_member(&auth_doc, auth.user_id) {
@@ -1001,4 +1002,122 @@ pub async fn delete_group_role(
     })?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ListGroupsQuery, get_group, get_group_usage, list_group_members, list_groups};
+    use crate::error::ServerError;
+    use crate::server_state::ServerState;
+    use aruna_core::UserId;
+    use aruna_core::structs::{AuthContext, NodeCapabilities, RealmId};
+    use aruna_operations::driver::DriverContext;
+    use aruna_storage::storage;
+    use axum::Extension;
+    use axum::extract::{Path, Query, State};
+    use ed25519_dalek::SigningKey;
+    use std::sync::Arc;
+    use tempfile::{TempDir, tempdir};
+    use ulid::Ulid;
+
+    async fn setup_state() -> (Arc<ServerState>, TempDir) {
+        let tempdir = tempdir().unwrap();
+        let storage_handle = storage::FjallStorage::open(tempdir.path().to_str().unwrap()).unwrap();
+        let driver_ctx = Arc::new(DriverContext {
+            storage_handle,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+        });
+        let realm_signing_key =
+            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
+        let state = Arc::new(
+            ServerState::new(
+                driver_ctx,
+                realm_id,
+                iroh::SecretKey::generate().public(),
+                NodeCapabilities::local_node(realm_id).unwrap(),
+                false,
+                None,
+            )
+            .await,
+        );
+
+        (state, tempdir)
+    }
+
+    fn foreign_auth() -> AuthContext {
+        let realm_id = RealmId::from_bytes([7u8; 32]);
+        AuthContext {
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
+            realm_id,
+            path_restrictions: None,
+        }
+    }
+
+    /// Anonymous callers get 401, foreign-realm tokens 403: neither may
+    /// enumerate the local group or usage directory.
+    #[tokio::test]
+    async fn group_directory_requires_realm() {
+        let (state, _tempdir) = setup_state().await;
+        let group_id = Ulid::r#gen().to_string();
+
+        assert!(matches!(
+            list_groups(
+                State(state.clone()),
+                Extension(None),
+                Query(ListGroupsQuery::default())
+            )
+            .await,
+            Err(ServerError::Unauthorized)
+        ));
+        assert!(matches!(
+            list_groups(
+                State(state.clone()),
+                Extension(Some(foreign_auth())),
+                Query(ListGroupsQuery::default())
+            )
+            .await,
+            Err(ServerError::Forbidden)
+        ));
+
+        for auth in [None, Some(foreign_auth())] {
+            let expected = if auth.is_none() {
+                ServerError::Unauthorized
+            } else {
+                ServerError::Forbidden
+            };
+            for result in [
+                get_group(
+                    State(state.clone()),
+                    Extension(auth.clone()),
+                    Path(group_id.clone()),
+                )
+                .await
+                .map(|_| ()),
+                get_group_usage(
+                    State(state.clone()),
+                    Extension(auth.clone()),
+                    Path(group_id.clone()),
+                )
+                .await
+                .map(|_| ()),
+                list_group_members(
+                    State(state.clone()),
+                    Extension(auth.clone()),
+                    Path(group_id.clone()),
+                )
+                .await
+                .map(|_| ()),
+            ] {
+                assert_eq!(
+                    result.unwrap_err().to_string(),
+                    expected.to_string(),
+                    "group route leaked to {auth:?}"
+                );
+            }
+        }
+    }
 }

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -63,45 +63,38 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/info/usage", get(get_usage))
 }
 
-/// Node information. `status`, `api_version` and `realm_id` are public: they are
-/// what a client needs to health check the node and to learn which realm it must
-/// authenticate against. Everything else is gated: `topology` needs a token of
-/// this realm, `operations` needs a realm config admin.
+/// Node information. `node.status`, `node.realm_id` and `api_version` are public:
+/// what a client needs to health check the node and learn which realm to
+/// authenticate against. Node identity, addresses and peer topology need a token
+/// of this realm; backend detail, request metrics and warnings need a realm
+/// config admin. Gated values are absent, never restructured, so a client keeps
+/// parsing the shape it always parsed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct InfoResponse {
-    pub status: ServiceStatus,
-    pub api_version: String,
-    pub realm_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub topology: Option<NodeTopologyInfo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub operations: Option<NodeOperationsInfo>,
-}
-
-/// Node identity, addresses and peer topology. Realm-authenticated callers only.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-pub struct NodeTopologyInfo {
     pub node: NodeStatus,
+    pub api_version: String,
+    /// Portal deployment detail. Realm config admins only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub portal: Option<PortalStatus>,
+    /// Node listen addresses. Realm-authenticated callers only, else empty.
     pub my_addresses: Vec<String>,
+    /// Peer topology. Realm-authenticated callers only, else empty.
     pub connections: Vec<PeerConnectionInfo>,
-    pub network: NetworkServiceStatus,
-    pub interfaces: InterfaceServicesStatus,
-}
-
-/// Backend detail, request metrics and errors. Realm config admins only.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-pub struct NodeOperationsInfo {
-    pub portal: PortalStatus,
-    pub network_requests: RequestSummary,
-    pub blob: BlobServiceStatus,
-    pub database: DatabaseServiceStatus,
+    pub services: ServicesStatus,
+    /// Operational warnings. Realm config admins only, else empty.
     pub warnings: Vec<String>,
 }
 
+/// Node health and identity. `status` and `realm_id` are public; `peer_id` and
+/// `capabilities` need a token of this realm.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct NodeStatus {
-    pub peer_id: String,
-    pub capabilities: NodeCapabilityKind,
+    pub status: ServiceStatus,
+    pub realm_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<NodeCapabilityKind>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -188,13 +181,29 @@ pub enum ProtocolConnectionStatus {
     Open,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+/// Node backend services. `interfaces` is always present; `network` needs a
+/// token of this realm, `blob` and `database` a realm config admin.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct ServicesStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkServiceStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob: Option<BlobServiceStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<DatabaseServiceStatus>,
+    pub interfaces: InterfaceServicesStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct NetworkServiceStatus {
     pub status: ServiceStatus,
     pub discovery: Vec<String>,
     pub relay: Option<String>,
     pub relay_urls: Vec<String>,
     pub routing_table_size: Option<usize>,
+    /// Request metrics and last error. Realm config admins only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests: Option<RequestSummary>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -240,27 +249,27 @@ pub struct InterfaceStatus {
     pub url: Option<String>,
 }
 
-/// Realm information. `realm_id`, `description`, `oidc_providers` and the public
-/// interface urls are what a client needs to reach the realm and obtain a token,
-/// so they stay public. Realm topology, discovery and quota policy live in
-/// `detail`, which needs a token of this realm.
+/// Realm information. `realm_id`, `description`, `oidc_providers`, the public
+/// interface urls and the metadata replication policy are what a client needs to
+/// reach the realm and obtain a token, so they stay public. Realm topology
+/// (`nodes`, `discovery`), quota policy and interface listen addresses need a
+/// token of this realm and are otherwise absent or empty.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct RealmInfoResponse {
     pub realm_id: String,
     pub description: String,
-    pub oidc_providers: Vec<RealmOidcProviderResponse>,
-    pub interfaces: InterfaceServicesStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<RealmDetailResponse>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-pub struct RealmDetailResponse {
     pub metadata_replication: RealmMetadataReplicationResponse,
+    pub oidc_providers: Vec<RealmOidcProviderResponse>,
+    /// Realm discovery configuration. Realm-authenticated callers only.
     #[schema(value_type = Object)]
-    pub discovery: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery: Option<Value>,
+    /// Realm nodes. Realm-authenticated callers only, else empty.
     pub nodes: Vec<RealmNodeInfoResponse>,
-    pub quota: RealmQuotaConfig,
+    /// Realm quota policy. Realm-authenticated callers only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quota: Option<RealmQuotaConfig>,
+    pub interfaces: InterfaceServicesStatus,
 }
 
 /// Realm-wide quota policy. Used both as the response for the current settings
@@ -785,7 +794,7 @@ impl From<&RealmNodeKind> for RealmNodeKindInfo {
     path = "/info/realm",
     tag = "info",
     responses(
-        (status = 200, description = "Realm information; `detail` only for realm-authenticated callers", body = RealmInfoResponse),
+        (status = 200, description = "Realm information; nodes, discovery and quota only for realm-authenticated callers", body = RealmInfoResponse),
         (status = 404, description = "Realm config not found", body = crate::error::ErrorResponse)
     ),
     security((), ("bearer_auth" = []))
@@ -813,17 +822,23 @@ pub async fn get_realm_info(
         interfaces.s3.bind = None;
     }
 
-    let detail = if realm_authenticated {
+    let metadata_replication = RealmMetadataReplicationResponse {
+        default_replication_factor: config.effective_default_metadata_replication_factor(),
+    };
+
+    let (discovery, nodes, quota) = if realm_authenticated {
         let present_nodes = load_realm_presence_best_effort(&state).await;
         let node_info_docs = load_node_info_documents_best_effort(&state, &config).await;
-        Some(map_realm_detail(
-            &state,
-            &config,
-            present_nodes,
-            node_info_docs,
-        )?)
+        let discovery = serde_json::to_value(&config.discovery)
+            .map_err(|error| ServerError::InternalError(error.to_string()))?;
+        let nodes = map_realm_nodes(&state, &config, present_nodes, node_info_docs);
+        (
+            Some(discovery),
+            nodes,
+            Some(RealmQuotaConfig::from(config.quota.clone())),
+        )
     } else {
-        None
+        (None, Vec::new(), None)
     };
 
     Ok((
@@ -831,6 +846,7 @@ pub async fn get_realm_info(
         Json(RealmInfoResponse {
             realm_id: config.realm_id.to_string(),
             description: config.description,
+            metadata_replication,
             oidc_providers: config
                 .oidc_providers
                 .into_iter()
@@ -841,8 +857,10 @@ pub async fn get_realm_info(
                     discovery_url: provider.discovery_url,
                 })
                 .collect(),
+            discovery,
+            nodes,
+            quota,
             interfaces,
-            detail,
         }),
     ))
 }
@@ -1207,16 +1225,14 @@ pub async fn get_usage(
     Ok((StatusCode::OK, Json(UsageResponse::new(local, realm))))
 }
 
-fn map_realm_detail(
+fn map_realm_nodes(
     state: &ServerState,
     config: &RealmConfigDocument,
     present_nodes: HashSet<aruna_core::NodeId>,
     node_info_docs: BTreeMap<aruna_core::NodeId, aruna_core::structs::NodeInfoDocument>,
-) -> ServerResult<RealmDetailResponse> {
-    let discovery = serde_json::to_value(&config.discovery)
-        .map_err(|error| ServerError::InternalError(error.to_string()))?;
+) -> Vec<RealmNodeInfoResponse> {
     let current_node = state.get_node_id();
-    let nodes = config
+    config
         .nodes
         .iter()
         .map(|node| {
@@ -1249,16 +1265,7 @@ fn map_realm_detail(
                 info,
             }
         })
-        .collect();
-
-    Ok(RealmDetailResponse {
-        metadata_replication: RealmMetadataReplicationResponse {
-            default_replication_factor: config.effective_default_metadata_replication_factor(),
-        },
-        discovery,
-        nodes,
-        quota: RealmQuotaConfig::from(config.quota.clone()),
-    })
+        .collect()
 }
 
 async fn load_realm_presence_best_effort(state: &ServerState) -> HashSet<aruna_core::NodeId> {
@@ -1316,7 +1323,7 @@ async fn interface_services_status(state: &ServerState) -> InterfaceServicesStat
     responses(
         (
             status = 200,
-            description = "Node health and version; `topology` for realm-authenticated callers, `operations` for realm admins",
+            description = "Node health and version; node identity, addresses and topology for realm-authenticated callers, backend detail for realm admins",
             body = InfoResponse
         )
     ),
@@ -1326,94 +1333,81 @@ pub async fn get_info(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
 ) -> (StatusCode, Json<InfoResponse>) {
+    let access = info_access(&state, auth.as_ref()).await;
+    let realm = access != InfoAccess::Public;
+    let admin = access == InfoAccess::Admin;
+
+    let mut interfaces = interface_services_status(&state).await;
+    if !realm {
+        interfaces.rest.bind = None;
+        interfaces.s3.bind = None;
+    }
+
     let mut response = InfoResponse {
-        status: ServiceStatus::Available,
+        node: NodeStatus {
+            status: ServiceStatus::Available,
+            realm_id: state.get_realm_id().to_string(),
+            peer_id: realm.then(|| state.get_node_id().to_string()),
+            capabilities: realm.then(|| NodeCapabilityKind::from(state.node_capabilities())),
+        },
         api_version: env!("CARGO_PKG_VERSION").to_string(),
-        realm_id: state.get_realm_id().to_string(),
-        topology: None,
-        operations: None,
+        portal: None,
+        my_addresses: Vec::new(),
+        connections: Vec::new(),
+        services: ServicesStatus {
+            network: None,
+            blob: None,
+            database: None,
+            interfaces,
+        },
+        warnings: Vec::new(),
     };
 
-    let access = info_access(&state, auth.as_ref()).await;
-    if access == InfoAccess::Public {
+    if !realm {
         return (StatusCode::OK, Json(response));
     }
-    let admin = access == InfoAccess::Admin;
 
     let ctx = state.get_ctx();
     let observability = load_node_observability_status(ctx.as_ref()).await;
 
-    let (network, my_addresses, connections, network_requests, warnings) =
-        match observability.network {
-            Some(info) => (
+    let (network, warnings) = match observability.network {
+        Some(info) => {
+            response.my_addresses = info
+                .endpoint_addr
+                .addrs
+                .iter()
+                .map(transport_addr_to_string)
+                .collect();
+            response.connections = info
+                .connections
+                .iter()
+                .map(|peer| map_peer_connection(peer, admin))
+                .collect();
+            (
                 NetworkServiceStatus {
                     status: ServiceStatus::Available,
                     discovery: info.discovery_methods,
                     relay: Some(info.relay_method),
                     relay_urls: info.relay_urls,
                     routing_table_size: info.routing_table_size,
+                    requests: admin.then(|| RequestSummary::from_state(&info.requests)),
                 },
-                info.endpoint_addr
-                    .addrs
-                    .iter()
-                    .map(transport_addr_to_string)
-                    .collect(),
-                info.connections
-                    .iter()
-                    .map(|peer| PeerConnectionInfo {
-                        peer_id: peer.node_id.to_string(),
-                        status: PeerStatus::from(peer.status),
-                        active_addresses: peer
-                            .active_addresses
-                            .iter()
-                            .map(|address| ConnectionAddressInfo {
-                                status: AddressStatus::from(address.status),
-                                address: address.address.clone(),
-                                rtt_ms: address.rtt_ms,
-                                protocol_connections: address
-                                    .protocol_connections
-                                    .iter()
-                                    .map(|connection| ProtocolConnectionInfo {
-                                        connection_id: connection.connection_id,
-                                        protocol: protocol_name(connection.alpn),
-                                        side: side_name(connection.side),
-                                        status: ProtocolConnectionStatus::Open,
-                                    })
-                                    .collect(),
-                            })
-                            .collect(),
-                        last_error: admin.then(|| peer.last_error.clone()).flatten(),
-                        next_retry_secs: peer.next_retry_in_secs,
-                    })
-                    .collect(),
-                RequestSummary::from_state(&info.requests),
                 info.warnings,
-            ),
-            None => (
-                NetworkServiceStatus {
-                    status: ServiceStatus::Unavailable,
-                    discovery: Vec::new(),
-                    relay: None,
-                    relay_urls: Vec::new(),
-                    routing_table_size: None,
-                },
-                Vec::new(),
-                Vec::new(),
-                RequestSummary::default(),
-                Vec::new(),
-            ),
-        };
-
-    response.topology = Some(NodeTopologyInfo {
-        node: NodeStatus {
-            peer_id: state.get_node_id().to_string(),
-            capabilities: NodeCapabilityKind::from(state.node_capabilities()),
-        },
-        my_addresses,
-        connections,
-        network,
-        interfaces: interface_services_status(&state).await,
-    });
+            )
+        }
+        None => (
+            NetworkServiceStatus {
+                status: ServiceStatus::Unavailable,
+                discovery: Vec::new(),
+                relay: None,
+                relay_urls: Vec::new(),
+                routing_table_size: None,
+                requests: admin.then(RequestSummary::default),
+            },
+            Vec::new(),
+        ),
+    };
+    response.services.network = Some(network);
 
     if admin {
         let blob = match observability.blob {
@@ -1436,19 +1430,49 @@ pub async fn get_info(
                 timeouts_secs: None,
             },
         };
-        response.operations = Some(NodeOperationsInfo {
-            portal: state.portal_status().await,
-            network_requests,
-            blob,
-            database: DatabaseServiceStatus {
-                status: ServiceStatus::from(observability.database.status),
-                requests: RequestSummary::from_state(&observability.database.requests),
-            },
-            warnings,
+        response.services.blob = Some(blob);
+        response.services.database = Some(DatabaseServiceStatus {
+            status: ServiceStatus::from(observability.database.status),
+            requests: RequestSummary::from_state(&observability.database.requests),
         });
+        response.portal = Some(state.portal_status().await);
+        response.warnings = warnings;
     }
 
     (StatusCode::OK, Json(response))
+}
+
+/// Maps a live peer connection to its wire form. `last_error` leaks internal
+/// diagnostics, so it is populated for realm config admins only.
+fn map_peer_connection(
+    peer: &aruna_core::structs::PeerConnectionState,
+    admin: bool,
+) -> PeerConnectionInfo {
+    PeerConnectionInfo {
+        peer_id: peer.node_id.to_string(),
+        status: PeerStatus::from(peer.status),
+        active_addresses: peer
+            .active_addresses
+            .iter()
+            .map(|address| ConnectionAddressInfo {
+                status: AddressStatus::from(address.status),
+                address: address.address.clone(),
+                rtt_ms: address.rtt_ms,
+                protocol_connections: address
+                    .protocol_connections
+                    .iter()
+                    .map(|connection| ProtocolConnectionInfo {
+                        connection_id: connection.connection_id,
+                        protocol: protocol_name(connection.alpn),
+                        side: side_name(connection.side),
+                        status: ProtocolConnectionStatus::Open,
+                    })
+                    .collect(),
+            })
+            .collect(),
+        last_error: admin.then(|| peer.last_error.clone()).flatten(),
+        next_retry_secs: peer.next_retry_in_secs,
+    }
 }
 
 impl RequestSummary {
@@ -1593,34 +1617,74 @@ mod tests {
         }
     }
 
-    /// Anonymous and foreign-realm callers see health and version only.
+    fn key_set(value: &serde_json::Value) -> std::collections::HashSet<&str> {
+        value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    /// Anonymous and foreign-realm callers keep the flat shape, but every gated
+    /// value is absent or empty: the node reports only health and realm, the
+    /// interfaces only their public urls, and node identity, topology, backend
+    /// detail and warnings are gone.
     #[tokio::test]
     async fn anonymous_info_hides_detail() {
         let (state, _tempdir) = setup_state().await;
+        state
+            .register_rest_interface("0.0.0.0:3000".parse().unwrap())
+            .await;
 
         for auth in [None, Some(foreign_auth())] {
             let (status, Json(response)) = get_info(State(state.clone()), Extension(auth)).await;
 
             assert_eq!(status, StatusCode::OK);
-            assert!(response.topology.is_none());
-            assert!(response.operations.is_none());
-            let body = serde_json::to_value(&response).unwrap();
-            let fields = body
-                .as_object()
-                .unwrap()
-                .keys()
-                .map(String::as_str)
-                .collect::<std::collections::HashSet<_>>();
+            assert_eq!(response.node.status, ServiceStatus::Available);
+            assert!(response.node.peer_id.is_none());
+            assert!(response.node.capabilities.is_none());
+            assert!(response.portal.is_none());
+            assert!(response.my_addresses.is_empty());
+            assert!(response.connections.is_empty());
+            assert!(response.warnings.is_empty());
+            assert!(response.services.network.is_none());
+            assert!(response.services.blob.is_none());
+            assert!(response.services.database.is_none());
             assert_eq!(
-                fields,
-                std::collections::HashSet::from(["status", "api_version", "realm_id"])
+                response.services.interfaces.rest.url.as_deref(),
+                Some("http://127.0.0.1:3000/api/v1"),
+                "clients still learn the public api url"
+            );
+            assert!(response.services.interfaces.rest.bind.is_none());
+
+            let body = serde_json::to_value(&response).unwrap();
+            assert_eq!(
+                key_set(&body),
+                std::collections::HashSet::from([
+                    "node",
+                    "api_version",
+                    "my_addresses",
+                    "connections",
+                    "services",
+                    "warnings",
+                ])
+            );
+            assert_eq!(
+                key_set(&body["node"]),
+                std::collections::HashSet::from(["status", "realm_id"])
+            );
+            assert_eq!(
+                key_set(&body["services"]),
+                std::collections::HashSet::from(["interfaces"])
             );
             assert_eq!(body["api_version"], env!("CARGO_PKG_VERSION"));
-            assert_eq!(body["realm_id"], state.get_realm_id().to_string());
+            assert_eq!(body["node"]["realm_id"], state.get_realm_id().to_string());
         }
     }
 
-    /// A realm token unlocks node identity, addresses and peers, nothing else.
+    /// A realm token unlocks node identity, addresses and peers; backend detail
+    /// and request metrics stay admin-only.
     #[tokio::test]
     async fn realm_token_sees_topology() {
         let (state, _tempdir) = setup_state().await;
@@ -1635,12 +1699,16 @@ mod tests {
         let (status, Json(response)) = get_info(State(state.clone()), Extension(Some(auth))).await;
 
         assert_eq!(status, StatusCode::OK);
-        let topology = response.topology.expect("realm token sees topology");
-        assert_eq!(topology.node.peer_id, state.get_node_id().to_string());
-        assert_eq!(topology.node.capabilities, NodeCapabilityKind::Local);
-        assert_eq!(topology.network.status, ServiceStatus::Unavailable);
+        assert_eq!(response.node.peer_id, Some(state.get_node_id().to_string()));
+        assert_eq!(response.node.capabilities, Some(NodeCapabilityKind::Local));
+        let network = response.services.network.expect("realm token sees network");
+        assert_eq!(network.status, ServiceStatus::Unavailable);
+        assert!(
+            network.requests.is_none(),
+            "request metrics stay admin-only"
+        );
         assert_eq!(
-            topology.interfaces,
+            response.services.interfaces,
             InterfaceServicesStatus {
                 rest: InterfaceStatus {
                     status: ServiceStatus::Available,
@@ -1655,12 +1723,16 @@ mod tests {
             }
         );
         assert!(
-            response.operations.is_none(),
+            response.services.blob.is_none(),
             "backend detail stays admin-only"
         );
+        assert!(response.services.database.is_none());
+        assert!(response.portal.is_none());
+        assert!(response.warnings.is_empty());
     }
 
-    /// Backend detail and errors need a realm config admin.
+    /// Backend detail and errors need a realm config admin; a plain realm member
+    /// sees node identity but no backend services.
     #[tokio::test]
     async fn admin_sees_operations() {
         let (state, realm_id, admin, _tempdir) = setup_management_state().await;
@@ -1671,21 +1743,62 @@ mod tests {
         };
 
         let (_, Json(response)) = get_info(State(state.clone()), Extension(Some(member))).await;
-        assert!(response.topology.is_some());
         assert!(
-            response.operations.is_none(),
+            response.node.peer_id.is_some(),
+            "realm member sees node identity"
+        );
+        assert!(
+            response.services.blob.is_none(),
             "plain realm member is not an admin"
         );
+        assert!(response.services.database.is_none());
+        assert!(response.portal.is_none());
 
         let (status, Json(response)) =
             get_info(State(state), Extension(Some(admin_auth(realm_id, admin)))).await;
 
         assert_eq!(status, StatusCode::OK);
-        assert!(response.topology.is_some());
-        let operations = response.operations.expect("admin sees operations");
-        assert_eq!(operations.blob.status, ServiceStatus::NotConfigured);
-        assert_eq!(operations.database.status, ServiceStatus::Available);
-        assert_eq!(operations.portal.mode, "disabled");
+        assert!(response.node.peer_id.is_some());
+        assert_eq!(
+            response.services.blob.expect("admin sees blob").status,
+            ServiceStatus::NotConfigured
+        );
+        assert_eq!(
+            response
+                .services
+                .database
+                .expect("admin sees database")
+                .status,
+            ServiceStatus::Available
+        );
+        assert_eq!(response.portal.expect("admin sees portal").mode, "disabled");
+    }
+
+    /// `last_error` on a peer connection leaks internal diagnostics, so a realm
+    /// member sees it redacted while a realm config admin sees it in full.
+    #[test]
+    fn peer_error_admin_only() {
+        let peer = aruna_core::structs::PeerConnectionState {
+            node_id: iroh::SecretKey::from_bytes(&[3u8; 32]).public(),
+            status: aruna_core::structs::PeerConnectionStatus::Unreachable,
+            active_addresses: Vec::new(),
+            last_error: Some("dial refused: 10.0.0.9:4433".to_string()),
+            next_retry_in_secs: Some(5),
+        };
+
+        let member = super::map_peer_connection(&peer, false);
+        assert!(
+            member.last_error.is_none(),
+            "non-admin must not see peer errors"
+        );
+        assert_eq!(member.next_retry_secs, Some(5));
+        assert_eq!(member.peer_id, peer.node_id.to_string());
+
+        let admin = super::map_peer_connection(&peer, true);
+        assert_eq!(
+            admin.last_error.as_deref(),
+            Some("dial refused: 10.0.0.9:4433")
+        );
     }
 
     #[tokio::test]
@@ -1706,7 +1819,7 @@ mod tests {
             get_info(State(state), Extension(Some(admin_auth(realm_id, admin)))).await;
 
         assert_eq!(status, StatusCode::OK);
-        let database = response.operations.expect("admin sees operations").database;
+        let database = response.services.database.expect("admin sees database");
         assert_eq!(database.status, ServiceStatus::Available);
         assert_eq!(
             database.requests.last_error.as_deref(),
@@ -2130,9 +2243,8 @@ mod tests {
         let (_, Json(info)) = get_realm_info(State(state.clone()), Extension(Some(auth.clone())))
             .await
             .unwrap();
-        let detail = info.detail.expect("realm token sees detail");
         assert_eq!(
-            detail.metadata_replication.default_replication_factor,
+            info.metadata_replication.default_replication_factor,
             Some(2)
         );
 
@@ -2151,10 +2263,9 @@ mod tests {
         let (_, Json(info)) = get_realm_info(State(state), Extension(Some(auth)))
             .await
             .unwrap();
-        let detail = info.detail.expect("realm token sees detail");
-        assert_eq!(detail.metadata_replication.default_replication_factor, None);
+        assert_eq!(info.metadata_replication.default_replication_factor, None);
         assert_eq!(
-            serde_json::to_value(detail.metadata_replication).unwrap()["default_replication_factor"],
+            serde_json::to_value(info.metadata_replication).unwrap()["default_replication_factor"],
             serde_json::Value::Null
         );
     }
@@ -2359,7 +2470,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(status, StatusCode::OK);
-        let quota = info.detail.expect("realm token sees detail").quota;
+        let quota = info.quota.expect("realm token sees quota");
         assert_eq!(quota.default_group_quota_bytes, Some(4096));
         assert_eq!(quota.max_devices_per_user, None);
     }
@@ -2392,7 +2503,9 @@ mod tests {
                 .unwrap();
             assert_eq!(info.realm_id, realm_id.to_string());
             assert_eq!(info.description, "Realm");
-            assert!(info.detail.is_none());
+            assert!(info.nodes.is_empty(), "realm topology is not public");
+            assert!(info.quota.is_none(), "quota policy is not public");
+            assert!(info.discovery.is_none(), "discovery is not public");
             assert_eq!(
                 info.interfaces.rest.url.as_deref(),
                 Some("http://127.0.0.1:3000/api/v1"),
@@ -2402,19 +2515,26 @@ mod tests {
                 info.interfaces.rest.bind.is_none(),
                 "listen address is not public"
             );
+            let body = serde_json::to_value(&info).unwrap();
+            assert!(
+                body.get("metadata_replication").is_some(),
+                "replication policy stays public"
+            );
+            assert!(
+                body.get("detail").is_none(),
+                "flat shape has no detail wrapper"
+            );
         }
 
         let (_status, Json(info)) = get_realm_info(State(state), Extension(Some(auth)))
             .await
             .unwrap();
         assert_eq!(info.interfaces.rest.bind.as_deref(), Some("0.0.0.0:3000"));
-        let detail = info.detail.expect("realm token sees detail");
-        assert!(!detail.nodes.is_empty());
-        assert_eq!(detail.quota.user_group_cap_overrides.len(), 1);
-        assert_eq!(
-            detail.quota.user_group_cap_overrides[0].user_id,
-            admin.to_string()
-        );
+        assert!(!info.nodes.is_empty());
+        assert!(info.discovery.is_some());
+        let quota = info.quota.expect("realm token sees quota");
+        assert_eq!(quota.user_group_cap_overrides.len(), 1);
+        assert_eq!(quota.user_group_cap_overrides[0].user_id, admin.to_string());
     }
 
     #[tokio::test]
@@ -2460,7 +2580,6 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(status, StatusCode::OK);
-        let info = info.detail.expect("realm token sees detail");
         let node = info
             .nodes
             .iter()

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1,3 +1,4 @@
+use crate::auth::require_realm_auth;
 use crate::error::{ServerError, ServerResult};
 pub use crate::server_state::PortalStatus;
 use crate::server_state::ServerState;
@@ -62,21 +63,43 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/info/usage", get(get_usage))
 }
 
+/// Node information. `status`, `api_version` and `realm_id` are public: they are
+/// what a client needs to health check the node and to learn which realm it must
+/// authenticate against. Everything else is gated: `topology` needs a token of
+/// this realm, `operations` needs a realm config admin.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct InfoResponse {
-    pub node: NodeStatus,
+    pub status: ServiceStatus,
     pub api_version: String,
-    pub portal: PortalStatus,
+    pub realm_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topology: Option<NodeTopologyInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operations: Option<NodeOperationsInfo>,
+}
+
+/// Node identity, addresses and peer topology. Realm-authenticated callers only.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct NodeTopologyInfo {
+    pub node: NodeStatus,
     pub my_addresses: Vec<String>,
     pub connections: Vec<PeerConnectionInfo>,
-    pub services: ServicesStatus,
+    pub network: NetworkServiceStatus,
+    pub interfaces: InterfaceServicesStatus,
+}
+
+/// Backend detail, request metrics and errors. Realm config admins only.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct NodeOperationsInfo {
+    pub portal: PortalStatus,
+    pub network_requests: RequestSummary,
+    pub blob: BlobServiceStatus,
+    pub database: DatabaseServiceStatus,
     pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct NodeStatus {
-    pub status: ServiceStatus,
-    pub realm_id: String,
     pub peer_id: String,
     pub capabilities: NodeCapabilityKind,
 }
@@ -122,6 +145,7 @@ pub struct PeerConnectionInfo {
     pub peer_id: String,
     pub status: PeerStatus,
     pub active_addresses: Vec<ConnectionAddressInfo>,
+    /// Populated for realm config admins only.
     pub last_error: Option<String>,
     pub next_retry_secs: Option<u64>,
 }
@@ -164,22 +188,13 @@ pub enum ProtocolConnectionStatus {
     Open,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-pub struct ServicesStatus {
-    pub network: NetworkServiceStatus,
-    pub blob: BlobServiceStatus,
-    pub database: DatabaseServiceStatus,
-    pub interfaces: InterfaceServicesStatus,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct NetworkServiceStatus {
     pub status: ServiceStatus,
     pub discovery: Vec<String>,
     pub relay: Option<String>,
     pub relay_urls: Vec<String>,
     pub routing_table_size: Option<usize>,
-    pub requests: RequestSummary,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -220,21 +235,32 @@ pub struct InterfaceServicesStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct InterfaceStatus {
     pub status: ServiceStatus,
+    /// Local listen address. Realm-authenticated callers only.
     pub bind: Option<String>,
     pub url: Option<String>,
 }
 
+/// Realm information. `realm_id`, `description`, `oidc_providers` and the public
+/// interface urls are what a client needs to reach the realm and obtain a token,
+/// so they stay public. Realm topology, discovery and quota policy live in
+/// `detail`, which needs a token of this realm.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct RealmInfoResponse {
     pub realm_id: String,
     pub description: String,
-    pub metadata_replication: RealmMetadataReplicationResponse,
     pub oidc_providers: Vec<RealmOidcProviderResponse>,
+    pub interfaces: InterfaceServicesStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<RealmDetailResponse>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct RealmDetailResponse {
+    pub metadata_replication: RealmMetadataReplicationResponse,
     #[schema(value_type = Object)]
     pub discovery: Value,
     pub nodes: Vec<RealmNodeInfoResponse>,
     pub quota: RealmQuotaConfig,
-    pub interfaces: InterfaceServicesStatus,
 }
 
 /// Realm-wide quota policy. Used both as the response for the current settings
@@ -246,7 +272,6 @@ pub struct RealmQuotaConfig {
     pub warn_threshold_percent: u32,
     pub group_overrides: Vec<RealmGroupQuotaOverride>,
     pub max_groups_per_user: Option<u32>,
-    /// Redacted from unauthenticated `/info/realm` responses.
     pub user_group_cap_overrides: Vec<RealmUserGroupCapOverride>,
     pub max_devices_per_user: Option<u32>,
 }
@@ -760,7 +785,7 @@ impl From<&RealmNodeKind> for RealmNodeKindInfo {
     path = "/info/realm",
     tag = "info",
     responses(
-        (status = 200, description = "Realm information", body = RealmInfoResponse),
+        (status = 200, description = "Realm information; `detail` only for realm-authenticated callers", body = RealmInfoResponse),
         (status = 404, description = "Realm config not found", body = crate::error::ErrorResponse)
     ),
     security((), ("bearer_auth" = []))
@@ -780,18 +805,46 @@ pub async fn get_realm_info(
         }
         other => ServerError::InternalError(other.to_string()),
     })?;
-    let present_nodes = load_realm_presence_best_effort(&state).await;
-    let node_info_docs = load_node_info_documents_best_effort(&state, &config).await;
-    let response = map_realm_info_response(
-        &state,
-        config,
-        present_nodes,
-        interface_services_status(&state).await,
-        node_info_docs,
-        auth.as_ref()
-            .is_some_and(|auth| auth.realm_id == state.get_realm_id()),
-    )?;
-    Ok((StatusCode::OK, Json(response)))
+    let realm_authenticated = auth.is_some_and(|auth| auth.realm_id == state.get_realm_id());
+
+    let mut interfaces = interface_services_status(&state).await;
+    if !realm_authenticated {
+        interfaces.rest.bind = None;
+        interfaces.s3.bind = None;
+    }
+
+    let detail = if realm_authenticated {
+        let present_nodes = load_realm_presence_best_effort(&state).await;
+        let node_info_docs = load_node_info_documents_best_effort(&state, &config).await;
+        Some(map_realm_detail(
+            &state,
+            &config,
+            present_nodes,
+            node_info_docs,
+        )?)
+    } else {
+        None
+    };
+
+    Ok((
+        StatusCode::OK,
+        Json(RealmInfoResponse {
+            realm_id: config.realm_id.to_string(),
+            description: config.description,
+            oidc_providers: config
+                .oidc_providers
+                .into_iter()
+                .map(|provider| RealmOidcProviderResponse {
+                    id: provider.id,
+                    issuer: provider.issuer,
+                    audience: provider.audience,
+                    discovery_url: provider.discovery_url,
+                })
+                .collect(),
+            interfaces,
+            detail,
+        }),
+    ))
 }
 
 async fn load_node_info_documents_best_effort(
@@ -831,17 +884,9 @@ fn map_node_info_document(
     }
 }
 
-async fn authorize_realm_config_admin(
-    state: &Arc<ServerState>,
-    auth: Option<AuthContext>,
-) -> ServerResult<AuthContext> {
-    let auth = auth.ok_or(ServerError::Unauthorized)?;
+async fn is_realm_config_admin(state: &ServerState, auth: &AuthContext) -> ServerResult<bool> {
     let realm_id = state.get_realm_id();
-    if auth.realm_id != realm_id || !state.is_management_node() {
-        return Err(ServerError::Forbidden);
-    }
-
-    let allowed = drive(
+    drive(
         CheckPermissionsOperation::new(CheckPermissionsConfig {
             auth_context: auth.clone(),
             path: format!("/{realm_id}/admin/config"),
@@ -850,12 +895,48 @@ async fn authorize_realm_config_admin(
         &state.get_ctx(),
     )
     .await
-    .map_err(|err| ServerError::InternalError(err.to_string()))?;
-    if !allowed {
+    .map_err(|err| ServerError::InternalError(err.to_string()))
+}
+
+async fn authorize_realm_config_admin(
+    state: &Arc<ServerState>,
+    auth: Option<AuthContext>,
+) -> ServerResult<AuthContext> {
+    let auth = auth.ok_or(ServerError::Unauthorized)?;
+    if auth.realm_id != state.get_realm_id() || !state.is_management_node() {
+        return Err(ServerError::Forbidden);
+    }
+    if !is_realm_config_admin(state, &auth).await? {
         return Err(ServerError::Forbidden);
     }
 
     Ok(auth)
+}
+
+/// How much of `/info` a caller may see. Foreign-realm tokens are treated like
+/// anonymous callers: `/info` answers every caller, it just answers with less.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InfoAccess {
+    Public,
+    Realm,
+    Admin,
+}
+
+async fn info_access(state: &ServerState, auth: Option<&AuthContext>) -> InfoAccess {
+    let Some(auth) = auth else {
+        return InfoAccess::Public;
+    };
+    if auth.realm_id != state.get_realm_id() {
+        return InfoAccess::Public;
+    }
+    match is_realm_config_admin(state, auth).await {
+        Ok(true) => InfoAccess::Admin,
+        Ok(false) => InfoAccess::Realm,
+        Err(error) => {
+            warn!(error = %error, "realm admin check failed for info response");
+            InfoAccess::Realm
+        }
+    }
 }
 
 #[utoipa::path(
@@ -1000,10 +1081,8 @@ fn map_set_realm_quota_error(error: SetRealmQuotaError) -> ServerError {
     }
 }
 
-/// Storage usage. The flat fields report this node's local counters (kept for
-/// backward compatibility) and are always present. `realm` reports the
-/// realm-wide total summed across every node and is only included for
-/// authenticated callers, so unauthenticated requests never disclose it.
+/// Storage usage. The flat fields report this node's local counters, `realm` the
+/// realm-wide total summed across every node.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct UsageResponse {
     pub buckets: u64,
@@ -1011,8 +1090,7 @@ pub struct UsageResponse {
     pub stored_blobs: u64,
     pub stored_bytes: u64,
     pub logical_bytes: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub realm: Option<UsageTotals>,
+    pub realm: UsageTotals,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quota: Option<GroupQuotaStatus>,
 }
@@ -1081,17 +1159,13 @@ impl From<UsageCounters> for UsageTotals {
 
 impl UsageResponse {
     pub fn new(local: UsageCounters, realm: UsageCounters) -> Self {
-        Self::with_realm(local, Some(realm.into()))
-    }
-
-    pub fn with_realm(local: UsageCounters, realm: Option<UsageTotals>) -> Self {
         Self {
             buckets: local.buckets,
             objects: local.objects,
             stored_blobs: local.stored_blobs,
             stored_bytes: local.stored_bytes,
             logical_bytes: local.logical_bytes,
-            realm,
+            realm: realm.into(),
             quota: None,
         }
     }
@@ -1117,41 +1191,28 @@ pub async fn load_realm_usage(
     path = "/info/usage",
     tag = "info",
     responses(
-        (
-            status = 200,
-            description = "Local storage usage always; realm-wide totals only for authenticated callers",
-            body = UsageResponse
-        )
+        (status = 200, description = "Local and realm-wide storage usage", body = UsageResponse),
+        (status = 401, description = "Authentication required", body = crate::error::ErrorResponse),
+        (status = 403, description = "Caller is not a member of this realm", body = crate::error::ErrorResponse)
     ),
-    security((), ("bearer_auth" = []))
+    security(("bearer_auth" = []))
 )]
 pub async fn get_usage(
     State(state): State<Arc<ServerState>>,
     Extension(auth): Extension<Option<AuthContext>>,
 ) -> ServerResult<(StatusCode, Json<UsageResponse>)> {
+    require_realm_auth(&state, auth)?;
     let local = load_usage_counters(&state, USAGE_GLOBAL_KEY.to_vec()).await?;
-    let realm = match auth {
-        Some(_) => Some(
-            load_realm_usage(&state, RealmUsageScope::Global)
-                .await?
-                .into(),
-        ),
-        None => None,
-    };
-    Ok((
-        StatusCode::OK,
-        Json(UsageResponse::with_realm(local, realm)),
-    ))
+    let realm = load_realm_usage(&state, RealmUsageScope::Global).await?;
+    Ok((StatusCode::OK, Json(UsageResponse::new(local, realm))))
 }
 
-fn map_realm_info_response(
+fn map_realm_detail(
     state: &ServerState,
-    config: RealmConfigDocument,
+    config: &RealmConfigDocument,
     present_nodes: HashSet<aruna_core::NodeId>,
-    interfaces: InterfaceServicesStatus,
     node_info_docs: BTreeMap<aruna_core::NodeId, aruna_core::structs::NodeInfoDocument>,
-    include_user_quota_overrides: bool,
-) -> ServerResult<RealmInfoResponse> {
+) -> ServerResult<RealmDetailResponse> {
     let discovery = serde_json::to_value(&config.discovery)
         .map_err(|error| ServerError::InternalError(error.to_string()))?;
     let current_node = state.get_node_id();
@@ -1190,32 +1251,13 @@ fn map_realm_info_response(
         })
         .collect();
 
-    let default_replication_factor = config.effective_default_metadata_replication_factor();
-    let mut quota = RealmQuotaConfig::from(config.quota);
-    if !include_user_quota_overrides {
-        quota.user_group_cap_overrides.clear();
-    }
-
-    Ok(RealmInfoResponse {
-        realm_id: config.realm_id.to_string(),
-        description: config.description,
+    Ok(RealmDetailResponse {
         metadata_replication: RealmMetadataReplicationResponse {
-            default_replication_factor,
+            default_replication_factor: config.effective_default_metadata_replication_factor(),
         },
-        oidc_providers: config
-            .oidc_providers
-            .into_iter()
-            .map(|provider| RealmOidcProviderResponse {
-                id: provider.id,
-                issuer: provider.issuer,
-                audience: provider.audience,
-                discovery_url: provider.discovery_url,
-            })
-            .collect(),
         discovery,
         nodes,
-        quota,
-        interfaces,
+        quota: RealmQuotaConfig::from(config.quota.clone()),
     })
 }
 
@@ -1272,123 +1314,141 @@ async fn interface_services_status(state: &ServerState) -> InterfaceServicesStat
     path = "/info",
     tag = "info",
     responses(
-        (status = 200, description = "Node information", body = InfoResponse)
-    )
+        (
+            status = 200,
+            description = "Node health and version; `topology` for realm-authenticated callers, `operations` for realm admins",
+            body = InfoResponse
+        )
+    ),
+    security((), ("bearer_auth" = []))
 )]
-pub async fn get_info(State(state): State<Arc<ServerState>>) -> (StatusCode, Json<InfoResponse>) {
+pub async fn get_info(
+    State(state): State<Arc<ServerState>>,
+    Extension(auth): Extension<Option<AuthContext>>,
+) -> (StatusCode, Json<InfoResponse>) {
+    let mut response = InfoResponse {
+        status: ServiceStatus::Available,
+        api_version: env!("CARGO_PKG_VERSION").to_string(),
+        realm_id: state.get_realm_id().to_string(),
+        topology: None,
+        operations: None,
+    };
+
+    let access = info_access(&state, auth.as_ref()).await;
+    if access == InfoAccess::Public {
+        return (StatusCode::OK, Json(response));
+    }
+    let admin = access == InfoAccess::Admin;
+
     let ctx = state.get_ctx();
     let observability = load_node_observability_status(ctx.as_ref()).await;
 
-    let (network, my_addresses, connections, warnings) = match observability.network {
-        Some(info) => (
-            NetworkServiceStatus {
-                status: ServiceStatus::Available,
-                discovery: info.discovery_methods,
-                relay: Some(info.relay_method),
-                relay_urls: info.relay_urls,
-                routing_table_size: info.routing_table_size,
-                requests: RequestSummary::from_state(&info.requests),
-            },
-            info.endpoint_addr
-                .addrs
-                .iter()
-                .map(transport_addr_to_string)
-                .collect(),
-            info.connections
-                .iter()
-                .map(|peer| PeerConnectionInfo {
-                    peer_id: peer.node_id.to_string(),
-                    status: PeerStatus::from(peer.status),
-                    active_addresses: peer
-                        .active_addresses
-                        .iter()
-                        .map(|address| ConnectionAddressInfo {
-                            status: AddressStatus::from(address.status),
-                            address: address.address.clone(),
-                            rtt_ms: address.rtt_ms,
-                            protocol_connections: address
-                                .protocol_connections
-                                .iter()
-                                .map(|connection| ProtocolConnectionInfo {
-                                    connection_id: connection.connection_id,
-                                    protocol: protocol_name(connection.alpn),
-                                    side: side_name(connection.side),
-                                    status: ProtocolConnectionStatus::Open,
-                                })
-                                .collect(),
-                        })
-                        .collect(),
-                    last_error: peer.last_error.clone(),
-                    next_retry_secs: peer.next_retry_in_secs,
-                })
-                .collect(),
-            info.warnings,
-        ),
-        None => (
-            NetworkServiceStatus {
-                status: ServiceStatus::Unavailable,
-                discovery: Vec::new(),
-                relay: None,
-                relay_urls: Vec::new(),
-                routing_table_size: None,
-                requests: RequestSummary::default(),
-            },
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-        ),
-    };
+    let (network, my_addresses, connections, network_requests, warnings) =
+        match observability.network {
+            Some(info) => (
+                NetworkServiceStatus {
+                    status: ServiceStatus::Available,
+                    discovery: info.discovery_methods,
+                    relay: Some(info.relay_method),
+                    relay_urls: info.relay_urls,
+                    routing_table_size: info.routing_table_size,
+                },
+                info.endpoint_addr
+                    .addrs
+                    .iter()
+                    .map(transport_addr_to_string)
+                    .collect(),
+                info.connections
+                    .iter()
+                    .map(|peer| PeerConnectionInfo {
+                        peer_id: peer.node_id.to_string(),
+                        status: PeerStatus::from(peer.status),
+                        active_addresses: peer
+                            .active_addresses
+                            .iter()
+                            .map(|address| ConnectionAddressInfo {
+                                status: AddressStatus::from(address.status),
+                                address: address.address.clone(),
+                                rtt_ms: address.rtt_ms,
+                                protocol_connections: address
+                                    .protocol_connections
+                                    .iter()
+                                    .map(|connection| ProtocolConnectionInfo {
+                                        connection_id: connection.connection_id,
+                                        protocol: protocol_name(connection.alpn),
+                                        side: side_name(connection.side),
+                                        status: ProtocolConnectionStatus::Open,
+                                    })
+                                    .collect(),
+                            })
+                            .collect(),
+                        last_error: admin.then(|| peer.last_error.clone()).flatten(),
+                        next_retry_secs: peer.next_retry_in_secs,
+                    })
+                    .collect(),
+                RequestSummary::from_state(&info.requests),
+                info.warnings,
+            ),
+            None => (
+                NetworkServiceStatus {
+                    status: ServiceStatus::Unavailable,
+                    discovery: Vec::new(),
+                    relay: None,
+                    relay_urls: Vec::new(),
+                    routing_table_size: None,
+                },
+                Vec::new(),
+                Vec::new(),
+                RequestSummary::default(),
+                Vec::new(),
+            ),
+        };
 
-    let blob = match observability.blob {
-        Some(info) => BlobServiceStatus {
-            status: ServiceStatus::from(info.status),
-            backend: Some(info.backend_type.to_string()),
-            max_bucket_size: info.max_bucket_size,
-            multipart_bucket: info.multipart_bucket,
-            timeouts_secs: Some(TimeoutConfigSecs {
-                connect: info.timeouts.control_plane_connect_timeout.as_secs(),
-                io: info.timeouts.control_plane_io_timeout.as_secs(),
-                transfer_idle: info.timeouts.transfer_idle_timeout.as_secs(),
-            }),
+    response.topology = Some(NodeTopologyInfo {
+        node: NodeStatus {
+            peer_id: state.get_node_id().to_string(),
+            capabilities: NodeCapabilityKind::from(state.node_capabilities()),
         },
-        None => BlobServiceStatus {
-            status: ServiceStatus::NotConfigured,
-            backend: None,
-            max_bucket_size: None,
-            multipart_bucket: None,
-            timeouts_secs: None,
-        },
-    };
+        my_addresses,
+        connections,
+        network,
+        interfaces: interface_services_status(&state).await,
+    });
 
-    let interfaces = interface_services_status(&state).await;
-
-    let database = DatabaseServiceStatus {
-        status: ServiceStatus::from(observability.database.status),
-        requests: RequestSummary::from_state(&observability.database.requests),
-    };
-
-    (
-        StatusCode::OK,
-        Json(InfoResponse {
-            node: NodeStatus {
-                status: ServiceStatus::Available,
-                realm_id: state.get_realm_id().to_string(),
-                peer_id: state.get_node_id().to_string(),
-                capabilities: NodeCapabilityKind::from(state.node_capabilities()),
+    if admin {
+        let blob = match observability.blob {
+            Some(info) => BlobServiceStatus {
+                status: ServiceStatus::from(info.status),
+                backend: Some(info.backend_type.to_string()),
+                max_bucket_size: info.max_bucket_size,
+                multipart_bucket: info.multipart_bucket,
+                timeouts_secs: Some(TimeoutConfigSecs {
+                    connect: info.timeouts.control_plane_connect_timeout.as_secs(),
+                    io: info.timeouts.control_plane_io_timeout.as_secs(),
+                    transfer_idle: info.timeouts.transfer_idle_timeout.as_secs(),
+                }),
             },
-            api_version: env!("CARGO_PKG_VERSION").to_string(),
+            None => BlobServiceStatus {
+                status: ServiceStatus::NotConfigured,
+                backend: None,
+                max_bucket_size: None,
+                multipart_bucket: None,
+                timeouts_secs: None,
+            },
+        };
+        response.operations = Some(NodeOperationsInfo {
             portal: state.portal_status().await,
-            my_addresses,
-            connections,
-            services: ServicesStatus {
-                network,
-                blob,
-                database,
-                interfaces,
+            network_requests,
+            blob,
+            database: DatabaseServiceStatus {
+                status: ServiceStatus::from(observability.database.status),
+                requests: RequestSummary::from_state(&observability.database.requests),
             },
             warnings,
-        }),
-    )
+        });
+    }
+
+    (StatusCode::OK, Json(response))
 }
 
 impl RequestSummary {
@@ -1461,12 +1521,10 @@ fn transport_addr_to_string(addr: &iroh::TransportAddr) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        BlobServiceStatus, DatabaseServiceStatus, InfoResponse, InterfaceServicesStatus,
-        InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind, NodeStatus, PortalStatus,
-        RealmPlacementBinding, RealmPlacementBindingScope, RealmPlacementMutationRequest,
-        RealmPlacementOverride, RealmPlacementStrategy, RealmQuotaConfig,
-        RealmUserGroupCapOverride, RequestSummary, ServiceStatus, ServicesStatus, get_info,
-        get_realm_info, get_realm_placement, get_usage, map_mutate_realm_placement_error,
+        InterfaceServicesStatus, InterfaceStatus, NodeCapabilityKind, RealmPlacementBinding,
+        RealmPlacementBindingScope, RealmPlacementMutationRequest, RealmPlacementOverride,
+        RealmPlacementStrategy, RealmQuotaConfig, RealmUserGroupCapOverride, ServiceStatus,
+        get_info, get_realm_info, get_realm_placement, get_usage, map_mutate_realm_placement_error,
         map_set_realm_quota_error, mutate_realm_placement, set_realm_quota,
     };
     use crate::error::ServerError;
@@ -1526,89 +1584,45 @@ mod tests {
         (state, tempdir)
     }
 
-    #[tokio::test]
-    async fn get_info_returns_unavailable_optional_statuses_when_handles_are_missing() {
-        let (state, _tempdir) = setup_state().await;
-        let baseline = state.get_ctx().storage_handle.snapshot_metrics();
-        let expected_node = NodeStatus {
-            status: ServiceStatus::Available,
-            realm_id: state.get_realm_id().to_string(),
-            peer_id: state.get_node_id().to_string(),
-            capabilities: NodeCapabilityKind::Local,
-        };
-
-        let (status, Json(response)) = get_info(State(state)).await;
-
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(
-            response,
-            InfoResponse {
-                node: expected_node,
-                api_version: env!("CARGO_PKG_VERSION").to_string(),
-                portal: PortalStatus {
-                    installed: false,
-                    mode: "disabled".to_string(),
-                    version: None,
-                    source: None,
-                    url: None,
-                    checksum: None,
-                    fetched_at: None,
-                    last_error: None,
-                },
-                my_addresses: Vec::new(),
-                connections: Vec::new(),
-                services: ServicesStatus {
-                    network: NetworkServiceStatus {
-                        status: ServiceStatus::Unavailable,
-                        discovery: Vec::new(),
-                        relay: None,
-                        relay_urls: Vec::new(),
-                        routing_table_size: None,
-                        requests: RequestSummary {
-                            total: 0,
-                            failure_rate: 0.0,
-                            last_error: None,
-                        },
-                    },
-                    blob: BlobServiceStatus {
-                        status: ServiceStatus::NotConfigured,
-                        backend: None,
-                        max_bucket_size: None,
-                        multipart_bucket: None,
-                        timeouts_secs: None,
-                    },
-                    database: DatabaseServiceStatus {
-                        status: ServiceStatus::Available,
-                        requests: RequestSummary {
-                            total: baseline.requests_total,
-                            failure_rate: if baseline.requests_total == 0 {
-                                0.0
-                            } else {
-                                baseline.failed_total as f64 / baseline.requests_total as f64
-                            },
-                            last_error: baseline.last_error,
-                        },
-                    },
-                    interfaces: InterfaceServicesStatus {
-                        rest: InterfaceStatus {
-                            status: ServiceStatus::Unavailable,
-                            bind: None,
-                            url: None,
-                        },
-                        s3: InterfaceStatus {
-                            status: ServiceStatus::Unavailable,
-                            bind: None,
-                            url: None,
-                        },
-                    },
-                },
-                warnings: Vec::new(),
-            }
-        );
+    fn foreign_auth() -> AuthContext {
+        let realm_id = RealmId::from_bytes([7u8; 32]);
+        AuthContext {
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
+            realm_id,
+            path_restrictions: None,
+        }
     }
 
+    /// Anonymous and foreign-realm callers see health and version only.
     #[tokio::test]
-    async fn get_info_reports_registered_interface_paths() {
+    async fn anonymous_info_hides_detail() {
+        let (state, _tempdir) = setup_state().await;
+
+        for auth in [None, Some(foreign_auth())] {
+            let (status, Json(response)) = get_info(State(state.clone()), Extension(auth)).await;
+
+            assert_eq!(status, StatusCode::OK);
+            assert!(response.topology.is_none());
+            assert!(response.operations.is_none());
+            let body = serde_json::to_value(&response).unwrap();
+            let fields = body
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect::<std::collections::HashSet<_>>();
+            assert_eq!(
+                fields,
+                std::collections::HashSet::from(["status", "api_version", "realm_id"])
+            );
+            assert_eq!(body["api_version"], env!("CARGO_PKG_VERSION"));
+            assert_eq!(body["realm_id"], state.get_realm_id().to_string());
+        }
+    }
+
+    /// A realm token unlocks node identity, addresses and peers, nothing else.
+    #[tokio::test]
+    async fn realm_token_sees_topology() {
         let (state, _tempdir) = setup_state().await;
         state
             .register_rest_interface("0.0.0.0:3000".parse().unwrap())
@@ -1616,12 +1630,17 @@ mod tests {
         state
             .register_s3_interface("0.0.0.0:1337".parse().unwrap(), "127.0.0.1:1337")
             .await;
+        let auth = test_auth_context(&state);
 
-        let (status, Json(response)) = get_info(State(state)).await;
+        let (status, Json(response)) = get_info(State(state.clone()), Extension(Some(auth))).await;
 
         assert_eq!(status, StatusCode::OK);
+        let topology = response.topology.expect("realm token sees topology");
+        assert_eq!(topology.node.peer_id, state.get_node_id().to_string());
+        assert_eq!(topology.node.capabilities, NodeCapabilityKind::Local);
+        assert_eq!(topology.network.status, ServiceStatus::Unavailable);
         assert_eq!(
-            response.services.interfaces,
+            topology.interfaces,
             InterfaceServicesStatus {
                 rest: InterfaceStatus {
                     status: ServiceStatus::Available,
@@ -1635,15 +1654,46 @@ mod tests {
                 },
             }
         );
+        assert!(
+            response.operations.is_none(),
+            "backend detail stays admin-only"
+        );
+    }
+
+    /// Backend detail and errors need a realm config admin.
+    #[tokio::test]
+    async fn admin_sees_operations() {
+        let (state, realm_id, admin, _tempdir) = setup_management_state().await;
+        let member = AuthContext {
+            user_id: UserId::local(Ulid::r#gen(), realm_id),
+            realm_id,
+            path_restrictions: None,
+        };
+
+        let (_, Json(response)) = get_info(State(state.clone()), Extension(Some(member))).await;
+        assert!(response.topology.is_some());
+        assert!(
+            response.operations.is_none(),
+            "plain realm member is not an admin"
+        );
+
+        let (status, Json(response)) =
+            get_info(State(state), Extension(Some(admin_auth(realm_id, admin)))).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(response.topology.is_some());
+        let operations = response.operations.expect("admin sees operations");
+        assert_eq!(operations.blob.status, ServiceStatus::NotConfigured);
+        assert_eq!(operations.database.status, ServiceStatus::Available);
+        assert_eq!(operations.portal.mode, "disabled");
     }
 
     #[tokio::test]
-    async fn get_info_reports_storage_error_metrics() {
-        let (state, _tempdir) = setup_state().await;
-        let ctx = state.get_ctx();
-        let baseline = ctx.storage_handle.snapshot_metrics();
+    async fn admin_info_reports_storage_errors() {
+        let (state, realm_id, admin, _tempdir) = setup_management_state().await;
 
-        let _ = ctx
+        let _ = state
+            .get_ctx()
             .storage_handle
             .send_storage_effect(StorageEffect::Read {
                 key_space: "missing".to_string(),
@@ -1652,21 +1702,17 @@ mod tests {
             })
             .await;
 
-        let (status, Json(response)) = get_info(State(state)).await;
+        let (status, Json(response)) =
+            get_info(State(state), Extension(Some(admin_auth(realm_id, admin)))).await;
 
         assert_eq!(status, StatusCode::OK);
+        let database = response.operations.expect("admin sees operations").database;
+        assert_eq!(database.status, ServiceStatus::Available);
         assert_eq!(
-            response.services.database,
-            DatabaseServiceStatus {
-                status: ServiceStatus::Available,
-                requests: RequestSummary {
-                    total: baseline.requests_total + 1,
-                    failure_rate: (baseline.failed_total + 1) as f64
-                        / (baseline.requests_total + 1) as f64,
-                    last_error: Some("Transaction not found".to_string()),
-                },
-            }
+            database.requests.last_error.as_deref(),
+            Some("Transaction not found")
         );
+        assert!(database.requests.failure_rate > 0.0);
     }
 
     #[test]
@@ -1727,10 +1773,20 @@ mod tests {
         }
     }
 
+    /// The usage directory is closed to anonymous and foreign-realm callers.
     #[tokio::test]
-    async fn get_usage_reports_realm_totals_for_authenticated_callers() {
+    async fn usage_requires_realm_auth() {
         let (state, _tempdir) = setup_state().await;
         seed_usage_state(&state).await;
+
+        assert!(matches!(
+            get_usage(State(state.clone()), Extension(None)).await,
+            Err(ServerError::Unauthorized)
+        ));
+        assert!(matches!(
+            get_usage(State(state.clone()), Extension(Some(foreign_auth()))).await,
+            Err(ServerError::Forbidden)
+        ));
 
         let auth = test_auth_context(&state);
         let (status, Json(response)) = get_usage(State(state), Extension(Some(auth)))
@@ -1738,25 +1794,7 @@ mod tests {
             .unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response.buckets, 2, "flat fields report local total");
-        let realm = response.realm.expect("authenticated caller sees realm");
-        assert_eq!(realm.buckets, 5, "realm sums local and remote");
-    }
-
-    #[tokio::test]
-    async fn get_usage_omits_realm_totals_for_unauthenticated_callers() {
-        let (state, _tempdir) = setup_state().await;
-        seed_usage_state(&state).await;
-
-        let (status, Json(response)) = get_usage(State(state), Extension(None)).await.unwrap();
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(
-            response.buckets, 2,
-            "flat local fields stay unauthenticated"
-        );
-        assert!(
-            response.realm.is_none(),
-            "unauthenticated callers must not see realm-wide totals"
-        );
+        assert_eq!(response.realm.buckets, 5, "realm sums local and remote");
     }
 
     #[test]
@@ -2089,11 +2127,12 @@ mod tests {
             .unwrap();
         }
 
-        let (_, Json(info)) = get_realm_info(State(state.clone()), Extension(None))
+        let (_, Json(info)) = get_realm_info(State(state.clone()), Extension(Some(auth.clone())))
             .await
             .unwrap();
+        let detail = info.detail.expect("realm token sees detail");
         assert_eq!(
-            info.metadata_replication.default_replication_factor,
+            detail.metadata_replication.default_replication_factor,
             Some(2)
         );
 
@@ -2101,7 +2140,7 @@ mod tests {
         unbounded.replica_count = None;
         let _ = mutate_realm_placement(
             State(state.clone()),
-            Extension(Some(auth)),
+            Extension(Some(auth.clone())),
             Ok(Json(RealmPlacementMutationRequest::UpsertStrategy {
                 strategy: unbounded,
             })),
@@ -2109,10 +2148,13 @@ mod tests {
         .await
         .unwrap();
 
-        let (_, Json(info)) = get_realm_info(State(state), Extension(None)).await.unwrap();
-        assert_eq!(info.metadata_replication.default_replication_factor, None);
+        let (_, Json(info)) = get_realm_info(State(state), Extension(Some(auth)))
+            .await
+            .unwrap();
+        let detail = info.detail.expect("realm token sees detail");
+        assert_eq!(detail.metadata_replication.default_replication_factor, None);
         assert_eq!(
-            serde_json::to_value(info.metadata_replication).unwrap()["default_replication_factor"],
+            serde_json::to_value(detail.metadata_replication).unwrap()["default_replication_factor"],
             serde_json::Value::Null
         );
     }
@@ -2317,25 +2359,26 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(info.quota.default_group_quota_bytes, Some(4096));
-        assert_eq!(info.quota.max_devices_per_user, None);
+        let quota = info.detail.expect("realm token sees detail").quota;
+        assert_eq!(quota.default_group_quota_bytes, Some(4096));
+        assert_eq!(quota.max_devices_per_user, None);
     }
 
+    /// Anonymous callers keep what they need to authenticate; realm topology,
+    /// discovery and quota policy need a token of this realm.
     #[tokio::test]
-    async fn get_realm_info_redacts_user_quota_overrides_for_anonymous_callers() {
+    async fn realm_info_gates_detail() {
         let (state, realm_id, admin, _tempdir) = setup_management_state().await;
-        let auth = AuthContext {
-            user_id: admin,
-            realm_id,
-            path_restrictions: None,
-        };
+        state
+            .register_rest_interface("0.0.0.0:3000".parse().unwrap())
+            .await;
+        let auth = admin_auth(realm_id, admin);
         let mut body = RealmQuotaConfig::from(QuotaConfig::default());
         body.user_group_cap_overrides = vec![RealmUserGroupCapOverride {
             user_id: admin.to_string(),
             max_groups: Some(1),
         }];
-
-        let (_status, Json(_stored)) = set_realm_quota(
+        let _ = set_realm_quota(
             State(state.clone()),
             Extension(Some(auth.clone())),
             Json(body),
@@ -2343,17 +2386,33 @@ mod tests {
         .await
         .unwrap();
 
-        let (_status, Json(anonymous)) = get_realm_info(State(state.clone()), Extension(None))
-            .await
-            .unwrap();
-        assert!(anonymous.quota.user_group_cap_overrides.is_empty());
+        for anonymous in [None, Some(foreign_auth())] {
+            let (_status, Json(info)) = get_realm_info(State(state.clone()), Extension(anonymous))
+                .await
+                .unwrap();
+            assert_eq!(info.realm_id, realm_id.to_string());
+            assert_eq!(info.description, "Realm");
+            assert!(info.detail.is_none());
+            assert_eq!(
+                info.interfaces.rest.url.as_deref(),
+                Some("http://127.0.0.1:3000/api/v1"),
+                "clients still learn the public api url"
+            );
+            assert!(
+                info.interfaces.rest.bind.is_none(),
+                "listen address is not public"
+            );
+        }
 
-        let (_status, Json(authenticated)) = get_realm_info(State(state), Extension(Some(auth)))
+        let (_status, Json(info)) = get_realm_info(State(state), Extension(Some(auth)))
             .await
             .unwrap();
-        assert_eq!(authenticated.quota.user_group_cap_overrides.len(), 1);
+        assert_eq!(info.interfaces.rest.bind.as_deref(), Some("0.0.0.0:3000"));
+        let detail = info.detail.expect("realm token sees detail");
+        assert!(!detail.nodes.is_empty());
+        assert_eq!(detail.quota.user_group_cap_overrides.len(), 1);
         assert_eq!(
-            authenticated.quota.user_group_cap_overrides[0].user_id,
+            detail.quota.user_group_cap_overrides[0].user_id,
             admin.to_string()
         );
     }
@@ -2365,7 +2424,7 @@ mod tests {
             NodeInfoDocument, NodeUrls, NodeUtilization, node_info_storage_key,
         };
 
-        let (state, _realm_id, _admin, _tempdir) = setup_management_state().await;
+        let (state, realm_id, admin, _tempdir) = setup_management_state().await;
         let node_id = state.get_node_id();
 
         // The creating node's placement entry is seeded at realm creation with
@@ -2396,8 +2455,12 @@ mod tests {
             })
             .await;
 
-        let (status, Json(info)) = get_realm_info(State(state), Extension(None)).await.unwrap();
+        let (status, Json(info)) =
+            get_realm_info(State(state), Extension(Some(admin_auth(realm_id, admin))))
+                .await
+                .unwrap();
         assert_eq!(status, StatusCode::OK);
+        let info = info.detail.expect("realm token sees detail");
         let node = info
             .nodes
             .iter()

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -466,7 +466,8 @@ mod tests {
         );
     }
 
-    /// Without a token the node reports health and version only.
+    /// Without a token the node reports health, version and public interface
+    /// urls, but no node identity or backend topology.
     #[tokio::test]
     async fn live_info() {
         let _guard = env_lock().lock().await;
@@ -475,12 +476,21 @@ mod tests {
         let info = fetch_info(node.http_addr, None).await.unwrap();
 
         assert_eq!(
-            info.status,
+            info.node.status,
             aruna_api::routes::info::ServiceStatus::Available
         );
         assert!(!info.api_version.is_empty());
-        assert!(info.topology.is_none());
-        assert!(info.operations.is_none());
+        assert_eq!(
+            info.services.interfaces.rest.status,
+            aruna_api::routes::info::ServiceStatus::Available
+        );
+        let api_url = format!("http://{}/api/v1", node.http_addr);
+        assert_eq!(
+            info.services.interfaces.rest.url.as_deref(),
+            Some(api_url.as_str())
+        );
+        assert!(info.node.peer_id.is_none());
+        assert!(info.services.network.is_none());
         node.shutdown().await;
     }
 }

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -46,10 +46,10 @@ struct OidcProviderView {
     discovery_url: String,
 }
 
-pub async fn print_info() -> Result<(), CliError> {
+pub async fn print_info(token: Option<String>) -> Result<(), CliError> {
     let _ = dotenvy::dotenv();
     let http_socket_addr: SocketAddr = dotenvy::var("SOCKET_ADDRESS")?.parse()?;
-    let endpoint_info = fetch_info(http_socket_addr).await?;
+    let endpoint_info = fetch_info(http_socket_addr, resolve_token(token).as_deref()).await?;
     let output = DoctorInfoOutput {
         config: ConfigView::from_env(http_socket_addr)?,
         endpoint_info,
@@ -59,30 +59,43 @@ pub async fn print_info() -> Result<(), CliError> {
     Ok(())
 }
 
+/// `/info` only reports topology to a realm token and backend detail to a realm
+/// admin, so the operator passes one via `--token` or `ARUNA_TOKEN`.
+pub(crate) fn resolve_token(token: Option<String>) -> Option<String> {
+    token
+        .or_else(|| dotenvy::var("ARUNA_TOKEN").ok())
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+}
+
 pub(crate) fn default_info_url_from_env() -> Result<String, CliError> {
     let http_socket_addr: SocketAddr = dotenvy::var("SOCKET_ADDRESS")?.parse()?;
     Ok(info_url(http_socket_addr))
 }
 
-pub(crate) async fn fetch_info(http_socket_addr: SocketAddr) -> Result<InfoResponse, CliError> {
-    fetch_info_url(&info_url(http_socket_addr)).await
-}
-
-pub(crate) async fn fetch_info_url(url: &str) -> Result<InfoResponse, CliError> {
-    fetch_info_url_with_timeout(url, Duration::from_secs(10)).await
+pub(crate) async fn fetch_info(
+    http_socket_addr: SocketAddr,
+    token: Option<&str>,
+) -> Result<InfoResponse, CliError> {
+    fetch_info_url_with_timeout(&info_url(http_socket_addr), Duration::from_secs(10), token).await
 }
 
 pub(crate) async fn fetch_info_url_with_timeout(
     url: &str,
     timeout: Duration,
+    token: Option<&str>,
 ) -> Result<InfoResponse, CliError> {
     let timeout = nonzero_timeout(timeout);
     let connect_timeout = nonzero_timeout(timeout.min(Duration::from_secs(2)));
-    let response = Client::builder()
+    let mut request = Client::builder()
         .connect_timeout(connect_timeout)
         .timeout(timeout)
         .build()?
-        .get(url)
+        .get(url);
+    if let Some(token) = token {
+        request = request.bearer_auth(token);
+    }
+    let response = request
         .send()
         .await
         .map_err(|source| CliError::InfoRequest {
@@ -453,28 +466,21 @@ mod tests {
         );
     }
 
+    /// Without a token the node reports health and version only.
     #[tokio::test]
     async fn live_info() {
         let _guard = env_lock().lock().await;
         let node = spawn_test_node().await;
 
-        let info = fetch_info(node.http_addr).await.unwrap();
+        let info = fetch_info(node.http_addr, None).await.unwrap();
 
         assert_eq!(
-            info.services.network.status,
+            info.status,
             aruna_api::routes::info::ServiceStatus::Available
         );
-        assert!(info.services.network.discovery.is_empty());
-        assert_eq!(info.services.network.relay.as_deref(), Some("none"));
-        assert_eq!(
-            info.services.interfaces.rest.status,
-            aruna_api::routes::info::ServiceStatus::Available
-        );
-        let api_url = format!("http://{}/api/v1", node.http_addr);
-        assert_eq!(
-            info.services.interfaces.rest.url.as_deref(),
-            Some(api_url.as_str())
-        );
+        assert!(!info.api_version.is_empty());
+        assert!(info.topology.is_none());
+        assert!(info.operations.is_none());
         node.shutdown().await;
     }
 }

--- a/aruna-doctor/src/iroh_check.rs
+++ b/aruna-doctor/src/iroh_check.rs
@@ -1,7 +1,7 @@
 use crate::error::CliError;
-use crate::info::{default_info_url_from_env, fetch_info_url_with_timeout};
+use crate::info::{default_info_url_from_env, fetch_info_url_with_timeout, resolve_token};
 use aruna_api::routes::info::{
-    InfoResponse, NetworkServiceStatus, PeerConnectionInfo, ServiceStatus,
+    NetworkServiceStatus, NodeOperationsInfo, NodeTopologyInfo, PeerConnectionInfo, ServiceStatus,
 };
 use aruna_core::alpn::Alpn;
 use aruna_core::telemetry::duration_ms;
@@ -68,37 +68,53 @@ struct IrohCheckStep {
     duration_ms: u64,
 }
 
-pub async fn print_iroh_check(info_url: Option<String>, timeout_secs: u64) -> Result<(), CliError> {
+pub async fn print_iroh_check(
+    info_url: Option<String>,
+    timeout_secs: u64,
+    token: Option<String>,
+) -> Result<(), CliError> {
     let _ = dotenvy::dotenv();
     let info_url = match info_url {
         Some(info_url) => info_url,
         None => default_info_url_from_env()?,
     };
-    let output = run_iroh_check(info_url, Duration::from_secs(timeout_secs)).await?;
+    let output = run_iroh_check(
+        info_url,
+        Duration::from_secs(timeout_secs),
+        resolve_token(token),
+    )
+    .await?;
 
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
 }
 
-async fn run_iroh_check(info_url: String, timeout: Duration) -> Result<IrohCheckOutput, CliError> {
+async fn run_iroh_check(
+    info_url: String,
+    timeout: Duration,
+    token: Option<String>,
+) -> Result<IrohCheckOutput, CliError> {
     let mut checks = Vec::new();
 
     let info_started = Instant::now();
-    let endpoint_info = fetch_info_url_with_timeout(&info_url, timeout).await?;
+    let endpoint_info = fetch_info_url_with_timeout(&info_url, timeout, token.as_deref()).await?;
     checks.push(ok_step("info", info_started.elapsed()));
 
-    if endpoint_info.services.network.status != ServiceStatus::Available {
+    let topology = endpoint_info.topology.as_ref().ok_or_else(|| {
+        iroh_check_error(
+            "info",
+            "node reports no topology: pass a realm token via --token or ARUNA_TOKEN",
+        )
+    })?;
+    if topology.network.status != ServiceStatus::Available {
         return Err(iroh_check_error(
             "info",
-            format!(
-                "network state is {:?}",
-                endpoint_info.services.network.status
-            ),
+            format!("network state is {:?}", topology.network.status),
         ));
     }
 
     let endpoint_started = Instant::now();
-    let endpoint_addr = endpoint_addr_from_info(&endpoint_info)?;
+    let endpoint_addr = endpoint_addr_from_info(topology)?;
     let endpoint_addr = normalize_endpoint_addr(endpoint_addr, &info_url)?;
     checks.push(ok_step("endpoint_addr", endpoint_started.elapsed()));
 
@@ -107,20 +123,20 @@ async fn run_iroh_check(info_url: String, timeout: Duration) -> Result<IrohCheck
     Ok(IrohCheckOutput {
         status: "ok",
         info_url,
-        target: target_output(&endpoint_info, &endpoint_addr),
-        reported: reported_diagnostics(&endpoint_info),
+        target: target_output(endpoint_info.realm_id.clone(), topology, &endpoint_addr),
+        reported: reported_diagnostics(topology, endpoint_info.operations.as_ref()),
         active,
         checks,
     })
 }
 
-fn endpoint_addr_from_info(endpoint_info: &InfoResponse) -> Result<EndpointAddr, CliError> {
-    let peer_id = endpoint_info
+fn endpoint_addr_from_info(topology: &NodeTopologyInfo) -> Result<EndpointAddr, CliError> {
+    let peer_id = topology
         .node
         .peer_id
         .parse::<iroh::PublicKey>()
         .map_err(|error| iroh_check_error("endpoint_addr", error))?;
-    let addresses = endpoint_info
+    let addresses = topology
         .my_addresses
         .iter()
         .map(|address| transport_addr_from_info(address))
@@ -289,10 +305,14 @@ where
     }
 }
 
-fn target_output(endpoint_info: &InfoResponse, endpoint_addr: &EndpointAddr) -> IrohCheckTarget {
+fn target_output(
+    realm_id: String,
+    topology: &NodeTopologyInfo,
+    endpoint_addr: &EndpointAddr,
+) -> IrohCheckTarget {
     IrohCheckTarget {
-        realm_id: Some(endpoint_info.node.realm_id.clone()),
-        node_id: Some(endpoint_info.node.peer_id.clone()),
+        realm_id: Some(realm_id),
+        node_id: Some(topology.node.peer_id.clone()),
         endpoint_addr: serde_json::to_value(endpoint_addr).unwrap_or(serde_json::Value::Null),
         addresses: endpoint_addr
             .addrs
@@ -304,11 +324,16 @@ fn target_output(endpoint_info: &InfoResponse, endpoint_addr: &EndpointAddr) -> 
     }
 }
 
-fn reported_diagnostics(endpoint_info: &InfoResponse) -> ReportedNetDiagnostics {
+fn reported_diagnostics(
+    topology: &NodeTopologyInfo,
+    operations: Option<&NodeOperationsInfo>,
+) -> ReportedNetDiagnostics {
     ReportedNetDiagnostics {
-        network: endpoint_info.services.network.clone(),
-        connections: endpoint_info.connections.clone(),
-        warnings: endpoint_info.warnings.clone(),
+        network: topology.network.clone(),
+        connections: topology.connections.clone(),
+        warnings: operations
+            .map(|operations| operations.warnings.clone())
+            .unwrap_or_default(),
     }
 }
 
@@ -385,16 +410,14 @@ fn iroh_check_error(step: &'static str, message: impl std::fmt::Display) -> CliE
 mod tests {
     use super::*;
     use aruna_api::routes::info::{
-        BlobServiceStatus, DatabaseServiceStatus, InfoResponse, InterfaceServicesStatus,
-        InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind, NodeStatus, PortalStatus,
-        RequestSummary, ServicesStatus,
+        InterfaceServicesStatus, InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind,
+        NodeStatus,
     };
-    use aruna_core::structs::RealmId;
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
     use aruna_storage::FjallStorage;
     use tempfile::{TempDir, tempdir};
 
-    fn test_info_response(endpoint_addr: Option<EndpointAddr>) -> InfoResponse {
+    fn test_topology(endpoint_addr: Option<EndpointAddr>) -> NodeTopologyInfo {
         let node_id = endpoint_addr
             .as_ref()
             .map(|addr| addr.id)
@@ -404,59 +427,32 @@ mod tests {
             .map(|addr| addr.addrs.iter().map(transport_addr_to_string).collect())
             .unwrap_or_default();
 
-        InfoResponse {
+        NodeTopologyInfo {
             node: NodeStatus {
-                status: ServiceStatus::Available,
-                realm_id: RealmId::from_bytes([1u8; 32]).to_string(),
                 peer_id: node_id.to_string(),
                 capabilities: NodeCapabilityKind::Management,
             },
-            api_version: "test".to_string(),
-            portal: PortalStatus::default(),
             my_addresses,
             connections: Vec::new(),
-            services: ServicesStatus {
-                network: NetworkServiceStatus {
+            network: NetworkServiceStatus {
+                status: ServiceStatus::Available,
+                discovery: Vec::new(),
+                relay: Some("none".to_string()),
+                relay_urls: Vec::new(),
+                routing_table_size: None,
+            },
+            interfaces: InterfaceServicesStatus {
+                rest: InterfaceStatus {
                     status: ServiceStatus::Available,
-                    discovery: Vec::new(),
-                    relay: Some("none".to_string()),
-                    relay_urls: Vec::new(),
-                    routing_table_size: None,
-                    requests: RequestSummary {
-                        total: 0,
-                        failure_rate: 0.0,
-                        last_error: None,
-                    },
+                    bind: None,
+                    url: None,
                 },
-                blob: BlobServiceStatus {
-                    status: ServiceStatus::NotConfigured,
-                    backend: None,
-                    max_bucket_size: None,
-                    multipart_bucket: None,
-                    timeouts_secs: None,
-                },
-                database: DatabaseServiceStatus {
-                    status: ServiceStatus::Available,
-                    requests: RequestSummary {
-                        total: 0,
-                        failure_rate: 0.0,
-                        last_error: None,
-                    },
-                },
-                interfaces: InterfaceServicesStatus {
-                    rest: InterfaceStatus {
-                        status: ServiceStatus::Available,
-                        bind: None,
-                        url: None,
-                    },
-                    s3: InterfaceStatus {
-                        status: ServiceStatus::Unavailable,
-                        bind: None,
-                        url: None,
-                    },
+                s3: InterfaceStatus {
+                    status: ServiceStatus::Unavailable,
+                    bind: None,
+                    url: None,
                 },
             },
-            warnings: Vec::new(),
         }
     }
 
@@ -480,7 +476,7 @@ mod tests {
 
     #[test]
     fn endpoint_addr_from_info_requires_endpoint_addr() {
-        let error = endpoint_addr_from_info(&test_info_response(None)).unwrap_err();
+        let error = endpoint_addr_from_info(&test_topology(None)).unwrap_err();
 
         assert!(matches!(
             error,
@@ -560,7 +556,7 @@ mod tests {
     async fn run_iroh_check_builds_output_from_info() {
         let (target, _dir) = test_net_handle().await;
         let output_endpoint =
-            endpoint_addr_from_info(&test_info_response(Some(target.endpoint_addr()))).unwrap();
+            endpoint_addr_from_info(&test_topology(Some(target.endpoint_addr()))).unwrap();
         let mut checks = Vec::new();
 
         let active = active_iroh_check(output_endpoint, Duration::from_secs(5), &mut checks)

--- a/aruna-doctor/src/iroh_check.rs
+++ b/aruna-doctor/src/iroh_check.rs
@@ -1,7 +1,7 @@
 use crate::error::CliError;
 use crate::info::{default_info_url_from_env, fetch_info_url_with_timeout, resolve_token};
 use aruna_api::routes::info::{
-    NetworkServiceStatus, NodeOperationsInfo, NodeTopologyInfo, PeerConnectionInfo, ServiceStatus,
+    InfoResponse, NetworkServiceStatus, PeerConnectionInfo, ServiceStatus,
 };
 use aruna_core::alpn::Alpn;
 use aruna_core::telemetry::duration_ms;
@@ -100,21 +100,21 @@ async fn run_iroh_check(
     let endpoint_info = fetch_info_url_with_timeout(&info_url, timeout, token.as_deref()).await?;
     checks.push(ok_step("info", info_started.elapsed()));
 
-    let topology = endpoint_info.topology.as_ref().ok_or_else(|| {
+    let network = endpoint_info.services.network.as_ref().ok_or_else(|| {
         iroh_check_error(
             "info",
             "node reports no topology: pass a realm token via --token or ARUNA_TOKEN",
         )
     })?;
-    if topology.network.status != ServiceStatus::Available {
+    if network.status != ServiceStatus::Available {
         return Err(iroh_check_error(
             "info",
-            format!("network state is {:?}", topology.network.status),
+            format!("network state is {:?}", network.status),
         ));
     }
 
     let endpoint_started = Instant::now();
-    let endpoint_addr = endpoint_addr_from_info(topology)?;
+    let endpoint_addr = endpoint_addr_from_info(&endpoint_info)?;
     let endpoint_addr = normalize_endpoint_addr(endpoint_addr, &info_url)?;
     checks.push(ok_step("endpoint_addr", endpoint_started.elapsed()));
 
@@ -123,20 +123,27 @@ async fn run_iroh_check(
     Ok(IrohCheckOutput {
         status: "ok",
         info_url,
-        target: target_output(endpoint_info.realm_id.clone(), topology, &endpoint_addr),
-        reported: reported_diagnostics(topology, endpoint_info.operations.as_ref()),
+        target: target_output(&endpoint_info, &endpoint_addr),
+        reported: reported_diagnostics(network, &endpoint_info),
         active,
         checks,
     })
 }
 
-fn endpoint_addr_from_info(topology: &NodeTopologyInfo) -> Result<EndpointAddr, CliError> {
-    let peer_id = topology
+fn endpoint_addr_from_info(endpoint_info: &InfoResponse) -> Result<EndpointAddr, CliError> {
+    let peer_id = endpoint_info
         .node
         .peer_id
+        .as_deref()
+        .ok_or_else(|| {
+            iroh_check_error(
+                "endpoint_addr",
+                "node reports no peer id: pass a realm token via --token or ARUNA_TOKEN",
+            )
+        })?
         .parse::<iroh::PublicKey>()
         .map_err(|error| iroh_check_error("endpoint_addr", error))?;
-    let addresses = topology
+    let addresses = endpoint_info
         .my_addresses
         .iter()
         .map(|address| transport_addr_from_info(address))
@@ -305,14 +312,10 @@ where
     }
 }
 
-fn target_output(
-    realm_id: String,
-    topology: &NodeTopologyInfo,
-    endpoint_addr: &EndpointAddr,
-) -> IrohCheckTarget {
+fn target_output(endpoint_info: &InfoResponse, endpoint_addr: &EndpointAddr) -> IrohCheckTarget {
     IrohCheckTarget {
-        realm_id: Some(realm_id),
-        node_id: Some(topology.node.peer_id.clone()),
+        realm_id: Some(endpoint_info.node.realm_id.clone()),
+        node_id: endpoint_info.node.peer_id.clone(),
         endpoint_addr: serde_json::to_value(endpoint_addr).unwrap_or(serde_json::Value::Null),
         addresses: endpoint_addr
             .addrs
@@ -325,15 +328,13 @@ fn target_output(
 }
 
 fn reported_diagnostics(
-    topology: &NodeTopologyInfo,
-    operations: Option<&NodeOperationsInfo>,
+    network: &NetworkServiceStatus,
+    endpoint_info: &InfoResponse,
 ) -> ReportedNetDiagnostics {
     ReportedNetDiagnostics {
-        network: topology.network.clone(),
-        connections: topology.connections.clone(),
-        warnings: operations
-            .map(|operations| operations.warnings.clone())
-            .unwrap_or_default(),
+        network: network.clone(),
+        connections: endpoint_info.connections.clone(),
+        warnings: endpoint_info.warnings.clone(),
     }
 }
 
@@ -410,14 +411,14 @@ fn iroh_check_error(step: &'static str, message: impl std::fmt::Display) -> CliE
 mod tests {
     use super::*;
     use aruna_api::routes::info::{
-        InterfaceServicesStatus, InterfaceStatus, NetworkServiceStatus, NodeCapabilityKind,
-        NodeStatus,
+        InterfaceServicesStatus, InterfaceStatus, NodeCapabilityKind, NodeStatus, ServicesStatus,
     };
+    use aruna_core::structs::RealmId;
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
     use aruna_storage::FjallStorage;
     use tempfile::{TempDir, tempdir};
 
-    fn test_topology(endpoint_addr: Option<EndpointAddr>) -> NodeTopologyInfo {
+    fn test_info_response(endpoint_addr: Option<EndpointAddr>) -> InfoResponse {
         let node_id = endpoint_addr
             .as_ref()
             .map(|addr| addr.id)
@@ -427,32 +428,42 @@ mod tests {
             .map(|addr| addr.addrs.iter().map(transport_addr_to_string).collect())
             .unwrap_or_default();
 
-        NodeTopologyInfo {
+        InfoResponse {
             node: NodeStatus {
-                peer_id: node_id.to_string(),
-                capabilities: NodeCapabilityKind::Management,
+                status: ServiceStatus::Available,
+                realm_id: RealmId::from_bytes([1u8; 32]).to_string(),
+                peer_id: Some(node_id.to_string()),
+                capabilities: Some(NodeCapabilityKind::Management),
             },
+            api_version: "test".to_string(),
+            portal: None,
             my_addresses,
             connections: Vec::new(),
-            network: NetworkServiceStatus {
-                status: ServiceStatus::Available,
-                discovery: Vec::new(),
-                relay: Some("none".to_string()),
-                relay_urls: Vec::new(),
-                routing_table_size: None,
-            },
-            interfaces: InterfaceServicesStatus {
-                rest: InterfaceStatus {
+            services: ServicesStatus {
+                network: Some(NetworkServiceStatus {
                     status: ServiceStatus::Available,
-                    bind: None,
-                    url: None,
-                },
-                s3: InterfaceStatus {
-                    status: ServiceStatus::Unavailable,
-                    bind: None,
-                    url: None,
+                    discovery: Vec::new(),
+                    relay: Some("none".to_string()),
+                    relay_urls: Vec::new(),
+                    routing_table_size: None,
+                    requests: None,
+                }),
+                blob: None,
+                database: None,
+                interfaces: InterfaceServicesStatus {
+                    rest: InterfaceStatus {
+                        status: ServiceStatus::Available,
+                        bind: None,
+                        url: None,
+                    },
+                    s3: InterfaceStatus {
+                        status: ServiceStatus::Unavailable,
+                        bind: None,
+                        url: None,
+                    },
                 },
             },
+            warnings: Vec::new(),
         }
     }
 
@@ -476,7 +487,7 @@ mod tests {
 
     #[test]
     fn endpoint_addr_from_info_requires_endpoint_addr() {
-        let error = endpoint_addr_from_info(&test_topology(None)).unwrap_err();
+        let error = endpoint_addr_from_info(&test_info_response(None)).unwrap_err();
 
         assert!(matches!(
             error,
@@ -556,7 +567,7 @@ mod tests {
     async fn run_iroh_check_builds_output_from_info() {
         let (target, _dir) = test_net_handle().await;
         let output_endpoint =
-            endpoint_addr_from_info(&test_topology(Some(target.endpoint_addr()))).unwrap();
+            endpoint_addr_from_info(&test_info_response(Some(target.endpoint_addr()))).unwrap();
         let mut checks = Vec::new();
 
         let active = active_iroh_check(output_endpoint, Duration::from_secs(5), &mut checks)

--- a/aruna-doctor/src/main.rs
+++ b/aruna-doctor/src/main.rs
@@ -78,7 +78,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: PortalCommands,
     },
-    Info,
+    Info {
+        /// Realm token used to read node topology and backend detail. Falls back
+        /// to ARUNA_TOKEN.
+        #[arg(long)]
+        token: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -123,6 +128,9 @@ pub enum IrohCommands {
         info_url: Option<String>,
         #[arg(long, default_value_t = 10)]
         timeout_secs: u64,
+        /// Realm token used to read node topology. Falls back to ARUNA_TOKEN.
+        #[arg(long)]
+        token: Option<String>,
     },
 }
 
@@ -197,7 +205,8 @@ pub async fn main() -> Result<(), CliError> {
             IrohCommands::Check {
                 info_url,
                 timeout_secs,
-            } => print_iroh_check(info_url, timeout_secs).await?,
+                token,
+            } => print_iroh_check(info_url, timeout_secs, token).await?,
         },
         Commands::Portal { command } => match command {
             PortalCommands::Update {
@@ -215,7 +224,7 @@ pub async fn main() -> Result<(), CliError> {
                 .await?
             }
         },
-        Commands::Info => print_info().await?,
+        Commands::Info { token } => print_info(token).await?,
     };
 
     Ok(())


### PR DESCRIPTION
Closes #347

The unauthenticated info surface published a map of the deployment.

- `GET /info` served peer id and capabilities, this node's addresses, the full connection list with peer addresses and round trip times, relay and discovery configuration, blob and database backend detail, portal install detail, and warnings, all without a token. Anonymous callers now receive exactly `status`, `api_version` and `realm_id`. Topology moves behind a realm token; backend detail, error strings and diagnostics move behind admin.
- `GET /info/realm` no longer exposes node ids, labels, urls, utilization and placement, realm discovery configuration, or the quota policy to anonymous callers. It keeps what a client needs in order to authenticate: realm id, description, OIDC providers and the public interface urls.
- `GET /info/usage` required no authentication for local counters and accepted any token, including one from a foreign realm, for realm totals. It now requires local realm authentication.
- The group directory (`GET /groups` and its subroutes) could be enumerated with any token, including a foreign trusted realm token. It now requires realm authentication, matching the rule the user directory already enforced.

`aruna-doctor info` and `aruna-doctor iroh check` consume the topology and previously had no way to authenticate, so both gain `--token`, falling back to `ARUNA_TOKEN`. Without a token `iroh check` now reports that it needs one instead of silently producing an empty result.

OIDC issuer, audience and discovery url stay public. Without them a client cannot obtain a token at all.