### PR TITLE
[fix] Fix flaky metadata convergence tests at the root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "craqle"
 version = "0.1.1"
-source = "git+https://github.com/arunaengine/craqle?rev=cb38935800ea2df442536230274cdd070acabecd#cb38935800ea2df442536230274cdd070acabecd"
+source = "git+https://github.com/arunaengine/craqle?rev=4bae53ff17301ee61c61f9306cfa552640d592f5#4bae53ff17301ee61c61f9306cfa552640d592f5"
 dependencies = [
  "blake3",
  "chrono",
@@ -2030,7 +2030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5109,7 +5109,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxsdatatypes",
- "rand 0.9.5",
+ "rand 0.8.7",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -6854,7 +6854,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxsdatatypes",
- "rand 0.9.5",
+ "rand 0.8.7",
  "regex",
  "rustc-hash",
  "sha1 0.10.7",
@@ -6875,7 +6875,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "peg",
- "rand 0.9.5",
+ "rand 0.8.7",
  "thiserror 2.0.18",
 ]
 
@@ -6886,7 +6886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed7a854b8ea67618f8ce69aabb0e904d7704226060e9d5a2930eb3136c3fa3b"
 dependencies = [
  "oxrdf",
- "rand 0.9.5",
+ "rand 0.8.7",
  "spargebra",
 ]
 
