### PR TITLE
[feat] Structured MetaResourceId codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "oxrdf",
  "postcard",
  "prometheus-client",
+ "proptest",
  "serde",
  "serde_json",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "hex",
  "iroh",
  "irokle",
+ "nix",
  "oxrdf",
  "postcard",
  "prometheus-client",
@@ -739,7 +740,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -774,7 +775,7 @@ dependencies = [
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "lru 0.16.4",
  "percent-encoding",
  "regex-lite",
@@ -856,7 +857,7 @@ dependencies = [
  "crc-fast",
  "hex",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "md-5 0.11.0",
  "pin-project-lite",
@@ -890,7 +891,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -970,7 +971,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -1031,7 +1032,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -1082,7 +1083,7 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1113,7 +1114,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1328,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "serde_core",
@@ -2031,7 +2032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3194,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -3204,14 +3205,14 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -3254,7 +3255,7 @@ dependencies = [
  "futures-core",
  "h2",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -3304,7 +3305,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -4250,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -4451,6 +4452,18 @@ dependencies = [
  "windows",
  "windows-result",
  "wmi",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -4824,7 +4837,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "opendal-core",
  "reqwest",
 ]
@@ -5110,7 +5123,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.8.7",
+ "rand 0.9.5",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -6107,7 +6120,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -6298,9 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6423,7 +6436,7 @@ dependencies = [
  "hex-simd",
  "hmac 0.13.0",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "httparse",
  "hyper",
@@ -6749,15 +6762,15 @@ checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -6816,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6855,7 +6868,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.8.7",
+ "rand 0.9.5",
  "regex",
  "rustc-hash",
  "sha1 0.10.7",
@@ -6876,7 +6889,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.8.7",
+ "rand 0.9.5",
  "thiserror 2.0.18",
 ]
 
@@ -6887,7 +6900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
 dependencies = [
  "oxrdf",
- "rand 0.8.7",
+ "rand 0.9.5",
  "spargebra",
 ]
 
@@ -7672,9 +7685,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -7701,7 +7714,7 @@ dependencies = [
  "base64",
  "bytes",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -7768,7 +7781,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -7787,7 +7800,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -8136,9 +8149,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -8154,9 +8167,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+checksum = "5dd4ec1eb1d240636e354a30110a1dfcb37047169a4d9bd6d9d3469df574b5c4"
 
 [[package]]
 name = "varint-rs"
@@ -8421,7 +8434,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8776,9 +8789,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -9019,9 +9032,9 @@ checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
 lru = "0.18.1"
 md5 = "0.8.1"
 n0-future = "0.3.2"
+nix = { version = "0.31.3", features = ["time"] }
 opendal = { version = "0.58.0", features = [
     "services-postgresql",
     "services-fs",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,5 +30,8 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+nix = { workspace = true }
+
 [dev-dependencies]
 proptest = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,3 +29,6 @@ oxrdf = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,6 +37,10 @@ pub use id::{DhtKeyId, NodeId, NodeIdExt, TopicId};
 pub use keyspaces::*;
 pub use metadata::*;
 pub use onboarding::*;
+pub use structured_id::{
+    BucketId, ClockHealthError, IdEnvironment, JobId, MetaResourceId, PlacementHandle,
+    StructuredId, StructuredIdGenerator, SystemEnvironment,
+};
 pub use task::{TaskEffect, TaskEvent, TaskKey};
 pub use trace_context::DistributedTraceContext;
 pub use user_id::UserId;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod operation;
 pub mod storage_entries;
 pub mod stream;
 pub mod structs;
+pub mod structured_id;
 pub mod task;
 pub mod telemetry;
 pub mod trace_context;

--- a/core/src/structured_id/generator.rs
+++ b/core/src/structured_id/generator.rs
@@ -78,10 +78,13 @@ struct ClockAnchor {
     monotonic_ms: u64,
 }
 
-/// Structured-ID generator: a monotonic ULID timestamp with a per
-/// `(timestamp_ms, handle, bucket)` monotonic nonce and a forward-clock-jump
-/// guard (REQ-META-ID-TIME-001, REQ-META-ID-NONCE-001). It never emits a
-/// generic ULID, so the structured fields are always preserved.
+/// Structured-ID generator: a monotonic ULID timestamp with a forward-clock-
+/// jump guard (REQ-META-ID-TIME-001, REQ-META-ID-NONCE-001). The nonce
+/// increments only across consecutive mints of the same
+/// `(timestamp_ms, handle, bucket)`; any other mint draws a fresh random
+/// nonce, so uniqueness rests on the 48 random bits, not on monotonicity.
+/// It never emits a generic ULID, so the structured fields are always
+/// preserved.
 pub struct StructuredIdGenerator<E: IdEnvironment = SystemEnvironment> {
     env: E,
     max_skew_ms: u64,
@@ -228,7 +231,9 @@ mod tests {
 
     #[test]
     fn nonce_monotonic() {
-        // Same millisecond and same (handle, bucket): the nonce increments by one.
+        // Consecutive mints in the same millisecond for the same
+        // (handle, bucket) increment the nonce by one; any interleaved mint
+        // for another key would reset it to a fresh random nonce.
         let mut generator =
             StructuredIdGenerator::with_environment(MockEnv::new(1000, [100, 200]), 300_000);
         let (handle, bucket) = handle_bucket();

--- a/core/src/structured_id/generator.rs
+++ b/core/src/structured_id/generator.rs
@@ -12,6 +12,8 @@ pub const DEFAULT_MAX_ID_CLOCK_SKEW_MS: u64 = 300_000;
 pub enum ClockHealthError {
     #[error("wall clock jumped forward {jump_ms} ms, beyond max_id_clock_skew_ms {max_skew_ms}")]
     ForwardJump { jump_ms: u64, max_skew_ms: u64 },
+    #[error("timestamp {timestamp_ms} ms exceeds the 48-bit id timestamp range")]
+    TimestampOverflow { timestamp_ms: u64 },
 }
 
 /// Injectable time and entropy source. The production impl reads the system
@@ -167,6 +169,10 @@ impl<E: IdEnvironment> StructuredIdGenerator<E> {
             }
             _ => self.env.random_nonce() & layout::NONCE_MASK,
         };
+
+        if timestamp_ms > layout::MAX_TIMESTAMP_MS {
+            return Err(ClockHealthError::TimestampOverflow { timestamp_ms });
+        }
 
         self.last = Some(LastMint {
             timestamp_ms,
@@ -341,6 +347,44 @@ mod tests {
         let second: MetaResourceId = generator.mint(handle, BucketId::new(2).unwrap()).unwrap();
         assert_eq!(first.nonce(), 10);
         assert_eq!(second.nonce(), 20);
+    }
+
+    #[test]
+    fn timestamp_overflow_errs() {
+        // A wall clock past the 48-bit cap refuses instead of truncating.
+        let mut generator = StructuredIdGenerator::with_environment(
+            MockEnv::new(layout::MAX_TIMESTAMP_MS + 1, [1]),
+            300_000,
+        );
+        let (handle, bucket) = handle_bucket();
+        assert_eq!(
+            generator
+                .mint::<MetaResourceId>(handle, bucket)
+                .unwrap_err(),
+            ClockHealthError::TimestampOverflow {
+                timestamp_ms: layout::MAX_TIMESTAMP_MS + 1,
+            }
+        );
+    }
+
+    #[test]
+    fn overflow_bump_errs() {
+        // The nonce-overflow +1 ms bump past the cap refuses as well.
+        let mut generator = StructuredIdGenerator::with_environment(
+            MockEnv::new(layout::MAX_TIMESTAMP_MS, [layout::MAX_NONCE, 1]),
+            300_000,
+        );
+        let (handle, bucket) = handle_bucket();
+        let first: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(first.timestamp_ms(), layout::MAX_TIMESTAMP_MS);
+        assert_eq!(
+            generator
+                .mint::<MetaResourceId>(handle, bucket)
+                .unwrap_err(),
+            ClockHealthError::TimestampOverflow {
+                timestamp_ms: layout::MAX_TIMESTAMP_MS + 1,
+            }
+        );
     }
 
     #[test]

--- a/core/src/structured_id/generator.rs
+++ b/core/src/structured_id/generator.rs
@@ -1,4 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use ulid::Ulid;
 
@@ -19,12 +19,30 @@ pub enum ClockHealthError {
 pub trait IdEnvironment {
     /// Validated wall-clock time as Unix milliseconds.
     fn now_ms(&self) -> u64;
+    /// Milliseconds from a monotonic clock with an arbitrary but fixed origin.
+    fn monotonic_ms(&self) -> u64;
     /// A fresh 48-bit nonce drawn from a cryptographically secure source.
     fn random_nonce(&self) -> u64;
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-pub struct SystemEnvironment;
+#[derive(Debug, Clone, Copy)]
+pub struct SystemEnvironment {
+    origin: Instant,
+}
+
+impl SystemEnvironment {
+    pub fn new() -> Self {
+        Self {
+            origin: Instant::now(),
+        }
+    }
+}
+
+impl Default for SystemEnvironment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl IdEnvironment for SystemEnvironment {
     fn now_ms(&self) -> u64 {
@@ -32,6 +50,10 @@ impl IdEnvironment for SystemEnvironment {
             .duration_since(UNIX_EPOCH)
             .map(|elapsed| elapsed.as_millis() as u64)
             .unwrap_or(0)
+    }
+
+    fn monotonic_ms(&self) -> u64 {
+        self.origin.elapsed().as_millis() as u64
     }
 
     fn random_nonce(&self) -> u64 {
@@ -47,6 +69,15 @@ struct LastMint {
     nonce: u64,
 }
 
+/// Paired wall/monotonic reading from the most recent mint attempt. The wall
+/// clock is expected to advance in step with the monotonic clock; divergence
+/// beyond the skew bound is a forward jump.
+#[derive(Clone, Copy)]
+struct ClockAnchor {
+    wall_ms: u64,
+    monotonic_ms: u64,
+}
+
 /// Structured-ID generator: a monotonic ULID timestamp with a per
 /// `(timestamp_ms, handle, bucket)` monotonic nonce and a forward-clock-jump
 /// guard (REQ-META-ID-TIME-001, REQ-META-ID-NONCE-001). It never emits a
@@ -54,12 +85,13 @@ struct LastMint {
 pub struct StructuredIdGenerator<E: IdEnvironment = SystemEnvironment> {
     env: E,
     max_skew_ms: u64,
+    anchor: Option<ClockAnchor>,
     last: Option<LastMint>,
 }
 
 impl StructuredIdGenerator<SystemEnvironment> {
     pub fn new() -> Self {
-        Self::with_environment(SystemEnvironment, DEFAULT_MAX_ID_CLOCK_SKEW_MS)
+        Self::with_environment(SystemEnvironment::new(), DEFAULT_MAX_ID_CLOCK_SKEW_MS)
     }
 }
 
@@ -74,6 +106,7 @@ impl<E: IdEnvironment> StructuredIdGenerator<E> {
         Self {
             env,
             max_skew_ms,
+            anchor: None,
             last: None,
         }
     }
@@ -91,15 +124,24 @@ impl<E: IdEnvironment> StructuredIdGenerator<E> {
 
     fn next_value(&mut self, handle: u32, bucket: u16) -> Result<u128, ClockHealthError> {
         let now = self.env.now_ms();
+        let monotonic = self.env.monotonic_ms();
 
-        if let Some(last) = self.last
-            && now > last.timestamp_ms
-            && now - last.timestamp_ms > self.max_skew_ms
-        {
-            return Err(ClockHealthError::ForwardJump {
-                jump_ms: now - last.timestamp_ms,
-                max_skew_ms: self.max_skew_ms,
-            });
+        // Re-anchoring on every attempt keeps the guard non-sticky: idle time
+        // is covered by the monotonic delta, and a refused jump accepts the
+        // new wall clock as reality on the next mint.
+        if let Some(anchor) = self.anchor.replace(ClockAnchor {
+            wall_ms: now,
+            monotonic_ms: monotonic,
+        }) {
+            let expected = anchor
+                .wall_ms
+                .saturating_add(monotonic.saturating_sub(anchor.monotonic_ms));
+            if now > expected && now - expected > self.max_skew_ms {
+                return Err(ClockHealthError::ForwardJump {
+                    jump_ms: now - expected,
+                    max_skew_ms: self.max_skew_ms,
+                });
+            }
         }
 
         let mut timestamp_ms = match self.last {
@@ -143,6 +185,7 @@ mod tests {
 
     struct MockEnv {
         now: Cell<u64>,
+        monotonic: Cell<u64>,
         nonces: RefCell<VecDeque<u64>>,
     }
 
@@ -150,6 +193,7 @@ mod tests {
         fn new(now: u64, nonces: impl IntoIterator<Item = u64>) -> Self {
             Self {
                 now: Cell::new(now),
+                monotonic: Cell::new(0),
                 nonces: RefCell::new(nonces.into_iter().collect()),
             }
         }
@@ -157,11 +201,20 @@ mod tests {
         fn set_now(&self, now: u64) {
             self.now.set(now);
         }
+
+        fn advance(&self, wall_ms: u64, monotonic_ms: u64) {
+            self.now.set(self.now.get() + wall_ms);
+            self.monotonic.set(self.monotonic.get() + monotonic_ms);
+        }
     }
 
     impl IdEnvironment for MockEnv {
         fn now_ms(&self) -> u64 {
             self.now.get()
+        }
+
+        fn monotonic_ms(&self) -> u64 {
+            self.monotonic.get()
         }
 
         fn random_nonce(&self) -> u64 {
@@ -201,12 +254,13 @@ mod tests {
 
     #[test]
     fn forward_jump_blocks() {
-        // A wall-clock jump beyond the skew bound raises a clock-health error.
+        // The wall clock jumps past the bound while the monotonic clock
+        // barely moves: a genuine discontinuity is refused.
         let mut generator =
             StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2]), 300_000);
         let (handle, bucket) = handle_bucket();
         let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
-        generator.env.set_now(1000 + 300_000 + 1);
+        generator.env.advance(300_002, 1);
         assert_eq!(
             generator
                 .mint::<MetaResourceId>(handle, bucket)
@@ -219,13 +273,42 @@ mod tests {
     }
 
     #[test]
-    fn within_skew_ok() {
-        // A forward step of exactly the bound is accepted.
+    fn jump_recovers() {
+        // A refused jump re-anchors: the next mint accepts the new wall clock.
         let mut generator =
             StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2]), 300_000);
         let (handle, bucket) = handle_bucket();
         let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
-        generator.env.set_now(1000 + 300_000);
+        generator.env.advance(600_000, 0);
+        assert!(generator.mint::<MetaResourceId>(handle, bucket).is_err());
+        let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(id.timestamp_ms(), 601_000);
+    }
+
+    #[test]
+    fn idle_gap_mints() {
+        // Wall and monotonic clocks advance together far beyond the bound:
+        // healthy idle time never errors and never bricks the generator.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2, 3]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        generator.env.advance(3_600_000, 3_600_000);
+        let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(id.timestamp_ms(), 3_601_000);
+        generator.env.advance(3_600_000, 3_600_000);
+        let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(id.timestamp_ms(), 7_201_000);
+    }
+
+    #[test]
+    fn within_skew_ok() {
+        // A wall-only divergence of exactly the bound is accepted.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        generator.env.advance(300_000, 0);
         let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
         assert_eq!(id.timestamp_ms(), 1000 + 300_000);
     }

--- a/core/src/structured_id/generator.rs
+++ b/core/src/structured_id/generator.rs
@@ -124,7 +124,7 @@ impl<E: IdEnvironment> StructuredIdGenerator<E> {
         bucket: BucketId,
     ) -> Result<T, ClockHealthError> {
         let value = self.next_value(handle.get(), bucket.get())?;
-        Ok(T::from_ulid(Ulid(value)))
+        Ok(T::from_ulid(Ulid(value), super::sealed::new()))
     }
 
     fn next_value(&mut self, handle: u32, bucket: u16) -> Result<u128, ClockHealthError> {

--- a/core/src/structured_id/generator.rs
+++ b/core/src/structured_id/generator.rs
@@ -1,0 +1,268 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use ulid::Ulid;
+
+use super::layout;
+use super::{BucketId, PlacementHandle, StructuredId};
+
+/// Realm skew bound default of five minutes (REQ-META-ID-TIME-001).
+pub const DEFAULT_MAX_ID_CLOCK_SKEW_MS: u64 = 300_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum ClockHealthError {
+    #[error("wall clock jumped forward {jump_ms} ms, beyond max_id_clock_skew_ms {max_skew_ms}")]
+    ForwardJump { jump_ms: u64, max_skew_ms: u64 },
+}
+
+/// Injectable time and entropy source. The production impl reads the system
+/// clock and the OS CSPRNG; tests supply deterministic values.
+pub trait IdEnvironment {
+    /// Validated wall-clock time as Unix milliseconds.
+    fn now_ms(&self) -> u64;
+    /// A fresh 48-bit nonce drawn from a cryptographically secure source.
+    fn random_nonce(&self) -> u64;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemEnvironment;
+
+impl IdEnvironment for SystemEnvironment {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_millis() as u64)
+            .unwrap_or(0)
+    }
+
+    fn random_nonce(&self) -> u64 {
+        (Ulid::r#gen().random() as u64) & layout::NONCE_MASK
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LastMint {
+    timestamp_ms: u64,
+    handle: u32,
+    bucket: u16,
+    nonce: u64,
+}
+
+/// Structured-ID generator: a monotonic ULID timestamp with a per
+/// `(timestamp_ms, handle, bucket)` monotonic nonce and a forward-clock-jump
+/// guard (REQ-META-ID-TIME-001, REQ-META-ID-NONCE-001). It never emits a
+/// generic ULID, so the structured fields are always preserved.
+pub struct StructuredIdGenerator<E: IdEnvironment = SystemEnvironment> {
+    env: E,
+    max_skew_ms: u64,
+    last: Option<LastMint>,
+}
+
+impl StructuredIdGenerator<SystemEnvironment> {
+    pub fn new() -> Self {
+        Self::with_environment(SystemEnvironment, DEFAULT_MAX_ID_CLOCK_SKEW_MS)
+    }
+}
+
+impl Default for StructuredIdGenerator<SystemEnvironment> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E: IdEnvironment> StructuredIdGenerator<E> {
+    pub fn with_environment(env: E, max_skew_ms: u64) -> Self {
+        Self {
+            env,
+            max_skew_ms,
+            last: None,
+        }
+    }
+
+    /// Mints the next structured id for `(handle, bucket)`, or refuses with a
+    /// clock-health error under a forward clock jump beyond the skew bound.
+    pub fn mint<T: StructuredId>(
+        &mut self,
+        handle: PlacementHandle,
+        bucket: BucketId,
+    ) -> Result<T, ClockHealthError> {
+        let value = self.next_value(handle.get(), bucket.get())?;
+        Ok(T::from_ulid(Ulid(value)))
+    }
+
+    fn next_value(&mut self, handle: u32, bucket: u16) -> Result<u128, ClockHealthError> {
+        let now = self.env.now_ms();
+
+        if let Some(last) = self.last
+            && now > last.timestamp_ms
+            && now - last.timestamp_ms > self.max_skew_ms
+        {
+            return Err(ClockHealthError::ForwardJump {
+                jump_ms: now - last.timestamp_ms,
+                max_skew_ms: self.max_skew_ms,
+            });
+        }
+
+        let mut timestamp_ms = match self.last {
+            Some(last) => now.max(last.timestamp_ms),
+            None => now,
+        };
+
+        let nonce = match self.last {
+            Some(last)
+                if last.timestamp_ms == timestamp_ms
+                    && last.handle == handle
+                    && last.bucket == bucket =>
+            {
+                if last.nonce >= layout::MAX_NONCE {
+                    timestamp_ms += 1;
+                    self.env.random_nonce() & layout::NONCE_MASK
+                } else {
+                    last.nonce + 1
+                }
+            }
+            _ => self.env.random_nonce() & layout::NONCE_MASK,
+        };
+
+        self.last = Some(LastMint {
+            timestamp_ms,
+            handle,
+            bucket,
+            nonce,
+        });
+        Ok(layout::pack(timestamp_ms, handle, bucket, nonce))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::layout;
+    use super::super::{BucketId, JobId, MetaResourceId, PlacementHandle, StructuredId};
+    use super::*;
+    use std::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
+
+    struct MockEnv {
+        now: Cell<u64>,
+        nonces: RefCell<VecDeque<u64>>,
+    }
+
+    impl MockEnv {
+        fn new(now: u64, nonces: impl IntoIterator<Item = u64>) -> Self {
+            Self {
+                now: Cell::new(now),
+                nonces: RefCell::new(nonces.into_iter().collect()),
+            }
+        }
+
+        fn set_now(&self, now: u64) {
+            self.now.set(now);
+        }
+    }
+
+    impl IdEnvironment for MockEnv {
+        fn now_ms(&self) -> u64 {
+            self.now.get()
+        }
+
+        fn random_nonce(&self) -> u64 {
+            self.nonces.borrow_mut().pop_front().unwrap_or(0)
+        }
+    }
+
+    fn handle_bucket() -> (PlacementHandle, BucketId) {
+        (PlacementHandle::new(7).unwrap(), BucketId::new(2).unwrap())
+    }
+
+    #[test]
+    fn nonce_monotonic() {
+        // Same millisecond and same (handle, bucket): the nonce increments by one.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [100, 200]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let first: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        let second: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(first.timestamp_ms(), second.timestamp_ms());
+        assert_eq!(first.nonce() + 1, second.nonce());
+    }
+
+    #[test]
+    fn overflow_waits_ms() {
+        // A fresh nonce already at the 48-bit max forces the next mint to the next ms.
+        let mut generator = StructuredIdGenerator::with_environment(
+            MockEnv::new(1000, [layout::MAX_NONCE, 42]),
+            300_000,
+        );
+        let (handle, bucket) = handle_bucket();
+        let first: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        let second: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(first.timestamp_ms() + 1, second.timestamp_ms());
+        assert_eq!(second.nonce(), 42);
+    }
+
+    #[test]
+    fn forward_jump_blocks() {
+        // A wall-clock jump beyond the skew bound raises a clock-health error.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        generator.env.set_now(1000 + 300_000 + 1);
+        assert_eq!(
+            generator
+                .mint::<MetaResourceId>(handle, bucket)
+                .unwrap_err(),
+            ClockHealthError::ForwardJump {
+                jump_ms: 300_001,
+                max_skew_ms: 300_000,
+            }
+        );
+    }
+
+    #[test]
+    fn within_skew_ok() {
+        // A forward step of exactly the bound is accepted.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        generator.env.set_now(1000 + 300_000);
+        let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(id.timestamp_ms(), 1000 + 300_000);
+    }
+
+    #[test]
+    fn backward_clock_clamps() {
+        // A backward clock does not regress the timestamp and stays monotonic.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(5000, [1, 2]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let first: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        generator.env.set_now(4000);
+        let second: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(first.timestamp_ms(), second.timestamp_ms());
+        assert_eq!(first.nonce() + 1, second.nonce());
+    }
+
+    #[test]
+    fn distinct_bucket_fresh() {
+        // A different bucket in the same ms draws a fresh random nonce.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [10, 20]), 300_000);
+        let handle = PlacementHandle::new(7).unwrap();
+        let first: MetaResourceId = generator.mint(handle, BucketId::new(1).unwrap()).unwrap();
+        let second: MetaResourceId = generator.mint(handle, BucketId::new(2).unwrap()).unwrap();
+        assert_eq!(first.nonce(), 10);
+        assert_eq!(second.nonce(), 20);
+    }
+
+    #[test]
+    fn job_id_mint() {
+        // The generator serves JobId through the same shared codec.
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [5]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let job: JobId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(job.placement_handle().get(), 7);
+        assert_eq!(job.nonce(), 5);
+    }
+}

--- a/core/src/structured_id/generator.rs
+++ b/core/src/structured_id/generator.rs
@@ -1,4 +1,8 @@
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use nix::{sys::time::TimeValLike, time::ClockId};
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+use std::time::Instant;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use ulid::Ulid;
 
@@ -21,20 +25,29 @@ pub enum ClockHealthError {
 pub trait IdEnvironment {
     /// Validated wall-clock time as Unix milliseconds.
     fn now_ms(&self) -> u64;
-    /// Milliseconds from a monotonic clock with an arbitrary but fixed origin.
+    /// Milliseconds from a suspend-aware monotonic clock with an arbitrary but
+    /// fixed origin.
     fn monotonic_ms(&self) -> u64;
+    /// Waits until the wall clock advances beyond `timestamp_ms`.
+    fn wait_next_ms(&self, timestamp_ms: u64) {
+        while self.now_ms() <= timestamp_ms {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
     /// A fresh 48-bit nonce drawn from a cryptographically secure source.
     fn random_nonce(&self) -> u64;
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct SystemEnvironment {
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     origin: Instant,
 }
 
 impl SystemEnvironment {
     pub fn new() -> Self {
         Self {
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
             origin: Instant::now(),
         }
     }
@@ -55,7 +68,22 @@ impl IdEnvironment for SystemEnvironment {
     }
 
     fn monotonic_ms(&self) -> u64 {
-        self.origin.elapsed().as_millis() as u64
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            #[cfg(target_os = "linux")]
+            let clock = ClockId::CLOCK_BOOTTIME;
+            #[cfg(target_os = "macos")]
+            let clock = ClockId::from_raw(nix::libc::CLOCK_MONOTONIC_RAW);
+
+            clock
+                .now()
+                .expect("suspend-aware monotonic clock is available")
+                .num_milliseconds() as u64
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            self.origin.elapsed().as_millis() as u64
+        }
     }
 
     fn random_nonce(&self) -> u64 {
@@ -66,14 +94,12 @@ impl IdEnvironment for SystemEnvironment {
 #[derive(Clone, Copy)]
 struct LastMint {
     timestamp_ms: u64,
-    handle: u32,
-    bucket: u16,
     nonce: u64,
 }
 
-/// Paired wall/monotonic reading from the most recent mint attempt. The wall
-/// clock is expected to advance in step with the monotonic clock; divergence
-/// beyond the skew bound is a forward jump.
+/// Paired wall/monotonic reading from the most recent validated clock sample.
+/// The wall clock is expected to advance in step with the monotonic clock;
+/// divergence beyond the skew bound is a forward jump.
 #[derive(Clone, Copy)]
 struct ClockAnchor {
     wall_ms: u64,
@@ -82,9 +108,9 @@ struct ClockAnchor {
 
 /// Structured-ID generator: a monotonic ULID timestamp with a forward-clock-
 /// jump guard (REQ-META-ID-TIME-001, REQ-META-ID-NONCE-001). The nonce
-/// increments only across consecutive mints of the same
-/// `(timestamp_ms, handle, bucket)`; any other mint draws a fresh random
-/// nonce, so uniqueness rests on the 48 random bits, not on monotonicity.
+/// starts from a fresh random value for each timestamp and increments across
+/// every subsequent mint at that timestamp, including interleaved handles and
+/// buckets.
 /// It never emits a generic ULID, so the structured fields are always
 /// preserved.
 pub struct StructuredIdGenerator<E: IdEnvironment = SystemEnvironment> {
@@ -127,17 +153,17 @@ impl<E: IdEnvironment> StructuredIdGenerator<E> {
         Ok(T::from_ulid(Ulid(value), super::sealed::new()))
     }
 
-    fn next_value(&mut self, handle: u32, bucket: u16) -> Result<u128, ClockHealthError> {
-        let now = self.env.now_ms();
-        let monotonic = self.env.monotonic_ms();
+    fn validated_now_ms(&mut self) -> Result<u64, ClockHealthError> {
+        let (now, monotonic) = loop {
+            let monotonic_before = self.env.monotonic_ms();
+            let now = self.env.now_ms();
+            let monotonic = self.env.monotonic_ms();
+            if monotonic.saturating_sub(monotonic_before) <= self.max_skew_ms {
+                break (now, monotonic);
+            }
+        };
 
-        // Re-anchoring on every attempt keeps the guard non-sticky: idle time
-        // is covered by the monotonic delta, and a refused jump accepts the
-        // new wall clock as reality on the next mint.
-        if let Some(anchor) = self.anchor.replace(ClockAnchor {
-            wall_ms: now,
-            monotonic_ms: monotonic,
-        }) {
+        if let Some(anchor) = self.anchor {
             let expected = anchor
                 .wall_ms
                 .saturating_add(monotonic.saturating_sub(anchor.monotonic_ms));
@@ -149,24 +175,31 @@ impl<E: IdEnvironment> StructuredIdGenerator<E> {
             }
         }
 
+        self.anchor = Some(ClockAnchor {
+            wall_ms: now,
+            monotonic_ms: monotonic,
+        });
+        Ok(now)
+    }
+
+    fn next_value(&mut self, handle: u32, bucket: u16) -> Result<u128, ClockHealthError> {
+        let now = self.validated_now_ms()?;
+
         let mut timestamp_ms = match self.last {
             Some(last) => now.max(last.timestamp_ms),
             None => now,
         };
 
+        while let Some(last) = self.last
+            && last.timestamp_ms == timestamp_ms
+            && last.nonce >= layout::MAX_NONCE
+        {
+            self.env.wait_next_ms(last.timestamp_ms);
+            timestamp_ms = self.validated_now_ms()?.max(last.timestamp_ms);
+        }
+
         let nonce = match self.last {
-            Some(last)
-                if last.timestamp_ms == timestamp_ms
-                    && last.handle == handle
-                    && last.bucket == bucket =>
-            {
-                if last.nonce >= layout::MAX_NONCE {
-                    timestamp_ms += 1;
-                    self.env.random_nonce() & layout::NONCE_MASK
-                } else {
-                    last.nonce + 1
-                }
-            }
+            Some(last) if last.timestamp_ms == timestamp_ms => last.nonce + 1,
             _ => self.env.random_nonce() & layout::NONCE_MASK,
         };
 
@@ -176,8 +209,6 @@ impl<E: IdEnvironment> StructuredIdGenerator<E> {
 
         self.last = Some(LastMint {
             timestamp_ms,
-            handle,
-            bucket,
             nonce,
         });
         Ok(layout::pack(timestamp_ms, handle, bucket, nonce))
@@ -195,6 +226,7 @@ mod tests {
     struct MockEnv {
         now: Cell<u64>,
         monotonic: Cell<u64>,
+        suspend_on_now: Cell<u64>,
         nonces: RefCell<VecDeque<u64>>,
     }
 
@@ -203,6 +235,7 @@ mod tests {
             Self {
                 now: Cell::new(now),
                 monotonic: Cell::new(0),
+                suspend_on_now: Cell::new(0),
                 nonces: RefCell::new(nonces.into_iter().collect()),
             }
         }
@@ -215,15 +248,26 @@ mod tests {
             self.now.set(self.now.get() + wall_ms);
             self.monotonic.set(self.monotonic.get() + monotonic_ms);
         }
+
+        fn suspend_on_next_now(&self, elapsed_ms: u64) {
+            self.suspend_on_now.set(elapsed_ms);
+        }
     }
 
     impl IdEnvironment for MockEnv {
         fn now_ms(&self) -> u64 {
+            let suspended_ms = self.suspend_on_now.replace(0);
+            self.advance(suspended_ms, suspended_ms);
             self.now.get()
         }
 
         fn monotonic_ms(&self) -> u64 {
             self.monotonic.get()
+        }
+
+        fn wait_next_ms(&self, timestamp_ms: u64) {
+            self.now.set(timestamp_ms + 1);
+            self.monotonic.set(self.monotonic.get() + 1);
         }
 
         fn random_nonce(&self) -> u64 {
@@ -237,9 +281,7 @@ mod tests {
 
     #[test]
     fn nonce_monotonic() {
-        // Consecutive mints in the same millisecond for the same
-        // (handle, bucket) increment the nonce by one; any interleaved mint
-        // for another key would reset it to a fresh random nonce.
+        // Consecutive mints in the same millisecond increment the nonce by one.
         let mut generator =
             StructuredIdGenerator::with_environment(MockEnv::new(1000, [100, 200]), 300_000);
         let (handle, bucket) = handle_bucket();
@@ -260,6 +302,7 @@ mod tests {
         let first: MetaResourceId = generator.mint(handle, bucket).unwrap();
         let second: MetaResourceId = generator.mint(handle, bucket).unwrap();
         assert_eq!(first.timestamp_ms() + 1, second.timestamp_ms());
+        assert_eq!(generator.env.now.get(), second.timestamp_ms());
         assert_eq!(second.nonce(), 42);
     }
 
@@ -284,16 +327,32 @@ mod tests {
     }
 
     #[test]
-    fn jump_recovers() {
-        // A refused jump re-anchors: the next mint accepts the new wall clock.
+    fn jump_remains_blocked() {
+        // A refused jump does not become the new trusted clock anchor.
         let mut generator =
             StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2]), 300_000);
         let (handle, bucket) = handle_bucket();
         let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
         generator.env.advance(600_000, 0);
-        assert!(generator.mint::<MetaResourceId>(handle, bucket).is_err());
+        let expected = ClockHealthError::ForwardJump {
+            jump_ms: 600_000,
+            max_skew_ms: 300_000,
+        };
+        assert_eq!(
+            generator
+                .mint::<MetaResourceId>(handle, bucket)
+                .unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            generator
+                .mint::<MetaResourceId>(handle, bucket)
+                .unwrap_err(),
+            expected
+        );
+        generator.env.set_now(1001);
         let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
-        assert_eq!(id.timestamp_ms(), 601_000);
+        assert_eq!(id.timestamp_ms(), 1001);
     }
 
     #[test]
@@ -310,6 +369,17 @@ mod tests {
         generator.env.advance(3_600_000, 3_600_000);
         let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
         assert_eq!(id.timestamp_ms(), 7_201_000);
+    }
+
+    #[test]
+    fn suspend_during_clock_sample_retries() {
+        let mut generator =
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [1, 2]), 300_000);
+        let (handle, bucket) = handle_bucket();
+        let _: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        generator.env.suspend_on_next_now(600_000);
+        let id: MetaResourceId = generator.mint(handle, bucket).unwrap();
+        assert_eq!(id.timestamp_ms(), 601_000);
     }
 
     #[test]
@@ -338,15 +408,18 @@ mod tests {
     }
 
     #[test]
-    fn distinct_bucket_fresh() {
-        // A different bucket in the same ms draws a fresh random nonce.
+    fn interleaved_bucket_does_not_collide() {
+        // Returning to a bucket in the same ms continues the shared nonce sequence.
         let mut generator =
-            StructuredIdGenerator::with_environment(MockEnv::new(1000, [10, 20]), 300_000);
+            StructuredIdGenerator::with_environment(MockEnv::new(1000, [10, 20, 10]), 300_000);
         let handle = PlacementHandle::new(7).unwrap();
         let first: MetaResourceId = generator.mint(handle, BucketId::new(1).unwrap()).unwrap();
         let second: MetaResourceId = generator.mint(handle, BucketId::new(2).unwrap()).unwrap();
+        let third: MetaResourceId = generator.mint(handle, BucketId::new(1).unwrap()).unwrap();
         assert_eq!(first.nonce(), 10);
-        assert_eq!(second.nonce(), 20);
+        assert_eq!(second.nonce(), 11);
+        assert_eq!(third.nonce(), 12);
+        assert_ne!(first, third);
     }
 
     #[test]
@@ -369,7 +442,7 @@ mod tests {
 
     #[test]
     fn overflow_bump_errs() {
-        // The nonce-overflow +1 ms bump past the cap refuses as well.
+        // Waiting past the timestamp cap refuses rather than truncating.
         let mut generator = StructuredIdGenerator::with_environment(
             MockEnv::new(layout::MAX_TIMESTAMP_MS, [layout::MAX_NONCE, 1]),
             300_000,

--- a/core/src/structured_id/layout.rs
+++ b/core/src/structured_id/layout.rs
@@ -1,0 +1,51 @@
+//! Sole owner of the Aruna Structured ULID bit layout (Appendix A.1):
+//! `timestamp_ms(48) | placement_handle(20) | bucket(12) | nonce(48)`.
+//! No other module performs raw field shifts or masks.
+
+pub const TIMESTAMP_BITS: u32 = 48;
+pub const HANDLE_BITS: u32 = 20;
+pub const BUCKET_BITS: u32 = 12;
+pub const NONCE_BITS: u32 = 48;
+
+pub const BUCKET_SHIFT: u32 = NONCE_BITS;
+pub const HANDLE_SHIFT: u32 = NONCE_BITS + BUCKET_BITS;
+pub const TIMESTAMP_SHIFT: u32 = NONCE_BITS + BUCKET_BITS + HANDLE_BITS;
+
+pub const HANDLE_MASK: u32 = (1u32 << HANDLE_BITS) - 1;
+pub const BUCKET_MASK: u16 = (1u16 << BUCKET_BITS) - 1;
+pub const TIMESTAMP_MASK: u64 = (1u64 << TIMESTAMP_BITS) - 1;
+pub const NONCE_MASK: u64 = (1u64 << NONCE_BITS) - 1;
+
+pub const MAX_HANDLE: u32 = HANDLE_MASK;
+pub const MAX_BUCKET: u16 = BUCKET_MASK;
+pub const MAX_TIMESTAMP_MS: u64 = TIMESTAMP_MASK;
+pub const MAX_NONCE: u64 = NONCE_MASK;
+
+/// Handle zero is reserved and MUST NOT be allocated (REQ-META-ID-FORMAT-001).
+pub const RESERVED_HANDLE: u32 = 0;
+/// The 12-bit bucket field spans the maximum `bucket_count` (REQ-META-ID-FORMAT-001).
+pub const MAX_BUCKET_COUNT: u16 = 1u16 << BUCKET_BITS;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fields {
+    pub timestamp_ms: u64,
+    pub handle: u32,
+    pub bucket: u16,
+    pub nonce: u64,
+}
+
+pub const fn pack(timestamp_ms: u64, handle: u32, bucket: u16, nonce: u64) -> u128 {
+    (((timestamp_ms & TIMESTAMP_MASK) as u128) << TIMESTAMP_SHIFT)
+        | (((handle & HANDLE_MASK) as u128) << HANDLE_SHIFT)
+        | (((bucket & BUCKET_MASK) as u128) << BUCKET_SHIFT)
+        | ((nonce & NONCE_MASK) as u128)
+}
+
+pub const fn unpack(value: u128) -> Fields {
+    Fields {
+        timestamp_ms: (value >> TIMESTAMP_SHIFT) as u64,
+        handle: ((value >> HANDLE_SHIFT) as u32) & HANDLE_MASK,
+        bucket: ((value >> BUCKET_SHIFT) as u16) & BUCKET_MASK,
+        nonce: (value as u64) & NONCE_MASK,
+    }
+}

--- a/core/src/structured_id/mod.rs
+++ b/core/src/structured_id/mod.rs
@@ -101,7 +101,7 @@ impl BucketId {
     /// Fail-closed `bucket < bucket_count` check (REQ-META-ID-FORMAT-001): an id
     /// whose bucket reaches the strategy's `bucket_count` is invalid.
     pub const fn in_strategy_range(self, bucket_count: u16) -> Result<(), BucketNotInRange> {
-        if self.0 < bucket_count {
+        if bucket_count <= layout::MAX_BUCKET_COUNT && self.0 < bucket_count {
             Ok(())
         } else {
             Err(BucketNotInRange {
@@ -381,6 +381,13 @@ mod tests {
             })
         );
         assert!(BucketId::new(0).unwrap().in_strategy_range(0).is_err());
+        assert!(BucketId::new(4095).unwrap().in_strategy_range(4096).is_ok());
+        assert!(
+            BucketId::new(4095)
+                .unwrap()
+                .in_strategy_range(4097)
+                .is_err()
+        );
     }
 
     #[test]

--- a/core/src/structured_id/mod.rs
+++ b/core/src/structured_id/mod.rs
@@ -126,16 +126,19 @@ fn decode_canonical(input: &str) -> Result<u128, ParseError> {
 }
 
 mod sealed {
-    pub trait Sealed {}
+    use ulid::Ulid;
+
+    /// The raw constructor lives here so no code outside this module can
+    /// wrap an unvalidated ULID (e.g. one carrying the reserved handle 0).
+    pub trait Sealed {
+        fn from_ulid(ulid: Ulid) -> Self;
+    }
 }
 
 /// Shared codec for the Aruna Structured ULID family (`MetaResourceId`,
 /// `JobId`). Every constructor guarantees a non-zero handle, so extracted
 /// fields are always valid.
 pub trait StructuredId: Sized + Copy + sealed::Sealed {
-    #[doc(hidden)]
-    fn from_ulid(ulid: Ulid) -> Self;
-
     fn as_ulid(&self) -> Ulid;
 
     /// Builds an id from its four fields, rejecting an out-of-range timestamp or
@@ -206,13 +209,13 @@ macro_rules! structured_id_newtype {
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $name(Ulid);
 
-        impl sealed::Sealed for $name {}
-
-        impl StructuredId for $name {
+        impl sealed::Sealed for $name {
             fn from_ulid(ulid: Ulid) -> Self {
                 Self(ulid)
             }
+        }
 
+        impl StructuredId for $name {
             fn as_ulid(&self) -> Ulid {
                 self.0
             }

--- a/core/src/structured_id/mod.rs
+++ b/core/src/structured_id/mod.rs
@@ -5,7 +5,13 @@
 //! bucket, and a 48-bit nonce. All raw bit knowledge lives in [`layout`]; this
 //! module exposes only typed fields so downstream code never touches raw bits.
 
+mod generator;
 mod layout;
+
+pub use generator::{
+    ClockHealthError, DEFAULT_MAX_ID_CLOCK_SKEW_MS, IdEnvironment, StructuredIdGenerator,
+    SystemEnvironment,
+};
 
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/core/src/structured_id/mod.rs
+++ b/core/src/structured_id/mod.rs
@@ -128,10 +128,16 @@ fn decode_canonical(input: &str) -> Result<u128, ParseError> {
 mod sealed {
     use ulid::Ulid;
 
+    pub struct Token(());
+
+    pub(super) fn new() -> Token {
+        Token(())
+    }
+
     /// The raw constructor lives here so no code outside this module can
     /// wrap an unvalidated ULID (e.g. one carrying the reserved handle 0).
     pub trait Sealed {
-        fn from_ulid(ulid: Ulid) -> Self;
+        fn from_ulid(ulid: Ulid, _token: Token) -> Self;
     }
 }
 
@@ -155,12 +161,15 @@ pub trait StructuredId: Sized + Copy + sealed::Sealed {
         if nonce > layout::MAX_NONCE {
             return Err(FieldError::NonceOutOfRange(nonce));
         }
-        Ok(Self::from_ulid(Ulid(layout::pack(
-            timestamp_ms,
-            handle.get(),
-            bucket.get(),
-            nonce,
-        ))))
+        Ok(Self::from_ulid(
+            Ulid(layout::pack(
+                timestamp_ms,
+                handle.get(),
+                bucket.get(),
+                nonce,
+            )),
+            sealed::new(),
+        ))
     }
 
     /// Parses the canonical 26-character form, normalizing lowercase and
@@ -170,7 +179,7 @@ pub trait StructuredId: Sized + Copy + sealed::Sealed {
         if layout::unpack(value).handle == layout::RESERVED_HANDLE {
             return Err(ParseError::ReservedHandle);
         }
-        Ok(Self::from_ulid(Ulid(value)))
+        Ok(Self::from_ulid(Ulid(value), sealed::new()))
     }
 
     fn timestamp_ms(&self) -> u64 {
@@ -210,7 +219,7 @@ macro_rules! structured_id_newtype {
         pub struct $name(Ulid);
 
         impl sealed::Sealed for $name {
-            fn from_ulid(ulid: Ulid) -> Self {
+            fn from_ulid(ulid: Ulid, _token: sealed::Token) -> Self {
                 Self(ulid)
             }
         }

--- a/core/src/structured_id/mod.rs
+++ b/core/src/structured_id/mod.rs
@@ -1,0 +1,471 @@
+//! Aruna Structured ULID codec (spec Appendix A.1, section 6.3.4).
+//!
+//! A `MetaResourceId`/`JobId` is a 26-character Crockford Base32 ULID whose
+//! 80-bit entropy field is partitioned into a 20-bit placement handle, a 12-bit
+//! bucket, and a 48-bit nonce. All raw bit knowledge lives in [`layout`]; this
+//! module exposes only typed fields so downstream code never touches raw bits.
+
+mod layout;
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use thiserror::Error;
+use ulid::{DecodeError, Ulid};
+
+/// Highest allocatable placement handle; handle zero is reserved.
+pub const MAX_PLACEMENT_HANDLE: u32 = layout::MAX_HANDLE;
+/// Highest bucket value the 12-bit field can hold.
+pub const MAX_BUCKET_ID: u16 = layout::MAX_BUCKET;
+/// Maximum `bucket_count` a strategy may declare (the 12-bit field cap).
+pub const MAX_BUCKET_COUNT: u16 = layout::MAX_BUCKET_COUNT;
+/// Number of allocatable handles (20 bits, handle zero reserved).
+pub const ALLOCATABLE_HANDLES: u32 = layout::MAX_HANDLE;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum FieldError {
+    #[error("placement handle 0 is reserved and must not be allocated")]
+    ReservedHandle,
+    #[error("placement handle {0} exceeds the 20-bit range")]
+    HandleOutOfRange(u32),
+    #[error("bucket {0} exceeds the 12-bit range")]
+    BucketOutOfRange(u16),
+    #[error("timestamp {0} exceeds the 48-bit range")]
+    TimestampOutOfRange(u64),
+    #[error("nonce {0} exceeds the 48-bit range")]
+    NonceOutOfRange(u64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum ParseError {
+    #[error("structured id must be 26 characters")]
+    InvalidLength,
+    #[error("invalid Crockford base32 character")]
+    InvalidChar,
+    #[error("first character exceeds 7: value does not fit 128 bits")]
+    Overflow,
+    #[error("placement handle 0 is reserved and must not be allocated")]
+    ReservedHandle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("bucket {bucket} is not less than bucket_count {bucket_count}")]
+pub struct BucketNotInRange {
+    pub bucket: u16,
+    pub bucket_count: u16,
+}
+
+/// A non-zero realm-local 20-bit placement handle (REQ-META-ID-FORMAT-001).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PlacementHandle(u32);
+
+impl PlacementHandle {
+    pub const fn new(value: u32) -> Result<Self, FieldError> {
+        if value == layout::RESERVED_HANDLE {
+            Err(FieldError::ReservedHandle)
+        } else if value > layout::MAX_HANDLE {
+            Err(FieldError::HandleOutOfRange(value))
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// A 12-bit bucket carried inside the id (REQ-META-ID-FORMAT-001).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BucketId(u16);
+
+impl BucketId {
+    pub const fn new(value: u16) -> Result<Self, FieldError> {
+        if value > layout::MAX_BUCKET {
+            Err(FieldError::BucketOutOfRange(value))
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    pub const fn get(self) -> u16 {
+        self.0
+    }
+
+    /// Fail-closed `bucket < bucket_count` check (REQ-META-ID-FORMAT-001): an id
+    /// whose bucket reaches the strategy's `bucket_count` is invalid.
+    pub const fn in_strategy_range(self, bucket_count: u16) -> Result<(), BucketNotInRange> {
+        if self.0 < bucket_count {
+            Ok(())
+        } else {
+            Err(BucketNotInRange {
+                bucket: self.0,
+                bucket_count,
+            })
+        }
+    }
+}
+
+fn decode_canonical(input: &str) -> Result<u128, ParseError> {
+    let value = Ulid::from_string(input).map_err(|error| match error {
+        DecodeError::InvalidLength => ParseError::InvalidLength,
+        DecodeError::InvalidChar => ParseError::InvalidChar,
+    })?;
+    // `from_string` silently truncates a first character whose value exceeds 7;
+    // a canonical 128-bit encoding always begins with a character in 0..=7.
+    if !matches!(input.as_bytes()[0], b'0'..=b'7') {
+        return Err(ParseError::Overflow);
+    }
+    Ok(value.0)
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Shared codec for the Aruna Structured ULID family (`MetaResourceId`,
+/// `JobId`). Every constructor guarantees a non-zero handle, so extracted
+/// fields are always valid.
+pub trait StructuredId: Sized + Copy + sealed::Sealed {
+    #[doc(hidden)]
+    fn from_ulid(ulid: Ulid) -> Self;
+
+    fn as_ulid(&self) -> Ulid;
+
+    /// Builds an id from its four fields, rejecting an out-of-range timestamp or
+    /// nonce. The handle and bucket are already range-checked newtypes.
+    fn from_parts(
+        timestamp_ms: u64,
+        handle: PlacementHandle,
+        bucket: BucketId,
+        nonce: u64,
+    ) -> Result<Self, FieldError> {
+        if timestamp_ms > layout::MAX_TIMESTAMP_MS {
+            return Err(FieldError::TimestampOutOfRange(timestamp_ms));
+        }
+        if nonce > layout::MAX_NONCE {
+            return Err(FieldError::NonceOutOfRange(nonce));
+        }
+        Ok(Self::from_ulid(Ulid(layout::pack(
+            timestamp_ms,
+            handle.get(),
+            bucket.get(),
+            nonce,
+        ))))
+    }
+
+    /// Parses the canonical 26-character form, normalizing lowercase and
+    /// rejecting overflow, excluded characters, and the reserved handle.
+    fn parse(input: &str) -> Result<Self, ParseError> {
+        let value = decode_canonical(input)?;
+        if layout::unpack(value).handle == layout::RESERVED_HANDLE {
+            return Err(ParseError::ReservedHandle);
+        }
+        Ok(Self::from_ulid(Ulid(value)))
+    }
+
+    fn timestamp_ms(&self) -> u64 {
+        layout::unpack(self.as_ulid().0).timestamp_ms
+    }
+
+    fn placement_handle(&self) -> PlacementHandle {
+        PlacementHandle(layout::unpack(self.as_ulid().0).handle)
+    }
+
+    fn bucket(&self) -> BucketId {
+        BucketId(layout::unpack(self.as_ulid().0).bucket)
+    }
+
+    fn nonce(&self) -> u64 {
+        layout::unpack(self.as_ulid().0).nonce
+    }
+
+    fn as_u128(&self) -> u128 {
+        self.as_ulid().0
+    }
+
+    fn to_bytes(&self) -> [u8; 16] {
+        self.as_ulid().to_bytes()
+    }
+
+    /// Fail-closed `bucket < bucket_count` check for this id.
+    fn validate_bucket(&self, bucket_count: u16) -> Result<(), BucketNotInRange> {
+        self.bucket().in_strategy_range(bucket_count)
+    }
+}
+
+macro_rules! structured_id_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(Ulid);
+
+        impl sealed::Sealed for $name {}
+
+        impl StructuredId for $name {
+            fn from_ulid(ulid: Ulid) -> Self {
+                Self(ulid)
+            }
+
+            fn as_ulid(&self) -> Ulid {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, concat!(stringify!($name), "({})"), self.0)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = ParseError;
+
+            fn from_str(input: &str) -> Result<Self, Self::Err> {
+                <$name as StructuredId>::parse(input)
+            }
+        }
+
+        impl TryFrom<u128> for $name {
+            type Error = FieldError;
+
+            fn try_from(value: u128) -> Result<Self, Self::Error> {
+                if layout::unpack(value).handle == layout::RESERVED_HANDLE {
+                    return Err(FieldError::ReservedHandle);
+                }
+                Ok(Self(Ulid(value)))
+            }
+        }
+
+        impl From<$name> for u128 {
+            fn from(id: $name) -> u128 {
+                id.0.0
+            }
+        }
+
+        impl From<$name> for Ulid {
+            fn from(id: $name) -> Ulid {
+                id.0
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.collect_str(self)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(
+                deserializer: D,
+            ) -> Result<Self, D::Error> {
+                let raw = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
+                <$name as StructuredId>::parse(&raw).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+structured_id_newtype!(
+    /// The stable 26-character placement-aware identity of a Meta Resource.
+    MetaResourceId
+);
+
+structured_id_newtype!(
+    /// The placement-aware identity of a durable job record (REQ-JOB-ID-FORMAT-001).
+    JobId
+);
+
+#[cfg(test)]
+mod tests {
+    use super::layout;
+    use super::*;
+    use proptest::prelude::*;
+
+    const KAT_STRING: &str = "014D2PF2DB1FQF0AG14D2PF2DB";
+    const KAT_U128: u128 = 0x0123456789ab0beef02a0123456789ab;
+
+    #[test]
+    fn known_answer_vector() {
+        // Appendix A.1 normative test vector: all six values must reproduce.
+        let handle = PlacementHandle::new(0x0beef).unwrap();
+        let bucket = BucketId::new(0x02a).unwrap();
+        let id =
+            MetaResourceId::from_parts(0x0123456789ab, handle, bucket, 0x0123456789ab).unwrap();
+        assert_eq!(id.as_u128(), KAT_U128);
+        assert_eq!(id.to_string(), KAT_STRING);
+
+        let parsed = MetaResourceId::parse(KAT_STRING).unwrap();
+        assert_eq!(parsed, id);
+        assert_eq!(parsed.timestamp_ms(), 0x0123456789ab);
+        assert_eq!(parsed.placement_handle().get(), 0x0beef);
+        assert_eq!(parsed.bucket().get(), 0x02a);
+        assert_eq!(parsed.nonce(), 0x0123456789ab);
+    }
+
+    proptest! {
+        #[test]
+        fn round_trip_random(
+            timestamp_ms in 0u64..=layout::MAX_TIMESTAMP_MS,
+            handle in 1u32..=layout::MAX_HANDLE,
+            bucket in 0u16..=layout::MAX_BUCKET,
+            nonce in 0u64..=layout::MAX_NONCE,
+        ) {
+            let id = MetaResourceId::from_parts(
+                timestamp_ms,
+                PlacementHandle::new(handle).unwrap(),
+                BucketId::new(bucket).unwrap(),
+                nonce,
+            ).unwrap();
+            let text = id.to_string();
+            prop_assert_eq!(text.len(), 26);
+            let parsed = MetaResourceId::parse(&text).unwrap();
+            prop_assert_eq!(parsed, id);
+            prop_assert_eq!(parsed.timestamp_ms(), timestamp_ms);
+            prop_assert_eq!(parsed.placement_handle().get(), handle);
+            prop_assert_eq!(parsed.bucket().get(), bucket);
+            prop_assert_eq!(parsed.nonce(), nonce);
+        }
+    }
+
+    #[test]
+    fn handle_zero_rejected() {
+        assert_eq!(PlacementHandle::new(0), Err(FieldError::ReservedHandle));
+        let zero_handle = layout::pack(1, 0, 5, 9);
+        assert_eq!(
+            MetaResourceId::try_from(zero_handle),
+            Err(FieldError::ReservedHandle)
+        );
+        let text = Ulid(zero_handle).to_string();
+        assert_eq!(
+            MetaResourceId::parse(&text),
+            Err(ParseError::ReservedHandle)
+        );
+    }
+
+    #[test]
+    fn width_overflow_rejected() {
+        assert_eq!(
+            PlacementHandle::new(0x100000),
+            Err(FieldError::HandleOutOfRange(0x100000))
+        );
+        assert_eq!(
+            BucketId::new(0x1000),
+            Err(FieldError::BucketOutOfRange(0x1000))
+        );
+    }
+
+    #[test]
+    fn bucket_count_check() {
+        assert!(BucketId::new(63).unwrap().in_strategy_range(64).is_ok());
+        assert_eq!(
+            BucketId::new(64).unwrap().in_strategy_range(64),
+            Err(BucketNotInRange {
+                bucket: 64,
+                bucket_count: 64,
+            })
+        );
+        assert!(BucketId::new(0).unwrap().in_strategy_range(0).is_err());
+    }
+
+    #[test]
+    fn generic_ulid_distinguishable() {
+        // A structured id always carries a non-zero handle and round-trips.
+        let structured = MetaResourceId::from_parts(
+            1,
+            PlacementHandle::new(42).unwrap(),
+            BucketId::new(3).unwrap(),
+            9,
+        )
+        .unwrap();
+        assert_ne!(structured.placement_handle().get(), 0);
+        assert!(MetaResourceId::parse(&structured.to_string()).is_ok());
+
+        // A generic ULID does not preserve the structured fields: a zero handle
+        // is rejected on parse, and a bucket outside a small bucket_count is
+        // flagged by validation.
+        let bucket_count = 8u16;
+        let mut flagged = 0;
+        for _ in 0..512 {
+            let generic = Ulid::r#gen();
+            let fields = layout::unpack(generic.0);
+            match MetaResourceId::parse(&generic.to_string()) {
+                Err(ParseError::ReservedHandle) => assert_eq!(fields.handle, 0),
+                Ok(parsed) => {
+                    assert_ne!(fields.handle, 0);
+                    if fields.bucket >= bucket_count {
+                        assert!(parsed.validate_bucket(bucket_count).is_err());
+                        flagged += 1;
+                    }
+                }
+                Err(other) => panic!("unexpected parse error: {other:?}"),
+            }
+        }
+        assert!(flagged > 0);
+    }
+
+    #[test]
+    fn lowercase_normalized() {
+        let parsed = MetaResourceId::parse(&KAT_STRING.to_ascii_lowercase()).unwrap();
+        assert_eq!(parsed.as_u128(), KAT_U128);
+    }
+
+    #[test]
+    fn overflow_first_char() {
+        let mut mutated = KAT_STRING.to_string();
+        mutated.replace_range(0..1, "8");
+        assert_eq!(MetaResourceId::parse(&mutated), Err(ParseError::Overflow));
+        assert_eq!(
+            MetaResourceId::parse(&"Z".repeat(26)),
+            Err(ParseError::Overflow)
+        );
+    }
+
+    #[test]
+    fn excluded_chars_rejected() {
+        for bad in ['I', 'L', 'O', 'U'] {
+            let mut mutated = KAT_STRING.to_string();
+            mutated.replace_range(5..6, &bad.to_string());
+            assert_eq!(
+                MetaResourceId::parse(&mutated),
+                Err(ParseError::InvalidChar)
+            );
+        }
+        assert_eq!(
+            MetaResourceId::parse("TOO-SHORT"),
+            Err(ParseError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let id = MetaResourceId::parse(KAT_STRING).unwrap();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, format!("\"{KAT_STRING}\""));
+        let back: MetaResourceId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
+
+        let zero = Ulid(layout::pack(1, 0, 1, 1)).to_string();
+        assert!(serde_json::from_str::<MetaResourceId>(&format!("\"{zero}\"")).is_err());
+    }
+
+    #[test]
+    fn job_id_shares_codec() {
+        let job = JobId::from_parts(
+            0x0123456789ab,
+            PlacementHandle::new(0x0beef).unwrap(),
+            BucketId::new(0x02a).unwrap(),
+            0x0123456789ab,
+        )
+        .unwrap();
+        assert_eq!(job.to_string(), KAT_STRING);
+        assert_eq!(JobId::parse(KAT_STRING).unwrap(), job);
+        assert_eq!(job.placement_handle().get(), 0x0beef);
+    }
+}


### PR DESCRIPTION
Closes part of #403

Adds the structured identifier substrate the placement and identity model builds on: the MetaResourceId and JobId layout, encode and decode, and a monotonic generator.

- `MetaResourceId` and `JobId` over the layout `timestamp_ms (48) | placement_handle (20) | bucket (12) | nonce (48)`, serialized as the canonical 26 character Crockford Base32 form. All bit layout knowledge lives in one module behind a sealed trait so callers never touch raw bits.
- `PlacementHandle` (20 bit, rejects the reserved zero) and `BucketId` (12 bit) newtypes, with a reusable fail closed `bucket < bucket_count` check.
- A monotonic nonce generator with a clock skew guard: a forward clock jump beyond the realm bound refuses to mint, and nonce overflow waits for the next millisecond. The nonce comes from a cryptographic source.
- An explicit overflow guard on decode, since the underlying ULID decoder silently truncates a first character that would overflow 128 bits.

The normative known answer vector from the spec round trips exactly. The types are shaped so the binding resolver can resolve a handle to its binding and validate the bucket without reaching into the codec.