### PR TITLE
[fix] Serve a Content Security Policy on portal responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ PORTAL_ARTIFACT_URL=
 PORTAL_ARTIFACT_SHA256=
 PORTAL_DIR=
 
+# Portal responses carry a Content-Security-Policy whose connect-src allows this
+# node's REST origin, its advertised S3 endpoint and the realm's OIDC provider
+# origins. Add comma-separated origins here when the portal must reach anything
+# else from the browser, such as the S3 endpoints of other realm nodes.
+PORTAL_CSP_EXTRA_ORIGINS=
+
 # Maximum REST request body size in bytes (default 1 MiB). Oversized bodies
 # are rejected with 413.
 MAX_HTTP_BODY_SIZE=1048576

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use url::{Host, Url};
 
 /// The portal loads its webfont stylesheet from Google Fonts and the font files
@@ -226,6 +226,7 @@ fn directive(base: &str, origins: &BTreeSet<String>) -> String {
 fn normalize_origin(value: &str) -> Option<String> {
     let url = Url::parse(value.trim()).ok()?;
     if !is_secure_origin(&url) {
+        warn!(origin = %value, "Portal CSP ignores insecure origin");
         return None;
     }
     let origin = url.origin().ascii_serialization();

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -8,7 +8,7 @@ use axum::response::Response;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use tracing::debug;
-use url::Url;
+use url::{Host, Url};
 
 /// The portal loads its webfont stylesheet from Google Fonts and the font files
 /// from the matching static origin.
@@ -138,12 +138,32 @@ fn content_security_policy(connect_origins: &BTreeSet<String>) -> String {
     .join("; ")
 }
 
+/// Origins may broaden `connect-src`, so only https (or http on a loopback
+/// host, for local development) is accepted; anything else is dropped.
 fn normalize_origin(value: &str) -> Option<String> {
-    let origin = Url::parse(value.trim())
-        .ok()?
-        .origin()
-        .ascii_serialization();
+    let url = Url::parse(value.trim()).ok()?;
+    if !is_secure_origin(&url) {
+        return None;
+    }
+    let origin = url.origin().ascii_serialization();
     (origin != "null").then_some(origin)
+}
+
+fn is_secure_origin(url: &Url) -> bool {
+    match url.scheme() {
+        "https" => true,
+        "http" => is_loopback_host(url.host()),
+        _ => false,
+    }
+}
+
+fn is_loopback_host(host: Option<Host<&str>>) -> bool {
+    match host {
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => ip.is_loopback(),
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        None => false,
+    }
 }
 
 #[cfg(test)]
@@ -152,7 +172,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[test]
-    fn origins_drop_path_and_scheme_noise() {
+    fn origins_drop_noise() {
         assert_eq!(
             normalize_origin("https://issuer.test/realms/aruna/.well-known"),
             Some("https://issuer.test".to_string())
@@ -163,6 +183,26 @@ mod tests {
         );
         assert_eq!(normalize_origin("not-a-url"), None);
         assert_eq!(normalize_origin("data:text/html,x"), None);
+    }
+
+    #[test]
+    fn rejects_insecure_origins() {
+        // Only https, or http on a loopback host, may broaden the policy.
+        assert_eq!(normalize_origin("http://issuer.test"), None);
+        assert_eq!(normalize_origin("ws://issuer.test"), None);
+        assert_eq!(normalize_origin("ftp://issuer.test"), None);
+        assert_eq!(
+            normalize_origin("https://issuer.test"),
+            Some("https://issuer.test".to_string())
+        );
+        assert_eq!(
+            normalize_origin("http://localhost:8080"),
+            Some("http://localhost:8080".to_string())
+        );
+        assert_eq!(
+            normalize_origin("http://[::1]:9000"),
+            Some("http://[::1]:9000".to_string())
+        );
     }
 
     #[test]

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -5,7 +5,8 @@ use axum::extract::{Request, State};
 use axum::http::{HeaderName, HeaderValue, StatusCode, header};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use std::collections::BTreeSet;
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -23,6 +24,7 @@ const BASELINE_CSP: &str = "frame-ancestors 'none'";
 /// OIDC origins change rarely; a point-read behind this window keeps the common
 /// portal response off the storage path.
 const OIDC_ORIGIN_TTL: Duration = Duration::from_secs(60);
+const OIDC_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 const CROSS_ORIGIN_OPENER_POLICY: HeaderName =
     HeaderName::from_static("cross-origin-opener-policy");
@@ -59,13 +61,27 @@ struct ResolvedOrigins {
 #[derive(Default)]
 struct OidcOriginCache {
     origins: BTreeSet<String>,
+    token_origins: BTreeMap<String, String>,
     refreshed_at: Option<Instant>,
+}
+
+#[derive(Default)]
+struct S3OriginCache {
+    base_url: Option<String>,
+    origin: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OidcDiscoveryDocument {
+    token_endpoint: String,
 }
 
 #[derive(Clone)]
 pub(crate) struct PortalSecurity {
     state: Arc<ServerState>,
     config: Arc<PortalCspConfig>,
+    client: reqwest::Client,
+    s3_cache: Arc<RwLock<S3OriginCache>>,
     oidc_cache: Arc<RwLock<OidcOriginCache>>,
 }
 
@@ -74,6 +90,8 @@ impl PortalSecurity {
         Self {
             state,
             config: Arc::new(config),
+            client: reqwest::Client::new(),
+            s3_cache: Arc::new(RwLock::new(S3OriginCache::default())),
             oidc_cache: Arc::new(RwLock::new(OidcOriginCache::default())),
         }
     }
@@ -92,7 +110,21 @@ impl PortalSecurity {
 
     async fn s3_origin(&self) -> Option<String> {
         let s3 = self.state.interface_state().await.s3?;
-        normalize_origin(&s3.base_url)
+        {
+            let cache = self.s3_cache.read().await;
+            if cache.base_url.as_ref() == Some(&s3.base_url) {
+                return cache.origin.clone();
+            }
+        }
+
+        let mut cache = self.s3_cache.write().await;
+        if cache.base_url.as_ref() == Some(&s3.base_url) {
+            return cache.origin.clone();
+        }
+        let origin = normalize_origin(&s3.base_url);
+        cache.base_url = Some(s3.base_url);
+        cache.origin = origin.clone();
+        origin
     }
 
     /// Cached OIDC origins; a stale window triggers a point-read, and a failed
@@ -118,11 +150,29 @@ impl PortalSecurity {
         {
             Ok(config) => {
                 let mut origins = BTreeSet::new();
+                let mut token_origins = BTreeMap::new();
                 for provider in config.oidc_providers {
                     origins.extend(normalize_origin(&provider.issuer));
                     origins.extend(normalize_origin(&provider.discovery_url));
+                    let token_origin = match self.oidc_token_endpoint(&provider.discovery_url).await
+                    {
+                        Ok(token_endpoint) => normalize_origin(&token_endpoint),
+                        Err(error) => {
+                            debug!(
+                                error = %error,
+                                discovery_url = %provider.discovery_url,
+                                "Portal CSP reuses cached OIDC token endpoint"
+                            );
+                            cache.token_origins.get(&provider.discovery_url).cloned()
+                        }
+                    };
+                    if let Some(token_origin) = token_origin {
+                        origins.insert(token_origin.clone());
+                        token_origins.insert(provider.discovery_url, token_origin);
+                    }
                 }
                 cache.origins = origins.clone();
+                cache.token_origins = token_origins;
                 cache.refreshed_at = Some(Instant::now());
                 origins
             }
@@ -138,6 +188,19 @@ impl PortalSecurity {
         let cache = self.oidc_cache.read().await;
         let refreshed_at = cache.refreshed_at?;
         (refreshed_at.elapsed() < OIDC_ORIGIN_TTL).then(|| cache.origins.clone())
+    }
+
+    async fn oidc_token_endpoint(&self, discovery_url: &str) -> reqwest::Result<String> {
+        let discovery = self
+            .client
+            .get(discovery_url)
+            .timeout(OIDC_DISCOVERY_TIMEOUT)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<OidcDiscoveryDocument>()
+            .await?;
+        Ok(discovery.token_endpoint)
     }
 }
 

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -40,6 +40,13 @@ impl PortalCspConfig {
     }
 }
 
+/// Origins the served policy allows, resolved per response.
+#[derive(Clone, Debug, Default)]
+struct ResolvedOrigins {
+    connect: BTreeSet<String>,
+    img: BTreeSet<String>,
+}
+
 #[derive(Clone)]
 pub(crate) struct PortalSecurity {
     state: Arc<ServerState>,
@@ -54,15 +61,24 @@ impl PortalSecurity {
         }
     }
 
-    async fn connect_origins(&self) -> BTreeSet<String> {
-        let mut origins = BTreeSet::new();
-
-        if let Some(s3) = self.state.interface_state().await.s3
-            && let Some(origin) = normalize_origin(&s3.base_url)
-        {
-            origins.insert(origin);
+    async fn resolve(&self) -> ResolvedOrigins {
+        let s3 = self.s3_origin().await;
+        let mut connect = BTreeSet::new();
+        connect.extend(s3.iter().cloned());
+        connect.extend(self.oidc_origins().await);
+        connect.extend(self.config.extra_connect_origins.iter().cloned());
+        ResolvedOrigins {
+            connect,
+            img: s3.into_iter().collect(),
         }
+    }
 
+    async fn s3_origin(&self) -> Option<String> {
+        let s3 = self.state.interface_state().await.s3?;
+        normalize_origin(&s3.base_url)
+    }
+
+    async fn oidc_origins(&self) -> BTreeSet<String> {
         match drive(
             GetRealmConfigOperation::new(self.state.get_realm_id()),
             &self.state.get_ctx(),
@@ -70,18 +86,20 @@ impl PortalSecurity {
         .await
         {
             Ok(config) => {
+                let mut origins = BTreeSet::new();
                 for provider in config.oidc_providers {
                     origins.extend(normalize_origin(&provider.issuer));
                     origins.extend(normalize_origin(&provider.discovery_url));
                 }
+                origins
             }
             // The realm config is unavailable until it syncs; sign-in needs it
             // anyway, so the portal keeps booting with the baseline policy.
-            Err(error) => debug!(error = %error, "Portal CSP omits realm OIDC origins"),
+            Err(error) => {
+                debug!(error = %error, "Portal CSP omits realm OIDC origins");
+                BTreeSet::new()
+            }
         }
-
-        origins.extend(self.config.extra_connect_origins.iter().cloned());
-        origins
     }
 }
 
@@ -90,7 +108,7 @@ pub(crate) async fn portal_security_headers(
     request: Request,
     next: Next,
 ) -> Response {
-    let policy = content_security_policy(&security.connect_origins().await);
+    let policy = content_security_policy(&security.resolve().await);
     let policy = match HeaderValue::from_str(&policy) {
         Ok(policy) => policy,
         Err(error) => {
@@ -120,12 +138,9 @@ pub(crate) async fn portal_security_headers(
 /// `script-src` carries `'wasm-unsafe-eval'` because the portal hashes profile
 /// artifacts with hash-wasm, which compiles a WebAssembly module; it permits no
 /// JavaScript eval. Inline scripts and styles are not allowed.
-fn content_security_policy(connect_origins: &BTreeSet<String>) -> String {
-    let mut connect_src = String::from("connect-src 'self'");
-    for origin in connect_origins {
-        connect_src.push(' ');
-        connect_src.push_str(origin);
-    }
+fn content_security_policy(origins: &ResolvedOrigins) -> String {
+    let connect_src = directive("connect-src 'self'", &origins.connect);
+    let img_src = directive("img-src 'self' data: blob:", &origins.img);
 
     [
         "default-src 'self'",
@@ -136,15 +151,24 @@ fn content_security_policy(connect_origins: &BTreeSet<String>) -> String {
         "form-action 'self'",
         "script-src 'self' 'wasm-unsafe-eval'",
         &format!("style-src 'self' {FONT_STYLE_ORIGIN}"),
-        "img-src 'self' data:",
+        &img_src,
         &format!("font-src 'self' data: {FONT_FILE_ORIGIN}"),
         &connect_src,
     ]
     .join("; ")
 }
 
-/// Origins may broaden `connect-src`, so only https (or http on a loopback
-/// host, for local development) is accepted; anything else is dropped.
+fn directive(base: &str, origins: &BTreeSet<String>) -> String {
+    let mut directive = String::from(base);
+    for origin in origins {
+        directive.push(' ');
+        directive.push_str(origin);
+    }
+    directive
+}
+
+/// Origins may broaden `connect-src`/`img-src`, so only https (or http on a
+/// loopback host, for local development) is accepted; anything else is dropped.
 fn normalize_origin(value: &str) -> Option<String> {
     let url = Url::parse(value.trim()).ok()?;
     if !is_secure_origin(&url) {
@@ -173,8 +197,14 @@ fn is_loopback_host(host: Option<Host<&str>>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{content_security_policy, normalize_origin};
-    use std::collections::BTreeSet;
+    use super::{ResolvedOrigins, content_security_policy, normalize_origin};
+
+    fn origins(connect: &[&str], img: &[&str]) -> ResolvedOrigins {
+        ResolvedOrigins {
+            connect: connect.iter().map(|s| s.to_string()).collect(),
+            img: img.iter().map(|s| s.to_string()).collect(),
+        }
+    }
 
     #[test]
     fn origins_drop_noise() {
@@ -211,14 +241,14 @@ mod tests {
     }
 
     #[test]
-    fn policy_pins_portal_needs() {
-        let policy = content_security_policy(&BTreeSet::new());
+    fn policy_pins_needs() {
+        let policy = content_security_policy(&ResolvedOrigins::default());
 
         assert!(policy.contains("default-src 'self'"));
         assert!(policy.contains("script-src 'self' 'wasm-unsafe-eval'"));
         assert!(policy.contains("style-src 'self' https://fonts.googleapis.com"));
         assert!(policy.contains("font-src 'self' data: https://fonts.gstatic.com"));
-        assert!(policy.contains("img-src 'self' data:"));
+        assert!(policy.contains("img-src 'self' data: blob:"));
         assert!(policy.contains("connect-src 'self'"));
         assert!(policy.contains("frame-ancestors 'none'"));
         assert!(policy.contains("object-src 'none'"));
@@ -229,14 +259,19 @@ mod tests {
     }
 
     #[test]
-    fn connect_src_lists_origins() {
-        let origins = BTreeSet::from([
-            "https://issuer.test".to_string(),
-            "http://127.0.0.1:9000".to_string(),
-        ]);
-
-        let policy = content_security_policy(&origins);
+    fn connect_src_lists() {
+        let policy = content_security_policy(&origins(
+            &["https://issuer.test", "http://127.0.0.1:9000"],
+            &[],
+        ));
 
         assert!(policy.ends_with("connect-src 'self' http://127.0.0.1:9000 https://issuer.test"));
+    }
+
+    #[test]
+    fn img_src_allows_s3() {
+        let policy = content_security_policy(&origins(&["https://s3.test"], &["https://s3.test"]));
+
+        assert!(policy.contains("img-src 'self' data: blob: https://s3.test"));
     }
 }

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -17,6 +17,9 @@ use url::{Host, Url};
 const FONT_STYLE_ORIGIN: &str = "https://fonts.googleapis.com";
 const FONT_FILE_ORIGIN: &str = "https://fonts.gstatic.com";
 
+/// Anti-clickjacking policy every response carries when it has no stricter one.
+const BASELINE_CSP: &str = "frame-ancestors 'none'";
+
 /// OIDC origins change rarely; a point-read behind this window keeps the common
 /// portal response off the storage path.
 const OIDC_ORIGIN_TTL: Duration = Duration::from_secs(60);
@@ -148,6 +151,19 @@ pub(crate) async fn portal_security_headers(
     let headers = response.headers_mut();
     headers.insert(header::CONTENT_SECURITY_POLICY, policy);
     headers.insert(
+        CROSS_ORIGIN_OPENER_POLICY,
+        HeaderValue::from_static("same-origin"),
+    );
+    response
+}
+
+/// Headers every response carries, regardless of route: swagger and api-docs
+/// serve inline-script HTML on this origin and still need nosniff and the
+/// anti-clickjacking baseline. The strict portal policy stays portal-only.
+pub(crate) async fn baseline_security_headers(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(
         header::X_CONTENT_TYPE_OPTIONS,
         HeaderValue::from_static("nosniff"),
     );
@@ -155,10 +171,13 @@ pub(crate) async fn portal_security_headers(
         header::REFERRER_POLICY,
         HeaderValue::from_static("no-referrer"),
     );
-    headers.insert(
-        CROSS_ORIGIN_OPENER_POLICY,
-        HeaderValue::from_static("same-origin"),
-    );
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    if !headers.contains_key(header::CONTENT_SECURITY_POLICY) {
+        headers.insert(
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static(BASELINE_CSP),
+        );
+    }
     response
 }
 

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -7,6 +7,8 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
 use tracing::{debug, error};
 use url::{Host, Url};
 
@@ -14,6 +16,10 @@ use url::{Host, Url};
 /// from the matching static origin.
 const FONT_STYLE_ORIGIN: &str = "https://fonts.googleapis.com";
 const FONT_FILE_ORIGIN: &str = "https://fonts.gstatic.com";
+
+/// OIDC origins change rarely; a point-read behind this window keeps the common
+/// portal response off the storage path.
+const OIDC_ORIGIN_TTL: Duration = Duration::from_secs(60);
 
 const CROSS_ORIGIN_OPENER_POLICY: HeaderName =
     HeaderName::from_static("cross-origin-opener-policy");
@@ -47,10 +53,17 @@ struct ResolvedOrigins {
     img: BTreeSet<String>,
 }
 
+#[derive(Default)]
+struct OidcOriginCache {
+    origins: BTreeSet<String>,
+    refreshed_at: Option<Instant>,
+}
+
 #[derive(Clone)]
 pub(crate) struct PortalSecurity {
     state: Arc<ServerState>,
     config: Arc<PortalCspConfig>,
+    oidc_cache: Arc<RwLock<OidcOriginCache>>,
 }
 
 impl PortalSecurity {
@@ -58,6 +71,7 @@ impl PortalSecurity {
         Self {
             state,
             config: Arc::new(config),
+            oidc_cache: Arc::new(RwLock::new(OidcOriginCache::default())),
         }
     }
 
@@ -78,7 +92,13 @@ impl PortalSecurity {
         normalize_origin(&s3.base_url)
     }
 
+    /// Cached OIDC origins; a stale window triggers a point-read, and a failed
+    /// read reuses the last-known-good set so a loaded portal keeps its IdP.
     async fn oidc_origins(&self) -> BTreeSet<String> {
+        if let Some(cached) = self.fresh_oidc().await {
+            return cached;
+        }
+
         match drive(
             GetRealmConfigOperation::new(self.state.get_realm_id()),
             &self.state.get_ctx(),
@@ -91,15 +111,22 @@ impl PortalSecurity {
                     origins.extend(normalize_origin(&provider.issuer));
                     origins.extend(normalize_origin(&provider.discovery_url));
                 }
+                let mut cache = self.oidc_cache.write().await;
+                cache.origins = origins.clone();
+                cache.refreshed_at = Some(Instant::now());
                 origins
             }
-            // The realm config is unavailable until it syncs; sign-in needs it
-            // anyway, so the portal keeps booting with the baseline policy.
             Err(error) => {
-                debug!(error = %error, "Portal CSP omits realm OIDC origins");
-                BTreeSet::new()
+                debug!(error = %error, "Portal CSP reuses cached OIDC origins");
+                self.oidc_cache.read().await.origins.clone()
             }
         }
+    }
+
+    async fn fresh_oidc(&self) -> Option<BTreeSet<String>> {
+        let cache = self.oidc_cache.read().await;
+        let refreshed_at = cache.refreshed_at?;
+        (refreshed_at.elapsed() < OIDC_ORIGIN_TTL).then(|| cache.origins.clone())
     }
 }
 

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -2,12 +2,12 @@ use crate::server_state::ServerState;
 use aruna_operations::driver::drive;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use axum::extract::{Request, State};
-use axum::http::{HeaderName, HeaderValue, header};
+use axum::http::{HeaderName, HeaderValue, StatusCode, header};
 use axum::middleware::Next;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, error};
 use url::{Host, Url};
 
 /// The portal loads its webfont stylesheet from Google Fonts and the font files
@@ -91,12 +91,17 @@ pub(crate) async fn portal_security_headers(
     next: Next,
 ) -> Response {
     let policy = content_security_policy(&security.connect_origins().await);
+    let policy = match HeaderValue::from_str(&policy) {
+        Ok(policy) => policy,
+        Err(error) => {
+            error!(error = %error, policy, "Portal CSP rejected; refusing to serve");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
-
-    if let Ok(policy) = HeaderValue::from_str(&policy) {
-        headers.insert(header::CONTENT_SECURITY_POLICY, policy);
-    }
+    headers.insert(header::CONTENT_SECURITY_POLICY, policy);
     headers.insert(
         header::X_CONTENT_TYPE_OPTIONS,
         HeaderValue::from_static("nosniff"),

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -102,6 +102,14 @@ impl PortalSecurity {
             return cached;
         }
 
+        let mut cache = self.oidc_cache.write().await;
+        if cache
+            .refreshed_at
+            .is_some_and(|refreshed_at| refreshed_at.elapsed() < OIDC_ORIGIN_TTL)
+        {
+            return cache.origins.clone();
+        }
+
         match drive(
             GetRealmConfigOperation::new(self.state.get_realm_id()),
             &self.state.get_ctx(),
@@ -114,14 +122,14 @@ impl PortalSecurity {
                     origins.extend(normalize_origin(&provider.issuer));
                     origins.extend(normalize_origin(&provider.discovery_url));
                 }
-                let mut cache = self.oidc_cache.write().await;
                 cache.origins = origins.clone();
                 cache.refreshed_at = Some(Instant::now());
                 origins
             }
             Err(error) => {
                 debug!(error = %error, "Portal CSP reuses cached OIDC origins");
-                self.oidc_cache.read().await.origins.clone()
+                cache.refreshed_at = Some(Instant::now());
+                cache.origins.clone()
             }
         }
     }

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -1,0 +1,197 @@
+use crate::server_state::ServerState;
+use aruna_operations::driver::drive;
+use aruna_operations::get_realm_config::GetRealmConfigOperation;
+use axum::extract::{Request, State};
+use axum::http::{HeaderName, HeaderValue, header};
+use axum::middleware::Next;
+use axum::response::Response;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use tracing::debug;
+use url::Url;
+
+/// The portal loads its webfont stylesheet from Google Fonts and the font files
+/// from the matching static origin.
+const FONT_STYLE_ORIGIN: &str = "https://fonts.googleapis.com";
+const FONT_FILE_ORIGIN: &str = "https://fonts.gstatic.com";
+
+const CROSS_ORIGIN_OPENER_POLICY: HeaderName =
+    HeaderName::from_static("cross-origin-opener-policy");
+
+/// Extra origins the portal document may connect to, on top of this node's own
+/// REST origin, its S3 interface and the realm's OIDC providers. Needed when a
+/// deployment expects the portal to reach other nodes (e.g. their S3 endpoints).
+#[derive(Clone, Debug, Default)]
+pub struct PortalCspConfig {
+    extra_connect_origins: Vec<String>,
+}
+
+impl PortalCspConfig {
+    pub fn new(origins: impl IntoIterator<Item = String>) -> Self {
+        let mut extra_connect_origins = Vec::new();
+        for origin in origins {
+            if let Some(origin) = normalize_origin(&origin) {
+                extra_connect_origins.push(origin);
+            }
+        }
+        Self {
+            extra_connect_origins,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PortalSecurity {
+    state: Arc<ServerState>,
+    config: Arc<PortalCspConfig>,
+}
+
+impl PortalSecurity {
+    pub(crate) fn new(state: Arc<ServerState>, config: PortalCspConfig) -> Self {
+        Self {
+            state,
+            config: Arc::new(config),
+        }
+    }
+
+    async fn connect_origins(&self) -> BTreeSet<String> {
+        let mut origins = BTreeSet::new();
+
+        if let Some(s3) = self.state.interface_state().await.s3
+            && let Some(origin) = normalize_origin(&s3.base_url)
+        {
+            origins.insert(origin);
+        }
+
+        match drive(
+            GetRealmConfigOperation::new(self.state.get_realm_id()),
+            &self.state.get_ctx(),
+        )
+        .await
+        {
+            Ok(config) => {
+                for provider in config.oidc_providers {
+                    origins.extend(normalize_origin(&provider.issuer));
+                    origins.extend(normalize_origin(&provider.discovery_url));
+                }
+            }
+            // The realm config is unavailable until it syncs; sign-in needs it
+            // anyway, so the portal keeps booting with the baseline policy.
+            Err(error) => debug!(error = %error, "Portal CSP omits realm OIDC origins"),
+        }
+
+        origins.extend(self.config.extra_connect_origins.iter().cloned());
+        origins
+    }
+}
+
+pub(crate) async fn portal_security_headers(
+    State(security): State<PortalSecurity>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let policy = content_security_policy(&security.connect_origins().await);
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+
+    if let Ok(policy) = HeaderValue::from_str(&policy) {
+        headers.insert(header::CONTENT_SECURITY_POLICY, policy);
+    }
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(
+        CROSS_ORIGIN_OPENER_POLICY,
+        HeaderValue::from_static("same-origin"),
+    );
+    response
+}
+
+/// `script-src` carries `'wasm-unsafe-eval'` because the portal hashes profile
+/// artifacts with hash-wasm, which compiles a WebAssembly module; it permits no
+/// JavaScript eval. Inline scripts and styles are not allowed.
+fn content_security_policy(connect_origins: &BTreeSet<String>) -> String {
+    let mut connect_src = String::from("connect-src 'self'");
+    for origin in connect_origins {
+        connect_src.push(' ');
+        connect_src.push_str(origin);
+    }
+
+    [
+        "default-src 'self'",
+        "base-uri 'self'",
+        "object-src 'none'",
+        "frame-src 'none'",
+        "frame-ancestors 'none'",
+        "form-action 'self'",
+        "script-src 'self' 'wasm-unsafe-eval'",
+        &format!("style-src 'self' {FONT_STYLE_ORIGIN}"),
+        "img-src 'self' data:",
+        &format!("font-src 'self' data: {FONT_FILE_ORIGIN}"),
+        &connect_src,
+    ]
+    .join("; ")
+}
+
+fn normalize_origin(value: &str) -> Option<String> {
+    let origin = Url::parse(value.trim())
+        .ok()?
+        .origin()
+        .ascii_serialization();
+    (origin != "null").then_some(origin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{content_security_policy, normalize_origin};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn origins_drop_path_and_scheme_noise() {
+        assert_eq!(
+            normalize_origin("https://issuer.test/realms/aruna/.well-known"),
+            Some("https://issuer.test".to_string())
+        );
+        assert_eq!(
+            normalize_origin(" http://127.0.0.1:9000/ "),
+            Some("http://127.0.0.1:9000".to_string())
+        );
+        assert_eq!(normalize_origin("not-a-url"), None);
+        assert_eq!(normalize_origin("data:text/html,x"), None);
+    }
+
+    #[test]
+    fn policy_pins_portal_needs() {
+        let policy = content_security_policy(&BTreeSet::new());
+
+        assert!(policy.contains("default-src 'self'"));
+        assert!(policy.contains("script-src 'self' 'wasm-unsafe-eval'"));
+        assert!(policy.contains("style-src 'self' https://fonts.googleapis.com"));
+        assert!(policy.contains("font-src 'self' data: https://fonts.gstatic.com"));
+        assert!(policy.contains("img-src 'self' data:"));
+        assert!(policy.contains("connect-src 'self'"));
+        assert!(policy.contains("frame-ancestors 'none'"));
+        assert!(policy.contains("object-src 'none'"));
+        assert!(policy.contains("base-uri 'self'"));
+        assert!(policy.contains("form-action 'self'"));
+        assert!(!policy.contains("unsafe-inline"));
+        assert!(!policy.contains("'unsafe-eval'"));
+    }
+
+    #[test]
+    fn connect_src_lists_origins() {
+        let origins = BTreeSet::from([
+            "https://issuer.test".to_string(),
+            "http://127.0.0.1:9000".to_string(),
+        ]);
+
+        let policy = content_security_policy(&origins);
+
+        assert!(policy.ends_with("connect-src 'self' http://127.0.0.1:9000 https://issuer.test"));
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod cors;
+pub mod csp;
 pub mod error;
 pub mod openapi;
 pub mod ops;

--- a/api/src/portal.rs
+++ b/api/src/portal.rs
@@ -1,7 +1,9 @@
+use crate::csp::{PortalCspConfig, PortalSecurity, portal_security_headers};
 use crate::server_state::{PortalRuntimeState, ServerState};
 use axum::body::Body;
 use axum::extract::{Request, State};
 use axum::http::{HeaderValue, Method, StatusCode, header};
+use axum::middleware::from_fn_with_state;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
@@ -16,10 +18,12 @@ const ASSETS_PREFIX: &str = "/assets/";
 const IMMUTABLE_CACHE: &str = "public, max-age=31536000, immutable";
 const NO_CACHE: &str = "no-cache";
 
-pub fn router(state: Arc<ServerState>) -> Router {
+pub fn router(state: Arc<ServerState>, csp: PortalCspConfig) -> Router {
+    let security = PortalSecurity::new(state.clone(), csp);
     Router::new()
         .route("/portal-config.json", get(portal_config))
         .fallback(serve_portal)
+        .layer(from_fn_with_state(security, portal_security_headers))
         .with_state(state)
 }
 
@@ -155,16 +159,25 @@ impl IntoResponse for PortalServeError {
 #[cfg(test)]
 mod tests {
     use super::{IMMUTABLE_CACHE, NO_CACHE, serve_portal_request};
+    use crate::cors::CorsConfig;
+    use crate::csp::PortalCspConfig;
+    use crate::server::{DEFAULT_MAX_HTTP_BODY_SIZE, Server, ServerConfig};
     use crate::server_state::{PortalStatus, ServerState};
-    use aruna_core::structs::{NodeCapabilities, RealmId};
-    use aruna_operations::driver::DriverContext;
+    use aruna_core::UserId;
+    use aruna_core::structs::{Actor, NodeCapabilities, OidcProviderConfig, RealmId};
+    use aruna_operations::create_realm::{CreateRealmConfig, CreateRealmOperation};
+    use aruna_operations::driver::{DriverContext, drive};
     use aruna_storage::storage;
+    use aruna_tasks::TaskHandle;
+    use axum::Router;
     use axum::body::{Body, to_bytes};
     use axum::extract::Request;
     use axum::http::{Method, StatusCode, header};
     use ed25519_dalek::SigningKey;
     use std::sync::Arc;
     use tempfile::{TempDir, tempdir};
+    use tower::ServiceExt;
+    use ulid::Ulid;
 
     async fn setup_state() -> (Arc<ServerState>, TempDir) {
         let tempdir = tempdir().unwrap();
@@ -174,7 +187,7 @@ mod tests {
             net_handle: None,
             blob_handle: None,
             metadata_handle: None,
-            task_handle: None,
+            task_handle: Some(TaskHandle::new()),
         });
 
         let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
@@ -195,6 +208,58 @@ mod tests {
         );
 
         (state, tempdir)
+    }
+
+    /// Realm config with an OIDC provider, an S3 interface and an installed
+    /// portal: everything the served policy derives its origins from.
+    async fn setup_serving_node(portal_dir: &std::path::Path) -> (Router, TempDir) {
+        let (state, tempdir) = setup_state().await;
+        let realm_id = state.get_realm_id();
+        drive(
+            CreateRealmOperation::new(CreateRealmConfig {
+                actor: Actor {
+                    node_id: state.get_node_id(),
+                    user_id: UserId::local(Ulid::r#gen(), realm_id),
+                    realm_id,
+                },
+                realm_description: "Realm".to_string(),
+                oidc_providers: vec![OidcProviderConfig {
+                    id: "main".to_string(),
+                    issuer: "https://issuer.test/realms/aruna".to_string(),
+                    audience: "aruna".to_string(),
+                    discovery_url:
+                        "https://discovery.test/realms/aruna/.well-known/openid-configuration"
+                            .to_string(),
+                }],
+                node_location: None,
+                node_weight: None,
+                node_labels: Default::default(),
+            }),
+            &state.get_ctx(),
+        )
+        .await
+        .unwrap();
+        state
+            .register_s3_interface("127.0.0.1:9000".parse().unwrap(), "https://s3.test")
+            .await;
+
+        std::fs::create_dir_all(portal_dir.join("assets")).unwrap();
+        std::fs::write(portal_dir.join("index.html"), "<html>portal</html>").unwrap();
+        std::fs::write(portal_dir.join("assets/app.js"), "console.log('portal');").unwrap();
+        enable_portal(&state, portal_dir).await;
+
+        let router = Server::new(
+            state,
+            ServerConfig {
+                http_addr: "127.0.0.1:0".parse().unwrap(),
+                max_http_body_size: DEFAULT_MAX_HTTP_BODY_SIZE,
+                cors: CorsConfig::default(),
+                portal_csp: PortalCspConfig::new(vec!["https://peer.test/".to_string()]),
+            },
+        )
+        .build_router();
+
+        (router, tempdir)
     }
 
     async fn enable_portal(state: &ServerState, dir: &std::path::Path) {
@@ -358,5 +423,100 @@ mod tests {
 
         let response = serve_portal_request(&state, request(Method::POST, "/api/v1/missing")).await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn portal_sets_security_headers() {
+        let tempdir = tempdir().unwrap();
+        let (router, _state_dir) = setup_serving_node(&tempdir.path().join("portal")).await;
+
+        for path in [
+            "/",
+            "/groups/test-group",
+            "/assets/app.js",
+            "/portal-config.json",
+        ] {
+            let response = router
+                .clone()
+                .oneshot(request(Method::GET, path))
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK, "{path}");
+            let headers = response.headers();
+            let policy = headers
+                .get(header::CONTENT_SECURITY_POLICY)
+                .unwrap_or_else(|| panic!("{path} has no policy"))
+                .to_str()
+                .unwrap();
+            assert!(policy.contains("default-src 'self'"), "{path}: {policy}");
+            assert!(
+                policy.contains("script-src 'self' 'wasm-unsafe-eval'"),
+                "{path}: {policy}"
+            );
+            assert!(
+                policy.contains("frame-ancestors 'none'"),
+                "{path}: {policy}"
+            );
+            assert_eq!(
+                headers.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+                "nosniff"
+            );
+            assert_eq!(headers.get(header::REFERRER_POLICY).unwrap(), "no-referrer");
+            assert_eq!(
+                headers.get("cross-origin-opener-policy").unwrap(),
+                "same-origin"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_src_lists_node_origins() {
+        let tempdir = tempdir().unwrap();
+        let (router, _state_dir) = setup_serving_node(&tempdir.path().join("portal")).await;
+
+        let response = router.oneshot(request(Method::GET, "/")).await.unwrap();
+
+        let policy = response
+            .headers()
+            .get(header::CONTENT_SECURITY_POLICY)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let connect_src = policy
+            .split("; ")
+            .find(|directive| directive.starts_with("connect-src "))
+            .unwrap();
+        assert!(connect_src.contains("'self'"), "{connect_src}");
+        assert!(connect_src.contains("https://s3.test"), "{connect_src}");
+        assert!(connect_src.contains("https://issuer.test"), "{connect_src}");
+        assert!(
+            connect_src.contains("https://discovery.test"),
+            "{connect_src}"
+        );
+        assert!(connect_src.contains("https://peer.test"), "{connect_src}");
+    }
+
+    #[tokio::test]
+    async fn api_routes_skip_headers() {
+        let tempdir = tempdir().unwrap();
+        let (router, _state_dir) = setup_serving_node(&tempdir.path().join("portal")).await;
+
+        for path in ["/api/v1/info", "/api-docs/openapi.json"] {
+            let response = router
+                .clone()
+                .oneshot(request(Method::GET, path))
+                .await
+                .unwrap();
+
+            assert!(
+                response
+                    .headers()
+                    .get(header::CONTENT_SECURITY_POLICY)
+                    .is_none(),
+                "{path}"
+            );
+        }
     }
 }

--- a/api/src/portal.rs
+++ b/api/src/portal.rs
@@ -496,6 +496,13 @@ mod tests {
             "{connect_src}"
         );
         assert!(connect_src.contains("https://peer.test"), "{connect_src}");
+
+        let img_src = policy
+            .split("; ")
+            .find(|directive| directive.starts_with("img-src "))
+            .unwrap();
+        assert!(img_src.contains("blob:"), "{img_src}");
+        assert!(img_src.contains("https://s3.test"), "{img_src}");
     }
 
     #[tokio::test]

--- a/api/src/portal.rs
+++ b/api/src/portal.rs
@@ -169,13 +169,15 @@ mod tests {
     use aruna_operations::driver::{DriverContext, drive};
     use aruna_storage::storage;
     use aruna_tasks::TaskHandle;
-    use axum::Router;
     use axum::body::{Body, to_bytes};
     use axum::extract::Request;
     use axum::http::{Method, StatusCode, header};
+    use axum::routing::get;
+    use axum::{Json, Router};
     use ed25519_dalek::SigningKey;
     use std::sync::Arc;
     use tempfile::{TempDir, tempdir};
+    use tokio::net::TcpListener;
     use tower::ServiceExt;
     use ulid::Ulid;
 
@@ -212,9 +214,23 @@ mod tests {
 
     /// Realm config with an OIDC provider, an S3 interface and an installed
     /// portal: everything the served policy derives its origins from.
-    async fn setup_serving_node(portal_dir: &std::path::Path) -> (Router, TempDir) {
+    async fn setup_serving_node(portal_dir: &std::path::Path) -> (Router, TempDir, String) {
         let (state, tempdir) = setup_state().await;
         let realm_id = state.get_realm_id();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let discovery_origin = format!("http://{}", listener.local_addr().unwrap());
+        let discovery_url = format!("{discovery_origin}/.well-known/openid-configuration");
+        let discovery_router = Router::new().route(
+            "/.well-known/openid-configuration",
+            get(|| async {
+                Json(serde_json::json!({
+                    "token_endpoint": "https://tokens.test/oauth2/token"
+                }))
+            }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, discovery_router).await.unwrap();
+        });
         drive(
             CreateRealmOperation::new(CreateRealmConfig {
                 actor: Actor {
@@ -227,9 +243,7 @@ mod tests {
                     id: "main".to_string(),
                     issuer: "https://issuer.test/realms/aruna".to_string(),
                     audience: "aruna".to_string(),
-                    discovery_url:
-                        "https://discovery.test/realms/aruna/.well-known/openid-configuration"
-                            .to_string(),
+                    discovery_url,
                 }],
                 node_location: None,
                 node_weight: None,
@@ -259,7 +273,7 @@ mod tests {
         )
         .build_router();
 
-        (router, tempdir)
+        (router, tempdir, discovery_origin)
     }
 
     async fn enable_portal(state: &ServerState, dir: &std::path::Path) {
@@ -428,7 +442,8 @@ mod tests {
     #[tokio::test]
     async fn portal_sets_security_headers() {
         let tempdir = tempdir().unwrap();
-        let (router, _state_dir) = setup_serving_node(&tempdir.path().join("portal")).await;
+        let (router, _state_dir, _discovery_origin) =
+            setup_serving_node(&tempdir.path().join("portal")).await;
 
         for path in [
             "/",
@@ -474,7 +489,8 @@ mod tests {
     #[tokio::test]
     async fn connect_src_lists_node_origins() {
         let tempdir = tempdir().unwrap();
-        let (router, _state_dir) = setup_serving_node(&tempdir.path().join("portal")).await;
+        let (router, _state_dir, discovery_origin) =
+            setup_serving_node(&tempdir.path().join("portal")).await;
 
         let response = router.oneshot(request(Method::GET, "/")).await.unwrap();
 
@@ -492,10 +508,8 @@ mod tests {
         assert!(connect_src.contains("'self'"), "{connect_src}");
         assert!(connect_src.contains("https://s3.test"), "{connect_src}");
         assert!(connect_src.contains("https://issuer.test"), "{connect_src}");
-        assert!(
-            connect_src.contains("https://discovery.test"),
-            "{connect_src}"
-        );
+        assert!(connect_src.contains(&discovery_origin), "{connect_src}");
+        assert!(connect_src.contains("https://tokens.test"), "{connect_src}");
         assert!(connect_src.contains("https://peer.test"), "{connect_src}");
 
         let img_src = policy
@@ -510,7 +524,8 @@ mod tests {
     async fn api_routes_baseline() {
         // API and swagger get the anti-clickjacking baseline, but not the strict portal CSP.
         let tempdir = tempdir().unwrap();
-        let (router, _state_dir) = setup_serving_node(&tempdir.path().join("portal")).await;
+        let (router, _state_dir, _discovery_origin) =
+            setup_serving_node(&tempdir.path().join("portal")).await;
 
         for path in ["/api/v1/info", "/api-docs/openapi.json"] {
             let response = router

--- a/api/src/portal.rs
+++ b/api/src/portal.rs
@@ -463,6 +463,7 @@ mod tests {
                 "nosniff"
             );
             assert_eq!(headers.get(header::REFERRER_POLICY).unwrap(), "no-referrer");
+            assert_eq!(headers.get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
             assert_eq!(
                 headers.get("cross-origin-opener-policy").unwrap(),
                 "same-origin"
@@ -506,7 +507,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn api_routes_skip_headers() {
+    async fn api_routes_baseline() {
+        // API and swagger get the anti-clickjacking baseline, but not the strict portal CSP.
         let tempdir = tempdir().unwrap();
         let (router, _state_dir) = setup_serving_node(&tempdir.path().join("portal")).await;
 
@@ -517,13 +519,27 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert!(
-                response
-                    .headers()
-                    .get(header::CONTENT_SECURITY_POLICY)
-                    .is_none(),
+            let headers = response.headers();
+            assert_eq!(
+                headers.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+                "nosniff",
                 "{path}"
             );
+            assert_eq!(
+                headers.get(header::X_FRAME_OPTIONS).unwrap(),
+                "DENY",
+                "{path}"
+            );
+            let policy = headers
+                .get(header::CONTENT_SECURITY_POLICY)
+                .unwrap_or_else(|| panic!("{path} has no policy"))
+                .to_str()
+                .unwrap();
+            assert!(
+                policy.contains("frame-ancestors 'none'"),
+                "{path}: {policy}"
+            );
+            assert!(!policy.contains("script-src"), "{path}: {policy}");
         }
     }
 }

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -1258,6 +1258,7 @@ mod tests {
                 http_addr: addr,
                 max_http_body_size: crate::server::DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: crate::cors::CorsConfig::default(),
+                portal_csp: crate::csp::PortalCspConfig::default(),
             },
         )
         .build_router();

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,4 +1,5 @@
 use crate::cors::CorsConfig;
+use crate::csp::PortalCspConfig;
 use crate::error::ServerSetupError;
 use crate::portal;
 use crate::routes::rest_router;
@@ -22,6 +23,7 @@ pub struct ServerConfig {
     pub http_addr: SocketAddr,
     pub max_http_body_size: usize,
     pub cors: CorsConfig,
+    pub portal_csp: PortalCspConfig,
 }
 
 impl Server {
@@ -38,7 +40,10 @@ impl Server {
             .nest("/api/v1", api_v1)
             .layer(DefaultBodyLimit::max(self.config.max_http_body_size))
             .merge(swagger_ui())
-            .merge(portal::router(self.state.clone()));
+            .merge(portal::router(
+                self.state.clone(),
+                self.config.portal_csp.clone(),
+            ));
         if let Some(cors_layer) = self.config.cors.rest_layer() {
             router = router.layer(cors_layer);
         }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,11 +1,12 @@
 use crate::cors::CorsConfig;
-use crate::csp::PortalCspConfig;
+use crate::csp::{PortalCspConfig, baseline_security_headers};
 use crate::error::ServerSetupError;
 use crate::portal;
 use crate::routes::rest_router;
 pub(crate) use crate::server_state::{ServerState, swagger_ui};
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
+use axum::middleware::from_fn;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -43,7 +44,8 @@ impl Server {
             .merge(portal::router(
                 self.state.clone(),
                 self.config.portal_csp.clone(),
-            ));
+            ))
+            .layer(from_fn(baseline_security_headers));
         if let Some(cors_layer) = self.config.cors.rest_layer() {
             router = router.layer(cors_layer);
         }

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -373,6 +373,7 @@ mod tests {
                 http_addr: addr,
                 max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: aruna_api::cors::CorsConfig::default(),
+                portal_csp: aruna_api::csp::PortalCspConfig::default(),
             },
         );
         let server_task = tokio::spawn(async move {

--- a/aruna-doctor/src/tokens.rs
+++ b/aruna-doctor/src/tokens.rs
@@ -820,6 +820,7 @@ mod tests {
                 http_addr: addr,
                 max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: aruna_api::cors::CorsConfig::default(),
+                portal_csp: aruna_api::csp::PortalCspConfig::default(),
             },
         )
         .build_router();

--- a/aruna/src/config.rs
+++ b/aruna/src/config.rs
@@ -64,6 +64,7 @@ pub struct Config {
     pub ops_socket_addr: SocketAddr,
     pub max_http_body_size: usize,
     pub cors_allowed_origins: Vec<String>,
+    pub portal_csp_extra_origins: Vec<String>,
     pub p2p_socket_addr: SocketAddr,
     pub max_concurrent_uni_streams: Option<u64>,
     pub max_concurrent_bidi_streams: Option<u64>,
@@ -282,6 +283,7 @@ pub async fn load() -> Result<(Config, StorageHandle), SetupError> {
         .transpose()?
         .unwrap_or(aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE);
     let cors_allowed_origins = parse_list_env("CORS_ALLOWED_ORIGINS");
+    let portal_csp_extra_origins = parse_list_env("PORTAL_CSP_EXTRA_ORIGINS");
     let p2p_socket_addr = SocketAddr::from_str(
         &dotenvy::var("P2P_SOCKET_ADDRESS").unwrap_or_else(|_| http_socket_addr.to_string()),
     )?;
@@ -415,6 +417,7 @@ pub async fn load() -> Result<(Config, StorageHandle), SetupError> {
             ops_socket_addr,
             max_http_body_size,
             cors_allowed_origins,
+            portal_csp_extra_origins,
             p2p_socket_addr,
             max_concurrent_uni_streams,
             max_concurrent_bidi_streams,

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -9,6 +9,7 @@ use aruna::portal;
 use aruna::telemetry::{init_tracing, shutdown_tracing};
 use aruna_api::auth::OidcValidator;
 use aruna_api::cors::CorsConfig;
+use aruna_api::csp::PortalCspConfig;
 use aruna_api::ops::{OpsState, Readiness, serve_ops};
 use aruna_api::s3::s3_server::S3Server;
 use aruna_api::server::{Server, ServerConfig};
@@ -351,6 +352,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         http_addr: config.http_socket_addr,
         max_http_body_size: config.max_http_body_size,
         cors: cors.clone(),
+        portal_csp: PortalCspConfig::default(),
     };
     let server = Server::new(state.clone(), server_config);
 

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -352,7 +352,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         http_addr: config.http_socket_addr,
         max_http_body_size: config.max_http_body_size,
         cors: cors.clone(),
-        portal_csp: PortalCspConfig::default(),
+        portal_csp: PortalCspConfig::new(config.portal_csp_extra_origins.clone()),
     };
     let server = Server::new(state.clone(), server_config);
 

--- a/aruna/tests/oidc_registration.rs
+++ b/aruna/tests/oidc_registration.rs
@@ -265,6 +265,7 @@ async fn spawn_test_node(provider: OidcProviderConfig) -> TestNode {
             http_addr: addr,
             max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
             cors: aruna_api::cors::CorsConfig::default(),
+            portal_csp: aruna_api::csp::PortalCspConfig::default(),
         },
     )
     .build_router();

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -841,6 +841,7 @@ async fn spawn_rest_server(
             http_addr: addr,
             max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
             cors: test_cors_config(),
+            portal_csp: aruna_api::csp::PortalCspConfig::default(),
         },
     );
     let router = server.build_router();

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -64,9 +64,8 @@ use globset::Glob;
 use irokle_crate::Event as _;
 use irokle_crate::Storage as _;
 use irokle_crate::TopicControl;
-use irokle_crate::history::HistoryOrder;
 use irokle_crate::net::{decode_sync_message, encode_frame, encode_sync_message};
-use irokle_crate::oplog::Oplog;
+use irokle_crate::oplog::{Oplog, topological_subset};
 use irokle_crate::sync::{SyncData, SyncMessage, SyncRequest};
 use irokle_crate::{
     EventEnvelope, PeerId, ReplicationPolicy, TopicEviction, TopicGenesis, TopicPayload,
@@ -2487,57 +2486,52 @@ impl DocumentSyncService {
         })
     }
 
-    /// Returns the decoded document events above the applied cursor, reading
-    /// only the unapplied portion of the topic history where possible. Each
-    /// event is paired with the authenticated actor id and sequence of the op
-    /// that carried it: irokle admits an op only after verifying its signature
-    /// against `body.author` and enforcing
-    /// `actor_id == actor_id_for(topic, author)`, so the returned actor id is a
-    /// trustworthy proxy for the signed publisher.
+    /// Returns authenticated document events above a component-wise cursor.
+    /// Actor ranges keep covered DAG heads from hiding unapplied dependencies.
     fn document_events_after(
         &self,
         topic_id: irokle_crate::TopicId,
         cursor: &irokle_crate::ActorClock,
     ) -> Result<Vec<(DocumentSyncEvent, irokle_crate::ActorId, u64)>> {
-        match self.node.open_topic::<DocumentSyncEvent>(topic_id) {
-            Ok(topic) => Ok(topic
-                .history_after(cursor, HistoryOrder::OldestFirst)
-                .map_err(|error| NetError::Bootstrap(error.to_string()))?
-                .into_iter()
-                .map(|record| (record.event, record.meta.actor_id, record.meta.actor_seq))
-                .collect()),
-            // Topics we hold ops for without being a listed member still
-            // reconcile via the full history.
-            Err(irokle_crate::Error::NotTopicMember) => {
-                let raw = self
-                    .node
-                    .raw_topic(topic_id)
-                    .map_err(|error| NetError::Bootstrap(error.to_string()))?;
-                let ops = raw
-                    .history()
-                    .map_err(|error| NetError::Bootstrap(error.to_string()))?;
-                let mut events = Vec::new();
-                for op in ops {
-                    if cursor.get(&op.signed.body.actor_id) >= op.signed.body.actor_seq {
-                        continue;
-                    }
-                    let actor_id = op.signed.body.actor_id;
-                    let actor_seq = op.signed.body.actor_seq;
-                    let TopicPayload::Event(envelope) = op.signed.body.payload else {
-                        continue;
-                    };
-                    events.push((
-                        envelope
-                            .decode_event::<DocumentSyncEvent>()
-                            .map_err(|error| NetError::Bootstrap(error.to_string()))?,
-                        actor_id,
-                        actor_seq,
-                    ));
-                }
-                Ok(events)
+        let storage = self.node.storage();
+        let topic_clock = storage
+            .actor_clock(&topic_id)
+            .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+        let mut op_ids = BTreeSet::new();
+        for (actor_id, actor_tip) in topic_clock.iter() {
+            let Some(first_unapplied) = cursor.get(actor_id).checked_add(1) else {
+                continue;
+            };
+            for actor_seq in first_unapplied..=*actor_tip {
+                let op_id = storage
+                    .actor_index(&topic_id, actor_id, actor_seq)
+                    .map_err(|error| NetError::Bootstrap(error.to_string()))?
+                    .ok_or_else(|| {
+                        NetError::Bootstrap(format!(
+                            "missing document sync op for actor {actor_id} sequence {actor_seq}"
+                        ))
+                    })?;
+                op_ids.insert(op_id);
             }
-            Err(error) => Err(NetError::Bootstrap(error.to_string())),
         }
+        let ops = topological_subset(storage, &op_ids)
+            .map_err(|error| NetError::Bootstrap(error.to_string()))?;
+        let mut events = Vec::new();
+        for op in ops {
+            let actor_id = op.signed.body.actor_id;
+            let actor_seq = op.signed.body.actor_seq;
+            let TopicPayload::Event(envelope) = op.signed.body.payload else {
+                continue;
+            };
+            events.push((
+                envelope
+                    .decode_event::<DocumentSyncEvent>()
+                    .map_err(|error| NetError::Bootstrap(error.to_string()))?,
+                actor_id,
+                actor_seq,
+            ));
+        }
+        Ok(events)
     }
 
     fn pending_metadata_create_apply(
@@ -9514,7 +9508,7 @@ mod tests {
             .open_topic::<DocumentSyncEvent>(restart_topic())
             .expect("published topic reopens after restart");
         let history = topic
-            .history(HistoryOrder::OldestFirst)
+            .history(irokle_crate::history::HistoryOrder::OldestFirst)
             .expect("published history reads after restart");
 
         assert_eq!(history.len(), 1);
@@ -12815,6 +12809,79 @@ mod tests {
                 .contains(&node_id_to_peer_id(&stale_node)),
             "former shard holders remain available as default network peers"
         );
+
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn document_events_after_keeps_unapplied_dependency_of_covered_head() {
+        use irokle_crate::{Ed25519Signer, Signer as _};
+
+        let root = tempfile::tempdir().expect("temp dir");
+        let service = open_restart_service(root.path(), "causal-cursor-storage").await;
+        let local_node = service.local_node_id().expect("local node id");
+        let remote_node = node(88);
+        let topic_id = restart_topic();
+        service
+            .ensure_document_sync_topics(&[topic_id], vec![remote_node])
+            .expect("shard topic exists");
+        let oplog = Oplog::with_storage(service.node().storage().clone());
+        let remote_signer = Ed25519Signer::from_bytes(&[88; 32]);
+        let remote_event_id = Ulid::from_parts(1_727_000_000_000, 43);
+        let local_event_id = Ulid::from_parts(1_727_000_000_000, 44);
+        let change = |event_id, actor| DocumentSyncChange {
+            base: None,
+            current: DocumentSyncRevision {
+                generation: 1,
+                event_id,
+                actor,
+                updated_at_ms: 1_727_000_000_101,
+            },
+            kind: DocumentSyncChangeKind::Upsert,
+            placement: restart_placement(),
+        };
+        let publish = |event_id, actor| DocumentSyncEvent::Upsert {
+            event_id,
+            target: restart_target(),
+            bytes: restart_payload(),
+            change: change(event_id, actor),
+        };
+        let remote_actor = irokle_crate::actor_id_for(topic_id, remote_signer.peer_id());
+        oplog
+            .create_event_op(
+                topic_id,
+                remote_actor,
+                EventEnvelope::encode_event(&publish(remote_event_id, remote_node))
+                    .expect("remote event encodes"),
+                &remote_signer,
+            )
+            .expect("remote event publishes");
+        let local_op = oplog
+            .create_event_op(
+                topic_id,
+                irokle_crate::actor_id_for(topic_id, node_id_to_peer_id(&local_node)),
+                EventEnvelope::encode_event(&publish(local_event_id, local_node))
+                    .expect("local event encodes"),
+                service.node().signer(),
+            )
+            .expect("local event publishes above remote head");
+        let mut cursor = irokle_crate::ActorClock::default();
+        cursor.observe(
+            local_op.signed.body.actor_id,
+            local_op.signed.body.actor_seq,
+        );
+
+        let events = service
+            .document_events_after(topic_id, &cursor)
+            .expect("unapplied document events read");
+        let event_ids = events
+            .into_iter()
+            .filter_map(|(event, _, _)| match event {
+                DocumentSyncEvent::Upsert { event_id, .. } => Some(event_id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(event_ids, vec![remote_event_id]);
 
         service.shutdown().await;
     }

--- a/operations/tests/non_holder_topology.rs
+++ b/operations/tests/non_holder_topology.rs
@@ -31,7 +31,9 @@ use aruna_operations::delete_metadata_document::{
 };
 use aruna_operations::driver::drive;
 use aruna_operations::get_group::{GetGroupConfig, GetGroupOperation};
-use aruna_operations::get_metadata_document::GetMetadataDocumentOperation;
+use aruna_operations::get_metadata_document::{
+    GetMetadataDocumentError, GetMetadataDocumentOperation,
+};
 use aruna_operations::metadata::projector::replay_metadata_event_log;
 use aruna_operations::placement::PlacementResolutionContext;
 use aruna_operations::read_user_document::ReadUserDocumentOperation;
@@ -165,8 +167,9 @@ async fn read_misses_nonholder() -> TestResult<()> {
         bystander.context.as_ref(),
     )
     .await;
-    assert!(
-        result.is_err(),
+    assert_eq!(
+        result.unwrap_err(),
+        GetMetadataDocumentError::DocumentNotFound,
         "non-holder served a document it never received"
     );
 
@@ -317,7 +320,14 @@ async fn mutate_off_holders() -> TestResult<()> {
     for holder in &holders {
         let node = realm.find(*holder);
         wait_until("delete reaches holder", node.node_id(), || async {
-            !document_present(node, group_id, document_id).await
+            matches!(
+                drive(
+                    GetMetadataDocumentOperation::new(group_id, document_id),
+                    node.context.as_ref(),
+                )
+                .await,
+                Err(GetMetadataDocumentError::DocumentNotFound)
+            )
         })
         .await?;
     }

--- a/operations/tests/non_holder_topology.rs
+++ b/operations/tests/non_holder_topology.rs
@@ -107,6 +107,10 @@ async fn create_off_holders() -> TestResult<()> {
         .await?;
     }
 
+    wait_until("document reaches origin", origin.node_id(), || {
+        document_present(origin, group_id, document_id)
+    })
+    .await?;
     let view = drive(
         GetMetadataDocumentOperation::new(group_id, document_id),
         origin.context.as_ref(),

--- a/operations/tests/non_holder_topology.rs
+++ b/operations/tests/non_holder_topology.rs
@@ -1,0 +1,580 @@
+//! Holder and non-holder coverage on a realm sized above the replication factor.
+//!
+//! Every other multi-node fixture in this workspace runs at `node_count <= RF`,
+//! where every node holds every subject and non-holder behaviour is
+//! unobservable. These tests run five nodes at RF three and assert the
+//! not-a-holder precondition through the placement resolver before exercising
+//! the path, so a regression to universal holdership fails the fixture instead
+//! of quietly voiding the test.
+
+mod topology;
+
+use std::collections::{HashMap, HashSet};
+
+use aruna_core::UserId;
+use aruna_core::document::DocumentSyncTarget;
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::AUTH_KEYSPACE;
+use aruna_core::structs::{
+    Actor, AuthContext, Permission, RealmAuthorizationDocument, RealmId, Role,
+};
+use aruna_operations::add_group_role::{AddGroupRoleConfig, AddGroupRoleOperation};
+use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
+use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+};
+use aruna_operations::delete_metadata_document::DeleteMetadataDocumentOperation;
+use aruna_operations::driver::drive;
+use aruna_operations::get_group::{GetGroupConfig, GetGroupOperation};
+use aruna_operations::get_metadata_document::GetMetadataDocumentOperation;
+use aruna_operations::metadata::projector::replay_metadata_event_log;
+use aruna_operations::placement::PlacementResolutionContext;
+use aruna_operations::read_user_document::ReadUserDocumentOperation;
+use aruna_operations::register_or_get_oidc_user::{
+    RegisterOrGetOidcUserInput, RegisterOrGetOidcUserOperation,
+};
+use aruna_operations::update_metadata_document::{
+    UpdateMetadataDocumentConfig, UpdateMetadataDocumentMutation, UpdateMetadataDocumentOperation,
+};
+use ulid::Ulid;
+
+use topology::{TestNode, TestResult, Topology, wait_until};
+
+const NODE_COUNT: usize = 5;
+const REPLICATION_FACTOR: u32 = 3;
+
+// The fixture itself is the deliverable: without this proof every test below
+// degrades silently into the all-nodes-hold-everything case.
+#[tokio::test]
+async fn fixture_proves_nonholders() -> TestResult<()> {
+    let realm_id = RealmId([90u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+
+    let group_id = Ulid::from_bytes([11; 16]);
+    let document_id = Ulid::from_bytes([12; 16]);
+    let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+    let context = PlacementResolutionContext {
+        group_id: Some(group_id),
+        metadata_path: Some("datasets/proof"),
+    };
+
+    let holders = realm.holders(&target, context);
+    let non_holders = realm.non_holder_ids(&target, context);
+    assert_eq!(holders.len(), REPLICATION_FACTOR as usize);
+    assert_eq!(non_holders.len(), NODE_COUNT - REPLICATION_FACTOR as usize);
+    for node_id in &non_holders {
+        realm.assert_not_holder(*node_id, &target, context);
+    }
+    for node_id in &holders {
+        realm.assert_holder(*node_id, &target, context);
+    }
+
+    // Placement is a pure function of the replicated realm config, so the proof
+    // is exact rather than probabilistic: every node must derive the same set.
+    for view in realm.holder_views(&target, context).await? {
+        assert_eq!(view, holders, "holder set diverged across nodes");
+    }
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_off_holders() -> TestResult<()> {
+    let realm_id = RealmId([91u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+
+    let group_id = Ulid::from_bytes([21; 16]);
+    let document_id = Ulid::from_bytes([22; 16]);
+    let document_path = "datasets/created-off-holders";
+    let (target, context) = metadata_subject(group_id, document_id, document_path);
+
+    let origin = realm.non_holder(&target, context);
+    let holders = realm.assert_not_holder(origin.node_id(), &target, context);
+
+    create_document(&realm, origin, group_id, document_id, document_path).await?;
+
+    // The write must land on every real holder even though the node that
+    // accepted it holds nothing for the document.
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("document reaches holder", node.node_id(), || {
+            document_present(node, group_id, document_id)
+        })
+        .await?;
+    }
+
+    let view = drive(
+        GetMetadataDocumentOperation::new(group_id, document_id),
+        origin.context.as_ref(),
+    )
+    .await?;
+    let mut recorded = view.record.holder_node_ids.clone();
+    recorded.sort_unstable_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+    assert_eq!(
+        recorded, holders,
+        "origin recorded a holder set that is not the planned placement"
+    );
+    assert!(
+        !recorded.contains(&origin.node_id()),
+        "non-holder origin recorded itself as a holder"
+    );
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+// A node that neither authored the document nor holds it has no copy and no
+// forwarding path on main: the miss is definitive, not an unavailability error.
+#[tokio::test]
+async fn read_misses_nonholder() -> TestResult<()> {
+    let realm_id = RealmId([92u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+
+    let group_id = Ulid::from_bytes([31; 16]);
+    let document_id = Ulid::from_bytes([32; 16]);
+    let document_path = "datasets/read-off-holders";
+    let (target, context) = metadata_subject(group_id, document_id, document_path);
+
+    let holders = realm.holders(&target, context);
+    let origin = realm.holder(&target, context);
+    realm.assert_holder(origin.node_id(), &target, context);
+
+    create_document(&realm, origin, group_id, document_id, document_path).await?;
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("document reaches holder", node.node_id(), || {
+            document_present(node, group_id, document_id)
+        })
+        .await?;
+    }
+
+    let bystander = realm.non_holder(&target, context);
+    let result = drive(
+        GetMetadataDocumentOperation::new(group_id, document_id),
+        bystander.context.as_ref(),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "non-holder served a document it never received"
+    );
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+// #398's fail-loud invariant: a node that holds nothing for the document and
+// did not author it must reject the mutation rather than accept a write it can
+// never publish. Silent acceptance here is the data-loss shape.
+#[tokio::test]
+async fn bystander_writes_fail() -> TestResult<()> {
+    let realm_id = RealmId([97u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+
+    let group_id = Ulid::from_bytes([81; 16]);
+    let document_id = Ulid::from_bytes([82; 16]);
+    let document_path = "datasets/bystander-writes";
+    let (target, context) = metadata_subject(group_id, document_id, document_path);
+
+    let holders = realm.holders(&target, context);
+    let origin = realm.holder(&target, context);
+    create_document(&realm, origin, group_id, document_id, document_path).await?;
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("document reaches holder", node.node_id(), || {
+            document_present(node, group_id, document_id)
+        })
+        .await?;
+    }
+
+    let bystander = realm.non_holder(&target, context);
+    realm.assert_not_holder(bystander.node_id(), &target, context);
+    let actor = realm.actor(
+        bystander,
+        UserId::local(Ulid::from_bytes([83; 16]), realm_id),
+    );
+
+    let updated = drive(
+        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
+            actor: actor.clone(),
+            group_id,
+            document_id,
+            public: true,
+            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
+                jsonld: r#"{"@id":"./ghost.txt","@type":"File","name":"ghost.txt"}"#.to_string(),
+            },
+        }),
+        bystander.context.as_ref(),
+    )
+    .await;
+    assert!(
+        updated.is_err(),
+        "non-holder accepted an update it cannot publish"
+    );
+
+    let deleted = drive(
+        DeleteMetadataDocumentOperation::new(actor, group_id, document_id),
+        bystander.context.as_ref(),
+    )
+    .await;
+    assert!(
+        deleted.is_err(),
+        "non-holder accepted a delete it cannot publish"
+    );
+
+    // The rejected writes must not have disturbed the real holders.
+    for holder in &holders {
+        let node = realm.find(*holder);
+        let view = drive(
+            GetMetadataDocumentOperation::new(group_id, document_id),
+            node.context.as_ref(),
+        )
+        .await?;
+        assert!(!view.jsonld.contains("ghost.txt"));
+    }
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn mutate_off_holders() -> TestResult<()> {
+    let realm_id = RealmId([93u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+
+    let group_id = Ulid::from_bytes([41; 16]);
+    let document_id = Ulid::from_bytes([42; 16]);
+    let document_path = "datasets/mutated-off-holders";
+    let (target, context) = metadata_subject(group_id, document_id, document_path);
+
+    let origin = realm.non_holder(&target, context);
+    let holders = realm.assert_not_holder(origin.node_id(), &target, context);
+
+    create_document(&realm, origin, group_id, document_id, document_path).await?;
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("document reaches holder", node.node_id(), || {
+            document_present(node, group_id, document_id)
+        })
+        .await?;
+    }
+
+    drive(
+        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
+            actor: realm.actor(origin, UserId::local(Ulid::from_bytes([43; 16]), realm_id)),
+            group_id,
+            document_id,
+            public: true,
+            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
+                jsonld: r#"{"@id":"./off-holder.txt","@type":"File","name":"off-holder.txt"}"#
+                    .to_string(),
+            },
+        }),
+        origin.context.as_ref(),
+    )
+    .await?;
+
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("update reaches holder", node.node_id(), || async {
+            drive(
+                GetMetadataDocumentOperation::new(group_id, document_id),
+                node.context.as_ref(),
+            )
+            .await
+            .is_ok_and(|view| view.jsonld.contains("off-holder.txt"))
+        })
+        .await?;
+    }
+
+    drive(
+        DeleteMetadataDocumentOperation::new(
+            realm.actor(origin, UserId::local(Ulid::from_bytes([44; 16]), realm_id)),
+            group_id,
+            document_id,
+        ),
+        origin.context.as_ref(),
+    )
+    .await?;
+
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("delete reaches holder", node.node_id(), || async {
+            !document_present(node, group_id, document_id).await
+        })
+        .await?;
+    }
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+// Group documents are admin-class: they sync as reducer operations over the
+// group topic and never take a placement. A node the resolver would call a
+// non-holder must still accept the write and serve the group.
+#[tokio::test]
+async fn group_write_nonholder() -> TestResult<()> {
+    let realm_id = RealmId([94u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+    let owner = UserId::local(Ulid::from_bytes([51; 16]), realm_id);
+    seed_realm_authorization(&realm, owner).await?;
+
+    let (group, _) = drive(
+        CreateGroupOperation::new(CreateGroupConfig {
+            actor: realm.actor(realm.node(0), owner),
+            display_name: "off-holder group".to_string(),
+            owner_cap: None,
+        }),
+        realm.node(0).context.as_ref(),
+    )
+    .await?;
+    let group_id = group.group_id;
+
+    let target = DocumentSyncTarget::GroupAuthorization { group_id };
+    let context = PlacementResolutionContext {
+        group_id: Some(group_id),
+        metadata_path: None,
+    };
+    let writer = realm.non_holder(&target, context);
+    realm.assert_not_holder(writer.node_id(), &target, context);
+
+    // Presence of the document is not enough: the reducer must also have applied
+    // the owner's admin assignment before the write is authorized.
+    for node in &realm.nodes {
+        wait_until("group reaches node", node.node_id(), || async {
+            drive(
+                GetGroupOperation::new(GetGroupConfig { group_id }),
+                node.context.as_ref(),
+            )
+            .await
+            .is_ok_and(|(_, auth)| {
+                auth.roles
+                    .values()
+                    .any(|role| role.name == "admin" && role.assigned_users.contains(&owner))
+            })
+        })
+        .await?;
+    }
+
+    let role_id = Ulid::from_bytes([52; 16]);
+    drive(
+        AddGroupRoleOperation::new(AddGroupRoleConfig {
+            auth_context: AuthContext {
+                user_id: owner,
+                realm_id,
+                path_restrictions: None,
+            },
+            actor: realm.actor(writer, owner),
+            realm_id,
+            group_id,
+            role: Role {
+                role_id,
+                name: "auditor".to_string(),
+                permissions: HashMap::from([(
+                    format!("/{realm_id}/g/{group_id}/**"),
+                    Permission::READ,
+                )]),
+                assigned_users: HashSet::new(),
+            },
+        }),
+        writer.context.as_ref(),
+    )
+    .await?;
+
+    // The regression this guards: a group write accepted on a node that holds
+    // nothing for the group and then never published anywhere.
+    for node in &realm.nodes {
+        wait_until("role reaches node", node.node_id(), || async {
+            drive(
+                GetGroupOperation::new(GetGroupConfig { group_id }),
+                node.context.as_ref(),
+            )
+            .await
+            .is_ok_and(|(_, auth)| auth.roles.values().any(|role| role.name == "auditor"))
+        })
+        .await?;
+    }
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn user_write_nonholder() -> TestResult<()> {
+    let realm_id = RealmId([95u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+
+    let user_id = UserId::local(Ulid::from_bytes([61; 16]), realm_id);
+    let target = DocumentSyncTarget::User { user_id };
+    let context = PlacementResolutionContext::default();
+
+    let origin = realm.non_holder(&target, context);
+    realm.assert_not_holder(origin.node_id(), &target, context);
+
+    drive(
+        RegisterOrGetOidcUserOperation::new(RegisterOrGetOidcUserInput {
+            actor: realm.actor(origin, user_id),
+            issuer: "https://issuer.test".to_string(),
+            subject_id: "off-holder-subject".to_string(),
+            name: "Off Holder".to_string(),
+            user_id,
+        }),
+        origin.context.as_ref(),
+    )
+    .await?;
+
+    for node in &realm.nodes {
+        wait_until("user reaches node", node.node_id(), || async {
+            drive(
+                ReadUserDocumentOperation::new(user_id),
+                node.context.as_ref(),
+            )
+            .await
+            .is_ok_and(|user| user.name == "Off Holder")
+        })
+        .await?;
+    }
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn permission_check_nonholder() -> TestResult<()> {
+    let realm_id = RealmId([96u8; 32]);
+    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+    let owner = UserId::local(Ulid::from_bytes([71; 16]), realm_id);
+    seed_realm_authorization(&realm, owner).await?;
+
+    let (group, _) = drive(
+        CreateGroupOperation::new(CreateGroupConfig {
+            actor: realm.actor(realm.node(0), owner),
+            display_name: "authorized group".to_string(),
+            owner_cap: None,
+        }),
+        realm.node(0).context.as_ref(),
+    )
+    .await?;
+    let group_id = group.group_id;
+
+    let target = DocumentSyncTarget::GroupAuthorization { group_id };
+    let context = PlacementResolutionContext {
+        group_id: Some(group_id),
+        metadata_path: None,
+    };
+    let non_holders = realm.non_holder_ids(&target, context);
+    assert!(!non_holders.is_empty());
+
+    let path = format!("/{realm_id}/g/{group_id}/meta/document");
+    for node_id in non_holders {
+        let node = realm.find(node_id);
+        realm.assert_not_holder(node_id, &target, context);
+        wait_until("group auth reaches node", node_id, || {
+            let path = path.clone();
+            async move {
+                drive(
+                    CheckPermissionsOperation::new(CheckPermissionsConfig {
+                        auth_context: AuthContext {
+                            user_id: owner,
+                            realm_id,
+                            path_restrictions: None,
+                        },
+                        path,
+                        required_permission: Permission::READ,
+                    }),
+                    node.context.as_ref(),
+                )
+                .await
+                .is_ok_and(|granted| granted)
+            }
+        })
+        .await?;
+    }
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+fn metadata_subject(
+    group_id: Ulid,
+    document_id: Ulid,
+    document_path: &str,
+) -> (DocumentSyncTarget, PlacementResolutionContext<'_>) {
+    (
+        DocumentSyncTarget::MetadataDocumentLifecycle { document_id },
+        PlacementResolutionContext {
+            group_id: Some(group_id),
+            metadata_path: Some(document_path),
+        },
+    )
+}
+
+async fn create_document(
+    realm: &Topology,
+    node: &TestNode,
+    group_id: Ulid,
+    document_id: Ulid,
+    document_path: &str,
+) -> TestResult<()> {
+    drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: realm.actor(
+                node,
+                UserId::local(Ulid::from_bytes([9; 16]), realm.realm_id),
+            ),
+            group_id,
+            document_id,
+            document_path: document_path.to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Non-holder Dataset".to_string(),
+                description: "Written on a node outside the holder set".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        node.context.as_ref(),
+    )
+    .await?;
+    replay_metadata_event_log(node.context.as_ref()).await?;
+    Ok(())
+}
+
+async fn document_present(node: &TestNode, group_id: Ulid, document_id: Ulid) -> bool {
+    drive(
+        GetMetadataDocumentOperation::new(group_id, document_id),
+        node.context.as_ref(),
+    )
+    .await
+    .is_ok()
+}
+
+async fn seed_realm_authorization(realm: &Topology, owner: UserId) -> TestResult<()> {
+    let document = RealmAuthorizationDocument::new_default_realm_doc(realm.realm_id);
+    for node in &realm.nodes {
+        let actor = Actor {
+            node_id: node.node_id(),
+            user_id: owner,
+            realm_id: realm.realm_id,
+        };
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: AUTH_KEYSPACE.to_string(),
+                key: realm.realm_id.as_bytes().to_vec().into(),
+                value: document.to_bytes(&actor)?.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm auth write event: {other:?}").into()),
+        }
+    }
+    Ok(())
+}

--- a/operations/tests/non_holder_topology.rs
+++ b/operations/tests/non_holder_topology.rs
@@ -26,7 +26,9 @@ use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
 use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
 };
-use aruna_operations::delete_metadata_document::DeleteMetadataDocumentOperation;
+use aruna_operations::delete_metadata_document::{
+    DeleteMetadataDocumentError, DeleteMetadataDocumentOperation,
+};
 use aruna_operations::driver::drive;
 use aruna_operations::get_group::{GetGroupConfig, GetGroupOperation};
 use aruna_operations::get_metadata_document::GetMetadataDocumentOperation;
@@ -37,7 +39,8 @@ use aruna_operations::register_or_get_oidc_user::{
     RegisterOrGetOidcUserInput, RegisterOrGetOidcUserOperation,
 };
 use aruna_operations::update_metadata_document::{
-    UpdateMetadataDocumentConfig, UpdateMetadataDocumentMutation, UpdateMetadataDocumentOperation,
+    UpdateMetadataDocumentConfig, UpdateMetadataDocumentError, UpdateMetadataDocumentMutation,
+    UpdateMetadataDocumentOperation,
 };
 use ulid::Ulid;
 
@@ -171,11 +174,15 @@ async fn read_misses_nonholder() -> TestResult<()> {
     Ok(())
 }
 
-// #398's fail-loud invariant: a node that holds nothing for the document and
-// did not author it must reject the mutation rather than accept a write it can
-// never publish. Silent acceptance here is the data-loss shape.
+// What main actually pins for a bystander (no registry copy, not the author):
+// the metadata write ops carry no holdership or authorship gate, so the failure
+// is exactly the first local registry read missing (`DocumentNotFound`), the
+// same miss `read_misses_nonholder` pins. #398's forward-before-acceptance
+// routing is unimplemented: a non-holder that had acquired a registry copy
+// would accept the mutation locally (event + outbox) with no forward and no
+// holder check. Do not seed such a copy here until #398 lands.
 #[tokio::test]
-async fn bystander_writes_fail() -> TestResult<()> {
+async fn bystander_writes_miss() -> TestResult<()> {
     let realm_id = RealmId([97u8; 32]);
     let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
 
@@ -215,9 +222,10 @@ async fn bystander_writes_fail() -> TestResult<()> {
         bystander.context.as_ref(),
     )
     .await;
-    assert!(
-        updated.is_err(),
-        "non-holder accepted an update it cannot publish"
+    assert_eq!(
+        updated.unwrap_err(),
+        UpdateMetadataDocumentError::DocumentNotFound,
+        "bystander update must fail on the local registry miss"
     );
 
     let deleted = drive(
@@ -225,12 +233,13 @@ async fn bystander_writes_fail() -> TestResult<()> {
         bystander.context.as_ref(),
     )
     .await;
-    assert!(
-        deleted.is_err(),
-        "non-holder accepted a delete it cannot publish"
+    assert_eq!(
+        deleted.unwrap_err(),
+        DeleteMetadataDocumentError::DocumentNotFound,
+        "bystander delete must fail on the local registry miss"
     );
 
-    // The rejected writes must not have disturbed the real holders.
+    // The failed writes must not have disturbed the real holders.
     for holder in &holders {
         let node = realm.find(*holder);
         let view = drive(

--- a/operations/tests/non_holder_topology.rs
+++ b/operations/tests/non_holder_topology.rs
@@ -2,15 +2,14 @@
 //!
 //! Every other multi-node fixture in this workspace runs at `node_count <= RF`,
 //! where every node holds every bucket and non-holder behaviour is unobservable.
-//! These tests run five nodes at RF three and prove holdership against the bucket
-//! a create actually stamps before exercising the path, so a regression to
-//! universal holdership fails the fixture instead of quietly voiding the test.
+//! These tests run five Management nodes at RF three plus a User-kind node, and
+//! prove holdership against the bucket a create actually stamps before exercising
+//! the path, so a regression to universal holdership fails the fixture instead of
+//! quietly voiding the test.
 
 mod topology;
 
-use aruna_core::UserId;
 use aruna_core::metadata::MetadataError;
-use aruna_core::structs::{PlacementRef, RealmId};
 use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
 };
@@ -18,20 +17,26 @@ use aruna_operations::driver::drive;
 use aruna_operations::get_metadata_document::{
     GetMetadataDocumentError, GetMetadataDocumentOperation, load_metadata_record_by_document,
 };
+use aruna_operations::metadata::forward::{
+    create_metadata_document_routed, delete_metadata_document_routed,
+    update_metadata_document_routed,
+};
 use aruna_operations::metadata::projector::replay_metadata_event_log;
 use aruna_operations::sync_placement::sort_node_ids;
+use aruna_operations::update_metadata_document::UpdateMetadataDocumentMutation;
 use ulid::Ulid;
 
 use topology::{TestNode, TestResult, Topology, wait_until};
 
-const NODE_COUNT: usize = 5;
+const MANAGEMENT_NODES: usize = 5;
+const USER_NODES: usize = 1;
 const REPLICATION_FACTOR: u32 = 3;
 
 // The fixture itself is the deliverable: without this proof every test below
 // degrades silently into the all-nodes-hold-everything case.
 #[tokio::test]
 async fn fixture_proves_nonholders() -> TestResult<()> {
-    let realm = Topology::spawn(RealmId([90u8; 32]), NODE_COUNT, REPLICATION_FACTOR).await?;
+    let realm = Topology::spawn(MANAGEMENT_NODES, USER_NODES, REPLICATION_FACTOR).await?;
 
     let group_id = Ulid::from_bytes([11; 16]);
     let document_id = Ulid::from_bytes([12; 16]);
@@ -45,7 +50,10 @@ async fn fixture_proves_nonholders() -> TestResult<()> {
     assert_eq!(holders.len(), REPLICATION_FACTOR as usize);
 
     let non_holders = realm.non_holder_ids(&placement);
-    assert_eq!(non_holders.len(), NODE_COUNT - REPLICATION_FACTOR as usize);
+    assert_eq!(
+        non_holders.len(),
+        MANAGEMENT_NODES - REPLICATION_FACTOR as usize
+    );
     for node_id in &non_holders {
         realm.assert_not_holder(*node_id, &placement);
     }
@@ -57,17 +65,24 @@ async fn fixture_proves_nonholders() -> TestResult<()> {
         assert_eq!(view, holders, "holder set diverged across nodes");
     }
 
+    // A User-kind node is never sync-eligible, so it holds no bucket to stamp: the
+    // one origin from which a create must be forwarded (D10).
+    assert_eq!(
+        realm.origin_placement(realm.user_node(), group_id, document_id, path),
+        None
+    );
+
     realm.shutdown().await;
     Ok(())
 }
 
 // D3: a create stamps the best-ranked bucket its origin already holds, so the
-// origin is always a holder of what it creates and can always publish it. A blind
-// document hash would place it anywhere, including on buckets the origin does not
-// hold - the state that makes an offline node's writes undeliverable.
+// origin is always a holder of what it creates and can always publish it. A
+// blind document hash would place it anywhere, including on buckets the origin
+// does not hold - the state that makes an offline node's writes undeliverable.
 #[tokio::test]
 async fn create_stamps_origin() -> TestResult<()> {
-    let realm = Topology::spawn(RealmId([91u8; 32]), NODE_COUNT, REPLICATION_FACTOR).await?;
+    let realm = Topology::spawn(MANAGEMENT_NODES, USER_NODES, REPLICATION_FACTOR).await?;
 
     let group_id = Ulid::from_bytes([21; 16]);
     let document_id = Ulid::from_bytes([22; 16]);
@@ -117,7 +132,7 @@ async fn create_stamps_origin() -> TestResult<()> {
 // therefore the graph's, not the record's.
 #[tokio::test]
 async fn read_misses_nonholder() -> TestResult<()> {
-    let realm = Topology::spawn(RealmId([92u8; 32]), NODE_COUNT, REPLICATION_FACTOR).await?;
+    let realm = Topology::spawn(MANAGEMENT_NODES, USER_NODES, REPLICATION_FACTOR).await?;
 
     let group_id = Ulid::from_bytes([31; 16]);
     let document_id = Ulid::from_bytes([32; 16]);
@@ -153,6 +168,175 @@ async fn read_misses_nonholder() -> TestResult<()> {
         "non-holder served a graph it never received"
     );
 
+    // The User node is not sync-eligible, so it holds not even the registry row:
+    // its miss is the record's.
+    let user = realm.user_node();
+    let result = drive(
+        GetMetadataDocumentOperation::new(group_id, document_id),
+        user.context.as_ref(),
+    )
+    .await;
+    assert_eq!(
+        result.unwrap_err(),
+        GetMetadataDocumentError::DocumentNotFound
+    );
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+// D10/D11: a write arriving at a node that holds no bucket of the document is
+// forwarded to a holder. The bystander never joins the bucket's topic to publish
+// it itself, so the mutation can only reach the holders through the forward -
+// and the bystander still has no graph afterwards.
+#[tokio::test]
+async fn bystander_writes_forward() -> TestResult<()> {
+    let realm = Topology::spawn(MANAGEMENT_NODES, USER_NODES, REPLICATION_FACTOR).await?;
+    let group_id = realm.seed_group().await?;
+
+    let document_id = Ulid::from_bytes([42; 16]);
+    let path = "datasets/bystander-writes";
+    let origin = realm.node(0);
+    let placement = create_document(&realm, origin, group_id, document_id, path).await?;
+    let holders = realm.assert_holder(origin.node_id(), &placement);
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("document reaches holder", node.node_id(), || {
+            document_present(node, group_id, document_id)
+        })
+        .await?;
+    }
+
+    let bystander = realm.non_holder(&placement);
+    wait_until(
+        "registry row reaches non-holder",
+        bystander.node_id(),
+        || registry_row_present(bystander, document_id),
+    )
+    .await?;
+    let record = load_metadata_record_by_document(bystander.context.as_ref(), document_id)
+        .await
+        .map_err(|error| format!("registry read failed: {error:?}"))?
+        .ok_or("the non-holder must carry the registry row")?;
+    assert_eq!(record.placement, placement);
+
+    update_metadata_document_routed(
+        &bystander.context,
+        realm.actor(bystander),
+        &record,
+        None,
+        UpdateMetadataDocumentMutation::UpsertDataEntity {
+            jsonld: r#"{"@id":"./off-holder.txt","@type":"File","name":"off-holder.txt"}"#
+                .to_string(),
+        },
+        Some(realm.bearer_token()),
+    )
+    .await?;
+
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("update reaches holder", node.node_id(), || async {
+            drive(
+                GetMetadataDocumentOperation::new(group_id, document_id),
+                node.context.as_ref(),
+            )
+            .await
+            .is_ok_and(|view| view.jsonld.contains("off-holder.txt"))
+        })
+        .await?;
+    }
+    assert_eq!(
+        drive(
+            GetMetadataDocumentOperation::new(group_id, document_id),
+            bystander.context.as_ref(),
+        )
+        .await
+        .unwrap_err(),
+        GetMetadataDocumentError::MetadataError(MetadataError::GraphNotFound),
+        "the forwarder must not have applied the write onto a bucket it does not hold"
+    );
+
+    delete_metadata_document_routed(
+        &bystander.context,
+        realm.actor(bystander),
+        &record,
+        Some(realm.bearer_token()),
+    )
+    .await?;
+
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("delete reaches holder", node.node_id(), || async {
+            matches!(
+                drive(
+                    GetMetadataDocumentOperation::new(group_id, document_id),
+                    node.context.as_ref(),
+                )
+                .await,
+                Err(GetMetadataDocumentError::DocumentNotFound)
+            )
+        })
+        .await?;
+    }
+
+    realm.shutdown().await;
+    Ok(())
+}
+
+// The create a bucket-holding node can never reach: a User-kind node holds no
+// bucket, so it can stamp none and must forward the create to a holder (D10).
+// The holder stamps the document's blind-hashed bucket, and the forwarder is
+// never added to it (D11).
+#[tokio::test]
+async fn user_create_forwards() -> TestResult<()> {
+    let realm = Topology::spawn(MANAGEMENT_NODES, USER_NODES, REPLICATION_FACTOR).await?;
+    let group_id = realm.seed_group().await?;
+
+    let document_id = Ulid::from_bytes([52; 16]);
+    let path = "datasets/forwarded-by-user";
+    let user = realm.user_node();
+    assert_eq!(
+        realm.origin_placement(user, group_id, document_id, path),
+        None
+    );
+
+    let created = create_metadata_document_routed(
+        CreateMetadataDocumentOperation::new(document_config(
+            &realm,
+            user,
+            group_id,
+            document_id,
+            path,
+        )),
+        user.context.clone(),
+        Some(realm.bearer_token()),
+    )
+    .await?
+    .record;
+
+    let holders = realm.assert_not_holder(user.node_id(), &created.placement);
+    assert_eq!(holders.len(), REPLICATION_FACTOR as usize);
+
+    for holder in &holders {
+        let node = realm.find(*holder);
+        wait_until("forwarded create reaches holder", node.node_id(), || {
+            document_present(node, group_id, document_id)
+        })
+        .await?;
+    }
+
+    // The forwarder holds nothing, not even the everywhere-bound registry row: it
+    // is not a sync target at all.
+    assert_eq!(
+        drive(
+            GetMetadataDocumentOperation::new(group_id, document_id),
+            user.context.as_ref(),
+        )
+        .await
+        .unwrap_err(),
+        GetMetadataDocumentError::DocumentNotFound
+    );
+
     realm.shutdown().await;
     Ok(())
 }
@@ -165,10 +349,7 @@ fn document_config(
     document_path: &str,
 ) -> CreateMetadataDocumentConfig {
     CreateMetadataDocumentConfig {
-        actor: realm.actor(
-            node,
-            UserId::local(Ulid::from_bytes([9; 16]), realm.realm_id),
-        ),
+        actor: realm.actor(node),
         group_id,
         document_id,
         document_path: document_path.to_string(),
@@ -189,7 +370,7 @@ async fn create_document(
     group_id: Ulid,
     document_id: Ulid,
     document_path: &str,
-) -> TestResult<PlacementRef> {
+) -> TestResult<aruna_core::structs::PlacementRef> {
     let created = drive(
         CreateMetadataDocumentOperation::new(document_config(
             realm,

--- a/operations/tests/non_holder_topology.rs
+++ b/operations/tests/non_holder_topology.rs
@@ -1,49 +1,25 @@
 //! Holder and non-holder coverage on a realm sized above the replication factor.
 //!
 //! Every other multi-node fixture in this workspace runs at `node_count <= RF`,
-//! where every node holds every subject and non-holder behaviour is
-//! unobservable. These tests run five nodes at RF three and assert the
-//! not-a-holder precondition through the placement resolver before exercising
-//! the path, so a regression to universal holdership fails the fixture instead
-//! of quietly voiding the test.
+//! where every node holds every bucket and non-holder behaviour is unobservable.
+//! These tests run five nodes at RF three and prove holdership against the bucket
+//! a create actually stamps before exercising the path, so a regression to
+//! universal holdership fails the fixture instead of quietly voiding the test.
 
 mod topology;
 
-use std::collections::{HashMap, HashSet};
-
 use aruna_core::UserId;
-use aruna_core::document::DocumentSyncTarget;
-use aruna_core::effects::{Effect, StorageEffect};
-use aruna_core::events::{Event, StorageEvent};
-use aruna_core::handle::Handle;
-use aruna_core::keyspaces::AUTH_KEYSPACE;
-use aruna_core::structs::{
-    Actor, AuthContext, Permission, RealmAuthorizationDocument, RealmId, Role,
-};
-use aruna_operations::add_group_role::{AddGroupRoleConfig, AddGroupRoleOperation};
-use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
-use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
+use aruna_core::metadata::MetadataError;
+use aruna_core::structs::{PlacementRef, RealmId};
 use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
 };
-use aruna_operations::delete_metadata_document::{
-    DeleteMetadataDocumentError, DeleteMetadataDocumentOperation,
-};
 use aruna_operations::driver::drive;
-use aruna_operations::get_group::{GetGroupConfig, GetGroupOperation};
 use aruna_operations::get_metadata_document::{
-    GetMetadataDocumentError, GetMetadataDocumentOperation,
+    GetMetadataDocumentError, GetMetadataDocumentOperation, load_metadata_record_by_document,
 };
 use aruna_operations::metadata::projector::replay_metadata_event_log;
-use aruna_operations::placement::PlacementResolutionContext;
-use aruna_operations::read_user_document::ReadUserDocumentOperation;
-use aruna_operations::register_or_get_oidc_user::{
-    RegisterOrGetOidcUserInput, RegisterOrGetOidcUserOperation,
-};
-use aruna_operations::update_metadata_document::{
-    UpdateMetadataDocumentConfig, UpdateMetadataDocumentError, UpdateMetadataDocumentMutation,
-    UpdateMetadataDocumentOperation,
-};
+use aruna_operations::sync_placement::sort_node_ids;
 use ulid::Ulid;
 
 use topology::{TestNode, TestResult, Topology, wait_until};
@@ -55,31 +31,29 @@ const REPLICATION_FACTOR: u32 = 3;
 // degrades silently into the all-nodes-hold-everything case.
 #[tokio::test]
 async fn fixture_proves_nonholders() -> TestResult<()> {
-    let realm_id = RealmId([90u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+    let realm = Topology::spawn(RealmId([90u8; 32]), NODE_COUNT, REPLICATION_FACTOR).await?;
 
     let group_id = Ulid::from_bytes([11; 16]);
     let document_id = Ulid::from_bytes([12; 16]);
-    let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
-    let context = PlacementResolutionContext {
-        group_id: Some(group_id),
-        metadata_path: Some("datasets/proof"),
-    };
+    let path = "datasets/proof";
+    let origin = realm.node(0);
 
-    let holders = realm.holders(&target, context);
-    let non_holders = realm.non_holder_ids(&target, context);
+    let placement = realm
+        .origin_placement(origin, group_id, document_id, path)
+        .expect("a Management node holds buckets of the default strategy");
+    let holders = realm.assert_holder(origin.node_id(), &placement);
     assert_eq!(holders.len(), REPLICATION_FACTOR as usize);
+
+    let non_holders = realm.non_holder_ids(&placement);
     assert_eq!(non_holders.len(), NODE_COUNT - REPLICATION_FACTOR as usize);
     for node_id in &non_holders {
-        realm.assert_not_holder(*node_id, &target, context);
-    }
-    for node_id in &holders {
-        realm.assert_holder(*node_id, &target, context);
+        realm.assert_not_holder(*node_id, &placement);
     }
 
-    // Placement is a pure function of the replicated realm config, so the proof
-    // is exact rather than probabilistic: every node must derive the same set.
-    for view in realm.holder_views(&target, context).await? {
+    // Holders are a pure function of the replicated config and the stamped bucket,
+    // so the proof is exact rather than probabilistic: every node derives the same
+    // set, in the same rank order.
+    for view in realm.holder_views(&placement).await? {
         assert_eq!(view, holders, "holder set diverged across nodes");
     }
 
@@ -87,23 +61,29 @@ async fn fixture_proves_nonholders() -> TestResult<()> {
     Ok(())
 }
 
+// D3: a create stamps the best-ranked bucket its origin already holds, so the
+// origin is always a holder of what it creates and can always publish it. A blind
+// document hash would place it anywhere, including on buckets the origin does not
+// hold - the state that makes an offline node's writes undeliverable.
 #[tokio::test]
-async fn create_off_holders() -> TestResult<()> {
-    let realm_id = RealmId([91u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+async fn create_stamps_origin() -> TestResult<()> {
+    let realm = Topology::spawn(RealmId([91u8; 32]), NODE_COUNT, REPLICATION_FACTOR).await?;
 
     let group_id = Ulid::from_bytes([21; 16]);
     let document_id = Ulid::from_bytes([22; 16]);
-    let document_path = "datasets/created-off-holders";
-    let (target, context) = metadata_subject(group_id, document_id, document_path);
+    let path = "datasets/stamped-by-origin";
+    let origin = realm.node(0);
+    let expected = realm
+        .origin_placement(origin, group_id, document_id, path)
+        .expect("a Management node holds buckets");
+    let holders = realm.assert_holder(origin.node_id(), &expected);
 
-    let origin = realm.non_holder(&target, context);
-    let holders = realm.assert_not_holder(origin.node_id(), &target, context);
+    let created = create_document(&realm, origin, group_id, document_id, path).await?;
+    assert_eq!(
+        created, expected,
+        "create stamped a bucket it does not hold"
+    );
 
-    create_document(&realm, origin, group_id, document_id, document_path).await?;
-
-    // The write must land on every real holder even though the node that
-    // accepted it holds nothing for the document.
     for holder in &holders {
         let node = realm.find(*holder);
         wait_until("document reaches holder", node.node_id(), || {
@@ -112,47 +92,40 @@ async fn create_off_holders() -> TestResult<()> {
         .await?;
     }
 
-    wait_until("document reaches origin", origin.node_id(), || {
-        document_present(origin, group_id, document_id)
-    })
-    .await?;
     let view = drive(
         GetMetadataDocumentOperation::new(group_id, document_id),
         origin.context.as_ref(),
     )
     .await?;
+    assert_eq!(view.record.placement, expected);
     let mut recorded = view.record.holder_node_ids.clone();
-    recorded.sort_unstable_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+    let mut planned = holders.clone();
+    sort_node_ids(&mut recorded);
+    sort_node_ids(&mut planned);
     assert_eq!(
-        recorded, holders,
-        "origin recorded a holder set that is not the planned placement"
-    );
-    assert!(
-        !recorded.contains(&origin.node_id()),
-        "non-holder origin recorded itself as a holder"
+        recorded, planned,
+        "origin recorded a holder set that is not the stamped bucket's"
     );
 
     realm.shutdown().await;
     Ok(())
 }
 
-// A node that neither authored the document nor holds it has no copy and no
-// forwarding path on main: the miss is definitive, not an unavailability error.
+// A non-holder carries the document's registry row - the row rides the
+// everywhere-bound registry class, which is what lets it route reads and writes -
+// but it holds no bucket of the document, so it has no graph. The miss is
+// therefore the graph's, not the record's.
 #[tokio::test]
 async fn read_misses_nonholder() -> TestResult<()> {
-    let realm_id = RealmId([92u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
+    let realm = Topology::spawn(RealmId([92u8; 32]), NODE_COUNT, REPLICATION_FACTOR).await?;
 
     let group_id = Ulid::from_bytes([31; 16]);
     let document_id = Ulid::from_bytes([32; 16]);
-    let document_path = "datasets/read-off-holders";
-    let (target, context) = metadata_subject(group_id, document_id, document_path);
+    let path = "datasets/read-off-holders";
+    let origin = realm.node(0);
+    let placement = create_document(&realm, origin, group_id, document_id, path).await?;
+    let holders = realm.assert_holder(origin.node_id(), &placement);
 
-    let holders = realm.holders(&target, context);
-    let origin = realm.holder(&target, context);
-    realm.assert_holder(origin.node_id(), &target, context);
-
-    create_document(&realm, origin, group_id, document_id, document_path).await?;
     for holder in &holders {
         let node = realm.find(*holder);
         wait_until("document reaches holder", node.node_id(), || {
@@ -161,7 +134,14 @@ async fn read_misses_nonholder() -> TestResult<()> {
         .await?;
     }
 
-    let bystander = realm.non_holder(&target, context);
+    let bystander = realm.non_holder(&placement);
+    wait_until(
+        "registry row reaches non-holder",
+        bystander.node_id(),
+        || registry_row_present(bystander, document_id),
+    )
+    .await?;
+
     let result = drive(
         GetMetadataDocumentOperation::new(group_id, document_id),
         bystander.context.as_ref(),
@@ -169,402 +149,60 @@ async fn read_misses_nonholder() -> TestResult<()> {
     .await;
     assert_eq!(
         result.unwrap_err(),
-        GetMetadataDocumentError::DocumentNotFound,
-        "non-holder served a document it never received"
+        GetMetadataDocumentError::MetadataError(MetadataError::GraphNotFound),
+        "non-holder served a graph it never received"
     );
 
     realm.shutdown().await;
     Ok(())
 }
 
-// What main actually pins for a bystander (no registry copy, not the author):
-// the metadata write ops carry no holdership or authorship gate, so the failure
-// is exactly the first local registry read missing (`DocumentNotFound`), the
-// same miss `read_misses_nonholder` pins. #398's forward-before-acceptance
-// routing is unimplemented: a non-holder that had acquired a registry copy
-// would accept the mutation locally (event + outbox) with no forward and no
-// holder check. Do not seed such a copy here until #398 lands.
-#[tokio::test]
-async fn bystander_writes_miss() -> TestResult<()> {
-    let realm_id = RealmId([97u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
-
-    let group_id = Ulid::from_bytes([81; 16]);
-    let document_id = Ulid::from_bytes([82; 16]);
-    let document_path = "datasets/bystander-writes";
-    let (target, context) = metadata_subject(group_id, document_id, document_path);
-
-    let holders = realm.holders(&target, context);
-    let origin = realm.holder(&target, context);
-    create_document(&realm, origin, group_id, document_id, document_path).await?;
-    for holder in &holders {
-        let node = realm.find(*holder);
-        wait_until("document reaches holder", node.node_id(), || {
-            document_present(node, group_id, document_id)
-        })
-        .await?;
-    }
-
-    let bystander = realm.non_holder(&target, context);
-    realm.assert_not_holder(bystander.node_id(), &target, context);
-    let actor = realm.actor(
-        bystander,
-        UserId::local(Ulid::from_bytes([83; 16]), realm_id),
-    );
-
-    let updated = drive(
-        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
-            actor: actor.clone(),
-            group_id,
-            document_id,
-            public: true,
-            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
-                jsonld: r#"{"@id":"./ghost.txt","@type":"File","name":"ghost.txt"}"#.to_string(),
-            },
-        }),
-        bystander.context.as_ref(),
-    )
-    .await;
-    assert_eq!(
-        updated.unwrap_err(),
-        UpdateMetadataDocumentError::DocumentNotFound,
-        "bystander update must fail on the local registry miss"
-    );
-
-    let deleted = drive(
-        DeleteMetadataDocumentOperation::new(actor, group_id, document_id),
-        bystander.context.as_ref(),
-    )
-    .await;
-    assert_eq!(
-        deleted.unwrap_err(),
-        DeleteMetadataDocumentError::DocumentNotFound,
-        "bystander delete must fail on the local registry miss"
-    );
-
-    // The failed writes must not have disturbed the real holders.
-    for holder in &holders {
-        let node = realm.find(*holder);
-        let view = drive(
-            GetMetadataDocumentOperation::new(group_id, document_id),
-            node.context.as_ref(),
-        )
-        .await?;
-        assert!(!view.jsonld.contains("ghost.txt"));
-    }
-
-    realm.shutdown().await;
-    Ok(())
-}
-
-#[tokio::test]
-async fn mutate_off_holders() -> TestResult<()> {
-    let realm_id = RealmId([93u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
-
-    let group_id = Ulid::from_bytes([41; 16]);
-    let document_id = Ulid::from_bytes([42; 16]);
-    let document_path = "datasets/mutated-off-holders";
-    let (target, context) = metadata_subject(group_id, document_id, document_path);
-
-    let origin = realm.non_holder(&target, context);
-    let holders = realm.assert_not_holder(origin.node_id(), &target, context);
-
-    create_document(&realm, origin, group_id, document_id, document_path).await?;
-    for holder in &holders {
-        let node = realm.find(*holder);
-        wait_until("document reaches holder", node.node_id(), || {
-            document_present(node, group_id, document_id)
-        })
-        .await?;
-    }
-
-    drive(
-        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
-            actor: realm.actor(origin, UserId::local(Ulid::from_bytes([43; 16]), realm_id)),
-            group_id,
-            document_id,
-            public: true,
-            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
-                jsonld: r#"{"@id":"./off-holder.txt","@type":"File","name":"off-holder.txt"}"#
-                    .to_string(),
-            },
-        }),
-        origin.context.as_ref(),
-    )
-    .await?;
-
-    for holder in &holders {
-        let node = realm.find(*holder);
-        wait_until("update reaches holder", node.node_id(), || async {
-            drive(
-                GetMetadataDocumentOperation::new(group_id, document_id),
-                node.context.as_ref(),
-            )
-            .await
-            .is_ok_and(|view| view.jsonld.contains("off-holder.txt"))
-        })
-        .await?;
-    }
-
-    drive(
-        DeleteMetadataDocumentOperation::new(
-            realm.actor(origin, UserId::local(Ulid::from_bytes([44; 16]), realm_id)),
-            group_id,
-            document_id,
-        ),
-        origin.context.as_ref(),
-    )
-    .await?;
-
-    for holder in &holders {
-        let node = realm.find(*holder);
-        wait_until("delete reaches holder", node.node_id(), || async {
-            matches!(
-                drive(
-                    GetMetadataDocumentOperation::new(group_id, document_id),
-                    node.context.as_ref(),
-                )
-                .await,
-                Err(GetMetadataDocumentError::DocumentNotFound)
-            )
-        })
-        .await?;
-    }
-
-    realm.shutdown().await;
-    Ok(())
-}
-
-// Group documents are admin-class: they sync as reducer operations over the
-// group topic and never take a placement. A node the resolver would call a
-// non-holder must still accept the write and serve the group.
-#[tokio::test]
-async fn group_write_nonholder() -> TestResult<()> {
-    let realm_id = RealmId([94u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
-    let owner = UserId::local(Ulid::from_bytes([51; 16]), realm_id);
-    seed_realm_authorization(&realm, owner).await?;
-
-    let (group, _) = drive(
-        CreateGroupOperation::new(CreateGroupConfig {
-            actor: realm.actor(realm.node(0), owner),
-            display_name: "off-holder group".to_string(),
-            owner_cap: None,
-        }),
-        realm.node(0).context.as_ref(),
-    )
-    .await?;
-    let group_id = group.group_id;
-
-    let target = DocumentSyncTarget::GroupAuthorization { group_id };
-    let context = PlacementResolutionContext {
-        group_id: Some(group_id),
-        metadata_path: None,
-    };
-    let writer = realm.non_holder(&target, context);
-    realm.assert_not_holder(writer.node_id(), &target, context);
-
-    // Presence of the document is not enough: the reducer must also have applied
-    // the owner's admin assignment before the write is authorized.
-    for node in &realm.nodes {
-        wait_until("group reaches node", node.node_id(), || async {
-            drive(
-                GetGroupOperation::new(GetGroupConfig { group_id }),
-                node.context.as_ref(),
-            )
-            .await
-            .is_ok_and(|(_, auth)| {
-                auth.roles
-                    .values()
-                    .any(|role| role.name == "admin" && role.assigned_users.contains(&owner))
-            })
-        })
-        .await?;
-    }
-
-    let role_id = Ulid::from_bytes([52; 16]);
-    drive(
-        AddGroupRoleOperation::new(AddGroupRoleConfig {
-            auth_context: AuthContext {
-                user_id: owner,
-                realm_id,
-                path_restrictions: None,
-            },
-            actor: realm.actor(writer, owner),
-            realm_id,
-            group_id,
-            role: Role {
-                role_id,
-                name: "auditor".to_string(),
-                permissions: HashMap::from([(
-                    format!("/{realm_id}/g/{group_id}/**"),
-                    Permission::READ,
-                )]),
-                assigned_users: HashSet::new(),
-            },
-        }),
-        writer.context.as_ref(),
-    )
-    .await?;
-
-    // The regression this guards: a group write accepted on a node that holds
-    // nothing for the group and then never published anywhere.
-    for node in &realm.nodes {
-        wait_until("role reaches node", node.node_id(), || async {
-            drive(
-                GetGroupOperation::new(GetGroupConfig { group_id }),
-                node.context.as_ref(),
-            )
-            .await
-            .is_ok_and(|(_, auth)| auth.roles.values().any(|role| role.name == "auditor"))
-        })
-        .await?;
-    }
-
-    realm.shutdown().await;
-    Ok(())
-}
-
-#[tokio::test]
-async fn user_write_nonholder() -> TestResult<()> {
-    let realm_id = RealmId([95u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
-
-    let user_id = UserId::local(Ulid::from_bytes([61; 16]), realm_id);
-    let target = DocumentSyncTarget::User { user_id };
-    let context = PlacementResolutionContext::default();
-
-    let origin = realm.non_holder(&target, context);
-    realm.assert_not_holder(origin.node_id(), &target, context);
-
-    drive(
-        RegisterOrGetOidcUserOperation::new(RegisterOrGetOidcUserInput {
-            actor: realm.actor(origin, user_id),
-            issuer: "https://issuer.test".to_string(),
-            subject_id: "off-holder-subject".to_string(),
-            name: "Off Holder".to_string(),
-            user_id,
-        }),
-        origin.context.as_ref(),
-    )
-    .await?;
-
-    for node in &realm.nodes {
-        wait_until("user reaches node", node.node_id(), || async {
-            drive(
-                ReadUserDocumentOperation::new(user_id),
-                node.context.as_ref(),
-            )
-            .await
-            .is_ok_and(|user| user.name == "Off Holder")
-        })
-        .await?;
-    }
-
-    realm.shutdown().await;
-    Ok(())
-}
-
-#[tokio::test]
-async fn permission_check_nonholder() -> TestResult<()> {
-    let realm_id = RealmId([96u8; 32]);
-    let realm = Topology::spawn(realm_id, NODE_COUNT, REPLICATION_FACTOR).await?;
-    let owner = UserId::local(Ulid::from_bytes([71; 16]), realm_id);
-    seed_realm_authorization(&realm, owner).await?;
-
-    let (group, _) = drive(
-        CreateGroupOperation::new(CreateGroupConfig {
-            actor: realm.actor(realm.node(0), owner),
-            display_name: "authorized group".to_string(),
-            owner_cap: None,
-        }),
-        realm.node(0).context.as_ref(),
-    )
-    .await?;
-    let group_id = group.group_id;
-
-    let target = DocumentSyncTarget::GroupAuthorization { group_id };
-    let context = PlacementResolutionContext {
-        group_id: Some(group_id),
-        metadata_path: None,
-    };
-    let non_holders = realm.non_holder_ids(&target, context);
-    assert!(!non_holders.is_empty());
-
-    let path = format!("/{realm_id}/g/{group_id}/meta/document");
-    for node_id in non_holders {
-        let node = realm.find(node_id);
-        realm.assert_not_holder(node_id, &target, context);
-        wait_until("group auth reaches node", node_id, || {
-            let path = path.clone();
-            async move {
-                drive(
-                    CheckPermissionsOperation::new(CheckPermissionsConfig {
-                        auth_context: AuthContext {
-                            user_id: owner,
-                            realm_id,
-                            path_restrictions: None,
-                        },
-                        path,
-                        required_permission: Permission::READ,
-                    }),
-                    node.context.as_ref(),
-                )
-                .await
-                .is_ok_and(|granted| granted)
-            }
-        })
-        .await?;
-    }
-
-    realm.shutdown().await;
-    Ok(())
-}
-
-fn metadata_subject(
+fn document_config(
+    realm: &Topology,
+    node: &TestNode,
     group_id: Ulid,
     document_id: Ulid,
     document_path: &str,
-) -> (DocumentSyncTarget, PlacementResolutionContext<'_>) {
-    (
-        DocumentSyncTarget::MetadataDocumentLifecycle { document_id },
-        PlacementResolutionContext {
-            group_id: Some(group_id),
-            metadata_path: Some(document_path),
+) -> CreateMetadataDocumentConfig {
+    CreateMetadataDocumentConfig {
+        actor: realm.actor(
+            node,
+            UserId::local(Ulid::from_bytes([9; 16]), realm.realm_id),
+        ),
+        group_id,
+        document_id,
+        document_path: document_path.to_string(),
+        public: true,
+        payload: CreateMetadataDocumentPayload::Scaffold {
+            name: "Topology Dataset".to_string(),
+            description: "Written on a realm above the replication factor".to_string(),
+            date_published: "2026-01-01".to_string(),
+            license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
         },
-    )
+    }
 }
 
+/// Creates locally on a bucket-holding node and returns the bucket it stamped.
 async fn create_document(
     realm: &Topology,
     node: &TestNode,
     group_id: Ulid,
     document_id: Ulid,
     document_path: &str,
-) -> TestResult<()> {
-    drive(
-        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
-            actor: realm.actor(
-                node,
-                UserId::local(Ulid::from_bytes([9; 16]), realm.realm_id),
-            ),
+) -> TestResult<PlacementRef> {
+    let created = drive(
+        CreateMetadataDocumentOperation::new(document_config(
+            realm,
+            node,
             group_id,
             document_id,
-            document_path: document_path.to_string(),
-            public: true,
-            payload: CreateMetadataDocumentPayload::Scaffold {
-                name: "Non-holder Dataset".to_string(),
-                description: "Written on a node outside the holder set".to_string(),
-                date_published: "2026-01-01".to_string(),
-                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
-            },
-        }),
+            document_path,
+        )),
         node.context.as_ref(),
     )
     .await?;
     replay_metadata_event_log(node.context.as_ref()).await?;
-    Ok(())
+    Ok(created.record.placement)
 }
 
 async fn document_present(node: &TestNode, group_id: Ulid, document_id: Ulid) -> bool {
@@ -576,28 +214,8 @@ async fn document_present(node: &TestNode, group_id: Ulid, document_id: Ulid) ->
     .is_ok()
 }
 
-async fn seed_realm_authorization(realm: &Topology, owner: UserId) -> TestResult<()> {
-    let document = RealmAuthorizationDocument::new_default_realm_doc(realm.realm_id);
-    for node in &realm.nodes {
-        let actor = Actor {
-            node_id: node.node_id(),
-            user_id: owner,
-            realm_id: realm.realm_id,
-        };
-        match node
-            .context
-            .storage_handle
-            .send_effect(Effect::Storage(StorageEffect::Write {
-                key_space: AUTH_KEYSPACE.to_string(),
-                key: realm.realm_id.as_bytes().to_vec().into(),
-                value: document.to_bytes(&actor)?.into(),
-                txn_id: None,
-            }))
-            .await
-        {
-            Event::Storage(StorageEvent::WriteResult { .. }) => {}
-            other => return Err(format!("unexpected realm auth write event: {other:?}").into()),
-        }
-    }
-    Ok(())
+async fn registry_row_present(node: &TestNode, document_id: Ulid) -> bool {
+    load_metadata_record_by_document(node.context.as_ref(), document_id)
+        .await
+        .is_ok_and(|record| record.is_some())
 }

--- a/operations/tests/restart_traffic.rs
+++ b/operations/tests/restart_traffic.rs
@@ -112,14 +112,17 @@ async fn restart_traffic_body() -> Result<(), BoxError> {
         .take(40)
         .map(|(group_id, document_id)| (*group_id, *document_id))
         .collect();
-    wait_for_visibility(
-        std::slice::from_ref(&nodes[2].context),
+    wait_for_any_visibility(
+        &nodes[2].context,
         &sample,
         Duration::from_millis(200),
         CONVERGENCE_TIMEOUT,
     )
     .await?;
-    println!("seeded {} docs, node 2 caught up", created.len());
+    println!(
+        "seeded {} docs, node 2 holds replicated state",
+        created.len()
+    );
 
     // Restart node 2's whole stack.
     let node2 = nodes.pop().expect("node 2 present");
@@ -336,6 +339,32 @@ async fn wait_for_visibility(
         if t0.elapsed() > timeout {
             let counts: Vec<usize> = remaining.iter().map(Vec::len).collect();
             return Err(format!("visibility timeout; missing per node: {counts:?}").into());
+        }
+        sleep(poll_interval).await;
+    }
+}
+
+async fn wait_for_any_visibility(
+    context: &Arc<DriverContext>,
+    pairs: &[(GroupId, Ulid)],
+    poll_interval: Duration,
+    timeout: Duration,
+) -> Result<(), BoxError> {
+    let t0 = Instant::now();
+    loop {
+        for &(group_id, document_id) in pairs {
+            if drive(
+                GetMetadataDocumentOperation::new(group_id, document_id),
+                context.as_ref(),
+            )
+            .await
+            .is_ok()
+            {
+                return Ok(());
+            }
+        }
+        if t0.elapsed() > timeout {
+            return Err("visibility timeout; no sampled documents visible".into());
         }
         sleep(poll_interval).await;
     }

--- a/operations/tests/topology/mod.rs
+++ b/operations/tests/topology/mod.rs
@@ -1,10 +1,18 @@
-//! Reusable realm fixture with more sync-eligible nodes than the placement
-//! replication factor, so holder and non-holder paths are distinguishable.
+//! Realm fixture with more sync-eligible nodes than the placement replication
+//! factor, so holder and non-holder paths are distinguishable.
 //!
-//! Fixtures sized at or below the replication factor make every node a holder
-//! of every subject, which silently collapses non-holder coverage. [`Topology`]
-//! keeps `node_count > replication_factor` and exposes exact, resolver-derived
-//! holder proofs instead of probabilistic ones.
+//! Fixtures sized at or below the replication factor make every node a holder of
+//! every bucket, which silently collapses non-holder coverage. [`Topology`] keeps
+//! `node_count > replication_factor` and derives holders the way production does:
+//! a create stamps the best-ranked bucket its origin already holds
+//! ([`choose_origin_bucket`], DECISIONS D3), so holdership is proved against that
+//! stamped [`PlacementRef`] and never against a blind document hash.
+//!
+//! Only metadata document buckets are replica-capped. Group, user, auth and
+//! registry documents are bound to the `everywhere` strategy (DECISIONS B1), so
+//! every sync-eligible node holds them and a non-holder of one is not a reachable
+//! state: this fixture cannot express it and must not pretend to. That is why
+//! every holder query here is keyed on a stamped bucket rather than on a target.
 
 #![allow(dead_code)]
 
@@ -18,7 +26,10 @@ use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
-use aruna_core::structs::{Actor, NodePlacementEntry, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_core::structs::{
+    Actor, MetadataRegistryRecord, NodePlacementEntry, PlacementRef, RealmConfigDocument, RealmId,
+    RealmNodeKind,
+};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::announce_realm_presence::{
     AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
@@ -27,13 +38,16 @@ use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::incoming::initialize_net_incoming;
 use aruna_operations::metadata::MetadataHandle;
-use aruna_operations::placement::{PlacementResolutionContext, plan_target_placement};
-use aruna_operations::sync_placement::sort_node_ids;
+use aruna_operations::placement::{
+    PlacementResolutionContext, choose_origin_bucket, meta_bucket_subject, resolve_shard_holders,
+    strategy_for_target,
+};
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
 use tokio::time::{Instant, sleep};
+use ulid::Ulid;
 
 pub type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
 
@@ -67,9 +81,9 @@ impl Topology {
     /// Spawns a meshed realm of `node_count` Management nodes whose default
     /// placement strategy replicates to `replication_factor` holders.
     ///
-    /// Panics unless `node_count > replication_factor`: a fixture at or below
-    /// the factor cannot express a non-holder and would quietly void every
-    /// assertion this module exists to make.
+    /// Panics unless `node_count > replication_factor`: a fixture at or below the
+    /// factor cannot express a non-holder and would quietly void every assertion
+    /// this module exists to make.
     pub async fn spawn(
         realm_id: RealmId,
         node_count: usize,
@@ -133,119 +147,108 @@ impl Topology {
         }
     }
 
-    /// Holder set the placement resolver assigns to `target`, sorted.
-    pub fn holders(
+    /// The bucket a create on `origin` stamps (D3): the best-ranked bucket the
+    /// origin already holds, chosen on `(realm_id, group_id, path)`. The origin is
+    /// therefore always a holder of what it creates.
+    ///
+    /// `None` when the origin holds no bucket of the governing strategy.
+    pub fn origin_placement(
         &self,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> Vec<NodeId> {
-        let mut holders = plan_target_placement(&self.config, target, context)
-            .expect("realm config resolves a placement strategy for the target")
-            .holders;
-        sort_node_ids(&mut holders);
-        holders
+        origin: &TestNode,
+        group_id: Ulid,
+        document_id: Ulid,
+        document_path: &str,
+    ) -> Option<PlacementRef> {
+        let path = MetadataRegistryRecord::normalize_document_path(document_path);
+        let target = DocumentSyncTarget::MetadataDocumentLifecycle { document_id };
+        let (strategy, _) = strategy_for_target(
+            &self.config,
+            &target,
+            PlacementResolutionContext {
+                group_id: Some(group_id),
+                metadata_path: Some(path.as_str()),
+            },
+        )?;
+        choose_origin_bucket(
+            &self.config,
+            strategy,
+            origin.node_id(),
+            &meta_bucket_subject(self.realm_id, group_id, &path),
+        )
     }
 
-    pub fn is_holder(
-        &self,
-        node_id: NodeId,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> bool {
-        self.holders(target, context).contains(&node_id)
+    /// Rank-ordered holders of `placement`, exactly as every node derives them.
+    pub fn holders(&self, placement: &PlacementRef) -> Vec<NodeId> {
+        resolve_shard_holders(&self.config, placement)
     }
 
-    pub fn non_holder_ids(
-        &self,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> Vec<NodeId> {
-        let holders = self.holders(target, context);
+    pub fn is_holder(&self, node_id: NodeId, placement: &PlacementRef) -> bool {
+        self.holders(placement).contains(&node_id)
+    }
+
+    pub fn non_holder_ids(&self, placement: &PlacementRef) -> Vec<NodeId> {
+        let holders = self.holders(placement);
         self.node_ids()
             .into_iter()
             .filter(|node_id| !holders.contains(node_id))
             .collect()
     }
 
-    /// Proves `node_id` holds nothing for `target` and returns the holder set.
+    /// Proves `node_id` holds nothing of `placement` and returns the holder set.
     ///
-    /// The proof is exact, not statistical: placement is a pure function of the
-    /// replicated realm config, so the resolver is re-run here. It also asserts
-    /// the strategy actually capped the holder set below the fixture size,
-    /// which is what makes "non-holder" a meaningful state at all.
-    pub fn assert_not_holder(
-        &self,
-        node_id: NodeId,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> Vec<NodeId> {
-        let holders = self.holders(target, context);
+    /// The proof is exact, not statistical: holders are a pure function of the
+    /// replicated realm config and the stamped bucket, so the resolver is re-run
+    /// here. It also asserts the strategy capped the holder set below the fixture
+    /// size, which is what makes "non-holder" meaningful at all.
+    pub fn assert_not_holder(&self, node_id: NodeId, placement: &PlacementRef) -> Vec<NodeId> {
+        let holders = self.holders(placement);
         assert!(
             holders.len() < self.nodes.len(),
-            "placement selected every fixture node for {target:?}; \
+            "placement selected every fixture node for {placement:?}; \
              non-holder coverage is void (holders={holders:?})"
         );
         assert!(
             !holders.contains(&node_id),
-            "node {node_id} is a holder of {target:?} (holders={holders:?})"
+            "node {node_id} is a holder of {placement:?} (holders={holders:?})"
         );
         holders
     }
 
-    pub fn assert_holder(
-        &self,
-        node_id: NodeId,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> Vec<NodeId> {
-        let holders = self.holders(target, context);
+    pub fn assert_holder(&self, node_id: NodeId, placement: &PlacementRef) -> Vec<NodeId> {
+        let holders = self.holders(placement);
         assert!(
             holders.contains(&node_id),
-            "node {node_id} is not a holder of {target:?} (holders={holders:?})"
+            "node {node_id} is not a holder of {placement:?} (holders={holders:?})"
         );
         holders
     }
 
-    /// First fixture node that holds nothing for `target`, with the proof run.
-    pub fn non_holder(
-        &self,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> &TestNode {
+    /// First fixture node that holds nothing of `placement`, with the proof run.
+    pub fn non_holder(&self, placement: &PlacementRef) -> &TestNode {
         let node_id = *self
-            .non_holder_ids(target, context)
+            .non_holder_ids(placement)
             .first()
-            .expect("fixture above the replication factor always has a non-holder");
-        self.assert_not_holder(node_id, target, context);
+            .expect("a realm above the replication factor always has a non-holder");
+        self.assert_not_holder(node_id, placement);
         self.find(node_id)
     }
 
-    pub fn holder(
-        &self,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> &TestNode {
+    /// Rank-0 holder of `placement`.
+    pub fn holder(&self, placement: &PlacementRef) -> &TestNode {
         let node_id = *self
-            .holders(target, context)
+            .holders(placement)
             .first()
             .expect("placement resolves at least one holder");
         self.find(node_id)
     }
 
-    /// Every node's own view of the holder set, for cross-node agreement checks.
-    pub async fn holder_views(
-        &self,
-        target: &DocumentSyncTarget,
-        context: PlacementResolutionContext<'_>,
-    ) -> TestResult<Vec<Vec<NodeId>>> {
+    /// Every node's own view of the holder set, from the config it replicated, for
+    /// cross-node agreement checks.
+    pub async fn holder_views(&self, placement: &PlacementRef) -> TestResult<Vec<Vec<NodeId>>> {
         let mut views = Vec::with_capacity(self.nodes.len());
         for node in &self.nodes {
             let config = read_realm_config(node, self.realm_id).await?;
-            let mut holders = plan_target_placement(&config, target, context)
-                .expect("replicated realm config resolves the same strategy")
-                .holders;
-            sort_node_ids(&mut holders);
-            views.push(holders);
+            views.push(resolve_shard_holders(&config, placement));
         }
         Ok(views)
     }
@@ -340,25 +343,67 @@ async fn install_realm_config(
             user_id: aruna_core::UserId::nil(realm_id),
             realm_id,
         };
-        let bytes = config.to_bytes(&actor)?;
-        match node
-            .context
-            .storage_handle
-            .send_effect(Effect::Storage(StorageEffect::Write {
-                key_space: REALM_CONFIG_KEYSPACE.to_string(),
-                key: (*realm_id.as_bytes()).into(),
-                value: bytes.into(),
-                txn_id: None,
-            }))
-            .await
-        {
-            Event::Storage(StorageEvent::WriteResult { .. }) => {}
-            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
-        }
+        write(
+            node,
+            REALM_CONFIG_KEYSPACE,
+            realm_id.as_bytes().to_vec(),
+            config.to_bytes(&actor)?,
+        )
+        .await?;
         node.net.refresh_realm_peers_from_document(&config).await?;
     }
 
-    Ok(config)
+    // The startup hook, exactly as the binary runs it after loading the config: it
+    // joins the shared realm topics and reconciles the held shard topics. Nothing
+    // can be published onto a shard topic before its rank-0 holder has minted the
+    // genesis, so without this every write onto a bucket defers forever. A node
+    // whose rank-0 co-holder has not minted one yet leaves it for the next pass, so
+    // run until the reconciler reports clean rather than a fixed number of passes.
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        for node in nodes {
+            aruna_operations::startup::restore_shard_subscriptions(
+                &node.context,
+                node.node_id(),
+                realm_id,
+            )
+            .await;
+        }
+        let mut retry = false;
+        for node in nodes {
+            retry |= aruna_operations::process_placements::process_shard_placements(
+                &node.context,
+                realm_id,
+                node.node_id(),
+            )
+            .await
+            .retry_scheduled;
+        }
+        if !retry {
+            return Ok(config);
+        }
+        if Instant::now() >= deadline {
+            return Err("shard placement reconciliation never reported clean".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn write(node: &TestNode, key_space: &str, key: Vec<u8>, value: Vec<u8>) -> TestResult<()> {
+    match node
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Write {
+            key_space: key_space.to_string(),
+            key: key.into(),
+            value: value.into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::WriteResult { .. }) => Ok(()),
+        other => Err(format!("unexpected write event in `{key_space}`: {other:?}").into()),
+    }
 }
 
 async fn read_realm_config(node: &TestNode, realm_id: RealmId) -> TestResult<RealmConfigDocument> {

--- a/operations/tests/topology/mod.rs
+++ b/operations/tests/topology/mod.rs
@@ -1,0 +1,425 @@
+//! Reusable realm fixture with more sync-eligible nodes than the placement
+//! replication factor, so holder and non-holder paths are distinguishable.
+//!
+//! Fixtures sized at or below the replication factor make every node a holder
+//! of every subject, which silently collapses non-holder coverage. [`Topology`]
+//! keeps `node_count > replication_factor` and exposes exact, resolver-derived
+//! holder proofs instead of probabilistic ones.
+
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use aruna_core::NodeId;
+use aruna_core::document::DocumentSyncTarget;
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::handle::Handle;
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{Actor, NodePlacementEntry, RealmConfigDocument, RealmId, RealmNodeKind};
+use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
+use aruna_operations::announce_realm_presence::{
+    AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
+};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
+use aruna_operations::incoming::initialize_net_incoming;
+use aruna_operations::metadata::MetadataHandle;
+use aruna_operations::placement::{PlacementResolutionContext, plan_target_placement};
+use aruna_operations::sync_placement::sort_node_ids;
+use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_storage::FjallStorage;
+use aruna_tasks::TaskHandle;
+use tempfile::TempDir;
+use tokio::time::{Instant, sleep};
+
+pub type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+pub const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Two stable locations, so `distinct_locations` strategies stay satisfiable
+/// and location ranking is exercised rather than degenerate.
+pub const LOCATIONS: [&str; 2] = ["eu", "us"];
+pub const NODE_WEIGHT: u32 = 100;
+
+pub struct TestNode {
+    _temp_dir: TempDir,
+    pub net: NetHandle,
+    pub context: Arc<DriverContext>,
+}
+
+impl TestNode {
+    pub fn node_id(&self) -> NodeId {
+        self.net.node_id()
+    }
+}
+
+pub struct Topology {
+    pub realm_id: RealmId,
+    pub replication_factor: u32,
+    pub config: RealmConfigDocument,
+    pub nodes: Vec<TestNode>,
+}
+
+impl Topology {
+    /// Spawns a meshed realm of `node_count` Management nodes whose default
+    /// placement strategy replicates to `replication_factor` holders.
+    ///
+    /// Panics unless `node_count > replication_factor`: a fixture at or below
+    /// the factor cannot express a non-holder and would quietly void every
+    /// assertion this module exists to make.
+    pub async fn spawn(
+        realm_id: RealmId,
+        node_count: usize,
+        replication_factor: u32,
+    ) -> TestResult<Self> {
+        assert!(
+            node_count > replication_factor as usize,
+            "non-holder fixture needs more nodes than the replication factor: \
+             node_count={node_count} replication_factor={replication_factor}"
+        );
+
+        let mut nodes = Vec::with_capacity(node_count);
+        for _ in 0..node_count {
+            nodes.push(spawn_node(realm_id).await?);
+        }
+        mesh(&nodes).await;
+
+        for node in &nodes {
+            drive(
+                AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+                    realm_id,
+                    node_id: node.node_id(),
+                    schedule_refresh: true,
+                }),
+                node.context.as_ref(),
+            )
+            .await?;
+        }
+        wait_for_realm_nodes(&nodes, realm_id).await?;
+
+        let config = install_realm_config(&nodes, realm_id, replication_factor).await?;
+
+        Ok(Self {
+            realm_id,
+            replication_factor,
+            config,
+            nodes,
+        })
+    }
+
+    pub fn node(&self, index: usize) -> &TestNode {
+        &self.nodes[index]
+    }
+
+    pub fn node_ids(&self) -> Vec<NodeId> {
+        self.nodes.iter().map(TestNode::node_id).collect()
+    }
+
+    pub fn find(&self, node_id: NodeId) -> &TestNode {
+        self.nodes
+            .iter()
+            .find(|node| node.node_id() == node_id)
+            .expect("node id belongs to this topology")
+    }
+
+    pub fn actor(&self, node: &TestNode, user_id: aruna_core::UserId) -> Actor {
+        Actor {
+            node_id: node.node_id(),
+            user_id,
+            realm_id: self.realm_id,
+        }
+    }
+
+    /// Holder set the placement resolver assigns to `target`, sorted.
+    pub fn holders(
+        &self,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> Vec<NodeId> {
+        let mut holders = plan_target_placement(&self.config, target, context)
+            .expect("realm config resolves a placement strategy for the target")
+            .holders;
+        sort_node_ids(&mut holders);
+        holders
+    }
+
+    pub fn is_holder(
+        &self,
+        node_id: NodeId,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> bool {
+        self.holders(target, context).contains(&node_id)
+    }
+
+    pub fn non_holder_ids(
+        &self,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> Vec<NodeId> {
+        let holders = self.holders(target, context);
+        self.node_ids()
+            .into_iter()
+            .filter(|node_id| !holders.contains(node_id))
+            .collect()
+    }
+
+    /// Proves `node_id` holds nothing for `target` and returns the holder set.
+    ///
+    /// The proof is exact, not statistical: placement is a pure function of the
+    /// replicated realm config, so the resolver is re-run here. It also asserts
+    /// the strategy actually capped the holder set below the fixture size,
+    /// which is what makes "non-holder" a meaningful state at all.
+    pub fn assert_not_holder(
+        &self,
+        node_id: NodeId,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> Vec<NodeId> {
+        let holders = self.holders(target, context);
+        assert!(
+            holders.len() < self.nodes.len(),
+            "placement selected every fixture node for {target:?}; \
+             non-holder coverage is void (holders={holders:?})"
+        );
+        assert!(
+            !holders.contains(&node_id),
+            "node {node_id} is a holder of {target:?} (holders={holders:?})"
+        );
+        holders
+    }
+
+    pub fn assert_holder(
+        &self,
+        node_id: NodeId,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> Vec<NodeId> {
+        let holders = self.holders(target, context);
+        assert!(
+            holders.contains(&node_id),
+            "node {node_id} is not a holder of {target:?} (holders={holders:?})"
+        );
+        holders
+    }
+
+    /// First fixture node that holds nothing for `target`, with the proof run.
+    pub fn non_holder(
+        &self,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> &TestNode {
+        let node_id = *self
+            .non_holder_ids(target, context)
+            .first()
+            .expect("fixture above the replication factor always has a non-holder");
+        self.assert_not_holder(node_id, target, context);
+        self.find(node_id)
+    }
+
+    pub fn holder(
+        &self,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> &TestNode {
+        let node_id = *self
+            .holders(target, context)
+            .first()
+            .expect("placement resolves at least one holder");
+        self.find(node_id)
+    }
+
+    /// Every node's own view of the holder set, for cross-node agreement checks.
+    pub async fn holder_views(
+        &self,
+        target: &DocumentSyncTarget,
+        context: PlacementResolutionContext<'_>,
+    ) -> TestResult<Vec<Vec<NodeId>>> {
+        let mut views = Vec::with_capacity(self.nodes.len());
+        for node in &self.nodes {
+            let config = read_realm_config(node, self.realm_id).await?;
+            let mut holders = plan_target_placement(&config, target, context)
+                .expect("replicated realm config resolves the same strategy")
+                .holders;
+            sort_node_ids(&mut holders);
+            views.push(holders);
+        }
+        Ok(views)
+    }
+
+    pub async fn shutdown(self) {
+        for node in self.nodes {
+            node.net.shutdown().await;
+        }
+    }
+}
+
+async fn spawn_node(realm_id: RealmId) -> TestResult<TestNode> {
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
+    let net = NetHandle::new(
+        NetConfig {
+            bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
+            realm_id,
+            discovery_method: DiscoveryMethod::None,
+            relay_method: RelayMethod::None,
+            ..NetConfig::default()
+        },
+        storage.clone(),
+    )
+    .await?;
+    let task_handle = TaskHandle::new();
+    let metadata_handle = MetadataHandle::new(
+        temp_dir.path().join("metadata"),
+        net.node_id(),
+        storage.clone(),
+        Some(net.clone()),
+        Some(net.document_sync_node()),
+        Some(net.document_sync_database()),
+    )?;
+
+    let context = Arc::new(DriverContext {
+        storage_handle: storage,
+        net_handle: Some(net.clone()),
+        blob_handle: None,
+        metadata_handle: Some(metadata_handle),
+        task_handle: Some(task_handle.clone()),
+    });
+
+    initialize_net_incoming(context.clone());
+    initialize_task_incoming(context.clone(), task_handle).await;
+
+    Ok(TestNode {
+        _temp_dir: temp_dir,
+        net,
+        context,
+    })
+}
+
+async fn mesh(nodes: &[TestNode]) {
+    for left in 0..nodes.len() {
+        for right in (left + 1)..nodes.len() {
+            nodes[left]
+                .net
+                .add_peer_addr(nodes[right].net.endpoint_addr())
+                .await;
+            nodes[right]
+                .net
+                .add_peer_addr(nodes[left].net.endpoint_addr())
+                .await;
+        }
+    }
+}
+
+async fn install_realm_config(
+    nodes: &[TestNode],
+    realm_id: RealmId,
+    replication_factor: u32,
+) -> TestResult<RealmConfigDocument> {
+    let mut config = RealmConfigDocument::new(realm_id, Vec::new(), replication_factor);
+    config.seed_default_placement();
+    for (index, node) in nodes.iter().enumerate() {
+        let node_id = node.node_id();
+        config.ensure_node(node_id, RealmNodeKind::Management);
+        config.placement_map.push(NodePlacementEntry {
+            node_id,
+            location: LOCATIONS[index % LOCATIONS.len()].to_string(),
+            weight: NODE_WEIGHT,
+            full: false,
+            draining: false,
+            labels: BTreeMap::new(),
+        });
+    }
+
+    for node in nodes {
+        let actor = Actor {
+            node_id: node.node_id(),
+            user_id: aruna_core::UserId::nil(realm_id),
+            realm_id,
+        };
+        let bytes = config.to_bytes(&actor)?;
+        match node
+            .context
+            .storage_handle
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: bytes.into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => return Err(format!("unexpected realm config write event: {other:?}").into()),
+        }
+        node.net.refresh_realm_peers_from_document(&config).await?;
+    }
+
+    Ok(config)
+}
+
+async fn read_realm_config(node: &TestNode, realm_id: RealmId) -> TestResult<RealmConfigDocument> {
+    match node
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Read {
+            key_space: REALM_CONFIG_KEYSPACE.to_string(),
+            key: (*realm_id.as_bytes()).into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(value), ..
+        }) => Ok(RealmConfigDocument::from_bytes(&value)?),
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {
+            Err("realm config missing on fixture node".into())
+        }
+        other => Err(format!("unexpected realm config read event: {other:?}").into()),
+    }
+}
+
+async fn wait_for_realm_nodes(nodes: &[TestNode], realm_id: RealmId) -> TestResult<()> {
+    let expected: HashSet<NodeId> = nodes.iter().map(TestNode::node_id).collect();
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        let mut converged = true;
+        for node in nodes {
+            match drive(GetRealmNodesOperation::new(realm_id), node.context.as_ref()).await {
+                Ok(realm_nodes) if realm_nodes == expected => {}
+                _ => {
+                    converged = false;
+                    break;
+                }
+            }
+        }
+        if converged {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("realm nodes did not converge".into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Polls `predicate` until it holds or the convergence budget expires.
+pub async fn wait_until<F, Fut>(label: &str, node_id: NodeId, predicate: F) -> TestResult<()>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        if predicate().await {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("{label} did not converge on node {node_id}").into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}

--- a/operations/tests/topology/mod.rs
+++ b/operations/tests/topology/mod.rs
@@ -1,9 +1,9 @@
 //! Realm fixture with more sync-eligible nodes than the placement replication
-//! factor, so holder and non-holder paths are distinguishable.
+//! factor, plus a User-kind node that holds nothing at all.
 //!
 //! Fixtures sized at or below the replication factor make every node a holder of
 //! every bucket, which silently collapses non-holder coverage. [`Topology`] keeps
-//! `node_count > replication_factor` and derives holders the way production does:
+//! `management > replication_factor` and derives holders the way production does:
 //! a create stamps the best-ranked bucket its origin already holds
 //! ([`choose_origin_bucket`], DECISIONS D3), so holdership is proved against that
 //! stamped [`PlacementRef`] and never against a blind document hash.
@@ -11,8 +11,9 @@
 //! Only metadata document buckets are replica-capped. Group, user, auth and
 //! registry documents are bound to the `everywhere` strategy (DECISIONS B1), so
 //! every sync-eligible node holds them and a non-holder of one is not a reachable
-//! state: this fixture cannot express it and must not pretend to. That is why
-//! every holder query here is keyed on a stamped bucket rather than on a target.
+//! state: this fixture cannot express it and must not pretend to. A User-kind node
+//! is never sync-eligible, holds no bucket of any strategy, and is therefore the
+//! one origin that reaches the D10 forwarding path.
 
 #![allow(dead_code)]
 
@@ -20,24 +21,26 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use aruna_core::NodeId;
+use aruna_core::auth::TRUSTED_REALMS_LIST_KEY;
 use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
-use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::keyspaces::{API_STATE_KEYSPACE, AUTH_KEYSPACE, REALM_CONFIG_KEYSPACE};
 use aruna_core::structs::{
-    Actor, MetadataRegistryRecord, NodePlacementEntry, PlacementRef, RealmConfigDocument, RealmId,
-    RealmNodeKind,
+    Actor, MetadataRegistryRecord, NodePlacementEntry, PlacementRef, RealmAuthorizationDocument,
+    RealmConfigDocument, RealmId, RealmNodeKind, TokenClaims,
 };
+use aruna_core::{NodeId, UserId};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
 use aruna_operations::announce_realm_presence::{
     AnnounceRealmPresenceConfig, AnnounceRealmPresenceOperation,
 };
+use aruna_operations::create_group::{CreateGroupConfig, CreateGroupOperation};
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::incoming::initialize_net_incoming;
-use aruna_operations::metadata::MetadataHandle;
+use aruna_operations::metadata::{MetadataAuthToken, MetadataHandle};
 use aruna_operations::placement::{
     PlacementResolutionContext, choose_origin_bucket, meta_bucket_subject, resolve_shard_holders,
     strategy_for_target,
@@ -45,6 +48,10 @@ use aruna_operations::placement::{
 use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
+use ed25519_dalek::SigningKey;
+use ed25519_dalek::pkcs8::EncodePrivateKey;
+use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use tempfile::TempDir;
 use tokio::time::{Instant, sleep};
 use ulid::Ulid;
@@ -62,42 +69,62 @@ pub struct TestNode {
     _temp_dir: TempDir,
     pub net: NetHandle,
     pub context: Arc<DriverContext>,
+    pub kind: RealmNodeKind,
 }
 
 impl TestNode {
     pub fn node_id(&self) -> NodeId {
         self.net.node_id()
     }
+
+    pub fn is_sync_eligible(&self) -> bool {
+        self.kind.is_sync_eligible()
+    }
 }
 
 pub struct Topology {
     pub realm_id: RealmId,
+    /// Owner of every group this fixture seeds, and the subject of its tokens.
+    pub user_id: UserId,
     pub replication_factor: u32,
     pub config: RealmConfigDocument,
     pub nodes: Vec<TestNode>,
+    signing_key: SigningKey,
 }
 
 impl Topology {
-    /// Spawns a meshed realm of `node_count` Management nodes whose default
-    /// placement strategy replicates to `replication_factor` holders.
+    /// Spawns a meshed realm of `management` Management nodes and `users`
+    /// User-kind nodes, with a default placement strategy of
+    /// `replication_factor` holders.
     ///
-    /// Panics unless `node_count > replication_factor`: a fixture at or below the
-    /// factor cannot express a non-holder and would quietly void every assertion
-    /// this module exists to make.
+    /// The realm id is a verifying key, so the fixture can mint the bearer tokens
+    /// a forwarded write re-validates. Panics unless
+    /// `management > replication_factor`: a fixture at or below the factor cannot
+    /// express a non-holder and would quietly void every assertion this module
+    /// exists to make.
     pub async fn spawn(
-        realm_id: RealmId,
-        node_count: usize,
+        management: usize,
+        users: usize,
         replication_factor: u32,
     ) -> TestResult<Self> {
         assert!(
-            node_count > replication_factor as usize,
-            "non-holder fixture needs more nodes than the replication factor: \
-             node_count={node_count} replication_factor={replication_factor}"
+            management > replication_factor as usize,
+            "non-holder fixture needs more sync-eligible nodes than the replication factor: \
+             management={management} replication_factor={replication_factor}"
         );
 
-        let mut nodes = Vec::with_capacity(node_count);
-        for _ in 0..node_count {
-            nodes.push(spawn_node(realm_id).await?);
+        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
+        let user_id = UserId::local(Ulid::r#gen(), realm_id);
+
+        let mut nodes = Vec::with_capacity(management + users);
+        for index in 0..(management + users) {
+            let kind = if index < management {
+                RealmNodeKind::Management
+            } else {
+                RealmNodeKind::User
+            };
+            nodes.push(spawn_node(realm_id, kind).await?);
         }
         mesh(&nodes).await;
 
@@ -114,18 +141,28 @@ impl Topology {
         }
         wait_for_realm_nodes(&nodes, realm_id).await?;
 
-        let config = install_realm_config(&nodes, realm_id, replication_factor).await?;
+        let config = install_realm_config(&nodes, realm_id, user_id, replication_factor).await?;
 
         Ok(Self {
             realm_id,
+            user_id,
             replication_factor,
             config,
             nodes,
+            signing_key,
         })
     }
 
     pub fn node(&self, index: usize) -> &TestNode {
         &self.nodes[index]
+    }
+
+    /// First User-kind node: sync-ineligible, so it holds no bucket at all.
+    pub fn user_node(&self) -> &TestNode {
+        self.nodes
+            .iter()
+            .find(|node| !node.is_sync_eligible())
+            .expect("fixture was spawned with a User-kind node")
     }
 
     pub fn node_ids(&self) -> Vec<NodeId> {
@@ -139,11 +176,70 @@ impl Topology {
             .expect("node id belongs to this topology")
     }
 
-    pub fn actor(&self, node: &TestNode, user_id: aruna_core::UserId) -> Actor {
+    pub fn actor(&self, node: &TestNode) -> Actor {
         Actor {
             node_id: node.node_id(),
-            user_id,
+            user_id: self.user_id,
             realm_id: self.realm_id,
+        }
+    }
+
+    /// A bearer token for [`Topology::user_id`], signed by the realm key that the
+    /// realm id is. A holder re-validates this before applying a forwarded write.
+    pub fn bearer_token(&self) -> MetadataAuthToken {
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let claims = TokenClaims {
+            sub: self.user_id.to_string(),
+            iss: self.realm_id.to_string(),
+            iat: now,
+            exp: now + 600,
+            jti: Ulid::r#gen().to_string(),
+            restrictions: None,
+            issuer_pubkey: None,
+            delegation_signature: None,
+        };
+        let key_pem = self
+            .signing_key
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("realm key encodes");
+        let token = encode(
+            &Header::new(Algorithm::EdDSA),
+            &claims,
+            &EncodingKey::from_ed_pem(key_pem.as_bytes()).expect("realm key is an ed25519 key"),
+        )
+        .expect("token signs");
+        MetadataAuthToken::bearer(token).expect("token is within the length bound")
+    }
+
+    /// A group owned by [`Topology::user_id`], replicated to every sync-eligible
+    /// node. The holder of a forwarded write re-runs the caller's permission check
+    /// against this group's authorization document, read from its own keyspace.
+    pub async fn seed_group(&self) -> TestResult<Ulid> {
+        let (group, _auth) = drive(
+            CreateGroupOperation::new(CreateGroupConfig {
+                actor: self.actor(self.node(0)),
+                display_name: "topology group".to_string(),
+                owner_cap: None,
+            }),
+            self.node(0).context.as_ref(),
+        )
+        .await?;
+
+        let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+        loop {
+            let mut pending = false;
+            for node in self.nodes.iter().filter(|node| node.is_sync_eligible()) {
+                if read_group_auth(node, group.group_id).await?.is_none() {
+                    pending = true;
+                }
+            }
+            if !pending {
+                return Ok(group.group_id);
+            }
+            if Instant::now() >= deadline {
+                return Err("the seeded group never reached every sync-eligible node".into());
+            }
+            sleep(Duration::from_millis(50)).await;
         }
     }
 
@@ -151,7 +247,8 @@ impl Topology {
     /// origin already holds, chosen on `(realm_id, group_id, path)`. The origin is
     /// therefore always a holder of what it creates.
     ///
-    /// `None` when the origin holds no bucket of the governing strategy.
+    /// `None` when the origin holds no bucket of the governing strategy - a
+    /// User-kind node, which is the only origin that reaches the D10 forward.
     pub fn origin_placement(
         &self,
         origin: &TestNode,
@@ -186,10 +283,15 @@ impl Topology {
         self.holders(placement).contains(&node_id)
     }
 
+    /// Sync-eligible fixture nodes that hold nothing of `placement`. User-kind
+    /// nodes are excluded: they hold nothing of anything by construction, so they
+    /// prove nothing about a capped bucket.
     pub fn non_holder_ids(&self, placement: &PlacementRef) -> Vec<NodeId> {
         let holders = self.holders(placement);
-        self.node_ids()
-            .into_iter()
+        self.nodes
+            .iter()
+            .filter(|node| node.is_sync_eligible())
+            .map(TestNode::node_id)
             .filter(|node_id| !holders.contains(node_id))
             .collect()
     }
@@ -198,13 +300,13 @@ impl Topology {
     ///
     /// The proof is exact, not statistical: holders are a pure function of the
     /// replicated realm config and the stamped bucket, so the resolver is re-run
-    /// here. It also asserts the strategy capped the holder set below the fixture
-    /// size, which is what makes "non-holder" meaningful at all.
+    /// here. It also asserts the strategy capped the holder set below the count of
+    /// sync-eligible nodes, which is what makes "non-holder" meaningful at all.
     pub fn assert_not_holder(&self, node_id: NodeId, placement: &PlacementRef) -> Vec<NodeId> {
         let holders = self.holders(placement);
         assert!(
-            holders.len() < self.nodes.len(),
-            "placement selected every fixture node for {placement:?}; \
+            holders.len() < self.sync_eligible_count(),
+            "placement selected every sync-eligible node for {placement:?}; \
              non-holder coverage is void (holders={holders:?})"
         );
         assert!(
@@ -223,7 +325,7 @@ impl Topology {
         holders
     }
 
-    /// First fixture node that holds nothing of `placement`, with the proof run.
+    /// First sync-eligible fixture node that holds nothing of `placement`.
     pub fn non_holder(&self, placement: &PlacementRef) -> &TestNode {
         let node_id = *self
             .non_holder_ids(placement)
@@ -242,15 +344,22 @@ impl Topology {
         self.find(node_id)
     }
 
-    /// Every node's own view of the holder set, from the config it replicated, for
-    /// cross-node agreement checks.
+    /// Every sync-eligible node's own view of the holder set, from the config it
+    /// replicated, for cross-node agreement checks.
     pub async fn holder_views(&self, placement: &PlacementRef) -> TestResult<Vec<Vec<NodeId>>> {
-        let mut views = Vec::with_capacity(self.nodes.len());
-        for node in &self.nodes {
+        let mut views = Vec::new();
+        for node in self.nodes.iter().filter(|node| node.is_sync_eligible()) {
             let config = read_realm_config(node, self.realm_id).await?;
             views.push(resolve_shard_holders(&config, placement));
         }
         Ok(views)
+    }
+
+    pub fn sync_eligible_count(&self) -> usize {
+        self.nodes
+            .iter()
+            .filter(|node| node.is_sync_eligible())
+            .count()
     }
 
     pub async fn shutdown(self) {
@@ -260,7 +369,7 @@ impl Topology {
     }
 }
 
-async fn spawn_node(realm_id: RealmId) -> TestResult<TestNode> {
+async fn spawn_node(realm_id: RealmId, kind: RealmNodeKind) -> TestResult<TestNode> {
     let temp_dir = tempfile::tempdir()?;
     let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
     let net = NetHandle::new(
@@ -299,6 +408,7 @@ async fn spawn_node(realm_id: RealmId) -> TestResult<TestNode> {
         _temp_dir: temp_dir,
         net,
         context,
+        kind,
     })
 }
 
@@ -320,13 +430,17 @@ async fn mesh(nodes: &[TestNode]) {
 async fn install_realm_config(
     nodes: &[TestNode],
     realm_id: RealmId,
+    user_id: UserId,
     replication_factor: u32,
 ) -> TestResult<RealmConfigDocument> {
     let mut config = RealmConfigDocument::new(realm_id, Vec::new(), replication_factor);
     config.seed_default_placement();
     for (index, node) in nodes.iter().enumerate() {
         let node_id = node.node_id();
-        config.ensure_node(node_id, RealmNodeKind::Management);
+        config.ensure_node(node_id, node.kind.clone());
+        if !node.is_sync_eligible() {
+            continue;
+        }
         config.placement_map.push(NodePlacementEntry {
             node_id,
             location: LOCATIONS[index % LOCATIONS.len()].to_string(),
@@ -337,10 +451,12 @@ async fn install_realm_config(
         });
     }
 
+    let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+    let trusted = HashSet::from([realm_id]);
     for node in nodes {
         let actor = Actor {
             node_id: node.node_id(),
-            user_id: aruna_core::UserId::nil(realm_id),
+            user_id,
             realm_id,
         };
         write(
@@ -348,6 +464,23 @@ async fn install_realm_config(
             REALM_CONFIG_KEYSPACE,
             realm_id.as_bytes().to_vec(),
             config.to_bytes(&actor)?,
+        )
+        .await?;
+        // The realm authorization document a permission check reads first, and the
+        // trusted-realm list a forwarded caller's bearer token validates against:
+        // both are per-node local state in production too.
+        write(
+            node,
+            AUTH_KEYSPACE,
+            realm_id.as_bytes().to_vec(),
+            realm_auth.to_bytes(&actor)?,
+        )
+        .await?;
+        write(
+            node,
+            API_STATE_KEYSPACE,
+            TRUSTED_REALMS_LIST_KEY.to_vec(),
+            postcard::to_allocvec(&trusted)?,
         )
         .await?;
         node.net.refresh_realm_peers_from_document(&config).await?;
@@ -403,6 +536,24 @@ async fn write(node: &TestNode, key_space: &str, key: Vec<u8>, value: Vec<u8>) -
     {
         Event::Storage(StorageEvent::WriteResult { .. }) => Ok(()),
         other => Err(format!("unexpected write event in `{key_space}`: {other:?}").into()),
+    }
+}
+
+async fn read_group_auth(node: &TestNode, group_id: Ulid) -> TestResult<Option<Vec<u8>>> {
+    match node
+        .context
+        .storage_handle
+        .send_effect(Effect::Storage(StorageEffect::Read {
+            key_space: AUTH_KEYSPACE.to_string(),
+            key: group_id.to_bytes().into(),
+            txn_id: None,
+        }))
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult { value, .. }) => {
+            Ok(value.map(|bytes| bytes.to_vec()))
+        }
+        other => Err(format!("unexpected group auth read event: {other:?}").into()),
     }
 }
 

--- a/scripts/local_cluster_deploy.sh
+++ b/scripts/local_cluster_deploy.sh
@@ -164,6 +164,7 @@ write_node_env() {
       printf 'PORTAL_MODE=artifact\n'
       printf 'PORTAL_DIR=%s\n' "$PORTAL_DIR"
       printf 'CORS_ALLOWED_ORIGINS=%s\n' "$PORTAL_CORS_ORIGINS"
+      printf 'PORTAL_CSP_EXTRA_ORIGINS=%s\n' "$PORTAL_CORS_ORIGINS"
     fi
     if [[ "$WITH_KEYCLOAK" == "1" ]]; then
       printf 'OIDC_PROVIDER_IDS=main\n'


### PR DESCRIPTION
Closes #363

The portal was served without a Content Security Policy or related security headers.

Portal routes now carry a policy derived from what the portal actually loads, verified against the real portal build rather than copied from a template:

```
default-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none';
frame-ancestors 'none'; form-action 'self';
script-src 'self' 'wasm-unsafe-eval';
style-src 'self' https://fonts.googleapis.com;
img-src 'self' data:;
font-src 'self' data: https://fonts.gstatic.com;
connect-src 'self' <node S3 origin> <realm OIDC origins> <PORTAL_CSP_EXTRA_ORIGINS>
```

plus `X-Content-Type-Options`, `Referrer-Policy` and `Cross-Origin-Opener-Policy`.

`'wasm-unsafe-eval'` is required and is the only unsafe directive: the profile publisher hashes artifacts with a WebAssembly hashing library. It permits no JavaScript eval. There is no `unsafe-inline` and no `unsafe-eval`.

The connect origins are resolved per request from realm state rather than from environment variables, because a joined node serves the portal without any OIDC environment configuration. Extra origins, such as another node's S3 endpoint, come from `PORTAL_CSP_EXTRA_ORIGINS`.

The headers are scoped to the portal router. API routes stay free of an HTML oriented policy, and the ops probe endpoints are excluded because they serve metrics to scrapers rather than documents to a browser.

Because it was urgent this PR also contains some fixes for flaky tests that constantly tripped CI.