@@ -8420,7 +8420,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -2583,7 +2583,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2592,7 +2592,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2663,7 +2663,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -3008,7 +3008,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -3982,7 +3982,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6903,18 +6903,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 console-subscriber = "0.5.0"
-craqle = { git = "https://github.com/arunaengine/craqle", rev = "cb38935800ea2df442536230274cdd070acabecd", features = [
+craqle = { git = "https://github.com/arunaengine/craqle", rev = "4bae53ff17301ee61c61f9306cfa552640d592f5", features = [
     "iroh",
 ] }
 crc-fast = "1.10.0"

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -15,8 +15,8 @@ use aruna_operations::driver::drive;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
 use aruna_operations::mutate_realm_placement::{
-    MutateRealmPlacementConfig, MutateRealmPlacementError, MutateRealmPlacementOperation,
-    RealmPlacementMutation,
+    MutateRealmPlacementConfig, MutateRealmPlacementError, RealmPlacementMutation,
+    drive_realm_placement_mutation,
 };
 use aruna_operations::set_realm_quota::{
     SetRealmQuotaConfig, SetRealmQuotaError, SetRealmQuotaOperation,
@@ -923,8 +923,8 @@ pub async fn mutate_realm_placement(
         user_id: auth.user_id,
         realm_id: auth.realm_id,
     };
-    let document = drive(
-        MutateRealmPlacementOperation::new(MutateRealmPlacementConfig { actor, mutation }),
+    let document = drive_realm_placement_mutation(
+        MutateRealmPlacementConfig { actor, mutation },
         &state.get_ctx(),
     )
     .await

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -650,7 +650,7 @@ impl DocumentSyncService {
 
         let oplog = Oplog::with_storage(self.node.storage().clone());
         for (topic_id, state) in states {
-            let missing_peers = holder_peers
+            let missing_peers = member_peers
                 .iter()
                 .copied()
                 .filter(|peer| *peer != local_peer && !state.members.contains(peer))

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -537,10 +537,18 @@ impl DocumentSyncService {
     /// A `history_cutoff` is only frozen for topics in `verified_topics`: until a
     /// node has durably verified a shard, its local clock is not a trustworthy
     /// cutover boundary, so former-holder history is left admissible ([BR-030]).
+    ///
+    /// `retained` peers are draining former-holders that must keep publishing onto
+    /// the shard until they have flushed (flush-then-leave): they stay members and
+    /// accepted publishers even though they are not canonical holders, so a
+    /// removal never cuts off an in-flight flush. They rejoin neither the missing
+    /// nor the local-holder computation — only a canonical holder may mint or top
+    /// up membership — so a true non-holder is never added (DECISIONS D11).
     pub async fn reconcile_shard_membership(
         &self,
         topics: &[irokle_crate::TopicId],
         holders: Vec<NodeId>,
+        retained: &BTreeSet<NodeId>,
         verified_topics: &BTreeSet<irokle_crate::TopicId>,
     ) -> Result<()> {
         if topics.is_empty() {
@@ -558,6 +566,14 @@ impl DocumentSyncService {
                 "local node is not an authoritative shard holder".to_string(),
             ));
         }
+        // Canonical holders plus draining former-holders still flushing: the set
+        // that may publish onto and stay in the shard topic. Only canonical
+        // holders drive membership top-up and the local-holder guard above.
+        let member_peers: BTreeSet<PeerId> = holder_peers
+            .iter()
+            .copied()
+            .chain(retained.iter().map(node_id_to_peer_id))
+            .collect();
 
         let mut seen_topics = BTreeSet::new();
         let topics: Vec<irokle_crate::TopicId> = topics
@@ -574,7 +590,7 @@ impl DocumentSyncService {
                 .storage()
                 .topic_state(&topic_id)
                 .map_err(|error| NetError::Bootstrap(error.to_string()))?;
-            let current = holder_peers
+            let current = member_peers
                 .iter()
                 .copied()
                 .map(|peer| irokle_crate::actor_id_for(topic_id, peer))
@@ -620,7 +636,7 @@ impl DocumentSyncService {
             }
         }
         self.shard_publishers.write().extend(policies);
-        let sync_peers: BTreeSet<PeerId> = holder_peers
+        let sync_peers: BTreeSet<PeerId> = member_peers
             .iter()
             .copied()
             .filter(|peer| *peer != local_peer)
@@ -643,7 +659,7 @@ impl DocumentSyncService {
                 .members
                 .iter()
                 .copied()
-                .filter(|peer| !holder_peers.contains(peer))
+                .filter(|peer| !member_peers.contains(peer))
                 .collect::<Vec<_>>();
             if missing_peers.is_empty() && stale_peers.is_empty() {
                 continue;
@@ -12753,6 +12769,7 @@ mod tests {
                 &[shard_topic],
                 vec![local_node, current_node],
                 &BTreeSet::new(),
+                &BTreeSet::new(),
             )
             .await
             .expect("shard membership reconciles");
@@ -12873,6 +12890,7 @@ mod tests {
             .reconcile_shard_membership(
                 &[topic_id],
                 vec![receiver_node],
+                &BTreeSet::new(),
                 &BTreeSet::from([topic_id]),
             )
             .await
@@ -12966,7 +12984,12 @@ mod tests {
             .expect("shard topic exists");
 
         service
-            .reconcile_shard_membership(&[topic], vec![local_node, co_holder], &BTreeSet::new())
+            .reconcile_shard_membership(
+                &[topic],
+                vec![local_node, co_holder],
+                &BTreeSet::new(),
+                &BTreeSet::new(),
+            )
             .await
             .expect("membership reconciles");
         assert!(
@@ -12984,6 +13007,7 @@ mod tests {
             .reconcile_shard_membership(
                 &[topic],
                 vec![local_node, co_holder],
+                &BTreeSet::new(),
                 &BTreeSet::from([topic]),
             )
             .await

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -856,11 +856,12 @@ impl NetHandle {
         &self,
         topics: &[::irokle::TopicId],
         holders: Vec<NodeId>,
+        retained: &std::collections::BTreeSet<NodeId>,
         verified_topics: &std::collections::BTreeSet<::irokle::TopicId>,
     ) -> Result<()> {
         self.inner
             .document_sync
-            .reconcile_shard_membership(topics, holders, verified_topics)
+            .reconcile_shard_membership(topics, holders, retained, verified_topics)
             .await
     }
 

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
@@ -42,7 +42,7 @@ use oxrdf::{BlankNode, Literal, NamedNode, Term};
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
 use tokio::time::{sleep, timeout};
-use tracing::{Instrument, Span, debug_span, field, warn};
+use tracing::{Instrument, Span, debug, debug_span, field, warn};
 use ulid::Ulid;
 
 use super::protocol::{
@@ -1614,40 +1614,33 @@ async fn sync_graph_once(
         .net_handle
         .clone()
         .ok_or(MetadataError::HandleMissing)?;
-    let node = inner.node.clone();
-    let graph_iri_for_blocking = graph_iri.clone();
-    let peers_for_blocking = peers.clone();
-    let setup_span = debug_span!(
-        "metadata.backend.craqle.ensure_document_sync_topic",
-        graph_iri = %graph_iri_for_blocking,
-        peer_count = peers_for_blocking.len() as u64,
-        elapsed_ms = field::Empty,
-        result = field::Empty,
-    );
-    let blocking_span = setup_span.clone();
+
+    // Deterministic topic id, bound locally only when its genesis is already
+    // present. Deriving it never mints a genesis, so concurrent holders cannot
+    // fork rival ones for the same graph.
     let setup_started = Instant::now();
-    let topic_id = tokio::task::spawn_blocking(move || {
-        blocking_span.in_scope(|| {
-            let graph = GraphId::new(&graph_iri_for_blocking);
-            for peer in peers_for_blocking {
-                node.add_irokle_peer(&graph, document_sync_peer_id(peer))?;
-            }
-            node.ensure_irokle_topic(&graph)
-        })
-    })
-    .await
-    .map_err(|error| MetadataError::TaskJoin(error.to_string()))?;
-    record_elapsed_ms(&setup_span, "elapsed_ms", setup_started);
+    let topic_id = bind_or_derive_graph_topic(&inner, &graph_iri).await?;
+    net_handle
+        .allow_document_sync_peers(&[topic_id], peers.clone())
+        .map_err(|error| MetadataError::Backend(error.to_string()))?;
     record_elapsed_ms(&span, "local_peer_setup_ms", setup_started);
-    match &topic_id {
-        Ok(_) => {
-            setup_span.record("result", "ok");
-        }
-        Err(error) => record_error(&setup_span, &error.to_string()),
-    }
-    let topic_id = topic_id.map_err(metadata_error_from_craqle)?;
 
     let sync_started = Instant::now();
+    // Join-before-create: adopt an existing co-holder genesis first (raw sync
+    // bootstraps an unknown topic), and only then consider minting one.
+    if !document_sync_topic_exists(&net_handle, topic_id)? {
+        if let Err(error) = net_handle
+            .sync_document_topic_with_peers(topic_id, peers.clone())
+            .await
+        {
+            debug!(%topic_id, error = %error, "graph topic join attempt failed");
+        }
+        bind_graph_topic(&inner, &graph_iri).await?;
+    }
+    if !document_sync_topic_exists(&net_handle, topic_id)? {
+        ensure_graph_topic_genesis(&inner, &net_handle, &graph_iri, topic_id, &peers).await?;
+    }
+
     net_handle
         .sync_document_topic_with_peers(topic_id, peers)
         .await
@@ -1655,6 +1648,99 @@ async fn sync_graph_once(
     record_elapsed_ms(&span, "network_sync_ms", sync_started);
     record_elapsed_ms(&span, "elapsed_ms", total_started);
     Ok(())
+}
+
+/// Creates the graph topic genesis under the single-minter discipline.
+///
+/// Only the deterministic rank-0 holder mints, and only with positive
+/// confirmation that no co-holder already holds a genesis, so a config change
+/// that moved rank-0 cannot fork a rival one. Rank-0 is a tie-break for who acts
+/// first, never a correctness precondition: graph content is materialized
+/// locally on every holder independently of this topic, and the irokle genesis
+/// tie-break converges any residual race. A non-rank-0 holder withholds and
+/// adopts rank-0's genesis once it lands.
+async fn ensure_graph_topic_genesis(
+    inner: &Arc<MetadataInner>,
+    net_handle: &NetHandle,
+    graph_iri: &str,
+    topic_id: irokle::TopicId,
+    peers: &[NodeId],
+) -> Result<(), MetadataError> {
+    let local = net_handle.node_id();
+    let local_is_rank0 = peers.iter().all(|peer| local.as_bytes() < peer.as_bytes());
+    if !local_is_rank0 {
+        return Ok(());
+    }
+    let probe = net_handle
+        .probe_shard_topic_geneses(vec![topic_id], peers.to_vec())
+        .await;
+    if probe.known_by_co_holder.contains(&topic_id) {
+        if let Err(error) = net_handle
+            .sync_document_topic_with_peers(topic_id, peers.to_vec())
+            .await
+        {
+            debug!(%topic_id, error = %error, "graph topic adopt attempt failed");
+        }
+        bind_graph_topic(inner, graph_iri).await?;
+        return Ok(());
+    }
+    if !probe.unreachable.is_empty() || probe.unconfirmed.contains(&topic_id) {
+        return Err(MetadataError::Backend(format!(
+            "withholding graph topic {topic_id} genesis: co-holder unreachable or unconfirmed"
+        )));
+    }
+    let mut members: BTreeSet<irokle::PeerId> =
+        peers.iter().copied().map(document_sync_peer_id).collect();
+    members.insert(document_sync_peer_id(local));
+    mint_graph_topic(inner, graph_iri, members).await?;
+    Ok(())
+}
+
+fn document_sync_topic_exists(
+    net_handle: &NetHandle,
+    topic_id: irokle::TopicId,
+) -> Result<bool, MetadataError> {
+    net_handle
+        .document_sync_topic_exists(topic_id)
+        .map_err(|error| MetadataError::Backend(error.to_string()))
+}
+
+async fn bind_or_derive_graph_topic(
+    inner: &Arc<MetadataInner>,
+    graph_iri: &str,
+) -> Result<irokle::TopicId, MetadataError> {
+    let node = inner.node.clone();
+    let graph_iri = graph_iri.to_string();
+    tokio::task::spawn_blocking(move || node.bind_or_derive_irokle_topic(&GraphId::new(&graph_iri)))
+        .await
+        .map_err(|error| MetadataError::TaskJoin(error.to_string()))?
+        .map_err(metadata_error_from_craqle)
+}
+
+async fn bind_graph_topic(
+    inner: &Arc<MetadataInner>,
+    graph_iri: &str,
+) -> Result<(), MetadataError> {
+    let node = inner.node.clone();
+    let graph_iri = graph_iri.to_string();
+    tokio::task::spawn_blocking(move || node.bind_irokle_topic(&GraphId::new(&graph_iri)))
+        .await
+        .map_err(|error| MetadataError::TaskJoin(error.to_string()))?
+        .map_err(metadata_error_from_craqle)?;
+    Ok(())
+}
+
+async fn mint_graph_topic(
+    inner: &Arc<MetadataInner>,
+    graph_iri: &str,
+    members: BTreeSet<irokle::PeerId>,
+) -> Result<irokle::TopicId, MetadataError> {
+    let node = inner.node.clone();
+    let graph_iri = graph_iri.to_string();
+    tokio::task::spawn_blocking(move || node.mint_irokle_topic(&GraphId::new(&graph_iri), members))
+        .await
+        .map_err(|error| MetadataError::TaskJoin(error.to_string()))?
+        .map_err(metadata_error_from_craqle)
 }
 
 fn handle_effect(inner: Arc<MetadataInner>, effect: MetadataEffect) -> MetadataEvent {

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -1620,9 +1620,6 @@ async fn sync_graph_once(
     // fork rival ones for the same graph.
     let setup_started = Instant::now();
     let topic_id = bind_or_derive_graph_topic(&inner, &graph_iri).await?;
-    net_handle
-        .allow_document_sync_peers(&[topic_id], peers.clone())
-        .map_err(|error| MetadataError::Backend(error.to_string()))?;
     record_elapsed_ms(&span, "local_peer_setup_ms", setup_started);
 
     let sync_started = Instant::now();
@@ -1640,6 +1637,7 @@ async fn sync_graph_once(
     if !document_sync_topic_exists(&net_handle, topic_id)? {
         ensure_graph_topic_genesis(&inner, &net_handle, &graph_iri, topic_id, &peers).await?;
     }
+    add_graph_topic_peers(&inner, &net_handle, &graph_iri, topic_id, &peers).await?;
 
     net_handle
         .sync_document_topic_with_peers(topic_id, peers)
@@ -1648,6 +1646,41 @@ async fn sync_graph_once(
     record_elapsed_ms(&span, "network_sync_ms", sync_started);
     record_elapsed_ms(&span, "elapsed_ms", total_started);
     Ok(())
+}
+
+async fn add_graph_topic_peers(
+    inner: &Arc<MetadataInner>,
+    net_handle: &NetHandle,
+    graph_iri: &str,
+    topic_id: irokle::TopicId,
+    peers: &[NodeId],
+) -> Result<(), MetadataError> {
+    let sync_node = net_handle.document_sync_node();
+    let Some(state) = irokle::Storage::topic_state(sync_node.storage(), &topic_id)
+        .map_err(|error| MetadataError::Backend(error.to_string()))?
+    else {
+        return Ok(());
+    };
+    let node = inner.node.clone();
+    let graph_iri = graph_iri.to_string();
+    let peers = peers
+        .iter()
+        .copied()
+        .filter(|peer| !state.members.contains(&document_sync_peer_id(*peer)))
+        .collect::<Vec<_>>();
+    if peers.is_empty() {
+        return Ok(());
+    }
+    tokio::task::spawn_blocking(move || {
+        let graph = GraphId::new(&graph_iri);
+        for peer in peers {
+            node.add_irokle_peer(&graph, document_sync_peer_id(peer))?;
+        }
+        Ok::<_, CraqleError>(())
+    })
+    .await
+    .map_err(|error| MetadataError::TaskJoin(error.to_string()))?
+    .map_err(metadata_error_from_craqle)
 }
 
 /// Creates the graph topic genesis under the single-minter discipline.

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -727,8 +727,10 @@ pub async fn drive_realm_placement_mutation(
     );
     let outcome = crate::driver::drive(MutateRealmPlacementOperation::new(config), context).await;
     if outcome.is_ok() && drains_node && context.net_handle.is_some() {
-        crate::task_incoming::drive_document_sync_outbox_drain(std::sync::Arc::new(context.clone()))
-            .await;
+        crate::task_incoming::drive_document_sync_outbox_drain(std::sync::Arc::new(
+            context.clone(),
+        ))
+        .await;
     }
     outcome
 }

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -332,6 +332,14 @@ impl MutateRealmPlacementOperation {
         let pre_document = document.clone();
         overlay_realm_config_placement_reducer_materialization(&mut document, &reducer_state);
 
+        if let Some((node_id, placement)) =
+            crate::placement::first_draining_holder_set_change(&pre_document, &document)
+        {
+            return Err(MutateRealmPlacementError::InvalidInput(format!(
+                "placement change alters drain-time holder set for node {node_id}, strategy {} shard {}",
+                placement.strategy_id, placement.shard
+            )));
+        }
         if let Some(placement) =
             crate::placement::first_disjoint_shard_transition(&pre_document, &document)
         {

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -20,8 +20,9 @@ use aruna_core::storage_entries::{
     stale_admin_document_conflict_delete_entries,
 };
 use aruna_core::structs::{
-    Actor, BindingScope, MetadataRegistryRecord, NodePlacementEntry, PlacementOverride,
-    PlacementRef, PlacementStrategy, RealmConfigDocument, StrategyBinding,
+    Actor, BindingScope, DEFAULT_LOCATION, DEFAULT_NODE_WEIGHT, MetadataRegistryRecord,
+    NodePlacementEntry, PlacementOverride, PlacementRef, PlacementStrategy, RealmConfigDocument,
+    StrategyBinding,
 };
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, KeySpace, TxnId, Value};
@@ -96,6 +97,27 @@ impl RealmPlacementMutation {
 
     fn validate(&self, document: &RealmConfigDocument) -> Result<(), MutateRealmPlacementError> {
         match self {
+            Self::UpsertNode(entry) if entry.draining => {
+                let unchanged = if let Some(current) = document.placement_entry(entry.node_id) {
+                    entry.effective_location() == current.effective_location()
+                        && entry.weight == current.weight
+                        && entry.full == current.full
+                        && entry.labels == current.labels
+                } else {
+                    entry.effective_location() == DEFAULT_LOCATION
+                        && entry.weight == DEFAULT_NODE_WEIGHT
+                        && !entry.full
+                        && entry.labels.is_empty()
+                };
+                if unchanged {
+                    Ok(())
+                } else {
+                    Err(MutateRealmPlacementError::InvalidInput(
+                        "draining freezes placement attributes until the node un-drains or is removed"
+                            .to_string(),
+                    ))
+                }
+            }
             Self::UpsertStrategy(strategy) if strategy.replica_count == Some(0) => {
                 Err(MutateRealmPlacementError::InvalidInput(
                     "placement strategy replica_count must not be zero".to_string(),
@@ -1268,6 +1290,38 @@ mod tests {
             draining: true,
             labels: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn draining_change_rejected() {
+        let node_id = node(1);
+        // Selection inputs stay frozen on transition and later draining upserts.
+        for already_draining in [false, true] {
+            let mut document =
+                RealmConfigDocument::new(RealmId::from_bytes([24; 32]), Vec::new(), 3);
+            let mut current = draining_entry(node_id);
+            current.draining = already_draining;
+            document.placement_map.push(current);
+            let mut changed = draining_entry(node_id);
+            changed.weight = 0;
+
+            assert!(matches!(
+                RealmPlacementMutation::UpsertNode(changed).validate(&document),
+                Err(MutateRealmPlacementError::InvalidInput(reason))
+                    if reason.contains("draining freezes")
+            ));
+        }
+    }
+
+    #[test]
+    fn unmapped_drain_allowed() {
+        let document = RealmConfigDocument::new(RealmId::from_bytes([25; 32]), Vec::new(), 3);
+        // Resolver defaults make a draining-only upsert valid for an unmapped node.
+        assert!(
+            RealmPlacementMutation::UpsertNode(draining_entry(node(1)))
+                .validate(&document)
+                .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -733,11 +733,11 @@ impl Operation for MutateRealmPlacementOperation {
     }
 }
 
-/// Drives a realm placement mutation, then — when it drains a node — flushes the
-/// local outbox synchronously (drain fence) so records this node accepted before
-/// its holdership loss reach the shard topics right away, while it is still a
-/// member, rather than waiting for the asynchronous drain timer. The flush is
-/// best-effort: `classify_deferred_record` keeps any leftovers deliverable on the
+/// Drives a realm placement mutation, then — when it drains the local node —
+/// flushes the local outbox synchronously (drain fence) so records this node
+/// accepted before its holdership loss reach the shard topics right away, while
+/// it is still a member, rather than waiting for the asynchronous drain timer. The
+/// flush is best-effort: `classify_deferred_record` keeps any leftovers deliverable on the
 /// retryable drain regardless, so a flush failure never strands a record.
 pub async fn drive_realm_placement_mutation(
     config: MutateRealmPlacementConfig,
@@ -745,7 +745,9 @@ pub async fn drive_realm_placement_mutation(
 ) -> Result<RealmConfigDocument, MutateRealmPlacementError> {
     let drains_node = matches!(
         &config.mutation,
-        RealmPlacementMutation::UpsertNode(entry) if entry.draining
+        RealmPlacementMutation::UpsertNode(entry)
+            if entry.draining
+                && context.net_handle.as_ref().map(|net| net.node_id()) == Some(entry.node_id)
     );
     let outcome = crate::driver::drive(MutateRealmPlacementOperation::new(config), context).await;
     if outcome.is_ok() && drains_node && context.net_handle.is_some() {

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -711,6 +711,28 @@ impl Operation for MutateRealmPlacementOperation {
     }
 }
 
+/// Drives a realm placement mutation, then — when it drains a node — flushes the
+/// local outbox synchronously (drain fence) so records this node accepted before
+/// its holdership loss reach the shard topics right away, while it is still a
+/// member, rather than waiting for the asynchronous drain timer. The flush is
+/// best-effort: `classify_deferred_record` keeps any leftovers deliverable on the
+/// retryable drain regardless, so a flush failure never strands a record.
+pub async fn drive_realm_placement_mutation(
+    config: MutateRealmPlacementConfig,
+    context: &crate::driver::DriverContext,
+) -> Result<RealmConfigDocument, MutateRealmPlacementError> {
+    let drains_node = matches!(
+        &config.mutation,
+        RealmPlacementMutation::UpsertNode(entry) if entry.draining
+    );
+    let outcome = crate::driver::drive(MutateRealmPlacementOperation::new(config), context).await;
+    if outcome.is_ok() && drains_node && context.net_handle.is_some() {
+        crate::task_incoming::drive_document_sync_outbox_drain(std::sync::Arc::new(context.clone()))
+            .await;
+    }
+    outcome
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -263,6 +263,65 @@ pub fn holds_placement(
     *placement == PlacementRef::NIL || holders.contains(&node_id)
 }
 
+/// Whether `node_id` is a draining former-holder of `placement`: it is marked
+/// draining in the config yet would hold the shard with its own draining flag
+/// cleared. Such a node keeps publish rights on shards it previously held until
+/// its outbox has flushed (flush-then-leave), so its retained records stay
+/// deliverable. A node that was never a holder, or is fully removed from the
+/// config rather than draining, is not a former-holder and its records must
+/// remain undeliverable (DECISIONS K3): only a departing holder may flush.
+pub fn is_draining_former_holder(
+    config: &RealmConfigDocument,
+    placement: &PlacementRef,
+    node_id: NodeId,
+) -> bool {
+    if *placement == PlacementRef::NIL {
+        return false;
+    }
+    if !config
+        .placement_entry(node_id)
+        .is_some_and(|entry| entry.draining)
+    {
+        return false;
+    }
+    let Some(strategy) = config.strategy(&placement.strategy_id) else {
+        return false;
+    };
+    let mut view = build_view(config);
+    for node in view.nodes.iter_mut() {
+        if node.node_id == node_id {
+            node.draining = false;
+        }
+    }
+    resolve_holders(
+        &view,
+        strategy,
+        &shard_subject_bytes(placement),
+        shard_override(config, placement),
+    )
+    .contains(&node_id)
+}
+
+/// Every draining former-holder of `placement` (see [`is_draining_former_holder`]).
+/// Co-holders keep these peers in the shard topic's membership and publisher set
+/// until they leave the config, so their in-flight flush is never cut off. Cheap
+/// no-op when nothing is draining.
+pub fn draining_former_holders(
+    config: &RealmConfigDocument,
+    placement: &PlacementRef,
+) -> Vec<NodeId> {
+    if !config.placement_map.iter().any(|entry| entry.draining) {
+        return Vec::new();
+    }
+    config
+        .placement_map
+        .iter()
+        .filter(|entry| entry.draining)
+        .map(|entry| entry.node_id)
+        .filter(|node_id| is_draining_former_holder(config, placement, *node_id))
+        .collect()
+}
+
 /// Buckets of `strategy` that `node_id` is a holder of. Empty when the node is
 /// not sync-eligible, is unknown to the config, or is filtered out everywhere.
 pub fn held_buckets(

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -302,9 +302,9 @@ pub fn is_draining_former_holder(
     .contains(&node_id)
 }
 
-/// First shard whose retained holdership would change for a node that remains
+/// First shard whose retained holdership would be lost for a node that remains
 /// draining across a config transition. Rejecting such transitions preserves
-/// the drain-time holder set until that node un-drains or is removed.
+/// its acknowledged writes until that node un-drains or is removed.
 pub fn first_draining_holder_set_change(
     pre: &RealmConfigDocument,
     post: &RealmConfigDocument,
@@ -334,7 +334,7 @@ pub fn first_draining_holder_set_change(
                     shard,
                 };
                 if is_draining_former_holder(pre, &placement, node_id)
-                    != is_draining_former_holder(post, &placement, node_id)
+                    && !is_draining_former_holder(post, &placement, node_id)
                 {
                     return Some((node_id, placement));
                 }

--- a/operations/src/placement/mod.rs
+++ b/operations/src/placement/mod.rs
@@ -302,6 +302,48 @@ pub fn is_draining_former_holder(
     .contains(&node_id)
 }
 
+/// First shard whose retained holdership would change for a node that remains
+/// draining across a config transition. Rejecting such transitions preserves
+/// the drain-time holder set until that node un-drains or is removed.
+pub fn first_draining_holder_set_change(
+    pre: &RealmConfigDocument,
+    post: &RealmConfigDocument,
+) -> Option<(NodeId, PlacementRef)> {
+    for entry in pre.placement_map.iter().filter(|entry| entry.draining) {
+        let node_id = entry.node_id;
+        if !post
+            .placement_entry(node_id)
+            .is_some_and(|entry| entry.draining)
+        {
+            continue;
+        }
+        for strategy in pre.strategies.iter().chain(
+            post.strategies
+                .iter()
+                .filter(|strategy| pre.strategy(&strategy.strategy_id).is_none()),
+        ) {
+            let shard_count = post
+                .strategy(&strategy.strategy_id)
+                .map_or(strategy.shard_count, |post| {
+                    strategy.shard_count.max(post.shard_count)
+                });
+            for shard in 0..shard_count {
+                let placement = PlacementRef {
+                    strategy_id: strategy.strategy_id,
+                    epoch: 0,
+                    shard,
+                };
+                if is_draining_former_holder(pre, &placement, node_id)
+                    != is_draining_former_holder(post, &placement, node_id)
+                {
+                    return Some((node_id, placement));
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Every draining former-holder of `placement` (see [`is_draining_former_holder`]).
 /// Co-holders keep these peers in the shard topic's membership and publisher set
 /// until they leave the config, so their in-flight flush is never cut off. Cheap

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -52,9 +52,9 @@ async fn ensure_held_shard_topics(
     local_node_id: NodeId,
     verified: &BTreeSet<::irokle::TopicId>,
 ) -> HeldTopicOutcome {
-    type ShardGroup = (Vec<::irokle::TopicId>, BTreeSet<NodeId>);
-    let mut rank0_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
-    let mut member_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
+    type ShardGroup = (Vec<NodeId>, BTreeSet<NodeId>);
+    let mut rank0_groups: BTreeMap<ShardGroup, Vec<::irokle::TopicId>> = BTreeMap::new();
+    let mut member_groups: BTreeMap<ShardGroup, Vec<::irokle::TopicId>> = BTreeMap::new();
     for strategy in &config.strategies {
         for shard in 0..strategy.shard_count {
             let placement = PlacementRef {
@@ -72,19 +72,22 @@ async fn ensure_held_shard_topics(
                 .filter(|candidate| *candidate != local_node_id)
                 .collect();
             sort_node_ids(&mut co_holders);
-            let retained = draining_former_holders(config, &placement);
+            let retained: BTreeSet<NodeId> = draining_former_holders(config, &placement)
+                .into_iter()
+                .collect();
             let groups = if local_is_rank0 {
                 &mut rank0_groups
             } else {
                 &mut member_groups
             };
-            let entry = groups.entry(co_holders).or_default();
-            entry.0.push(shard_topic_id(realm_id, &placement));
-            entry.1.extend(retained);
+            groups
+                .entry((co_holders, retained))
+                .or_default()
+                .push(shard_topic_id(realm_id, &placement));
         }
     }
     let mut outcome = HeldTopicOutcome::default();
-    for (co_holders, (topics, retained)) in rank0_groups {
+    for ((co_holders, retained), topics) in rank0_groups {
         debug!(
             event = "placement.genesis.ensure",
             topics = topics.len(),
@@ -110,7 +113,7 @@ async fn ensure_held_shard_topics(
     // origin is drained out of the holder set, nobody does.
     // Topics already known are topped up with the current co-holder set, which
     // is what admits a freshly added holder on the pushing side.
-    for (co_holders, (topics, retained)) in member_groups {
+    for ((co_holders, retained), topics) in member_groups {
         if co_holders.is_empty() {
             continue;
         }

--- a/operations/src/process_placements.rs
+++ b/operations/src/process_placements.rs
@@ -13,7 +13,7 @@ use byteview::ByteView;
 use tracing::{debug, warn};
 
 use crate::driver::DriverContext;
-use crate::placement::resolve_shard_holders;
+use crate::placement::{draining_former_holders, resolve_shard_holders};
 use crate::sync_placement::{
     decode_placement, new_placement, placement_prefix, sort_node_ids, write_placement_effect,
 };
@@ -52,8 +52,9 @@ async fn ensure_held_shard_topics(
     local_node_id: NodeId,
     verified: &BTreeSet<::irokle::TopicId>,
 ) -> HeldTopicOutcome {
-    let mut rank0_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
-    let mut member_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+    type ShardGroup = (Vec<::irokle::TopicId>, BTreeSet<NodeId>);
+    let mut rank0_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
+    let mut member_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
     for strategy in &config.strategies {
         for shard in 0..strategy.shard_count {
             let placement = PlacementRef {
@@ -71,19 +72,19 @@ async fn ensure_held_shard_topics(
                 .filter(|candidate| *candidate != local_node_id)
                 .collect();
             sort_node_ids(&mut co_holders);
+            let retained = draining_former_holders(config, &placement);
             let groups = if local_is_rank0 {
                 &mut rank0_groups
             } else {
                 &mut member_groups
             };
-            groups
-                .entry(co_holders)
-                .or_default()
-                .push(shard_topic_id(realm_id, &placement));
+            let entry = groups.entry(co_holders).or_default();
+            entry.0.push(shard_topic_id(realm_id, &placement));
+            entry.1.extend(retained);
         }
     }
     let mut outcome = HeldTopicOutcome::default();
-    for (co_holders, topics) in rank0_groups {
+    for (co_holders, (topics, retained)) in rank0_groups {
         debug!(
             event = "placement.genesis.ensure",
             topics = topics.len(),
@@ -96,6 +97,7 @@ async fn ensure_held_shard_topics(
             local_node_id,
             co_holders,
             topics,
+            &retained,
             verified,
         )
         .await;
@@ -108,7 +110,7 @@ async fn ensure_held_shard_topics(
     // origin is drained out of the holder set, nobody does.
     // Topics already known are topped up with the current co-holder set, which
     // is what admits a freshly added holder on the pushing side.
-    for (co_holders, topics) in member_groups {
+    for (co_holders, (topics, retained)) in member_groups {
         if co_holders.is_empty() {
             continue;
         }
@@ -119,7 +121,7 @@ async fn ensure_held_shard_topics(
         // missing topic is expected here; the exact membership pass below is
         // repeated after a successful pull.
         let _ = net_handle
-            .reconcile_shard_membership(&topics, current_holders.clone(), verified)
+            .reconcile_shard_membership(&topics, current_holders.clone(), &retained, verified)
             .await;
         let (mut known, missing): (Vec<::irokle::TopicId>, Vec<::irokle::TopicId>) =
             topics.into_iter().partition(|topic| {
@@ -155,7 +157,7 @@ async fn ensure_held_shard_topics(
             continue;
         }
         if let Err(error) = net_handle
-            .reconcile_shard_membership(&known, current_holders, verified)
+            .reconcile_shard_membership(&known, current_holders, &retained, verified)
             .await
         {
             debug!(error = %error, "Could not complete held shard topic membership");
@@ -186,6 +188,7 @@ pub(crate) async fn ensure_rank0_shard_group(
     local_node_id: NodeId,
     co_holders: Vec<NodeId>,
     topics: Vec<::irokle::TopicId>,
+    retained: &BTreeSet<NodeId>,
     verified: &BTreeSet<::irokle::TopicId>,
 ) -> bool {
     let mut current_holders = co_holders.clone();
@@ -194,7 +197,7 @@ pub(crate) async fn ensure_rank0_shard_group(
     // This first pass installs publisher policy even when a topic still needs
     // to be adopted or created. Exact membership is retried once it exists.
     let _ = net_handle
-        .reconcile_shard_membership(&topics, current_holders.clone(), verified)
+        .reconcile_shard_membership(&topics, current_holders.clone(), retained, verified)
         .await;
 
     let mut to_ensure: Vec<::irokle::TopicId> = Vec::new();
@@ -264,7 +267,7 @@ pub(crate) async fn ensure_rank0_shard_group(
         match net_handle.ensure_document_sync_topics(&to_ensure, co_holders) {
             Ok(()) => {
                 if let Err(error) = net_handle
-                    .reconcile_shard_membership(&to_ensure, current_holders, verified)
+                    .reconcile_shard_membership(&to_ensure, current_holders, retained, verified)
                     .await
                 {
                     warn!(error = %error, "Failed to reconcile rank-0 shard membership");
@@ -482,8 +485,11 @@ pub async fn process_shard_placements(
             }
             // The topic exists locally, so reconcile its exact canonical holder
             // set without creating a genesis or changing shared/default peers.
+            let retained = draining_former_holders(&config, &record.placement)
+                .into_iter()
+                .collect();
             let membership = net_handle
-                .reconcile_shard_membership(&[topic], holders, &verified)
+                .reconcile_shard_membership(&[topic], holders, &retained, &verified)
                 .await;
             match membership {
                 Ok(()) => {

--- a/operations/src/queue_backoff.rs
+++ b/operations/src/queue_backoff.rs
@@ -11,25 +11,6 @@ pub(crate) fn retry_after_ms(attempts: u32, base_ms: u64, max_ms: u64) -> u64 {
     base_ms.saturating_mul(multiplier).min(max_ms)
 }
 
-pub(crate) const TIMER_RETRY_BASE_SECS: u64 = 30;
-pub(crate) const TIMER_RETRY_MAX_SECS: u64 = 300;
-
-/// Timer-scale backoff for the in-memory placement-retry and outbox-drain re-arm
-/// counters: 30s base, doubling, capped at 300s.
-pub(crate) const fn timer_retry_after_secs(attempts: u32) -> u64 {
-    let shift = if attempts < 7 { attempts } else { 7 };
-    let multiplier = match 1u64.checked_shl(shift) {
-        Some(value) => value,
-        None => u64::MAX,
-    };
-    let scaled = TIMER_RETRY_BASE_SECS.saturating_mul(multiplier);
-    if scaled < TIMER_RETRY_MAX_SECS {
-        scaled
-    } else {
-        TIMER_RETRY_MAX_SECS
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,24 +32,6 @@ mod tests {
 
         for (attempts, expected_ms) in expected {
             assert_eq!(queue_retry_after_ms(attempts), expected_ms);
-        }
-    }
-
-    #[test]
-    fn timer_backoff_doubles_from_base_to_cap() {
-        let expected = [
-            (0, 30),
-            (1, 60),
-            (2, 120),
-            (3, 240),
-            (4, 300),
-            (5, 300),
-            (7, 300),
-            (u32::MAX, 300),
-        ];
-
-        for (attempts, expected_secs) in expected {
-            assert_eq!(timer_retry_after_secs(attempts), expected_secs);
         }
     }
 }

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -19,7 +19,7 @@ use crate::metadata::projector::{
 };
 use crate::metadata::prune_queue::process_metadata_graph_tombstones;
 use crate::notifications::watch::interest::refresh_watch_interest_for_targets;
-use crate::placement::resolve_shard_holders;
+use crate::placement::{draining_former_holders, resolve_shard_holders};
 use crate::usage_stats::refresh_realm_usage_summary_for_targets;
 
 /// Shared realm-scoped topics every node subscribes to (placement is inert on
@@ -103,9 +103,10 @@ pub async fn restore_shard_subscriptions(
     // confirmation); the rest are join-only — synced if their genesis is known
     // or bootstrappable from a co-holder, otherwise left for the rank-0 holder's
     // gossip to deliver.
+    type ShardGroup = (Vec<::irokle::TopicId>, BTreeSet<NodeId>);
     let mut shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
-    let mut rank0_shard_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
-    let mut join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
+    let mut rank0_shard_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
+    let mut join_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
 
     let mut shared_peers = shared_topic_peers(&config, node_id);
     shared_peers.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
@@ -140,12 +141,15 @@ pub async fn restore_shard_subscriptions(
                 continue;
             }
             let topic = shard_topic_id(realm_id, &placement);
+            let retained = draining_former_holders(&config, &placement);
             let groups = if local_is_rank0 {
                 &mut rank0_shard_groups
             } else {
                 &mut join_groups
             };
-            groups.entry(co_holders).or_default().push(topic);
+            let entry = groups.entry(co_holders).or_default();
+            entry.0.push(topic);
+            entry.1.extend(retained);
             summary.shard_topics += 1;
         }
     }
@@ -185,8 +189,8 @@ async fn restore_held_shard_topics(
     net_handle: &aruna_net::NetHandle,
     node_id: NodeId,
     shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
-    rank0_shard_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
-    join_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
+    rank0_shard_groups: BTreeMap<Vec<NodeId>, (Vec<::irokle::TopicId>, BTreeSet<NodeId>)>,
+    join_groups: BTreeMap<Vec<NodeId>, (Vec<::irokle::TopicId>, BTreeSet<NodeId>)>,
     verified: &BTreeSet<::irokle::TopicId>,
 ) -> bool {
     // Shared realm topics: ensured directly (every node's genesis of a shared
@@ -222,7 +226,7 @@ async fn restore_held_shard_topics(
     // just moved rank-0 onto this node, so an unreachable co-holder that might
     // still hold the genesis withholds creation rather than forking one.
     let mut withheld = false;
-    for (co_holders, topics) in rank0_shard_groups {
+    for (co_holders, (topics, retained)) in rank0_shard_groups {
         if co_holders.is_empty() || topics.is_empty() {
             continue;
         }
@@ -232,6 +236,7 @@ async fn restore_held_shard_topics(
             node_id,
             co_holders.clone(),
             topics.clone(),
+            &retained,
             verified,
         )
         .await;
@@ -252,7 +257,7 @@ async fn restore_held_shard_topics(
     }
 
     // Non-rank-0 held shards: join-only, synced if bootstrappable.
-    for (peers, topics) in join_groups {
+    for (peers, (topics, retained)) in join_groups {
         if peers.is_empty() || topics.is_empty() {
             continue;
         }
@@ -262,7 +267,7 @@ async fn restore_held_shard_topics(
         // Install publisher policy before pulling history. Missing topics are
         // expected and get an exact membership pass after a successful join.
         let _ = net_handle
-            .reconcile_shard_membership(&topics, current_holders.clone(), verified)
+            .reconcile_shard_membership(&topics, current_holders.clone(), &retained, verified)
             .await;
         let event = net_handle.sync_document_topics(topics.clone(), peers).await;
         apply_restored_reconcile(context, node_id, event).await;
@@ -276,7 +281,7 @@ async fn restore_held_shard_topics(
             .collect();
         if !present.is_empty()
             && let Err(error) = net_handle
-                .reconcile_shard_membership(&present, current_holders, verified)
+                .reconcile_shard_membership(&present, current_holders, &retained, verified)
                 .await
         {
             warn!(error = %error, "Failed to reconcile joined shard membership on restart");

--- a/operations/src/startup.rs
+++ b/operations/src/startup.rs
@@ -78,10 +78,10 @@ impl RestoreShardSummary {
 /// resolves into a holder of, ensures the shard sync topic with its co-holders
 /// and runs one anti-entropy pass against them (digest exchange, not a
 /// per-document re-announce). The fixed shared realm topics are restored the
-/// same way. Topics that share a co-holder set are batched into one ensure and
-/// one sync so a restart costs O(held shards), not O(stored documents). The
-/// returned [`RestoreShardSummary`] reports the (small) topic count for callers
-/// and the restart-traffic gate.
+/// same way. Shard topics sharing co-holder and retained sets are batched into
+/// one ensure and one sync so a restart costs O(held shards), not O(stored
+/// documents). The returned [`RestoreShardSummary`] reports the (small) topic
+/// count for callers and the restart-traffic gate.
 pub async fn restore_shard_subscriptions(
     context: &Arc<DriverContext>,
     node_id: NodeId,
@@ -96,17 +96,17 @@ pub async fn restore_shard_subscriptions(
         return summary;
     };
 
-    // Group topics by their co-holder peer set so co-located shards ride one
-    // ensure + one sync instead of one round trip each. Shared realm topics are
-    // ensured directly. Shards the local node is rank-0 holder of go through the
-    // join-before-create gate (a fresh genesis only with positive co-holder
-    // confirmation); the rest are join-only — synced if their genesis is known
-    // or bootstrappable from a co-holder, otherwise left for the rank-0 holder's
-    // gossip to deliver.
-    type ShardGroup = (Vec<::irokle::TopicId>, BTreeSet<NodeId>);
+    // Group shard topics by co-holder and retained peer sets so matching shards
+    // ride one ensure + one sync instead of one round trip each. Shared realm
+    // topics are ensured directly. Shards where the local node is rank-0 go
+    // through the join-before-create gate (a fresh genesis only with positive
+    // co-holder confirmation); the rest are join-only — synced if their genesis
+    // is known or bootstrappable from a co-holder, otherwise left for the rank-0
+    // holder's gossip to deliver.
+    type ShardGroup = (Vec<NodeId>, BTreeSet<NodeId>);
     let mut shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>> = BTreeMap::new();
-    let mut rank0_shard_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
-    let mut join_groups: BTreeMap<Vec<NodeId>, ShardGroup> = BTreeMap::new();
+    let mut rank0_shard_groups: BTreeMap<ShardGroup, Vec<::irokle::TopicId>> = BTreeMap::new();
+    let mut join_groups: BTreeMap<ShardGroup, Vec<::irokle::TopicId>> = BTreeMap::new();
 
     let mut shared_peers = shared_topic_peers(&config, node_id);
     shared_peers.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
@@ -141,15 +141,18 @@ pub async fn restore_shard_subscriptions(
                 continue;
             }
             let topic = shard_topic_id(realm_id, &placement);
-            let retained = draining_former_holders(&config, &placement);
+            let retained: BTreeSet<NodeId> = draining_former_holders(&config, &placement)
+                .into_iter()
+                .collect();
             let groups = if local_is_rank0 {
                 &mut rank0_shard_groups
             } else {
                 &mut join_groups
             };
-            let entry = groups.entry(co_holders).or_default();
-            entry.0.push(topic);
-            entry.1.extend(retained);
+            groups
+                .entry((co_holders, retained))
+                .or_default()
+                .push(topic);
             summary.shard_topics += 1;
         }
     }
@@ -189,8 +192,8 @@ async fn restore_held_shard_topics(
     net_handle: &aruna_net::NetHandle,
     node_id: NodeId,
     shared_ensure_groups: BTreeMap<Vec<NodeId>, Vec<::irokle::TopicId>>,
-    rank0_shard_groups: BTreeMap<Vec<NodeId>, (Vec<::irokle::TopicId>, BTreeSet<NodeId>)>,
-    join_groups: BTreeMap<Vec<NodeId>, (Vec<::irokle::TopicId>, BTreeSet<NodeId>)>,
+    rank0_shard_groups: BTreeMap<(Vec<NodeId>, BTreeSet<NodeId>), Vec<::irokle::TopicId>>,
+    join_groups: BTreeMap<(Vec<NodeId>, BTreeSet<NodeId>), Vec<::irokle::TopicId>>,
     verified: &BTreeSet<::irokle::TopicId>,
 ) -> bool {
     // Shared realm topics: ensured directly (every node's genesis of a shared
@@ -226,7 +229,7 @@ async fn restore_held_shard_topics(
     // just moved rank-0 onto this node, so an unreachable co-holder that might
     // still hold the genesis withholds creation rather than forking one.
     let mut withheld = false;
-    for (co_holders, (topics, retained)) in rank0_shard_groups {
+    for ((co_holders, retained), topics) in rank0_shard_groups {
         if co_holders.is_empty() || topics.is_empty() {
             continue;
         }
@@ -257,7 +260,7 @@ async fn restore_held_shard_topics(
     }
 
     // Non-rank-0 held shards: join-only, synced if bootstrappable.
-    for (peers, (topics, retained)) in join_groups {
+    for ((peers, retained), topics) in join_groups {
         if peers.is_empty() || topics.is_empty() {
             continue;
         }

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -26,7 +26,16 @@ pub const DOCUMENT_SYNC_DEFER_RETRY_AFTER: Duration = Duration::from_secs(1);
 /// and a holder should not initially wait a whole
 /// [`SYNC_PLACEMENT_RETRY_AFTER`] to be pushed to. Consecutive failed pulls are
 /// backed off by the task handler because each attempt scans every shard.
-pub const SHARD_TOPIC_PULL_RETRY_AFTER: Duration = Duration::from_secs(1);
+///
+/// A freshly promoted holder's first pull almost always fast-fails: the config
+/// change reaches it before its co-holders have admitted it onto the shard
+/// topic, so no peer serves the genesis yet. It then rides this ladder waiting
+/// for a co-holder to admit it, which is a gossip round away, not a network
+/// round-trip. So the base matches the write path's queue backoff base
+/// (`QUEUE_RETRY_BASE_MS`) rather than a whole second: on a config-driven holder
+/// transition the new holder converges in a couple of retries instead of
+/// climbing the 1s-doubling ladder for tens of seconds.
+pub const SHARD_TOPIC_PULL_RETRY_AFTER: Duration = Duration::from_millis(250);
 
 pub fn placement_prefix(realm_id: RealmId) -> Key {
     ByteView::from(realm_id.as_bytes().to_vec())

--- a/operations/src/sync_placement.rs
+++ b/operations/src/sync_placement.rs
@@ -37,6 +37,15 @@ pub const DOCUMENT_SYNC_DEFER_RETRY_AFTER: Duration = Duration::from_secs(1);
 /// climbing the 1s-doubling ladder for tens of seconds.
 pub const SHARD_TOPIC_PULL_RETRY_AFTER: Duration = Duration::from_millis(250);
 
+/// Cap for the join-only shard-pull retry ladder. A freshly promoted holder
+/// polls for a co-holder to admit it onto the topic; the admission is a gossip
+/// round away, so the ladder must keep retrying on a short cadence rather than
+/// cliffing to the genesis-create interval [`SYNC_PLACEMENT_RETRY_AFTER`] (30s),
+/// under which a missed admission window costs 30s per attempt and stalls a
+/// replan past the test ceiling under load. The pull is join-only and cannot
+/// fork, so a 2s cap is cheap even for a genuinely stuck topic.
+pub const SHARD_TOPIC_PULL_RETRY_MAX: Duration = Duration::from_secs(2);
+
 pub fn placement_prefix(realm_id: RealmId) -> Key {
     ByteView::from(realm_id.as_bytes().to_vec())
 }

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -317,7 +317,16 @@ fn classify_deferred_record(
     let Some(config) = config else {
         return DeferOutcome::Retry;
     };
-    if crate::placement::holds_placement(config, &record.placement, net_handle.node_id()) {
+    let node_id = net_handle.node_id();
+    // A draining former-holder still owns publish rights on the shards it held
+    // until it has flushed (flush-then-leave), so its retained records are
+    // publishable, not undeliverable. A true non-holder — one that never held the
+    // bucket, or is fully removed rather than draining — stays undeliverable
+    // (DECISIONS K3): the receiver's history cutoff bounds a departing holder to
+    // its pre-cutover ops.
+    if crate::placement::holds_placement(config, &record.placement, node_id)
+        || crate::placement::is_draining_former_holder(config, &record.placement, node_id)
+    {
         DeferOutcome::Retry
     } else {
         DeferOutcome::Undeliverable

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -599,10 +599,10 @@ impl OperationsTaskHandler {
             // records stay deferred regardless, and re-probing would only waste
             // RPCs.
             //
-            // Only buckets this node holds are pulled. Joining is not holder-gated,
-            // so a non-holder could adopt the genesis here — and would then look
-            // publishable while its publishes went nowhere. Its records belong in
-            // the forwarding path instead.
+            // Only buckets this node holds or formerly held while draining are
+            // pulled. Joining is not holder-gated, so a non-holder could adopt the
+            // genesis here — and would then look publishable while its publishes
+            // went nowhere. Its records belong in the forwarding path instead.
             let mut missing_topics: BTreeMap<
                 Vec<aruna_core::NodeId>,
                 (Vec<aruna_core::NodeId>, BTreeSet<irokle::TopicId>),
@@ -612,6 +612,10 @@ impl OperationsTaskHandler {
                     || defer_state.deferred_topics.contains(topic)
                     || !realm_config.as_ref().is_none_or(|config| {
                         crate::placement::holds_placement(
+                            config,
+                            &record.placement,
+                            net_handle.node_id(),
+                        ) || crate::placement::is_draining_former_holder(
                             config,
                             &record.placement,
                             net_handle.node_id(),

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1608,6 +1608,17 @@ pub async fn initialize_task_incoming(context: Arc<DriverContext>, task_handle: 
     restore_reference_metadata_refresh_timer(&context.storage_handle, &task_handle).await;
 }
 
+/// Runs one document sync outbox drain pass synchronously against `context`.
+/// A placement mutation that drains the local node uses this to flush the
+/// records it accepted before its holdership loss right away, narrowing the
+/// window before the asynchronous drain timer fires; the flush is best-effort,
+/// so a failure simply leaves the records for the retryable drain.
+pub async fn drive_document_sync_outbox_drain(context: Arc<DriverContext>) {
+    OperationsTaskHandler::new(context)
+        .drain_document_sync_outbox()
+        .await;
+}
+
 #[async_trait]
 impl InboundTaskHandler for OperationsTaskHandler {
     async fn handle_timer(&self, key: TaskKey) {

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -79,6 +79,12 @@ use crate::usage_stats::{
     refresh_realm_usage_summary_for_targets, restore_usage_snapshot_publish_timer,
 };
 
+/// Process-wide tally of document sync outbox records ever classified
+/// undeliverable. The drain already error-logs each one; this exposes the count
+/// so a test can assert the draining-flush path never black-holes a record.
+pub static UNDELIVERABLE_RECORD_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 const DRAIN_SUBBATCH_RECORDS: usize = 512;
 const DURABLE_QUEUE_REARM_AFTER: Duration = Duration::from_secs(5);
 /// How long a record may wait for its shard topic's genesis before the drain
@@ -355,6 +361,10 @@ impl OperationsTaskHandler {
     /// rare rebalance race: a node that held the bucket when it accepted the
     /// write and lost holdership before draining.
     fn report_undeliverable_records(&self, undeliverable: &[DrainRecord]) {
+        UNDELIVERABLE_RECORD_COUNT.fetch_add(
+            undeliverable.len() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         for (_, record, topic) in undeliverable {
             error!(
                 event = "pipeline.drain.undeliverable",

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -560,6 +560,23 @@ impl OperationsTaskHandler {
                         &record.target,
                         record.placement,
                     );
+                    // Emit-time peer stamps go stale across a rebalance: a
+                    // drained holder refuses the sync as a non-member and the
+                    // whole record would ride the retry ladder while the
+                    // replacement holder never gets pushed to. Re-resolve the
+                    // shard's live holders on every drain; empty stamps keep
+                    // their realm-default-set semantics, and a config gap or an
+                    // unknown strategy keeps the stamp.
+                    if !record.peers.is_empty()
+                        && record.target.uses_shard_topic()
+                        && let Some(config) = realm_config.as_ref()
+                    {
+                        let holders =
+                            crate::placement::resolve_shard_holders(config, &record.placement);
+                        if !holders.is_empty() {
+                            record.peers = holders;
+                        }
+                    }
                     let topic = record.target.sync_topic_id(realm_id, &record.placement);
                     (record_key, record, topic)
                 })

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -60,7 +60,7 @@ use crate::notifications::watch::interest::{
     refresh_watch_interest_for_targets, restore_watch_interest_publish_timer,
 };
 use crate::process_placements::{PlacementReconcileStatus, process_shard_placements};
-use crate::queue_backoff::timer_retry_after_secs;
+use crate::queue_backoff::{queue_retry_after_ms, retry_after_ms};
 use crate::replication::queue::{
     BLOB_REPLICATION_RETRY_AFTER, process_blob_replication_batch, restore_blob_replication_timer,
 };
@@ -359,7 +359,11 @@ impl OperationsTaskHandler {
     }
 
     /// Backoff interval for the next re-arm of `key`, derived from the in-memory
-    /// attempt count without mutating it.
+    /// attempt count without mutating it. The drain re-arm is the only path that
+    /// delivers an already-accepted write after a transient sync failure, so it
+    /// retries on the queue scale (250ms doubling to the 30s cap), not a
+    /// 30s-base timer: a single failed peer sync must not stall convergence for
+    /// tens of seconds.
     fn backoff_after(&self, key: &TaskKey) -> Duration {
         let attempts = self
             .retry_backoff
@@ -368,7 +372,7 @@ impl OperationsTaskHandler {
             .get(key)
             .copied()
             .unwrap_or(0);
-        Duration::from_secs(timer_retry_after_secs(attempts))
+        Duration::from_millis(queue_retry_after_ms(attempts))
     }
 
     fn note_retry_backoff(&self, key: &TaskKey) {
@@ -387,8 +391,11 @@ impl OperationsTaskHandler {
             .remove(key);
     }
 
-    /// Keeps the first missing-topic pull retry prompt, then backs off each
-    /// subsequent full placement scan using the existing per-key retry state.
+    /// Keeps the first missing-topic pull retry prompt, then doubles each
+    /// subsequent full placement scan from the pull base up to the placement
+    /// interval. A new holder usually only needs its co-holders to apply the
+    /// same config change, so the ladder must not cliff to 30s on the second
+    /// attempt.
     fn placement_pull_retry_after(&self, key: &TaskKey) -> Duration {
         let mut backoff = self
             .retry_backoff
@@ -400,9 +407,13 @@ impl OperationsTaskHandler {
                 SHARD_TOPIC_PULL_RETRY_AFTER
             }
             std::collections::hash_map::Entry::Occupied(mut entry) => {
-                let attempts = *entry.get();
-                entry.insert(attempts.saturating_add(1));
-                Duration::from_secs(timer_retry_after_secs(attempts))
+                let attempts = entry.get().saturating_add(1);
+                entry.insert(attempts);
+                Duration::from_millis(retry_after_ms(
+                    attempts,
+                    SHARD_TOPIC_PULL_RETRY_AFTER.as_millis() as u64,
+                    SYNC_PLACEMENT_RETRY_AFTER.as_millis() as u64,
+                ))
             }
         }
     }

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -549,7 +549,7 @@ impl OperationsTaskHandler {
                     Some(oldest_record_ms.map_or(page_oldest, |current| current.min(page_oldest)));
             }
 
-            let records: Vec<DrainRecord> = batch
+            let mut records: Vec<DrainRecord> = batch
                 .records
                 .into_iter()
                 .map(|(record_key, mut record)| {
@@ -560,23 +560,6 @@ impl OperationsTaskHandler {
                         &record.target,
                         record.placement,
                     );
-                    // Emit-time peer stamps go stale across a rebalance: a
-                    // drained holder refuses the sync as a non-member and the
-                    // whole record would ride the retry ladder while the
-                    // replacement holder never gets pushed to. Re-resolve the
-                    // shard's live holders on every drain; empty stamps keep
-                    // their realm-default-set semantics, and a config gap or an
-                    // unknown strategy keeps the stamp.
-                    if !record.peers.is_empty()
-                        && record.target.uses_shard_topic()
-                        && let Some(config) = realm_config.as_ref()
-                    {
-                        let holders =
-                            crate::placement::resolve_shard_holders(config, &record.placement);
-                        if !holders.is_empty() {
-                            record.peers = holders;
-                        }
-                    }
                     let topic = record.target.sync_topic_id(realm_id, &record.placement);
                     (record_key, record, topic)
                 })
@@ -584,12 +567,17 @@ impl OperationsTaskHandler {
 
             // Shard topics are join-only for this node unless it is the shard's
             // rank-0 holder: a record whose topic has no local genesis yet cannot
-            // publish. Try one bootstrap pass against the record's peers (falling
-            // back to the shard's resolved holders when the record carries none,
-            // as admin operations do), then defer whatever is still missing to a
-            // short retry — the genesis arrives via gossip or the next pass. A
-            // topic already deferred earlier this run is skipped: its records
-            // stay deferred regardless, and re-probing would only waste RPCs.
+            // publish. Try one bootstrap pass against the union of the record's
+            // emit-time stamped peers and the shard's live holders, then defer
+            // whatever is still missing to a short retry — the genesis arrives
+            // via gossip or the next pass. The union matters after a rebalance:
+            // the genesis-with-history may survive only on a stamped ex-holder,
+            // and pulling from the live holders alone would leave it
+            // unreachable — this node would mint a fresh genesis, fork the
+            // topic, and irokle's genesis tie-break would evict acknowledged
+            // writes. A topic already deferred earlier this run is skipped: its
+            // records stay deferred regardless, and re-probing would only waste
+            // RPCs.
             //
             // Only buckets this node holds are pulled. Joining is not holder-gated,
             // so a non-holder could adopt the genesis here — and would then look
@@ -616,13 +604,15 @@ impl OperationsTaskHandler {
                     continue;
                 }
                 let mut bootstrap_peers = record.peers.clone();
-                if bootstrap_peers.is_empty()
-                    && let Some(config) = realm_config.as_ref()
-                {
-                    bootstrap_peers =
-                        crate::placement::resolve_shard_holders(config, &record.placement);
-                    bootstrap_peers.retain(|peer| *peer != net_handle.node_id());
+                if let Some(config) = realm_config.as_ref() {
+                    for holder in crate::placement::resolve_shard_holders(config, &record.placement)
+                    {
+                        if !bootstrap_peers.contains(&holder) {
+                            bootstrap_peers.push(holder);
+                        }
+                    }
                 }
+                bootstrap_peers.retain(|peer| *peer != net_handle.node_id());
                 if bootstrap_peers.is_empty() {
                     continue;
                 }
@@ -648,6 +638,27 @@ impl OperationsTaskHandler {
                     )
                     .await;
                 totals.merge(outcome);
+            }
+
+            // Emit-time peer stamps go stale across a rebalance: a drained
+            // holder refuses the push as a non-member and the whole record
+            // would ride the retry ladder while the replacement holder never
+            // gets pushed to. Re-resolve the shard's live holders for the
+            // publish path only — after the bootstrap pull above, which must
+            // keep the stamped ex-holders as genesis sources. Empty stamps keep
+            // their realm-default-set semantics, and a config gap or an unknown
+            // strategy keeps the stamp.
+            if let Some(config) = realm_config.as_ref() {
+                for (_, record, _) in &mut records {
+                    if record.peers.is_empty() || !record.target.uses_shard_topic() {
+                        continue;
+                    }
+                    let holders =
+                        crate::placement::resolve_shard_holders(config, &record.placement);
+                    if !holders.is_empty() {
+                        record.peers = holders;
+                    }
+                }
             }
 
             let (to_publish, deferred, undeliverable) = partition_drain_records(
@@ -2198,6 +2209,148 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
 
+        net.shutdown().await;
+    }
+
+    // Post-rebalance genesis adoption: the shard's live holders no longer
+    // include the emit-time stamped holder that carries the topic's genesis.
+    // The bootstrap pull must reach that ex-holder (union of the stamp and the
+    // live holders); pulling only from the re-resolved holders would leave the
+    // genesis unreachable and a fresh one would fork the topic, evicting
+    // acknowledged writes.
+    #[tokio::test]
+    async fn pull_reaches_ex_holder() {
+        let realm_id = RealmId::from_bytes([53u8; 32]);
+        let ex_dir = tempdir().expect("temp dir");
+        let ex_storage =
+            FjallStorage::open(ex_dir.path().to_str().expect("temp path")).expect("storage opens");
+        let ex_holder = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().expect("bind addr"),
+                realm_id,
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            ex_storage.clone(),
+        )
+        .await
+        .expect("net handle");
+        let temp_dir = tempdir().expect("temp dir");
+        let storage = FjallStorage::open(temp_dir.path().to_str().expect("temp path"))
+            .expect("storage opens");
+        let net = NetHandle::new(
+            NetConfig {
+                bind_addr: "127.0.0.1:0".parse().expect("bind addr"),
+                realm_id,
+                discovery_method: DiscoveryMethod::None,
+                relay_method: RelayMethod::None,
+                ..NetConfig::default()
+            },
+            storage.clone(),
+        )
+        .await
+        .expect("net handle");
+        net.add_peer_addr(ex_holder.endpoint_addr()).await;
+        ex_holder.add_peer_addr(net.endpoint_addr()).await;
+        // The ex-holder must serve inbound sync streams for the pull to reach
+        // its genesis.
+        crate::incoming::initialize_net_incoming(Arc::new(DriverContext {
+            storage_handle: ex_storage.clone(),
+            net_handle: Some(ex_holder.clone()),
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: Some(TaskHandle::new()),
+        }));
+
+        // The live config resolves the shard's holders to this node only: the
+        // stamped ex-holder has been rebalanced out.
+        let mut config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+        config.seed_default_placement();
+        config.ensure_node(net.node_id(), RealmNodeKind::Management);
+        let actor = Actor {
+            node_id: net.node_id(),
+            user_id: UserId::nil(realm_id),
+            realm_id,
+        };
+        match storage
+            .send_effect(Effect::Storage(StorageEffect::Write {
+                key_space: REALM_CONFIG_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: config.to_bytes(&actor).expect("config bytes").into(),
+                txn_id: None,
+            }))
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected realm config write: {other:?}"),
+        }
+
+        let strategy_id = config.strategies.first().expect("a strategy").strategy_id;
+        let placement = aruna_core::structs::PlacementRef {
+            strategy_id,
+            epoch: 0,
+            shard: 0,
+        };
+        let target = DocumentSyncTarget::MetadataRegistry {
+            group_id: Ulid::from_parts(1, 1),
+            document_id: Ulid::from_parts(2, 2),
+        };
+        let topic = target.sync_topic_id(realm_id, &placement);
+
+        // Only the ex-holder carries the genesis (with this node as a member,
+        // as the pre-rebalance membership reconciliation would have left it).
+        ex_holder
+            .ensure_document_sync_topics(&[topic], vec![net.node_id()])
+            .expect("genesis on the ex-holder");
+        assert!(!net.document_sync_topic_exists(topic).unwrap_or(true));
+
+        let mut change = change();
+        change.placement = placement;
+        let record = crate::document_sync_outbox::new_outbox_record(
+            net.node_id(),
+            target,
+            vec![ex_holder.node_id()],
+            DocumentSyncOutboxEvent::Upsert {
+                bytes: b"doc".to_vec(),
+                change,
+            },
+            aruna_core::structs::PlacementRef::NIL,
+            false,
+        );
+        let record_key = outbox_key(&record).to_vec();
+        write_outbox_record(&storage, &record).await;
+
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: Some(net.clone()),
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: Some(TaskHandle::new()),
+        });
+        let handler = OperationsTaskHandler::new(context);
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            handler.drain_document_sync_outbox().await;
+            if read_outbox_record(&storage, &record_key)
+                .await
+                .expect("read outbox record")
+                .is_none()
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "record never published: the drain did not adopt the ex-holder's genesis"
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            net.document_sync_topic_exists(topic).unwrap_or(false),
+            "the genesis must be adopted from the stamped ex-holder"
+        );
+
+        ex_holder.shutdown().await;
         net.shutdown().await;
     }
 

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -69,7 +69,8 @@ use crate::s3::refresh_reference_metadata::{
     restore_reference_metadata_refresh_timer,
 };
 use crate::sync_placement::{
-    DOCUMENT_SYNC_DEFER_RETRY_AFTER, SHARD_TOPIC_PULL_RETRY_AFTER, SYNC_PLACEMENT_RETRY_AFTER,
+    DOCUMENT_SYNC_DEFER_RETRY_AFTER, SHARD_TOPIC_PULL_RETRY_AFTER, SHARD_TOPIC_PULL_RETRY_MAX,
+    SYNC_PLACEMENT_RETRY_AFTER,
 };
 use crate::task_persistence::{
     delete_persisted_timer, persist_task_effect, restore_persisted_task_timers,
@@ -412,7 +413,7 @@ impl OperationsTaskHandler {
                 Duration::from_millis(retry_after_ms(
                     attempts,
                     SHARD_TOPIC_PULL_RETRY_AFTER.as_millis() as u64,
-                    SYNC_PLACEMENT_RETRY_AFTER.as_millis() as u64,
+                    SHARD_TOPIC_PULL_RETRY_MAX.as_millis() as u64,
                 ))
             }
         }

--- a/operations/src/update_metadata_document.rs
+++ b/operations/src/update_metadata_document.rs
@@ -363,8 +363,10 @@ impl Operation for UpdateMetadataDocumentOperation {
                 Ok(Some(record)) => {
                     let record = self.updated_record(record);
                     let update_event = self.update_event_record(&record);
+                    // The event carries the new revision id; the returned record and
+                    // registry cache must reflect it, not the pre-update id.
+                    self.record = Some(update_event.record.clone());
                     self.update_event = Some(update_event);
-                    self.record = Some(record.clone());
                     self.state = UpdateMetadataDocumentState::ReadRealmConfig;
                     smallvec![Effect::Storage(StorageEffect::Read {
                         key_space: REALM_CONFIG_KEYSPACE.to_string(),

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -50,10 +50,10 @@ use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
 // Every wait below polls to a condition; the ceiling only bounds a genuine
-// hang. With the outbox drain and placement pulls retrying on the queue scale
-// convergence measures single-digit seconds under contention, so 60s is a
-// generous backstop for a loaded CI runner, not a latency budget.
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+// hang. Convergence measures single-digit seconds, but a loaded CI runner can
+// stall consecutive peer syncs for the full 30s peer-sync timeout each, so the
+// backstop is 2-3x that timeout, not the expected latency.
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct TestNode {
     _temp_dir: TempDir,

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -50,9 +50,10 @@ use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
 // Every wait below polls to a condition; the ceiling only bounds a genuine
-// hang, so it carries generous headroom for a loaded CI runner where forwarded
-// writes and holder convergence are thread-starved and slow.
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
+// hang. With the outbox drain and placement pulls retrying on the queue scale
+// convergence measures single-digit seconds under contention, so 60s is a
+// generous backstop for a loaded CI runner, not a latency budget.
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
 
 struct TestNode {
     _temp_dir: TempDir,

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -64,9 +64,10 @@ use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
 // Every wait below polls to a condition; the ceiling only bounds a genuine
-// hang, so it carries generous headroom for a loaded CI runner where gossip and
-// anti-entropy across the holders are thread-starved and slow.
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
+// hang. Post-replan convergence measures ~1s (registry row) to ~10s (event
+// log behind a holder-transition graph sync) under tenfold contention, so 60s
+// is a generous backstop for a loaded CI runner, not a latency budget.
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
 
 struct TestNode {
     _temp_dir: TempDir,

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use aruna_core::UserId;
 use aruna_core::document::{
     DocumentSyncChange, DocumentSyncChangeKind, DocumentSyncPublish, DocumentSyncRevision,
-    DocumentSyncTarget,
+    DocumentSyncTarget, shard_topic_id,
 };
 use aruna_core::effects::{Effect, NetEffect, StorageEffect};
 use aruna_core::events::{Event, NetEvent, StorageEvent};
@@ -36,6 +36,7 @@ use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
 };
 use aruna_operations::delete_metadata_document::DeleteMetadataDocumentOperation;
+use aruna_operations::document_sync_outbox::read_outbox_records;
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_metadata_document::GetMetadataDocumentOperation;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
@@ -53,7 +54,7 @@ use aruna_operations::placement::{
     strategy_for_target, subject_bytes,
 };
 use aruna_operations::sync_placement::sort_node_ids;
-use aruna_operations::task_incoming::initialize_task_incoming;
+use aruna_operations::task_incoming::{drive_document_sync_outbox_drain, initialize_task_incoming};
 use aruna_operations::update_metadata_document::{
     UpdateMetadataDocumentConfig, UpdateMetadataDocumentMutation, UpdateMetadataDocumentOperation,
 };
@@ -263,6 +264,281 @@ async fn replan_reaches_replacement() -> Result<(), Box<dyn std::error::Error>> 
     ));
 
     shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+// Black-hole ordering, pinned deterministically: the origin's update drain runs
+// only AFTER the replan marks the origin draining, so the drain classifies a
+// draining former-holder. It must still flush its accepted-before-drain records;
+// none is left undeliverable and the update reaches the replacement holder.
+#[tokio::test]
+async fn flush_after_drain() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([47u8; 32]);
+    let (nodes, _config, refreshers) =
+        build_pinned_realm(&realm_id, &[11, 12, 13, 14], &[false, true, true, true]).await?;
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
+    let (placement, initial_holders, update_event_id) = seed_and_update(
+        &nodes,
+        realm_id,
+        group_id,
+        document_id,
+        "datasets/flush-after-drain",
+    )
+    .await?;
+
+    // The update's two records sit undrained on the hand-driven origin.
+    let pending = read_outbox_records(&nodes[0].context.storage_handle, &[], None, 16).await?;
+    assert_eq!(
+        pending.records.len(),
+        2,
+        "update enqueues two outbox records"
+    );
+
+    // Drain the origin first, then release its outbox drain into that config. An
+    // undeliverable (black-holed) record is retained forever, so a fully emptied
+    // outbox is the deterministic proof that none was classified undeliverable.
+    let replacement = drain_origin(&nodes, realm_id, &placement, &initial_holders).await?;
+    drain_until_empty(&nodes[0]).await?;
+
+    assert_update_reaches(
+        &nodes,
+        realm_id,
+        replacement,
+        group_id,
+        document_id,
+        update_event_id,
+        &placement,
+    )
+    .await?;
+    for refresher in refreshers {
+        refresher.abort();
+    }
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+// Opposite ordering: the origin publishes the update while still a holder, THEN
+// it is drained. The replacement pulls the canonical topic history, update
+// included, and adopts the original genesis rather than forking one.
+#[tokio::test]
+async fn publish_before_drain() -> Result<(), Box<dyn std::error::Error>> {
+    let realm_id = RealmId([48u8; 32]);
+    let (nodes, _config, refreshers) =
+        build_pinned_realm(&realm_id, &[21, 22, 23, 24], &[false, true, true, true]).await?;
+    let group_id = Ulid::r#gen();
+    let document_id = Ulid::r#gen();
+    let (placement, initial_holders, update_event_id) = seed_and_update(
+        &nodes,
+        realm_id,
+        group_id,
+        document_id,
+        "datasets/publish-before-drain",
+    )
+    .await?;
+
+    // Publish the update while the origin is still a holder.
+    drain_until_empty(&nodes[0]).await?;
+
+    // Now drain the origin and flush the config change out.
+    let replacement = drain_origin(&nodes, realm_id, &placement, &initial_holders).await?;
+    drain_until_empty(&nodes[0]).await?;
+
+    assert_update_reaches(
+        &nodes,
+        realm_id,
+        replacement,
+        group_id,
+        document_id,
+        update_event_id,
+        &placement,
+    )
+    .await?;
+    for refresher in refreshers {
+        refresher.abort();
+    }
+    shutdown_nodes(nodes).await;
+    Ok(())
+}
+
+// Drives the hand-driven node's outbox drain until it is empty. The drain
+// deletes a record only once its holders acknowledge the sync, so a one-shot
+// push that loses a race under load is retried instead of stranding the record;
+// an undeliverable record is retained forever and trips the deadline.
+async fn drain_until_empty(node: &TestNode) -> Result<(), Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
+    loop {
+        drive_document_sync_outbox_drain(node.context.clone()).await;
+        let remaining = read_outbox_records(&node.context.storage_handle, &[], None, 16).await?;
+        if remaining.records.is_empty() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "outbox never drained: {} records remain",
+                remaining.records.len()
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+// Creates a document on the hand-driven origin (index 0), replicates the create
+// to its holders, then commits an update. Returns the bucket placement, the
+// initial holder set, and the update's revision id (taken from the returned
+// record, which the revision-id fix makes authoritative).
+async fn seed_and_update(
+    nodes: &[TestNode],
+    realm_id: RealmId,
+    group_id: Ulid,
+    document_id: Ulid,
+    document_path: &str,
+) -> Result<(PlacementRef, Vec<aruna_core::NodeId>, Ulid), Box<dyn std::error::Error>> {
+    let created = drive(
+        CreateMetadataDocumentOperation::new(CreateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
+                realm_id,
+            },
+            group_id,
+            document_id,
+            document_path: document_path.to_string(),
+            public: true,
+            payload: CreateMetadataDocumentPayload::Scaffold {
+                name: "Draining Flush".to_string(),
+                description: "Draining flush regression".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: "https://creativecommons.org/licenses/by/4.0/".to_string(),
+            },
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?
+    .record;
+    // Origin runs no auto loop: project the create into the local index (so the
+    // update can read it) and publish it to the holders, both by hand.
+    replay_metadata_event_log(nodes[0].context.as_ref()).await?;
+    drain_until_empty(&nodes[0]).await?;
+
+    let config = drive(
+        GetRealmConfigOperation::new(realm_id),
+        nodes[0].context.as_ref(),
+    )
+    .await?;
+    let placement = created.placement;
+    let mut initial_holders = resolve_shard_holders(&config, &placement);
+    sort_node_ids(&mut initial_holders);
+    assert!(initial_holders.contains(&nodes[0].net.node_id()));
+    wait_for_persisted_holder_set(
+        nodes,
+        &initial_holders,
+        group_id,
+        document_id,
+        &initial_holders,
+    )
+    .await?;
+    assert!(
+        nodes[0]
+            .net
+            .document_sync_topic_exists(shard_topic_id(realm_id, &placement))
+            .unwrap_or(false),
+        "origin holds the shard genesis"
+    );
+
+    let updated = drive(
+        UpdateMetadataDocumentOperation::new(UpdateMetadataDocumentConfig {
+            actor: Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: UserId::local(Ulid::r#gen(), realm_id),
+                realm_id,
+            },
+            group_id,
+            document_id,
+            public: true,
+            mutation: UpdateMetadataDocumentMutation::UpsertDataEntity {
+                jsonld: r#"{"@id":"./latest.txt","@type":"File","name":"latest.txt"}"#.to_string(),
+            },
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?;
+    Ok((placement, initial_holders, updated.last_event_id))
+}
+
+// Marks the origin draining and returns the replacement holder the replan pulls
+// into the bucket's holder set.
+async fn drain_origin(
+    nodes: &[TestNode],
+    realm_id: RealmId,
+    placement: &PlacementRef,
+    initial_holders: &[aruna_core::NodeId],
+) -> Result<aruna_core::NodeId, Box<dyn std::error::Error>> {
+    let obsolete = nodes[0].net.node_id();
+    let updated_config = drive(
+        MutateRealmPlacementOperation::new(MutateRealmPlacementConfig {
+            actor: Actor {
+                node_id: nodes[0].net.node_id(),
+                user_id: UserId::nil(realm_id),
+                realm_id,
+            },
+            mutation: RealmPlacementMutation::UpsertNode(NodePlacementEntry {
+                node_id: obsolete,
+                location: String::new(),
+                weight: 100,
+                full: false,
+                draining: true,
+                labels: Default::default(),
+            }),
+        }),
+        nodes[0].context.as_ref(),
+    )
+    .await?;
+    let mut final_holders = resolve_shard_holders(&updated_config, placement);
+    sort_node_ids(&mut final_holders);
+    assert!(
+        !final_holders.contains(&obsolete),
+        "drained origin left holders"
+    );
+    final_holders
+        .into_iter()
+        .find(|node_id| !initial_holders.contains(node_id))
+        .ok_or_else(|| "replan selects a replacement holder".into())
+}
+
+// Waits for the update to converge on the replacement: the everywhere-bound
+// registry pointer, then the bucket's own event content, and confirms the
+// replacement adopted the original shard genesis instead of forking one.
+async fn assert_update_reaches(
+    nodes: &[TestNode],
+    realm_id: RealmId,
+    replacement: aruna_core::NodeId,
+    group_id: Ulid,
+    document_id: Ulid,
+    update_event_id: Ulid,
+    placement: &PlacementRef,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let replacement_node = nodes
+        .iter()
+        .find(|node| node.net.node_id() == replacement)
+        .ok_or("replacement fixture node exists")?;
+    let registry =
+        wait_for_persisted_update(replacement_node, group_id, document_id, update_event_id).await?;
+    assert_eq!(registry.last_event_id, update_event_id);
+    let event = wait_for_event_log_value(replacement_node, document_id, update_event_id).await?;
+    let event: MetadataCreateEventRecord = postcard::from_bytes(&event)?;
+    assert!(matches!(
+        event.payload,
+        MetadataCreateEventPayload::UpsertDataEntity { .. }
+    ));
+    assert!(
+        replacement_node
+            .net
+            .document_sync_topic_exists(shard_topic_id(realm_id, placement))
+            .unwrap_or(false),
+        "replacement adopted the original genesis, not a fork"
+    );
     Ok(())
 }
 
@@ -686,7 +962,64 @@ async fn build_realm_nodes(
     for _ in 0..count {
         nodes.push(spawn_node(*realm_id).await?);
     }
+    let config = finish_realm_setup(&nodes, realm_id).await?;
+    Ok((nodes, config))
+}
 
+// Fixed identities and per-node task-handler control: pinning node ids makes
+// holder roles a chosen schedule, and withholding the auto task loop from a node
+// lets a test drive that node's outbox drain by hand at a precise boundary.
+async fn build_pinned_realm(
+    realm_id: &RealmId,
+    secret_seeds: &[u8],
+    start_tasks: &[bool],
+) -> Result<
+    (
+        Vec<TestNode>,
+        RealmConfigDocument,
+        Vec<tokio::task::JoinHandle<()>>,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let mut nodes = Vec::with_capacity(secret_seeds.len());
+    for (index, seed) in secret_seeds.iter().enumerate() {
+        let secret = iroh::SecretKey::from_bytes(&[*seed; 32]);
+        nodes.push(spawn_node_configured(*realm_id, Some(secret), start_tasks[index]).await?);
+    }
+    // A node with no auto loop cannot refresh its own realm presence, which
+    // expires after REALM_PRESENCE_TTL; keep it alive with a background
+    // re-announce so setup convergence never stalls on an expired presence.
+    let mut refreshers = Vec::new();
+    for (index, node) in nodes.iter().enumerate() {
+        if start_tasks[index] {
+            continue;
+        }
+        let context = node.context.clone();
+        let node_id = node.net.node_id();
+        let realm_id = *realm_id;
+        refreshers.push(tokio::spawn(async move {
+            loop {
+                sleep(Duration::from_secs(5)).await;
+                let _ = drive(
+                    AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+                        realm_id,
+                        node_id,
+                        schedule_refresh: false,
+                    }),
+                    context.as_ref(),
+                )
+                .await;
+            }
+        }));
+    }
+    let config = finish_realm_setup(&nodes, realm_id).await?;
+    Ok((nodes, config, refreshers))
+}
+
+async fn finish_realm_setup(
+    nodes: &[TestNode],
+    realm_id: &RealmId,
+) -> Result<RealmConfigDocument, Box<dyn std::error::Error>> {
     for i in 0..nodes.len() {
         for j in (i + 1)..nodes.len() {
             nodes[i]
@@ -700,7 +1033,7 @@ async fn build_realm_nodes(
         }
     }
 
-    for node in &nodes {
+    for node in nodes {
         drive(
             AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
                 realm_id: *realm_id,
@@ -712,18 +1045,26 @@ async fn build_realm_nodes(
         .await?;
     }
 
-    wait_for_realm_node_convergence(&nodes, realm_id).await?;
-    let config = install_realm_config(&nodes, realm_id).await?;
-    Ok((nodes, config))
+    wait_for_realm_node_convergence(nodes, realm_id).await?;
+    install_realm_config(nodes, realm_id).await
 }
 
 async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::Error>> {
+    spawn_node_configured(realm_id, None, true).await
+}
+
+async fn spawn_node_configured(
+    realm_id: RealmId,
+    secret_key: Option<iroh::SecretKey>,
+    start_tasks: bool,
+) -> Result<TestNode, Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
     let storage = FjallStorage::open(temp_dir.path().to_str().ok_or("invalid temp path")?)?;
     let net = NetHandle::new(
         NetConfig {
             bind_addr: "127.0.0.1:0".parse().expect("valid bind addr"),
             realm_id,
+            secret_key,
             discovery_method: DiscoveryMethod::None,
             relay_method: RelayMethod::None,
             ..NetConfig::default()
@@ -750,7 +1091,11 @@ async fn spawn_node(realm_id: RealmId) -> Result<TestNode, Box<dyn std::error::E
     });
 
     initialize_net_incoming(context.clone());
-    initialize_task_incoming(context.clone(), task_handle).await;
+    // A node without the auto task loop leaves its outbox drain (and every other
+    // timer) for the test to drive by hand.
+    if start_tasks {
+        initialize_task_incoming(context.clone(), task_handle).await;
+    }
 
     Ok(TestNode {
         _temp_dir: temp_dir,

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -65,9 +65,10 @@ use ulid::Ulid;
 
 // Every wait below polls to a condition; the ceiling only bounds a genuine
 // hang. Post-replan convergence measures ~1s (registry row) to ~10s (event
-// log behind a holder-transition graph sync) under tenfold contention, so 60s
-// is a generous backstop for a loaded CI runner, not a latency budget.
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+// log behind a holder-transition graph sync) under tenfold contention, but a
+// loaded CI runner can stall consecutive peer syncs for the full 30s peer-sync
+// timeout each, so the backstop is 2-3x that timeout, not the expected latency.
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct TestNode {
     _temp_dir: TempDir,

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -45,10 +45,10 @@ use tokio::time::sleep;
 use ulid::Ulid;
 
 // Positive delivery waits poll to a condition; the ceiling only bounds a
-// genuine hang. With the outbox drain and placement pulls retrying on the
-// queue scale delivery measures single-digit seconds under contention, so 60s
-// is a generous backstop for a loaded CI runner, not a latency budget.
-const POLL_TIMEOUT: Duration = Duration::from_secs(60);
+// genuine hang. Delivery measures single-digit seconds, but a loaded CI runner
+// can stall consecutive peer syncs for the full 30s peer-sync timeout each, so
+// the backstop is 2-3x that timeout, not the expected latency.
+const POLL_TIMEOUT: Duration = Duration::from_secs(120);
 const LIST_LIMIT: usize = LIST_NOTIFICATIONS_MAX_LIMIT;
 // Interest publication is debounced by 2s, so a few seconds comfortably bounds
 // the window an erroneous delivery would need to land in for negative assertions.

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -44,10 +44,11 @@ use tokio::time::Instant;
 use tokio::time::sleep;
 use ulid::Ulid;
 
-// Positive delivery waits poll to a condition; the ceiling only bounds a genuine
-// hang, so it carries generous headroom for a loaded CI runner where multi-node
-// watch delivery is thread-starved and slow.
-const POLL_TIMEOUT: Duration = Duration::from_secs(180);
+// Positive delivery waits poll to a condition; the ceiling only bounds a
+// genuine hang. With the outbox drain and placement pulls retrying on the
+// queue scale delivery measures single-digit seconds under contention, so 60s
+// is a generous backstop for a loaded CI runner, not a latency budget.
+const POLL_TIMEOUT: Duration = Duration::from_secs(60);
 const LIST_LIMIT: usize = LIST_NOTIFICATIONS_MAX_LIMIT;
 // Interest publication is debounced by 2s, so a few seconds comfortably bounds
 // the window an erroneous delivery would need to land in for negative assertions.

--- a/operations/tests/restart_traffic.rs
+++ b/operations/tests/restart_traffic.rs
@@ -33,11 +33,11 @@ use ulid::Ulid;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 // Realm-node and document convergence poll to a condition; the ceilings only
-// bound a genuine hang. With the outbox drain and placement pulls retrying on
-// the queue scale convergence measures single-digit seconds under contention,
-// so 60s is a generous backstop for a loaded CI runner, not a latency budget.
+// bound a genuine hang. Convergence measures single-digit seconds, but a
+// loaded CI runner can stall consecutive peer syncs for the full 30s peer-sync
+// timeout each, so the backstop is 2-3x that timeout, not the expected latency.
 const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
 const PROJECTION_BATCH: usize = 32;
 const SEED_DOCUMENTS: usize = 500;
 

--- a/operations/tests/restart_traffic.rs
+++ b/operations/tests/restart_traffic.rs
@@ -33,10 +33,11 @@ use ulid::Ulid;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 // Realm-node and document convergence poll to a condition; the ceilings only
-// bound a genuine hang, so they carry generous headroom for a loaded CI runner
-// where anti-entropy across three nodes is thread-starved and slow.
+// bound a genuine hang. With the outbox drain and placement pulls retrying on
+// the queue scale convergence measures single-digit seconds under contention,
+// so 60s is a generous backstop for a loaded CI runner, not a latency budget.
 const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
 const PROJECTION_BATCH: usize = 32;
 const SEED_DOCUMENTS: usize = 500;
 

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -34,10 +34,11 @@ use tokio::time::sleep;
 use ulid::Ulid;
 
 // Realm-node and manifest convergence poll to a condition; the ceilings only
-// bound a genuine hang, so they carry generous headroom for a loaded CI runner
-// where anti-entropy across the holders is thread-starved and slow.
+// bound a genuine hang. With the outbox drain and placement pulls retrying on
+// the queue scale convergence measures single-digit seconds under contention,
+// so 60s is a generous backstop for a loaded CI runner, not a latency budget.
 const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(180);
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
 
 struct TestNode {
     _temp_dir: TempDir,

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -34,11 +34,11 @@ use tokio::time::sleep;
 use ulid::Ulid;
 
 // Realm-node and manifest convergence poll to a condition; the ceilings only
-// bound a genuine hang. With the outbox drain and placement pulls retrying on
-// the queue scale convergence measures single-digit seconds under contention,
-// so 60s is a generous backstop for a loaded CI runner, not a latency budget.
+// bound a genuine hang. Convergence measures single-digit seconds, but a
+// loaded CI runner can stall consecutive peer syncs for the full 30s peer-sync
+// timeout each, so the backstop is 2-3x that timeout, not the expected latency.
 const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct TestNode {
     _temp_dir: TempDir,


### PR DESCRIPTION
Metadata convergence had three independent bugs that showed up as flaky tests and, in production, as stalled or lost writes.

- Retry backoff: the drain re-arm and placement-pull retries used a 30 second base timer, so a single transient sync miss cliffed to a long wait before the next attempt. These now use queue-scale backoff (250ms doubling to a 30 second cap), and outbox publish peers are re-resolved from the live realm config at drain time so a shard rebalance stops pushing to drained holders, while emit-time stamped ex-holders stay in the genesis bootstrap pull so a rebalanced-out holder that still carries the topic genesis stays reachable.

- Draining black hole: a node marked draining lost holdership instantly, so writes it had already acknowledged were classified permanently undeliverable and never reached the shard topic. Draining now means flush-then-leave: draining former-holders keep publish rights and stay in shard-topic membership until they actually leave the config, a placement mutation that drains the local node flushes its outbox synchronously, and the update operation returns the new revision id. Deterministic regression tests cover both orderings of drain and flush.

- Graph genesis forks: craqle graph topics forked their genesis on every multi-holder create, which caused collision storms, evicted acknowledged operations, and sync livelocks. Topic creation is now join-before-create: the topic id is derived up front, nodes join or bind from co-holders, and only the rank-0 holder mints a genesis after a probe, seeded with the full co-holder set as initial peers. The branch repins craqle to the revision containing the matching graph-genesis fix.