### PR TITLE
feat: mount S3 inputs for Kubernetes tasks

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,10 +35,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang mold
 
       - name: Install Rust with LLVM tools
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: "1.95.0"
-          components: llvm-tools-preview
+        # rust-toolchain.toml overrides any pinned toolchain, so add the
+        # component to the channel that actually builds the instrumented tests.
+        run: rustup component add llvm-tools-preview
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -63,6 +62,12 @@ jobs:
             --ignore "/*" \
             --ignore "target/*" \
             --keep-only "*/src/*"
+          # grcov exits 0 even when llvm-profdata is missing; refuse an empty report.
+          records=$(grep -c '^DA:' coverage.lcov || true)
+          if [ "$records" -lt 1000 ]; then
+            echo "coverage.lcov has only $records DA records; grcov produced no data" >&2
+            exit 1
+          fi
 
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "aruna"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "aruna-api",
  "aruna-blob",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-api"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "ahash",
  "aruna-blob",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-blob"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "aruna-core",
  "aruna-net",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-compute"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "aruna-core",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-compute-helper"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "rustix",
  "serde_json",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-core"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "async-trait",
  "base64",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-doctor"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "ahash",
  "aruna",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-net"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "aruna-core",
  "aruna-storage",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-operations"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "aruna-blob",
  "aruna-compute",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-storage"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "aruna-core",
  "async-trait",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-tasks"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 dependencies = [
  "aruna-core",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 
 [workspace.package]
 description = "A federated data orchestration network"
-version = "3.0.0-alpha.40"
+version = "3.0.0-alpha.41"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/arunaengine/aruna"

--- a/api/src/routes/tes.rs
+++ b/api/src/routes/tes.rs
@@ -463,7 +463,7 @@ pub async fn create_task(
         caller.auth.user_id,
         state.get_node_id(),
         idempotency_key,
-        aruna_core::structs::WorkspaceMode::Kept,
+        aruna_core::structs::WorkspaceMode::None,
         None,
     )
     .await
@@ -888,7 +888,7 @@ fn map_input(input: &TesInput) -> Result<InputSelection, TesError> {
             version_id: None,
         },
         dest_key: input.path[1..].to_string(),
-        mode: InputMode::Snapshot,
+        mode: InputMode::Mount,
         container_path: Some(input.path.clone()),
         name: input.name.clone(),
         description: input.description.clone(),
@@ -1414,7 +1414,7 @@ mod tests {
     use aruna_core::keyspaces::{AUTH_KEYSPACE, USER_ACCESS_KEYSPACE};
     use aruna_core::structs::{
         Actor, GroupAuthorizationDocument, JobError, NodeCapabilities, OutputObject,
-        RealmAuthorizationDocument, RealmId, UserAccess,
+        RealmAuthorizationDocument, RealmId, UserAccess, WorkspaceMode,
     };
     use aruna_core::types::{NodeId, UserId};
     use aruna_operations::driver::DriverContext;
@@ -1688,6 +1688,7 @@ mod tests {
         assert_eq!(spec.resources.disk_bytes, Some(8_000_000_000));
         assert!(spec.resources.preemptible);
         assert_eq!(spec.inputs.len(), 1);
+        assert_eq!(spec.inputs[0].mode, InputMode::Mount);
         assert_eq!(spec.inputs[0].dest_key, "in/data.csv");
         assert_eq!(
             spec.inputs[0].container_path.as_deref(),
@@ -2164,6 +2165,8 @@ mod tests {
             panic!("TES created a non-execution job");
         };
         assert_eq!(spec.group_id, group);
+        assert_eq!(record.workspace_mode, WorkspaceMode::None);
+        assert!(record.workspace_bucket.is_none());
     }
 
     #[tokio::test]

--- a/api/src/routes/tes.rs
+++ b/api/src/routes/tes.rs
@@ -1446,7 +1446,7 @@ mod tests {
     fn credential(group_id: Ulid) -> UserAccess {
         let user_identity = user(2);
         UserAccess {
-            access_key: UserAccess::build_access_key(&user_identity, "tes").unwrap(),
+            access_key: UserAccess::build_access_key("tes").unwrap(),
             user_identity,
             group_id,
             secret: "tes-secret".to_string(),

--- a/api/src/routes/tes.rs
+++ b/api/src/routes/tes.rs
@@ -1603,7 +1603,7 @@ mod tests {
         record.state = JobState::Succeeded;
         record.result = Some(JobResultPayload::Execution {
             exit_code: Some(0),
-            workspace_bucket: "ws".to_string(),
+            workspace_bucket: Some("ws".to_string()),
             outputs: Vec::new(),
             stdout: String::new(),
             stderr: String::new(),
@@ -1965,7 +1965,7 @@ mod tests {
         assert_eq!(tes_state(&record), TesState::SystemError);
         record.result = Some(JobResultPayload::Execution {
             exit_code: Some(1),
-            workspace_bucket: "ws".to_string(),
+            workspace_bucket: Some("ws".to_string()),
             outputs: Vec::new(),
             stdout: String::new(),
             stderr: String::new(),
@@ -2006,7 +2006,7 @@ mod tests {
         record.last_error = Some(JobError::permanent("prior failure"));
         record.result = Some(JobResultPayload::Execution {
             exit_code: Some(0),
-            workspace_bucket: "ws-x".to_string(),
+            workspace_bucket: Some("ws-x".to_string()),
             outputs: vec![OutputObject {
                 bucket: "dest".to_string(),
                 key: "out/r.txt".to_string(),

--- a/api/src/routes/tes.rs
+++ b/api/src/routes/tes.rs
@@ -452,9 +452,18 @@ pub async fn create_task(
         return error.into_response();
     }
 
-    let (spec, idempotency_key) = match map_task_to_spec(&task, caller.credential_group) {
+    // S3 mounts are a local deployment property; without them TES stages inputs
+    // via a kept workspace snapshot, matching submit validation on both sides.
+    let s3_mounts = state.s3_mounts_available();
+    let (spec, idempotency_key) = match map_task_to_spec(&task, caller.credential_group, s3_mounts)
+    {
         Ok(mapped) => mapped,
         Err(error) => return error.into_response(),
+    };
+    let workspace_mode = if s3_mounts {
+        aruna_core::structs::WorkspaceMode::None
+    } else {
+        aruna_core::structs::WorkspaceMode::Kept
     };
 
     match submit_execution_job(
@@ -463,7 +472,7 @@ pub async fn create_task(
         caller.auth.user_id,
         state.get_node_id(),
         idempotency_key,
-        aruna_core::structs::WorkspaceMode::None,
+        workspace_mode,
         None,
     )
     .await
@@ -697,6 +706,7 @@ fn resolve_task_group(task: &TesTask, credential_group: Option<Ulid>) -> Result<
 fn map_task_to_spec(
     task: &TesTask,
     credential_group: Option<Ulid>,
+    s3_mounts: bool,
 ) -> Result<(ExecutionSpec, Option<String>), TesError> {
     if task.id.is_some()
         || task.state.is_some()
@@ -746,7 +756,7 @@ fn map_task_to_spec(
     }
     let mut inputs: Vec<InputSelection> = Vec::with_capacity(task.inputs.len());
     for input in &task.inputs {
-        let input = map_input(input)?;
+        let input = map_input(input, s3_mounts)?;
         if inputs
             .iter()
             .any(|existing| existing.container_path == input.container_path)
@@ -866,7 +876,7 @@ fn map_task_to_spec(
     Ok((spec, idempotency_key))
 }
 
-fn map_input(input: &TesInput) -> Result<InputSelection, TesError> {
+fn map_input(input: &TesInput, s3_mounts: bool) -> Result<InputSelection, TesError> {
     if input.kind != TesFileType::File {
         return Err(TesError::bad_request("directory inputs are not supported"));
     }
@@ -888,7 +898,11 @@ fn map_input(input: &TesInput) -> Result<InputSelection, TesError> {
             version_id: None,
         },
         dest_key: input.path[1..].to_string(),
-        mode: InputMode::Mount,
+        mode: if s3_mounts {
+            InputMode::Mount
+        } else {
+            InputMode::Snapshot
+        },
         container_path: Some(input.path.clone()),
         name: input.name.clone(),
         description: input.description.clone(),
@@ -1509,7 +1523,7 @@ mod tests {
         }
     }
 
-    async fn build_state() -> (TempDir, Arc<ServerState>) {
+    async fn build_state(s3_mounts: bool) -> (TempDir, Arc<ServerState>) {
         let dir = tempfile::tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
         let ctx = Arc::new(DriverContext {
@@ -1529,7 +1543,8 @@ mod tests {
             None,
             JobsRuntime::new(),
         )
-        .await;
+        .await
+        .with_s3_mounts(s3_mounts);
         (dir, Arc::new(state))
     }
 
@@ -1591,7 +1606,7 @@ mod tests {
         // TES 1.1 requires taskLog.logs and taskLog.outputs to be present;
         // executor logs appear only once the task is terminal.
         let group = Ulid::from_bytes([5u8; 16]);
-        let (spec, _) = map_task_to_spec(&sample_task(group), None).unwrap();
+        let (spec, _) = map_task_to_spec(&sample_task(group), None, true).unwrap();
         let mut record = execution_record(JobId::from_bytes([9u8; 16]), user(2), spec);
 
         let running = build_task_log(&record, "");
@@ -1660,19 +1675,19 @@ mod tests {
         let group = Ulid::from_bytes([5u8; 16]);
         let mut task = sample_task(group);
         task.inputs = vec![task.inputs[0].clone(); MAX_TASK_IO + 1];
-        let error = map_task_to_spec(&task, None).unwrap_err();
+        let error = map_task_to_spec(&task, None, true).unwrap_err();
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
 
         let mut task = sample_task(group);
         task.outputs = vec![task.outputs[0].clone(); MAX_TASK_IO + 1];
-        let error = map_task_to_spec(&task, None).unwrap_err();
+        let error = map_task_to_spec(&task, None, true).unwrap_err();
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
     }
 
     #[test]
     fn maps_task() {
         let group = Ulid::from_bytes([5u8; 16]);
-        let (spec, dedup) = map_task_to_spec(&sample_task(group), None).unwrap();
+        let (spec, dedup) = map_task_to_spec(&sample_task(group), None, true).unwrap();
         assert_eq!(spec.group_id, group);
         assert_eq!(spec.name.as_deref(), Some("align reads"));
         assert_eq!(spec.description.as_deref(), Some("sample task"));
@@ -1717,7 +1732,7 @@ mod tests {
     #[test]
     fn filters_tasks() {
         let group = Ulid::from_bytes([5u8; 16]);
-        let (spec, _) = map_task_to_spec(&sample_task(group), None).unwrap();
+        let (spec, _) = map_task_to_spec(&sample_task(group), None, true).unwrap();
         let mut record = execution_record(JobId::from_bytes([6u8; 16]), user(2), spec);
         record.state = JobState::Running;
         let uri: axum::http::Uri = "/ga4gh/tes/v1/tasks?state=RUNNING&name_prefix=align&tag_key=project&tag_key=aruna-engine.org%2Fgroup&tag_value=alpha"
@@ -1789,7 +1804,7 @@ mod tests {
         input.url = Some("s3://src/other.csv".to_string());
         task.inputs.push(input);
         assert_eq!(
-            map_task_to_spec(&task, None).unwrap_err().status,
+            map_task_to_spec(&task, None, true).unwrap_err().status,
             StatusCode::BAD_REQUEST
         );
     }
@@ -1800,13 +1815,13 @@ mod tests {
         for size_gb in [-1.0, 0.0, f64::NAN, 1e-10, f64::MAX] {
             task.resources.as_mut().unwrap().ram_gb = Some(size_gb);
             assert_eq!(
-                map_task_to_spec(&task, None).unwrap_err().status,
+                map_task_to_spec(&task, None, true).unwrap_err().status,
                 StatusCode::BAD_REQUEST
             );
             task.resources.as_mut().unwrap().ram_gb = Some(4.0);
             task.resources.as_mut().unwrap().disk_gb = Some(size_gb);
             assert_eq!(
-                map_task_to_spec(&task, None).unwrap_err().status,
+                map_task_to_spec(&task, None, true).unwrap_err().status,
                 StatusCode::BAD_REQUEST
             );
             task.resources.as_mut().unwrap().disk_gb = Some(8.0);
@@ -1817,7 +1832,7 @@ mod tests {
     fn rejects_multi_executor() {
         let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
         task.executors.push(task.executors[0].clone());
-        let error = map_task_to_spec(&task, None).unwrap_err();
+        let error = map_task_to_spec(&task, None, true).unwrap_err();
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
         assert!(error.message.contains("single executor"));
     }
@@ -1826,7 +1841,7 @@ mod tests {
     fn rejects_missing_group() {
         let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
         task.tags.clear();
-        let error = map_task_to_spec(&task, None).unwrap_err();
+        let error = map_task_to_spec(&task, None, true).unwrap_err();
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
         assert!(error.message.contains(GROUP_TAG_KEY));
     }
@@ -1836,7 +1851,7 @@ mod tests {
         let group = Ulid::from_bytes([5u8; 16]);
         let mut task = sample_task(group);
         task.tags.remove(GROUP_TAG_KEY);
-        let (spec, _) = map_task_to_spec(&task, Some(group)).unwrap();
+        let (spec, _) = map_task_to_spec(&task, Some(group), true).unwrap();
         assert_eq!(spec.group_id, group);
     }
 
@@ -1844,7 +1859,8 @@ mod tests {
     fn rejects_group_override() {
         let group = Ulid::from_bytes([5u8; 16]);
         let credential_group = Ulid::from_bytes([6u8; 16]);
-        let error = map_task_to_spec(&sample_task(group), Some(credential_group)).unwrap_err();
+        let error =
+            map_task_to_spec(&sample_task(group), Some(credential_group), true).unwrap_err();
         assert_eq!(error.status, StatusCode::FORBIDDEN);
     }
 
@@ -1853,19 +1869,19 @@ mod tests {
         let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
         task.executors[0].workdir = Some("work".to_string());
         assert_eq!(
-            map_task_to_spec(&task, None).unwrap_err().status,
+            map_task_to_spec(&task, None, true).unwrap_err().status,
             StatusCode::BAD_REQUEST
         );
         task.executors[0].workdir = Some("/work".to_string());
         task.inputs[0].path = "/in/../data.csv".to_string();
         assert_eq!(
-            map_task_to_spec(&task, None).unwrap_err().status,
+            map_task_to_spec(&task, None, true).unwrap_err().status,
             StatusCode::BAD_REQUEST
         );
         task.inputs[0].path = "/in/data.csv".to_string();
         task.outputs[0].path = "/out//report.txt".to_string();
         assert_eq!(
-            map_task_to_spec(&task, None).unwrap_err().status,
+            map_task_to_spec(&task, None, true).unwrap_err().status,
             StatusCode::BAD_REQUEST
         );
     }
@@ -1874,26 +1890,26 @@ mod tests {
     fn rejects_unsupported_fields() {
         let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
         task.id = Some("server-owned".to_string());
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
         task.id = None;
         task.inputs[0].kind = TesFileType::Directory;
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
         task.inputs[0].kind = TesFileType::File;
         task.outputs[0].kind = TesFileType::Directory;
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
         task.outputs[0].kind = TesFileType::File;
         task.executors[0].stdout = Some("/logs/out".to_string());
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
         task.executors[0].stdout = None;
         task.volumes.push("/data".to_string());
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
         task.volumes.clear();
         task.resources
             .as_mut()
             .unwrap()
             .zones
             .push("zone-a".to_string());
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
     }
 
     #[test]
@@ -1902,15 +1918,15 @@ mod tests {
         let mut output = task.outputs[0].clone();
         output.url = Some("s3://dest/out/other.txt".to_string());
         task.outputs.push(output);
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
 
         task.outputs[1].path = "/out/other.txt".to_string();
         task.outputs[1].url = task.outputs[0].url.clone();
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
 
         task.outputs.truncate(1);
         task.outputs[0].path = task.inputs[0].path.clone();
-        assert!(map_task_to_spec(&task, None).is_err());
+        assert!(map_task_to_spec(&task, None, true).is_err());
     }
 
     #[test]
@@ -1918,7 +1934,7 @@ mod tests {
         let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
         task.inputs[0].path = "/work/.command.sh".to_string();
         task.outputs[0].path = "/work/out.txt".to_string();
-        assert!(map_task_to_spec(&task, None).is_ok());
+        assert!(map_task_to_spec(&task, None, true).is_ok());
     }
 
     #[test]
@@ -1980,7 +1996,8 @@ mod tests {
 
     #[test]
     fn view_projections() {
-        let (spec, _) = map_task_to_spec(&sample_task(Ulid::from_bytes([5u8; 16])), None).unwrap();
+        let (spec, _) =
+            map_task_to_spec(&sample_task(Ulid::from_bytes([5u8; 16])), None, true).unwrap();
         let mut record = execution_record(JobId::from_bytes([2u8; 16]), user(2), spec);
         let queued = project_task(&record, TesView::Full, "http://x");
         assert!(queued.logs[0].start_time.is_none());
@@ -2090,7 +2107,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_basic() {
-        let (_dir, state) = build_state().await;
+        let (_dir, state) = build_state(false).await;
         let group = Ulid::from_bytes([5u8; 16]);
         let access = credential(group);
         let mut revoked = access.clone();
@@ -2116,7 +2133,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_restricted_basic() {
-        let (_dir, state) = build_state().await;
+        let (_dir, state) = build_state(false).await;
         let mut access = credential(Ulid::from_bytes([5u8; 16]));
         access.path_restrictions = Some(Vec::new());
         write_credential(&state, &access).await;
@@ -2133,7 +2150,7 @@ mod tests {
 
     #[tokio::test]
     async fn creates_tagless_basic() {
-        let (_dir, state) = build_state().await;
+        let (_dir, state) = build_state(true).await;
         let group = Ulid::from_bytes([5u8; 16]);
         let access = credential(group);
         write_credential(&state, &access).await;
@@ -2169,9 +2186,55 @@ mod tests {
         assert!(record.workspace_bucket.is_none());
     }
 
+    #[test]
+    fn switches_input_mode() {
+        // Inputs mount when S3 mounts are available and snapshot otherwise.
+        let group = Ulid::from_bytes([5u8; 16]);
+        let (mounted, _) = map_task_to_spec(&sample_task(group), None, true).unwrap();
+        assert_eq!(mounted.inputs[0].mode, InputMode::Mount);
+        let (snapshot, _) = map_task_to_spec(&sample_task(group), None, false).unwrap();
+        assert_eq!(snapshot.inputs[0].mode, InputMode::Snapshot);
+    }
+
+    #[tokio::test]
+    async fn snapshot_when_disabled() {
+        // Without S3 mounts, TES falls back to a kept workspace and snapshot inputs.
+        let (_dir, state) = build_state(false).await;
+        let group = Ulid::from_bytes([5u8; 16]);
+        let access = credential(group);
+        write_credential(&state, &access).await;
+        write_auth(&state, group, access.user_identity).await;
+
+        let response = create_task(
+            State(state.clone()),
+            Extension(None),
+            basic_headers(&access, access.secret.as_str()),
+            Json(sample_task(group)),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let created: TesCreateTaskResponse = serde_json::from_slice(&body).unwrap();
+        let record = read_owned_job(
+            &state.get_ctx(),
+            access.user_identity,
+            JobId::from_str(&created.id).unwrap(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(record.workspace_mode, WorkspaceMode::Kept);
+        let JobPayload::Execution(spec) = record.payload else {
+            panic!("TES created a non-execution job");
+        };
+        assert_eq!(spec.inputs[0].mode, InputMode::Snapshot);
+    }
+
     #[tokio::test]
     async fn basic_scopes_tasks() {
-        let (_dir, state) = build_state().await;
+        let (_dir, state) = build_state(false).await;
         let owner = user(2);
         let group = Ulid::from_bytes([5u8; 16]);
         let sibling = Ulid::from_bytes([6u8; 16]);
@@ -2185,7 +2248,7 @@ mod tests {
         let visible_id = JobId::from_bytes([9u8; 16]);
         let hidden_id = JobId::from_bytes([10u8; 16]);
         for (job_id, group_id) in [(visible_id, group), (hidden_id, sibling)] {
-            let (spec, _) = map_task_to_spec(&sample_task(group_id), None).unwrap();
+            let (spec, _) = map_task_to_spec(&sample_task(group_id), None, true).unwrap();
             insert_job(
                 &state.get_ctx().storage_handle,
                 &execution_record(job_id, owner, spec),
@@ -2250,13 +2313,13 @@ mod tests {
     #[tokio::test]
     async fn lists_zero_pagesize() {
         // page_size=0 must fall back to the default, not report an empty page.
-        let (_dir, state) = build_state().await;
+        let (_dir, state) = build_state(false).await;
         let owner = user(2);
         let group = Ulid::from_bytes([5u8; 16]);
         let access = credential(group);
         write_credential(&state, &access).await;
         let headers = basic_headers(&access, access.secret.as_str());
-        let (spec, _) = map_task_to_spec(&sample_task(group), None).unwrap();
+        let (spec, _) = map_task_to_spec(&sample_task(group), None, true).unwrap();
         insert_job(
             &state.get_ctx().storage_handle,
             &execution_record(JobId::from_bytes([9u8; 16]), owner, spec),
@@ -2285,9 +2348,10 @@ mod tests {
 
     #[tokio::test]
     async fn get_resolves() {
-        let (_dir, state) = build_state().await;
+        let (_dir, state) = build_state(false).await;
         let owner = user(2);
-        let (spec, _) = map_task_to_spec(&sample_task(Ulid::from_bytes([5u8; 16])), None).unwrap();
+        let (spec, _) =
+            map_task_to_spec(&sample_task(Ulid::from_bytes([5u8; 16])), None, true).unwrap();
         let job_id = JobId::from_bytes([9u8; 16]);
         insert_job(
             &state.get_ctx().storage_handle,
@@ -2322,9 +2386,10 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_maps_through() {
-        let (_dir, state) = build_state().await;
+        let (_dir, state) = build_state(false).await;
         let owner = user(2);
-        let (spec, _) = map_task_to_spec(&sample_task(Ulid::from_bytes([5u8; 16])), None).unwrap();
+        let (spec, _) =
+            map_task_to_spec(&sample_task(Ulid::from_bytes([5u8; 16])), None, true).unwrap();
         let job_id = JobId::from_bytes([9u8; 16]);
         insert_job(
             &state.get_ctx().storage_handle,

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -199,6 +199,14 @@ impl AuthProvider {
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn query_user_access(&self, access_key_id: &str) -> S3Result<UserAccess> {
+        // Legacy-format key ids can never match a stored credential; reject them
+        // before the lookup, indistinguishably from an unknown key.
+        if UserAccess::build_access_key(access_key_id).is_err() {
+            return Err(s3_error!(
+                InvalidAccessKeyId,
+                "The Access Key Id you provided does not exist in our records."
+            ));
+        }
         let operation = GetUserAccessOperation::new(access_key_id.to_string());
         match drive(operation, self.driver_ctx.as_ref())
             .await
@@ -302,5 +310,38 @@ impl AuthProvider {
 
     fn group_data_path(&self, group_id: ulid::Ulid) -> String {
         blob_group_permission_path(self.realm_id, group_id, self.node_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aruna_storage::FjallStorage;
+
+    fn provider(path: &str) -> AuthProvider {
+        let storage = FjallStorage::open(path).unwrap();
+        let driver_ctx = Arc::new(DriverContext {
+            storage_handle: storage,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+            compute_handle: None,
+        });
+        AuthProvider {
+            driver_ctx,
+            realm_id: RealmId([1u8; 32]),
+            node_id: iroh::SecretKey::from_bytes(&[7u8; 32]).public(),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_legacy_key() {
+        // Legacy `{ulid}@{ulid}:workspace-{ulid}` ids must fail before any lookup.
+        let dir = tempfile::tempdir().unwrap();
+        let provider = provider(dir.path().to_str().unwrap());
+        let legacy = "01ARZ3NDEKTSV4RRFFQ69G5FAV@01ARZ3NDEKTSV4RRFFQ69G5FAW:workspace-01ARZ3";
+        let error = provider.get_secret_key(legacy).await.unwrap_err();
+        assert_eq!(error.code(), &s3s::S3ErrorCode::InvalidAccessKeyId);
     }
 }

--- a/api/src/server_state.rs
+++ b/api/src/server_state.rs
@@ -69,6 +69,8 @@ pub struct ServerState {
     portal: Arc<RwLock<PortalRuntimeState>>,
     // Per-node Prometheus registry shared with the S3 server and ops listener.
     metrics: Arc<NodeMetrics>,
+    // True when this node can mount S3 inputs (Kubernetes with a CSI driver).
+    s3_mounts_available: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -171,6 +173,7 @@ impl ServerState {
             interface_state: Arc::new(RwLock::new(InterfaceRuntimeState::default())),
             portal: Arc::new(RwLock::new(PortalRuntimeState::default())),
             metrics: Arc::new(NodeMetrics::new()),
+            s3_mounts_available: false,
         };
         state.persist_trusted_realms().await;
         state
@@ -189,6 +192,17 @@ impl ServerState {
     pub fn with_metrics(mut self, metrics: Arc<NodeMetrics>) -> Self {
         self.metrics = metrics;
         self
+    }
+
+    /// Records whether this node can mount S3 inputs, gating TES between mounted
+    /// and snapshot staging. Call before serving.
+    pub fn with_s3_mounts(mut self, available: bool) -> Self {
+        self.s3_mounts_available = available;
+        self
+    }
+
+    pub fn s3_mounts_available(&self) -> bool {
+        self.s3_mounts_available
     }
 
     pub fn jobs_runtime(&self) -> Arc<JobsRuntime> {

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -620,6 +620,9 @@ async fn build_kubernetes(
         .map(|value| value.parse::<u16>())
         .unwrap_or(Ok(443))
         .map_err(|_| "ARUNA_COMPUTE_K8S_S3_PORT must be a valid port".to_string())?;
+    let s3_mount_driver = dotenvy::var("ARUNA_COMPUTE_K8S_S3_MOUNT_DRIVER")
+        .ok()
+        .filter(|driver| !driver.is_empty());
     let backend = aruna_compute::executor::kubernetes::KubernetesBackend::with_config(
         aruna_compute::KubernetesConfig {
             namespace: dotenvy::var("ARUNA_COMPUTE_K8S_NAMESPACE")
@@ -629,6 +632,7 @@ async fn build_kubernetes(
             pull_deadline: env_duration("ARUNA_COMPUTE_K8S_PULL_DEADLINE", 300)?,
             s3_cidrs,
             s3_port,
+            s3_mount_driver,
         },
     )
     .await

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -121,7 +121,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let compute_handle = build_compute_registry(&config)
+    let (compute_handle, s3_mounts_available) = build_compute_registry(&config)
         .await
         .map_err(std::io::Error::other)?;
 
@@ -387,7 +387,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             jobs_runtime.clone(),
         )
         .await
-        .with_metrics(metrics.clone()),
+        .with_metrics(metrics.clone())
+        .with_s3_mounts(s3_mounts_available),
     );
     portal::initialize(config.portal.clone(), state.clone()).await;
 
@@ -471,10 +472,10 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn build_compute_registry(
     config: &Config,
-) -> Result<Option<Arc<aruna_compute::ExecutorRegistry>>, String> {
+) -> Result<(Option<Arc<aruna_compute::ExecutorRegistry>>, bool), String> {
     let selected = dotenvy::var("ARUNA_COMPUTE_EXECUTOR").unwrap_or_else(|_| "none".to_string());
     let result = match selected.as_str() {
-        "none" => return Ok(None),
+        "none" => return Ok((None, false)),
         "docker" => build_docker(config).await,
         "apptainer" => build_apptainer(config).await,
         "kubernetes" => build_kubernetes(config).await,
@@ -482,14 +483,26 @@ async fn build_compute_registry(
             "unknown ARUNA_COMPUTE_EXECUTOR `{other}`"
         ))),
     };
-    match result {
-        Ok(registry) => Ok(Some(Arc::new(registry))),
+    let registry = match result {
+        Ok(registry) => Some(Arc::new(registry)),
         Err(ComputeBuildError::Unavailable(error)) if env_true("ARUNA_COMPUTE_OPTIONAL") => {
             warn!(executor = %selected, reason = %error, "Compute executor unavailable; running without compute");
-            Ok(None)
+            None
         }
-        Err(ComputeBuildError::Config(error) | ComputeBuildError::Unavailable(error)) => Err(error),
-    }
+        Err(ComputeBuildError::Config(error) | ComputeBuildError::Unavailable(error)) => {
+            return Err(error);
+        }
+    };
+    // S3 mounts are a local deployment property: Kubernetes with a CSI driver.
+    let s3_mounts_available =
+        registry.is_some() && selected == "kubernetes" && read_mount_driver().is_some();
+    Ok((registry, s3_mounts_available))
+}
+
+fn read_mount_driver() -> Option<String> {
+    dotenvy::var("ARUNA_COMPUTE_K8S_S3_MOUNT_DRIVER")
+        .ok()
+        .filter(|driver| !driver.is_empty())
 }
 
 enum ComputeBuildError {
@@ -620,9 +633,7 @@ async fn build_kubernetes(
         .map(|value| value.parse::<u16>())
         .unwrap_or(Ok(443))
         .map_err(|_| "ARUNA_COMPUTE_K8S_S3_PORT must be a valid port".to_string())?;
-    let s3_mount_driver = dotenvy::var("ARUNA_COMPUTE_K8S_S3_MOUNT_DRIVER")
-        .ok()
-        .filter(|driver| !driver.is_empty());
+    let s3_mount_driver = read_mount_driver();
     let backend = aruna_compute::executor::kubernetes::KubernetesBackend::with_config(
         aruna_compute::KubernetesConfig {
             namespace: dotenvy::var("ARUNA_COMPUTE_K8S_NAMESPACE")

--- a/compute/src/executor/apptainer/mod.rs
+++ b/compute/src/executor/apptainer/mod.rs
@@ -679,6 +679,11 @@ fn validate_spec(context: &FenceContext, spec: &TaskSpec) -> Result<(), BackendE
                 "Files staging does not support S3-only networking".to_string(),
             ));
         }
+        (StagingMode::S3Mount, _) => {
+            return Err(BackendError::InvalidSpec(
+                "S3 mounts are supported only by Kubernetes".to_string(),
+            ));
+        }
     }
     if spec.resources.disk_bytes.is_some() {
         return Err(BackendError::InvalidSpec(

--- a/compute/src/executor/config.rs
+++ b/compute/src/executor/config.rs
@@ -55,4 +55,6 @@ pub struct KubernetesConfig {
     pub pull_deadline: Duration,
     pub s3_cidrs: Vec<String>,
     pub s3_port: u16,
+    /// CSI driver name for S3 mounts; `None` disables the feature.
+    pub s3_mount_driver: Option<String>,
 }

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -111,6 +111,21 @@ pub fn job_manifest(
                 }));
             }
         }
+        // Mounted jobs have no workspace PVC, so give the task a writable
+        // working directory that read-only inputs nest beneath.
+        if let Some(workdir) = spec.workdir.as_deref() {
+            let scratch = normalize_container_path(workdir).map_err(BackendError::InvalidSpec)?;
+            let taken = layout.mounts.iter().any(|input| input.path == scratch)
+                || layout.output_parents.contains(&scratch);
+            if !taken {
+                let empty_dir = match spec.resources.disk_bytes {
+                    Some(bytes) => json!({"sizeLimit":bytes.to_string()}),
+                    None => json!({}),
+                };
+                volumes.push(json!({"name":"scratch","emptyDir":empty_dir}));
+                mounts.push(json!({"name":"scratch","mountPath":scratch}));
+            }
+        }
     } else if spec.staging_mode == StagingMode::DirectS3 {
         env_from.push(json!({"secretRef":{"name":secret_name(&name)}}));
     }
@@ -684,6 +699,34 @@ mod tests {
         )
         .unwrap();
         assert_eq!(pv["spec"]["csi"]["driver"], "s3.csi.example.org");
+    }
+
+    #[test]
+    fn mounts_scratch_dir() {
+        // Mounted jobs get a writable working directory instead of a workspace.
+        let mut spec = TaskSpec::new(context().attempt, "registry.example/task:latest");
+        spec.staging_mode = StagingMode::S3Mount;
+        spec.workdir = Some("/work".to_string());
+        let layout = StageLayout::from_spec(&spec).unwrap();
+        let job = job_manifest(&context(), &spec, &config(), &layout).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+
+        let mount = pod.containers[0]
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|mount| mount.mount_path == "/work")
+            .unwrap();
+        assert_eq!(mount.name, "scratch");
+        assert_ne!(mount.read_only, Some(true));
+        let volume = pod
+            .volumes
+            .unwrap()
+            .into_iter()
+            .find(|volume| volume.name == "scratch")
+            .unwrap();
+        assert!(volume.empty_dir.is_some());
     }
 
     #[test]

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -21,7 +21,6 @@ pub const MARKER_PATH: &str = "/aruna-marker/marker";
 pub const SENTINEL_PATH: &str = "/workspace/.aruna-stage";
 pub const TASK_SENTINEL: &str = "/aruna-workspace/.aruna-stage";
 pub const HELPER_PATH: &str = "/aruna-compute-helper";
-pub const S3_DRIVER: &str = "s3.csi.scality.com";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageMarker {
@@ -223,6 +222,9 @@ pub fn mount_pv_manifest(
     bucket: &str,
 ) -> Result<PersistentVolume, BackendError> {
     let name = mount_name(&context.attempt.external_name(), index);
+    let driver = config.s3_mount_driver.as_deref().ok_or_else(|| {
+        BackendError::InvalidSpec("S3 mounts are disabled on this backend".to_string())
+    })?;
     serde_json::from_value(json!({
         "apiVersion":"v1",
         "kind":"PersistentVolume",
@@ -241,7 +243,7 @@ pub fn mount_pv_manifest(
                 "uid=65534","gid=65534","allow-other","file-mode=0444","dir-mode=0555"
             ],
             "csi":{
-                "driver":S3_DRIVER,
+                "driver":driver,
                 "volumeHandle":name,
                 "readOnly":true,
                 "volumeAttributes":{
@@ -588,6 +590,7 @@ mod tests {
             pull_deadline: std::time::Duration::from_secs(30),
             s3_cidrs: Vec::new(),
             s3_port: 443,
+            s3_mount_driver: Some("s3.csi.scality.com".to_string()),
         }
     }
 
@@ -660,7 +663,7 @@ mod tests {
             mount_pv_manifest(&context(), &config(), 0, "input-bucket").unwrap(),
         )
         .unwrap();
-        assert_eq!(pv["spec"]["csi"]["driver"], S3_DRIVER);
+        assert_eq!(pv["spec"]["csi"]["driver"], "s3.csi.scality.com");
         assert_eq!(
             pv["spec"]["csi"]["volumeAttributes"]["bucketName"],
             "input-bucket"
@@ -670,6 +673,17 @@ mod tests {
             "aruna-job-a1-env"
         );
         assert_eq!(pv["spec"]["csi"]["readOnly"], true);
+    }
+
+    #[test]
+    fn uses_configured_driver() {
+        let mut config = config();
+        config.s3_mount_driver = Some("s3.csi.example.org".to_string());
+        let pv = serde_json::to_value(
+            mount_pv_manifest(&context(), &config, 0, "input-bucket").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(pv["spec"]["csi"]["driver"], "s3.csi.example.org");
     }
 
     #[test]

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -1,11 +1,11 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use aruna_core::compute::{
     BackendError, FenceContext, NetworkAccess, StagingMode, TaskSpec, normalize_container_path,
 };
 use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Pod, Secret};
+use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolume, PersistentVolumeClaim, Pod, Secret};
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -21,6 +21,7 @@ pub const MARKER_PATH: &str = "/aruna-marker/marker";
 pub const SENTINEL_PATH: &str = "/workspace/.aruna-stage";
 pub const TASK_SENTINEL: &str = "/aruna-workspace/.aruna-stage";
 pub const HELPER_PATH: &str = "/aruna-compute-helper";
+pub const S3_DRIVER: &str = "s3.csi.scality.com";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageMarker {
@@ -52,19 +53,21 @@ pub fn job_manifest(
     let mut mounts = Vec::new();
     let mut init = Vec::new();
     let mut env_from = Vec::new();
-    if spec.staging_mode == StagingMode::Files {
+    if needs_workspace(spec) {
         volumes.extend([
             json!({"name":"workspace","persistentVolumeClaim":{"claimName":workspace_name(&name)}}),
             json!({"name":"marker","configMap":{"name":marker_name(&name)}}),
             json!({"name":"tools","emptyDir":{}}),
         ]);
-        for input in &layout.files {
-            mounts.push(json!({
-                "name":"workspace",
-                "mountPath":input.path,
-                "subPath":relative_path(&input.path)?,
-                "readOnly":true
-            }));
+        if spec.staging_mode == StagingMode::Files {
+            for input in &layout.files {
+                mounts.push(json!({
+                    "name":"workspace",
+                    "mountPath":input.path,
+                    "subPath":relative_path(&input.path)?,
+                    "readOnly":true
+                }));
+            }
         }
         for output in &layout.output_parents {
             mounts.push(json!({
@@ -92,7 +95,24 @@ pub fn job_manifest(
                 {"name":"tools","mountPath":"/tools"}
             ]
         }));
-    } else {
+    }
+    if spec.staging_mode == StagingMode::S3Mount {
+        let buckets = mount_buckets(layout);
+        for (index, bucket) in buckets.iter().enumerate() {
+            volumes.push(json!({
+                "name":mount_name(&name,index),
+                "persistentVolumeClaim":{"claimName":mount_name(&name,index)}
+            }));
+            for input in layout.mounts.iter().filter(|input| &input.bucket == bucket) {
+                mounts.push(json!({
+                    "name":mount_name(&name,index),
+                    "mountPath":input.path,
+                    "subPath":input.key,
+                    "readOnly":true
+                }));
+            }
+        }
+    } else if spec.staging_mode == StagingMode::DirectS3 {
         env_from.push(json!({"secretRef":{"name":secret_name(&name)}}));
     }
     let mut env = spec
@@ -108,7 +128,7 @@ pub fn job_manifest(
             json!({"name":"ARUNA_WORKSPACE_BUCKET","value":workspace.bucket_name}),
         ]);
     }
-    let startup_probe = (spec.staging_mode == StagingMode::Files).then(|| {
+    let startup_probe = needs_workspace(spec).then(|| {
         json!({
             "exec":{"command":["/aruna-tools/probe","probe","--marker",MARKER_PATH,"--sentinel",TASK_SENTINEL]},
             "failureThreshold":3,
@@ -191,6 +211,73 @@ pub fn pvc_manifest(
             "accessModes":["ReadWriteOncePod"],
             "storageClassName":config.storage_class,
             "resources":{"requests":{"storage":bytes.to_string()}}
+        }
+    }))
+    .map_err(manifest_error)
+}
+
+pub fn mount_pv_manifest(
+    context: &FenceContext,
+    config: &KubernetesConfig,
+    index: usize,
+    bucket: &str,
+) -> Result<PersistentVolume, BackendError> {
+    let name = mount_name(&context.attempt.external_name(), index);
+    serde_json::from_value(json!({
+        "apiVersion":"v1",
+        "kind":"PersistentVolume",
+        "metadata":{
+            "name":name,
+            "labels":labels(context,"s3-mount"),
+            "annotations":annotations_base(context,"active")
+        },
+        "spec":{
+            "capacity":{"storage":"1Gi"},
+            "accessModes":["ReadWriteMany"],
+            "persistentVolumeReclaimPolicy":"Retain",
+            "storageClassName":"",
+            "claimRef":{"namespace":config.namespace,"name":name},
+            "mountOptions":[
+                "uid=65534","gid=65534","allow-other","file-mode=0444","dir-mode=0555"
+            ],
+            "csi":{
+                "driver":S3_DRIVER,
+                "volumeHandle":name,
+                "readOnly":true,
+                "volumeAttributes":{
+                    "bucketName":bucket,
+                    "authenticationSource":"secret"
+                },
+                "nodePublishSecretRef":{
+                    "name":secret_name(&context.attempt.external_name()),
+                    "namespace":config.namespace
+                }
+            }
+        }
+    }))
+    .map_err(manifest_error)
+}
+
+pub fn mount_pvc_manifest(
+    context: &FenceContext,
+    config: &KubernetesConfig,
+    index: usize,
+) -> Result<PersistentVolumeClaim, BackendError> {
+    let name = mount_name(&context.attempt.external_name(), index);
+    serde_json::from_value(json!({
+        "apiVersion":"v1",
+        "kind":"PersistentVolumeClaim",
+        "metadata":{
+            "name":name,
+            "namespace":config.namespace,
+            "labels":labels(context,"s3-mount"),
+            "annotations":annotations_base(context,"active")
+        },
+        "spec":{
+            "accessModes":["ReadWriteMany"],
+            "storageClassName":"",
+            "volumeName":name,
+            "resources":{"requests":{"storage":"1Gi"}}
         }
     }))
     .map_err(manifest_error)
@@ -331,6 +418,25 @@ pub fn workspace_name(name: &str) -> String {
     format!("{name}-ws")
 }
 
+pub fn mount_name(name: &str, index: usize) -> String {
+    format!("{name}-s3-{index}")
+}
+
+pub fn mount_buckets(layout: &StageLayout) -> Vec<String> {
+    layout
+        .mounts
+        .iter()
+        .map(|mount| mount.bucket.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+pub fn needs_workspace(spec: &TaskSpec) -> bool {
+    spec.staging_mode == StagingMode::Files
+        || (spec.staging_mode == StagingMode::S3Mount && !spec.output_paths.is_empty())
+}
+
 pub fn secret_name(name: &str) -> String {
     format!("{name}-env")
 }
@@ -375,8 +481,13 @@ fn annotations(
         match spec.staging_mode {
             StagingMode::Files => "files",
             StagingMode::DirectS3 => "direct-s3",
+            StagingMode::S3Mount => "s3-mount",
         }
         .to_string(),
+    );
+    annotations.insert(
+        "aruna-engine.org/workspace".to_string(),
+        needs_workspace(spec).to_string(),
     );
     annotations.insert(
         "aruna-engine.org/output-paths".to_string(),
@@ -455,7 +566,7 @@ fn manifest_error(error: serde_json::Error) -> BackendError {
 
 #[cfg(test)]
 mod tests {
-    use aruna_core::compute::{AttemptRef, TaskInput};
+    use aruna_core::compute::{AttemptRef, S3Mount, Secret, TaskInput};
 
     use super::*;
 
@@ -502,6 +613,63 @@ mod tests {
         let pod = job.spec.unwrap().template.spec.unwrap();
         assert_eq!(pod.init_containers.unwrap().len(), 1);
         assert!(pod.containers[0].startup_probe.is_some());
+    }
+
+    #[test]
+    fn runs_without_workspace() {
+        let mut spec = TaskSpec::new(context().attempt, "registry.example/task:latest");
+        spec.staging_mode = StagingMode::S3Mount;
+        let layout = StageLayout::from_spec(&spec).unwrap();
+        let job = job_manifest(&context(), &spec, &config(), &layout).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+
+        assert!(pod.volumes.unwrap_or_default().is_empty());
+        assert!(pod.init_containers.unwrap_or_default().is_empty());
+        assert!(pod.containers[0].startup_probe.is_none());
+    }
+
+    #[test]
+    fn mounts_s3_inputs() {
+        let mut spec = TaskSpec::new(context().attempt, "registry.example/task:latest");
+        spec.staging_mode = StagingMode::S3Mount;
+        spec.s3_mounts.push(S3Mount {
+            bucket: "input-bucket".to_string(),
+            key: "data/input.txt".to_string(),
+            path: "/input.txt".to_string(),
+        });
+        spec.secret_env
+            .insert("access_key_id".to_string(), Secret::new("temporary-access"));
+        spec.secret_env.insert(
+            "secret_access_key".to_string(),
+            Secret::new("temporary-secret"),
+        );
+        let layout = StageLayout::from_spec(&spec).unwrap();
+        let job = job_manifest(&context(), &spec, &config(), &layout).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+        let mount = pod.containers[0]
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|mount| mount.mount_path == "/input.txt")
+            .unwrap();
+        assert_eq!(mount.sub_path.as_deref(), Some("data/input.txt"));
+        assert_eq!(mount.read_only, Some(true));
+
+        let pv = serde_json::to_value(
+            mount_pv_manifest(&context(), &config(), 0, "input-bucket").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(pv["spec"]["csi"]["driver"], S3_DRIVER);
+        assert_eq!(
+            pv["spec"]["csi"]["volumeAttributes"]["bucketName"],
+            "input-bucket"
+        );
+        assert_eq!(
+            pv["spec"]["csi"]["nodePublishSecretRef"]["name"],
+            "aruna-job-a1-env"
+        );
+        assert_eq!(pv["spec"]["csi"]["readOnly"], true);
     }
 
     #[test]

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -17,10 +17,10 @@ use json_patch::Patch as JsonPatch;
 use k8s_openapi::api::authorization::v1::SelfSubjectAccessReview;
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{
-    ConfigMap, Namespace, PersistentVolumeClaim, Pod, Secret, ServiceAccount,
+    ConfigMap, Namespace, PersistentVolume, PersistentVolumeClaim, Pod, Secret, ServiceAccount,
 };
 use k8s_openapi::api::networking::v1::NetworkPolicy;
-use k8s_openapi::api::storage::v1::StorageClass;
+use k8s_openapi::api::storage::v1::{CSIDriver, StorageClass};
 use kube::api::{
     Api, AttachParams, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams,
     Preconditions,
@@ -41,7 +41,8 @@ use super::{BackendCaps, ExecutorBackend, digest_pinned};
 mod manifest;
 
 use manifest::{
-    HELPER_PATH, StageMarker, WORKLOAD_SA, helper_pod, job_manifest, marker_manifest, marker_name,
+    HELPER_PATH, S3_DRIVER, StageMarker, WORKLOAD_SA, helper_pod, job_manifest, marker_manifest,
+    marker_name, mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest, needs_workspace,
     network_policies, pvc_manifest, secret_manifest, secret_name, workspace_name,
 };
 
@@ -82,6 +83,10 @@ impl KubernetesBackend {
 
     fn pvcs(&self) -> Api<PersistentVolumeClaim> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
+    }
+
+    fn pvs(&self) -> Api<PersistentVolume> {
+        Api::all(self.client.clone())
     }
 
     fn markers(&self) -> Api<ConfigMap> {
@@ -172,6 +177,96 @@ impl KubernetesBackend {
             }
             Err(error) => Err(kube_error(error)),
         }
+    }
+
+    async fn ensure_mounts(
+        &self,
+        context: &FenceContext,
+        layout: &StageLayout,
+    ) -> Result<(), BackendError> {
+        for (index, bucket) in mount_buckets(layout).iter().enumerate() {
+            let name = mount_name(&context.attempt.external_name(), index);
+            let pv = mount_pv_manifest(context, &self.config, index, bucket)?;
+            match self.pvs().create(&PostParams::default(), &pv).await {
+                Ok(_) => {}
+                Err(error) if api_code(&error) == Some(409) => {
+                    let existing = self.pvs().get(&name).await.map_err(kube_error)?;
+                    let valid = existing
+                        .metadata
+                        .annotations
+                        .as_ref()
+                        .and_then(|annotations| annotations.get(EPOCH_ANNOTATION))
+                        .and_then(|epoch| epoch.parse::<u64>().ok())
+                        == Some(context.attempt_epoch)
+                        && existing
+                            .spec
+                            .as_ref()
+                            .and_then(|spec| spec.csi.as_ref())
+                            .is_some_and(|csi| {
+                                csi.driver == S3_DRIVER
+                                    && csi.volume_handle == name
+                                    && csi
+                                        .volume_attributes
+                                        .as_ref()
+                                        .and_then(|attributes| attributes.get("bucketName"))
+                                        == Some(bucket)
+                            });
+                    if !valid {
+                        return Err(BackendError::Conflict(format!(
+                            "S3 PersistentVolume `{name}` belongs to another attempt"
+                        )));
+                    }
+                }
+                Err(error) => return Err(kube_error(error)),
+            }
+            let pvc = mount_pvc_manifest(context, &self.config, index)?;
+            match self.pvcs().create(&PostParams::default(), &pvc).await {
+                Ok(_) => {}
+                Err(error) if api_code(&error) == Some(409) => {
+                    let existing = self.pvcs().get(&name).await.map_err(kube_error)?;
+                    let valid = existing
+                        .metadata
+                        .annotations
+                        .as_ref()
+                        .and_then(|annotations| annotations.get(EPOCH_ANNOTATION))
+                        .and_then(|epoch| epoch.parse::<u64>().ok())
+                        == Some(context.attempt_epoch)
+                        && existing
+                            .spec
+                            .as_ref()
+                            .and_then(|spec| spec.volume_name.as_deref())
+                            == Some(name.as_str());
+                    if !valid {
+                        return Err(BackendError::Conflict(format!(
+                            "S3 PersistentVolumeClaim `{name}` belongs to another attempt"
+                        )));
+                    }
+                }
+                Err(error) => return Err(kube_error(error)),
+            }
+        }
+        Ok(())
+    }
+
+    async fn remove_mounts(&self, context: &FenceContext) -> Result<(), BackendError> {
+        let selector = format!("{},{}=s3-mount", attempt_selector(context), ROLE_LABEL);
+        for pvc in self
+            .pvcs()
+            .list(&ListParams::default().labels(&selector))
+            .await
+            .map_err(kube_error)?
+        {
+            delete_named(self.pvcs(), &pvc.name_any()).await?;
+        }
+        for pv in self
+            .pvs()
+            .list(&ListParams::default().labels(&selector))
+            .await
+            .map_err(kube_error)?
+        {
+            delete_named(self.pvs(), &pv.name_any()).await?;
+        }
+        Ok(())
     }
 
     async fn apply_network(&self) -> Result<(), BackendError> {
@@ -671,6 +766,8 @@ impl ExecutorBackend for KubernetesBackend {
             .get(&self.config.storage_class)
             .await
             .map_err(kube_error)?;
+        let drivers: Api<CSIDriver> = Api::all(self.client.clone());
+        drivers.get(S3_DRIVER).await.map_err(kube_error)?;
         let accounts: Api<ServiceAccount> =
             Api::namespaced(self.client.clone(), &self.config.namespace);
         accounts.get(WORKLOAD_SA).await.map_err(kube_error)?;
@@ -743,6 +840,20 @@ impl ExecutorBackend for KubernetesBackend {
                 self.stage(context, spec, cancel).await?;
             }
             StagingMode::DirectS3 => self.ensure_secret(context, spec).await?,
+            StagingMode::S3Mount => {
+                if !spec.s3_mounts.is_empty() {
+                    self.ensure_secret(context, spec).await?;
+                    self.ensure_mounts(context, &layout).await?;
+                }
+                if needs_workspace(spec) {
+                    self.ensure_pvc(
+                        context,
+                        spec.resources.disk_bytes.unwrap_or(DEFAULT_WORKSPACE_BYTES),
+                    )
+                    .await?;
+                    self.stage(context, spec, cancel).await?;
+                }
+            }
         }
         self.unsuspend(context, cancel).await
     }
@@ -753,7 +864,7 @@ impl ExecutorBackend for KubernetesBackend {
         spec: &TaskSpec,
         cancel: &CancellationToken,
     ) -> Result<(), BackendError> {
-        if spec.staging_mode != StagingMode::Files {
+        if !needs_workspace(spec) {
             return Ok(());
         }
         let job = self.get_job(context).await?;
@@ -803,7 +914,7 @@ impl ExecutorBackend for KubernetesBackend {
             .as_ref()
             .and_then(|annotations| annotations.get("aruna-engine.org/staging-mode"))
             .map(String::as_str);
-        if staging == Some("files") {
+        if matches!(staging, Some("files" | "s3-mount")) && job_workspace(&job) {
             let marker = self
                 .markers()
                 .get(&marker_name(&context.attempt.external_name()))
@@ -953,16 +1064,22 @@ impl ExecutorBackend for KubernetesBackend {
                     .as_ref()
                     .is_some_and(|spec| spec.suspend == Some(true))
                 {
-                    let marker = self
-                        .markers()
-                        .get_opt(&marker_name(&context.attempt.external_name()))
-                        .await;
-                    if marker.is_ok_and(|marker| {
-                        marker.is_some_and(|marker| validate_marker(&marker, &job, context).is_ok())
-                    }) {
+                    if !job_workspace(&job) {
                         ResumePoint::Unsuspend
                     } else {
-                        ResumePoint::Stage
+                        let marker = self
+                            .markers()
+                            .get_opt(&marker_name(&context.attempt.external_name()))
+                            .await;
+                        if marker.is_ok_and(|marker| {
+                            marker.is_some_and(|marker| {
+                                validate_marker(&marker, &job, context).is_ok()
+                            })
+                        }) {
+                            ResumePoint::Unsuspend
+                        } else {
+                            ResumePoint::Stage
+                        }
                     }
                 } else {
                     ResumePoint::Observe
@@ -1012,6 +1129,7 @@ impl ExecutorBackend for KubernetesBackend {
         self.strip_finalizer(context, &job).await?;
         self.remove_helpers(context).await?;
         self.delete_tasks(context).await?;
+        self.remove_mounts(context).await?;
         delete_named(
             self.pvcs(),
             &workspace_name(&context.attempt.external_name()),
@@ -1058,7 +1176,13 @@ impl KubernetesBackend {
             .get_opt(&marker_name(&context.attempt.external_name()))
             .await
             .map_err(kube_error)?;
-        if pods.items.is_empty() && pvc.is_none() && marker.is_none() {
+        let mount_selector = format!("{},{}=s3-mount", attempt_selector(context), ROLE_LABEL);
+        let mounts = self
+            .pvs()
+            .list(&ListParams::default().labels(&mount_selector))
+            .await
+            .map_err(kube_error)?;
+        if pods.items.is_empty() && pvc.is_none() && marker.is_none() && mounts.items.is_empty() {
             return Ok(None);
         }
         let reference = pods
@@ -1066,14 +1190,20 @@ impl KubernetesBackend {
             .first()
             .and_then(|pod| pod.metadata.uid.clone())
             .or_else(|| pvc.and_then(|pvc| pvc.metadata.uid))
-            .or_else(|| marker.and_then(|marker| marker.metadata.uid));
+            .or_else(|| marker.and_then(|marker| marker.metadata.uid))
+            .or_else(|| {
+                mounts
+                    .items
+                    .first()
+                    .and_then(|mount| mount.metadata.uid.clone())
+            });
         Ok(Some(ArtifactEvidence {
             artifact_kind: "kubernetes-accessory".to_string(),
             backend_ref: reference,
             observed_epoch: Some(context.attempt_epoch),
             observed_generation: None,
             exact_identity: true,
-            multiple: pods.items.len() > 1,
+            multiple: pods.items.len() + mounts.items.len() > 1,
             foreign: false,
         }))
     }
@@ -1132,6 +1262,25 @@ fn validate_spec(
                 "Files staging does not support S3-only networking".to_string(),
             ));
         }
+        (
+            StagingMode::S3Mount,
+            aruna_core::compute::NetworkAccess::Isolated | aruna_core::compute::NetworkAccess::Open,
+        ) => {}
+        (StagingMode::S3Mount, _) => {
+            return Err(BackendError::InvalidSpec(
+                "S3Mount does not expose S3 networking to the task".to_string(),
+            ));
+        }
+    }
+    if spec.staging_mode == StagingMode::S3Mount
+        && !spec.s3_mounts.is_empty()
+        && !["access_key_id", "secret_access_key"]
+            .iter()
+            .all(|key| spec.secret_env.contains_key(*key))
+    {
+        return Err(BackendError::InvalidSpec(
+            "S3Mount credentials are incomplete".to_string(),
+        ));
     }
     if let Some(extension) = spec.resources.backend_extensions.keys().next() {
         return Err(BackendError::InvalidSpec(format!(
@@ -1311,6 +1460,14 @@ fn job_state(job: &Job) -> Option<&str> {
         .map(String::as_str)
 }
 
+fn job_workspace(job: &Job) -> bool {
+    job.metadata
+        .annotations
+        .as_ref()
+        .and_then(|annotations| annotations.get("aruna-engine.org/workspace"))
+        .is_some_and(|value| value == "true")
+}
+
 fn cas_patch(job: &Job, replacements: Vec<(String, Value)>) -> Result<JsonPatch, BackendError> {
     let uid = job_uid(job)?;
     let version = job
@@ -1367,6 +1524,10 @@ fn required_access() -> Vec<(
         ("", "pods", Some("exec"), "create"),
         ("", "pods", Some("exec"), "get"),
         ("", "pods", Some("log"), "get"),
+        ("", "persistentvolumes", None, "create"),
+        ("", "persistentvolumes", None, "get"),
+        ("", "persistentvolumes", None, "list"),
+        ("", "persistentvolumes", None, "delete"),
         ("", "persistentvolumeclaims", None, "create"),
         ("", "persistentvolumeclaims", None, "get"),
         ("", "persistentvolumeclaims", None, "list"),
@@ -1384,6 +1545,7 @@ fn required_access() -> Vec<(
         ("networking.k8s.io", "networkpolicies", None, "get"),
         ("networking.k8s.io", "networkpolicies", None, "patch"),
         ("storage.k8s.io", "storageclasses", None, "get"),
+        ("storage.k8s.io", "csidrivers", None, "get"),
     ]
 }
 
@@ -1400,12 +1562,12 @@ async fn check_access(
         "apiVersion":"authorization.k8s.io/v1",
         "kind":"SelfSubjectAccessReview",
         "spec":{"resourceAttributes":{
-            "namespace":if resource == "storageclasses" { None } else { Some(namespace) },
+            "namespace":if matches!(resource,"storageclasses" | "csidrivers" | "persistentvolumes") { None } else { Some(namespace) },
             "group":group,
             "resource":resource,
             "subresource":subresource,
             "verb":verb,
-            "name":if resource == "storageclasses" { Some("") } else { None }
+            "name":if matches!(resource,"storageclasses" | "csidrivers") { Some("") } else { None }
         }}
     }))
     .map_err(|error| BackendError::Api(format!("build access review: {error}")))?;
@@ -1772,6 +1934,14 @@ mod tests {
                     (200, job_json("tombstone"))
                 }
                 ("GET", "/api/v1/namespaces/compute/pods") => (200, pod_list()),
+                ("GET", "/api/v1/namespaces/compute/persistentvolumeclaims") => (
+                    200,
+                    json!({"apiVersion":"v1","kind":"PersistentVolumeClaimList","items":[]}),
+                ),
+                ("GET", "/api/v1/persistentvolumes") => (
+                    200,
+                    json!({"apiVersion":"v1","kind":"PersistentVolumeList","items":[]}),
+                ),
                 ("DELETE", "/api/v1/namespaces/compute/pods/task-pod") => {
                     (200, core_object("Pod", "task-pod"))
                 }

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -408,7 +408,7 @@ impl KubernetesBackend {
             .await
             .map_err(|error| BackendError::Api(format!("stage archive task failed: {error}")))?;
         built?;
-        attached.join().await.map_err(remote_error)
+        join_exec(attached).await
     }
 
     async fn cas_generation(&self, context: &FenceContext, job: Job) -> Result<(), BackendError> {
@@ -1365,6 +1365,7 @@ fn required_access() -> Vec<(
         ("", "pods", None, "watch"),
         ("", "pods", None, "delete"),
         ("", "pods", Some("exec"), "create"),
+        ("", "pods", Some("exec"), "get"),
         ("", "pods", Some("log"), "get"),
         ("", "persistentvolumeclaims", None, "create"),
         ("", "persistentvolumeclaims", None, "get"),
@@ -1575,9 +1576,28 @@ async fn stream_output<R: AsyncRead + Unpin>(
         }
     }
     let _ = tokio::io::copy(&mut stdout, &mut tokio::io::sink()).await;
-    if let Err(error) = attached.join().await {
-        let _ = tx.send(Err(remote_error(error))).await;
+    if let Err(error) = join_exec(attached).await {
+        let _ = tx.send(Err(error)).await;
     }
+}
+
+async fn join_exec(mut attached: kube::api::AttachedProcess) -> Result<(), BackendError> {
+    let status = attached.take_status().ok_or_else(|| {
+        BackendError::Api("Kubernetes exec status stream is unavailable".to_string())
+    })?;
+    attached.join().await.map_err(remote_error)?;
+    let status = status
+        .await
+        .ok_or_else(|| BackendError::Api("Kubernetes exec returned no status".to_string()))?;
+    if status.status.as_deref() == Some("Success") {
+        return Ok(());
+    }
+    Err(BackendError::Api(
+        status
+            .message
+            .or(status.reason)
+            .unwrap_or_else(|| "Kubernetes exec failed".to_string()),
+    ))
 }
 
 struct ChannelStream(mpsc::Receiver<Result<Bytes, BackendError>>);

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -41,8 +41,8 @@ use super::{BackendCaps, ExecutorBackend, digest_pinned};
 mod manifest;
 
 use manifest::{
-    HELPER_PATH, S3_DRIVER, StageMarker, WORKLOAD_SA, helper_pod, job_manifest, marker_manifest,
-    marker_name, mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest, needs_workspace,
+    HELPER_PATH, StageMarker, WORKLOAD_SA, helper_pod, job_manifest, marker_manifest, marker_name,
+    mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest, needs_workspace,
     network_policies, pvc_manifest, secret_manifest, secret_name, workspace_name,
 };
 
@@ -184,6 +184,9 @@ impl KubernetesBackend {
         context: &FenceContext,
         layout: &StageLayout,
     ) -> Result<(), BackendError> {
+        let driver = self.config.s3_mount_driver.as_deref().ok_or_else(|| {
+            BackendError::InvalidSpec("S3 mounts are disabled on this backend".to_string())
+        })?;
         for (index, bucket) in mount_buckets(layout).iter().enumerate() {
             let name = mount_name(&context.attempt.external_name(), index);
             let pv = mount_pv_manifest(context, &self.config, index, bucket)?;
@@ -203,7 +206,7 @@ impl KubernetesBackend {
                             .as_ref()
                             .and_then(|spec| spec.csi.as_ref())
                             .is_some_and(|csi| {
-                                csi.driver == S3_DRIVER
+                                csi.driver == driver
                                     && csi.volume_handle == name
                                     && csi
                                         .volume_attributes
@@ -766,12 +769,16 @@ impl ExecutorBackend for KubernetesBackend {
             .get(&self.config.storage_class)
             .await
             .map_err(kube_error)?;
-        let drivers: Api<CSIDriver> = Api::all(self.client.clone());
-        drivers.get(S3_DRIVER).await.map_err(kube_error)?;
+        if let Some(driver) = &self.config.s3_mount_driver {
+            let drivers: Api<CSIDriver> = Api::all(self.client.clone());
+            drivers.get(driver).await.map_err(kube_error)?;
+        }
         let accounts: Api<ServiceAccount> =
             Api::namespaced(self.client.clone(), &self.config.namespace);
         accounts.get(WORKLOAD_SA).await.map_err(kube_error)?;
-        for (group, resource, subresource, verb) in required_access() {
+        for (group, resource, subresource, verb) in
+            required_access(self.config.s3_mount_driver.is_some())
+        {
             check_access(
                 self.client.clone(),
                 &self.config.namespace,
@@ -1245,6 +1252,11 @@ fn validate_spec(
             "Kubernetes tasks must run as 65534:65534".to_string(),
         ));
     }
+    if spec.staging_mode == StagingMode::S3Mount && config.s3_mount_driver.is_none() {
+        return Err(BackendError::InvalidSpec(
+            "S3 mounts are disabled on this backend".to_string(),
+        ));
+    }
     match (spec.staging_mode, spec.security.network) {
         (
             StagingMode::Files,
@@ -1503,13 +1515,15 @@ fn logs_name(name: &str) -> String {
     format!("{name}-logs")
 }
 
-fn required_access() -> Vec<(
+fn required_access(
+    s3_mount: bool,
+) -> Vec<(
     &'static str,
     &'static str,
     Option<&'static str>,
     &'static str,
 )> {
-    vec![
+    let mut access = vec![
         ("batch", "jobs", None, "create"),
         ("batch", "jobs", None, "get"),
         ("batch", "jobs", None, "list"),
@@ -1545,8 +1559,11 @@ fn required_access() -> Vec<(
         ("networking.k8s.io", "networkpolicies", None, "get"),
         ("networking.k8s.io", "networkpolicies", None, "patch"),
         ("storage.k8s.io", "storageclasses", None, "get"),
-        ("storage.k8s.io", "csidrivers", None, "get"),
-    ]
+    ];
+    if s3_mount {
+        access.push(("storage.k8s.io", "csidrivers", None, "get"));
+    }
+    access
 }
 
 async fn check_access(
@@ -1825,6 +1842,7 @@ mod tests {
             pull_deadline: Duration::from_secs(30),
             s3_cidrs: Vec::new(),
             s3_port: 443,
+            s3_mount_driver: None,
         }
     }
 
@@ -2053,6 +2071,7 @@ mod tests {
             pull_deadline: Duration::from_secs(30),
             s3_cidrs: Vec::new(),
             s3_port: 443,
+            s3_mount_driver: None,
         };
         assert!(validate_config(&config).is_err());
     }
@@ -2083,6 +2102,101 @@ mod tests {
         assert_eq!(
             attempt_selector(&context()),
             "aruna-engine.org/job-id=job,aruna-engine.org/attempt=1"
+        );
+    }
+
+    #[test]
+    fn rejects_disabled_mount() {
+        // A disabled backend must refuse S3Mount specs before submission.
+        let context = context();
+        let mut spec = TaskSpec::new(context.attempt.clone(), "registry.example/task:latest");
+        spec.staging_mode = StagingMode::S3Mount;
+        assert!(matches!(
+            validate_spec(&context, &spec, &test_config()),
+            Err(BackendError::InvalidSpec(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn gates_driver_check() {
+        // Health probes the CSIDriver only when the S3-mount driver is set.
+        fn probe_client(seen: std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> Client {
+            fake_client(move |method, path| {
+                seen.lock().expect("record request").push(path.to_string());
+                if method == "POST" {
+                    return (
+                        200,
+                        json!({
+                            "apiVersion":"authorization.k8s.io/v1",
+                            "kind":"SelfSubjectAccessReview",
+                            "status":{"allowed":true}
+                        }),
+                    );
+                }
+                if path.contains("storageclasses") {
+                    return (
+                        200,
+                        json!({
+                            "apiVersion":"storage.k8s.io/v1","kind":"StorageClass",
+                            "metadata":{"name":"csi"},"provisioner":"driver"
+                        }),
+                    );
+                }
+                if path.contains("csidrivers") {
+                    return (
+                        200,
+                        json!({
+                            "apiVersion":"storage.k8s.io/v1","kind":"CSIDriver",
+                            "metadata":{"name":"driver"},"spec":{}
+                        }),
+                    );
+                }
+                if path.contains("serviceaccounts") {
+                    return (
+                        200,
+                        json!({
+                            "apiVersion":"v1","kind":"ServiceAccount",
+                            "metadata":{"name":WORKLOAD_SA}
+                        }),
+                    );
+                }
+                (
+                    200,
+                    json!({
+                        "apiVersion":"v1","kind":"Namespace","metadata":{"name":"compute"}
+                    }),
+                )
+            })
+        }
+
+        let disabled = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let backend = KubernetesBackend {
+            client: probe_client(disabled.clone()),
+            config: test_config(),
+        };
+        backend.health().await.unwrap();
+        assert!(
+            !disabled
+                .lock()
+                .expect("read requests")
+                .iter()
+                .any(|path| path.contains("csidrivers"))
+        );
+
+        let enabled = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut config = test_config();
+        config.s3_mount_driver = Some("s3.csi.scality.com".to_string());
+        let backend = KubernetesBackend {
+            client: probe_client(enabled.clone()),
+            config,
+        };
+        backend.health().await.unwrap();
+        assert!(
+            enabled
+                .lock()
+                .expect("read requests")
+                .iter()
+                .any(|path| path.contains("csidrivers"))
         );
     }
 }

--- a/compute/src/executor/staging.rs
+++ b/compute/src/executor/staging.rs
@@ -1,13 +1,15 @@
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use aruna_core::compute::{
     BackendError, InputStream, StagingMode, TaskSpec, normalize_container_path, paths_overlap,
 };
+use aruna_core::structs::ensure_confined_relative_path;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StageLayout {
     pub files: Vec<StagedPath>,
+    pub mounts: Vec<MountedPath>,
     pub output_parents: BTreeSet<PathBuf>,
     pub mode: StagingMode,
 }
@@ -17,6 +19,13 @@ pub struct StagedPath {
     pub path: PathBuf,
     pub size: u64,
     pub workspace_key: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MountedPath {
+    pub path: PathBuf,
+    pub bucket: String,
+    pub key: String,
 }
 
 pub struct StagePlan {
@@ -44,7 +53,26 @@ impl StageLayout {
                     "DirectS3 staging must not include container file inputs".to_string(),
                 ));
             }
+            StagingMode::S3Mount if !spec.inputs.is_empty() || spec.workspace.is_some() => {
+                return Err(BackendError::InvalidSpec(
+                    "S3Mount staging must not include copied inputs or a workspace binding"
+                        .to_string(),
+                ));
+            }
             _ => {}
+        }
+        if spec.staging_mode != StagingMode::S3Mount && !spec.s3_mounts.is_empty() {
+            return Err(BackendError::InvalidSpec(
+                "S3 mounts require S3Mount staging".to_string(),
+            ));
+        }
+        if spec.staging_mode == StagingMode::S3Mount
+            && !spec.s3_mounts.is_empty()
+            && spec.secret_env.is_empty()
+        {
+            return Err(BackendError::InvalidSpec(
+                "S3 mounts require credentials".to_string(),
+            ));
         }
         if spec.security.read_only_rootfs && !spec.output_paths.is_empty() {
             return Err(BackendError::InvalidSpec(
@@ -65,6 +93,23 @@ impl StageLayout {
                 path,
                 size: input.size(),
                 workspace_key: input.workspace_key.clone(),
+            });
+        }
+        let mut mounts = Vec::with_capacity(spec.s3_mounts.len());
+        for mount in &spec.s3_mounts {
+            let path = normalize_container_path(&mount.path).map_err(BackendError::InvalidSpec)?;
+            ensure_confined_relative_path(Path::new(&mount.key))
+                .map_err(|error| BackendError::InvalidSpec(error.to_string()))?;
+            if mount.bucket.is_empty() || !input_paths.insert(path.clone()) {
+                return Err(BackendError::InvalidSpec(format!(
+                    "duplicate or invalid S3 mount path `{}`",
+                    mount.path
+                )));
+            }
+            mounts.push(MountedPath {
+                path,
+                bucket: mount.bucket.clone(),
+                key: mount.key.clone(),
             });
         }
         for path in &input_paths {
@@ -98,15 +143,19 @@ impl StageLayout {
             }
             output_parents.insert(parent.to_path_buf());
         }
-        for input in &files {
-            if outputs.contains(&input.path) {
+        for input in files
+            .iter()
+            .map(|input| &input.path)
+            .chain(mounts.iter().map(|mount| &mount.path))
+        {
+            if outputs.contains(input) {
                 return Err(BackendError::InvalidSpec(
                     "input and output paths overlap".to_string(),
                 ));
             }
             for parent in &output_parents {
                 if paths_overlap(
-                    input.path.to_str().ok_or_else(|| {
+                    input.to_str().ok_or_else(|| {
                         BackendError::InvalidSpec("input path is not UTF-8".to_string())
                     })?,
                     parent.to_str().ok_or_else(|| {
@@ -123,6 +172,7 @@ impl StageLayout {
         }
         Ok(Self {
             files,
+            mounts,
             output_parents,
             mode: spec.staging_mode,
         })
@@ -141,6 +191,14 @@ impl StageLayout {
                 )
             })
             .collect::<Vec<_>>();
+        rows.extend(self.mounts.iter().map(|mount| {
+            format!(
+                "m\0{}\0{}\0{}",
+                mount.path.display(),
+                mount.bucket,
+                mount.key
+            )
+        }));
         rows.extend(
             self.output_parents
                 .iter()
@@ -151,6 +209,7 @@ impl StageLayout {
         hasher.update(match self.mode {
             StagingMode::Files => b"files",
             StagingMode::DirectS3 => b"direct-s3",
+            StagingMode::S3Mount => b"s3-mount",
         });
         for row in rows {
             hasher.update(row.as_bytes());
@@ -188,7 +247,7 @@ impl StagePlan {
 
 #[cfg(test)]
 mod tests {
-    use aruna_core::compute::{AttemptRef, TaskInput, TaskSpec};
+    use aruna_core::compute::{AttemptRef, S3Mount, Secret, TaskInput, TaskSpec};
 
     use super::*;
 
@@ -211,5 +270,20 @@ mod tests {
         spec.inputs = vec![TaskInput::from_bytes("/work/.command.sh", "data")];
         spec.output_paths = vec!["/work/out.txt".to_string()];
         assert!(StageLayout::from_spec(&spec).is_ok());
+    }
+
+    #[test]
+    fn rejects_mount_escape() {
+        let mut spec = TaskSpec::new(AttemptRef::new("job", 0), "image");
+        spec.staging_mode = StagingMode::S3Mount;
+        spec.s3_mounts.push(S3Mount {
+            bucket: "bucket".to_string(),
+            key: "../escape".to_string(),
+            path: "/input".to_string(),
+        });
+        spec.secret_env
+            .insert("access_key_id".to_string(), Secret::new("key"));
+
+        assert!(StageLayout::from_spec(&spec).is_err());
     }
 }

--- a/compute/tests/docker_backend.rs
+++ b/compute/tests/docker_backend.rs
@@ -86,6 +86,7 @@ impl DockerTestExt for DockerBackend {
             command: spec.command.clone(),
             workdir: spec.workdir.clone(),
             inputs,
+            s3_mounts: spec.s3_mounts.clone(),
             staging_mode: spec.staging_mode,
             output_paths: spec.output_paths.clone(),
             env: spec.env.clone(),

--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -166,10 +166,18 @@ pub struct WorkspaceBinding {
     pub region: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct S3Mount {
+    pub bucket: String,
+    pub key: String,
+    pub path: String,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StagingMode {
     Files,
     DirectS3,
+    S3Mount,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -332,6 +340,7 @@ pub struct TaskSpec {
     pub command: Vec<String>,
     pub workdir: Option<String>,
     pub inputs: Vec<TaskInput>,
+    pub s3_mounts: Vec<S3Mount>,
     pub staging_mode: StagingMode,
     pub output_paths: Vec<String>,
     pub env: BTreeMap<String, String>,
@@ -351,6 +360,7 @@ impl TaskSpec {
             command: Vec::new(),
             workdir: None,
             inputs: Vec::new(),
+            s3_mounts: Vec::new(),
             staging_mode: StagingMode::Files,
             output_paths: Vec::new(),
             env: BTreeMap::new(),

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -596,17 +596,20 @@ pub struct UserAccess {
 }
 
 impl UserAccess {
-    pub fn build_access_key(
-        user_identity: &UserId,
-        key_id: &str,
-    ) -> Result<String, ConversionError> {
-        let access_key = format!("{user_identity}:{key_id}");
-        if access_key.len() > ACCESS_KEY_MAX_LEN {
+    /// Access keys are the key id itself, kept strictly alphanumeric so every
+    /// S3 client and the CSI mount driver accept them verbatim.
+    pub fn build_access_key(key_id: &str) -> Result<String, ConversionError> {
+        if key_id.is_empty() || key_id.len() > ACCESS_KEY_MAX_LEN {
             return Err(ConversionError::InvalidLength(format!(
-                "access key must be <= {ACCESS_KEY_MAX_LEN} characters"
+                "access key must be 1..={ACCESS_KEY_MAX_LEN} characters"
             )));
         }
-        Ok(access_key)
+        if !key_id.bytes().all(|byte| byte.is_ascii_alphanumeric()) {
+            return Err(ConversionError::FromStrError(
+                "access key must be alphanumeric".to_string(),
+            ));
+        }
+        Ok(key_id.to_string())
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {

--- a/core/src/structs/job.rs
+++ b/core/src/structs/job.rs
@@ -885,7 +885,7 @@ pub fn cleanup_job_id(job_id: JobId) -> JobId {
 }
 
 pub fn workspace_credential_id(job_id: JobId) -> String {
-    format!("workspace-{job_id}")
+    format!("ws{job_id}")
 }
 
 /// Dedup key of a user-supplied idempotency key: namespaced under `user/` and
@@ -1224,7 +1224,7 @@ mod tests {
         assert_eq!(user_dedup_key(user_a, "k"), user_dedup_key(user_a, "k"));
         assert_eq!(cleanup_job_id(job), cleanup_job_id(job));
         assert_ne!(cleanup_job_id(job), crate_job_id(job));
-        assert_eq!(workspace_credential_id(job), format!("workspace-{job}"));
+        assert_eq!(workspace_credential_id(job), format!("ws{job}"));
     }
 
     #[test]

--- a/core/src/structs/job.rs
+++ b/core/src/structs/job.rs
@@ -121,11 +121,11 @@ impl JobState {
     }
 }
 
-/// How an input is captured into the workspace. v1 supports snapshot only:
-/// resolved bytes are copied into the workspace at submit time.
+/// How an input is exposed to the task.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InputMode {
     Snapshot,
+    Mount,
 }
 
 /// Where an input comes from. v1 supports internal S3 objects only.
@@ -466,7 +466,7 @@ pub enum JobResultPayload {
     Execution {
         /// Container exit code; `None` when the outcome is evidence-free.
         exit_code: Option<i32>,
-        workspace_bucket: String,
+        workspace_bucket: Option<String>,
         outputs: Vec<OutputObject>,
         stdout: String,
         stderr: String,
@@ -647,11 +647,13 @@ pub enum WorkspaceMode {
     #[default]
     Kept,
     Existing,
+    None,
 }
 
 impl WorkspaceMode {
     pub fn name(self) -> &'static str {
         match self {
+            Self::None => "none",
             Self::Temporary => "temporary",
             Self::Kept => "kept",
             Self::Existing => "existing",

--- a/docs/compute-executors.md
+++ b/docs/compute-executors.md
@@ -138,6 +138,9 @@ Required configuration:
   defaults to `300`.
 - `ARUNA_COMPUTE_K8S_S3_CIDRS`: comma-separated egress CIDRs for Direct-S3.
 - `ARUNA_COMPUTE_K8S_S3_PORT`: S3 TCP port; defaults to `443`.
+- `ARUNA_COMPUTE_K8S_S3_MOUNT_DRIVER`: CSI driver name for S3 mounts. Unset
+  disables S3-mount staging; set it to the deployed driver, for example
+  `s3.csi.scality.com`.
 
 The Kubernetes executor supports Kubernetes 1.32 or newer. Files mode requires a
 CSI driver that enforces `ReadWriteOncePod`. Each attempt creates a suspended Job
@@ -171,8 +174,9 @@ The controller ServiceAccount needs these namespace permissions:
 | NetworkPolicies | create, get, patch |
 | ServiceAccounts | get |
 
-Its narrowly bound ClusterRole needs `get` on StorageClasses and `create` on
-SelfSubjectAccessReviews. The `aruna-workload` ServiceAccount must already exist
+Its narrowly bound ClusterRole needs `get` on StorageClasses, `create` on
+SelfSubjectAccessReviews, and `get` on CSIDrivers only when
+`ARUNA_COMPUTE_K8S_S3_MOUNT_DRIVER` is set. The `aruna-workload` ServiceAccount must already exist
 in the namespace and must not have a Role or ClusterRole binding. Workload and
 helper Pods disable token automount.
 
@@ -185,9 +189,9 @@ The operator must also provide:
 - sufficient namespace quota for Jobs, Pods, PVCs, ConfigMaps, and Secrets;
 - routable, stable S3 CIDRs or an egress proxy when Direct-S3 is enabled.
 
-Startup health is intentionally cheap: namespace access, StorageClass GET,
-workload-ServiceAccount existence, and SelfSubjectAccessReview checks for the
-required verbs. It does not launch RWOP, NetworkPolicy, quota, or admission
+Startup health is intentionally cheap: namespace access, StorageClass GET, the
+S3-mount CSIDriver GET when that driver is configured, workload-ServiceAccount
+existence, and SelfSubjectAccessReview checks for the required verbs. It does not launch RWOP, NetworkPolicy, quota, or admission
 canaries. Those operator prerequisites are enforced lazily by the first real
 object, and a failure parks the attempt without force deletion or a weaker
 release fallback.

--- a/operations/src/jobs/service.rs
+++ b/operations/src/jobs/service.rs
@@ -33,6 +33,11 @@ pub async fn submit_execution_job(
     workspace_bucket: Option<String>,
 ) -> Result<SubmitJobResult, SubmitJobError> {
     match workspace_mode {
+        WorkspaceMode::None if workspace_bucket.is_some() => {
+            return Err(SubmitJobError::InvalidWorkspace(
+                "none mode does not accept a bucket".to_string(),
+            ));
+        }
         WorkspaceMode::Existing
             if workspace_bucket
                 .as_deref()
@@ -48,6 +53,28 @@ pub async fn submit_execution_job(
             ));
         }
         _ => {}
+    }
+    if workspace_mode == WorkspaceMode::None
+        && (spec
+            .inputs
+            .iter()
+            .any(|input| input.mode != aruna_core::structs::InputMode::Mount)
+            || !spec.workspace_outputs.is_empty()
+            || !spec.output_prefixes.is_empty())
+    {
+        return Err(SubmitJobError::InvalidWorkspace(
+            "none mode requires mounted inputs and explicit output destinations".to_string(),
+        ));
+    }
+    if workspace_mode != WorkspaceMode::None
+        && spec
+            .inputs
+            .iter()
+            .any(|input| input.mode == aruna_core::structs::InputMode::Mount)
+    {
+        return Err(SubmitJobError::InvalidWorkspace(
+            "mounted inputs require none workspace mode".to_string(),
+        ));
     }
     let dedup_key = idempotency_key.map(|key| user_dedup_key(created_by, &key));
     drive(

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -331,9 +331,8 @@ async fn insert_cleanup_obligation(
     if !matches!(&record.payload, JobPayload::Execution(_)) {
         return Ok(());
     }
-    let access_key =
-        UserAccess::build_access_key(&record.created_by, &workspace_credential_id(record.job_id))
-            .map_err(|error| JobMutationError::Storage(error.to_string()))?;
+    let access_key = UserAccess::build_access_key(&workspace_credential_id(record.job_id))
+        .map_err(|error| JobMutationError::Storage(error.to_string()))?;
     let now_ms = record.finished_at_ms.unwrap_or(record.updated_at_ms);
     let child = JobRecord::new(
         cleanup_job_id(record.job_id),
@@ -2674,7 +2673,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let expected_access =
-            UserAccess::build_access_key(&owner, &workspace_credential_id(job_id)).unwrap();
+            UserAccess::build_access_key(&workspace_credential_id(job_id)).unwrap();
         assert_eq!(
             child.payload,
             JobPayload::TerminalCleanup {

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -2368,7 +2368,7 @@ mod tests {
     fn execution_result() -> JobResultPayload {
         JobResultPayload::Execution {
             exit_code: Some(0),
-            workspace_bucket: "ws-test".to_string(),
+            workspace_bucket: Some("ws-test".to_string()),
             outputs: Vec::new(),
             stdout: String::new(),
             stderr: String::new(),
@@ -2657,7 +2657,7 @@ mod tests {
             token,
             JobResultPayload::Execution {
                 exit_code: Some(0),
-                workspace_bucket: "ws-test".to_string(),
+                workspace_bucket: Some("ws-test".to_string()),
                 outputs: Vec::new(),
                 stdout: String::new(),
                 stderr: String::new(),

--- a/operations/src/jobs/submit.rs
+++ b/operations/src/jobs/submit.rs
@@ -113,6 +113,7 @@ impl SubmitJobOperation {
                 WorkspaceMode::Temporary | WorkspaceMode::Kept => {
                     Some(JobRecord::workspace_bucket_name(record.job_id))
                 }
+                WorkspaceMode::None => None,
             };
             record.plan_digest = Some(workspace_plan_digest(
                 &record.payload,

--- a/operations/src/jobs/workflow/mod.rs
+++ b/operations/src/jobs/workflow/mod.rs
@@ -395,6 +395,7 @@ fn build_task_spec(
         },
         log_limits: Default::default(),
         inputs,
+        s3_mounts: Vec::new(),
         staging_mode: StagingMode::Files,
         output_paths: spec
             .file_outputs

--- a/operations/src/jobs/workflow/mod.rs
+++ b/operations/src/jobs/workflow/mod.rs
@@ -4,6 +4,7 @@ pub mod reconcile;
 pub mod run_crate;
 pub mod workspace;
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,14 +12,14 @@ use aruna_compute::ExecutorBackend;
 use aruna_compute::executor::logs::NullSink;
 use aruna_core::compute::{
     AttemptPhase, AttemptRef, AttemptStatus, BackendError, CancelEvidence, ExecutorKind,
-    FenceContext, LogLimits, LogTails, NetworkAccess, ReconcileEvidence, ResourceRequest,
-    SecurityContext, StagingMode, TaskInput, TaskSpec, TombstoneSpec, UserSpec,
+    FenceContext, LogLimits, LogTails, NetworkAccess, ReconcileEvidence, ResourceRequest, S3Mount,
+    Secret, SecurityContext, StagingMode, TaskInput, TaskSpec, TombstoneSpec, UserSpec,
 };
 use aruna_core::events::Event;
 use aruna_core::handle::Handle;
 use aruna_core::structs::{
     AttemptIntent, ExecutionSpec, JobError, JobId, JobPayload, JobRecord, JobResultPayload,
-    OutputObject,
+    OutputObject, WorkspaceMode,
 };
 use aruna_core::task::TaskEvent;
 use aruna_core::types::NodeId;
@@ -39,7 +40,7 @@ use crate::driver::DriverContext;
 use compute::{RecoveryAction, recovery_action};
 use workspace::{
     capture_outputs, collect_outputs, ensure_group_write, ensure_workspace_bucket, load_inputs,
-    merge_outputs, stage_inputs,
+    merge_outputs, mint_input_credential, prepare_mounts, stage_inputs,
 };
 
 /// Fallback walltime when a spec declares none. Enforcement, reconcile
@@ -64,11 +65,10 @@ pub async fn run_execution_job(
     let JobPayload::Execution(mut spec) = record.payload.clone() else {
         return;
     };
-    let bucket = record
-        .workspace_bucket
-        .clone()
-        .unwrap_or_else(|| JobRecord::workspace_bucket_name(job_id));
-    spec.resolve_outputs(&bucket);
+    let bucket = job_bucket(&record);
+    if !bucket.is_empty() {
+        spec.resolve_outputs(&bucket);
+    }
 
     // A fresh cancel before any attempt was submitted: no container exists, so
     // terminalize directly (Claimed -> Cancelled).
@@ -122,9 +122,7 @@ pub async fn run_execution_job(
     tokio::pin!(heartbeat);
 
     let prepare_and_submit = async {
-        let inputs = match prepare_workspace(&context, &spec, &record, node_id, &bucket, token)
-            .await
-        {
+        let prepared = match prepare_task(&context, &spec, &record, node_id, &bucket, token).await {
             Ok(prepared) => prepared,
             Err(error) => {
                 requeue_or_fail_pre_submit(&context, job_id, token, &record, error, false).await;
@@ -160,7 +158,7 @@ pub async fn run_execution_job(
             &spec,
             &attempt,
             &pinned_image,
-            inputs,
+            prepared,
             backend.run_identity(),
         );
 
@@ -351,13 +349,102 @@ async fn prepare_workspace(
     load_inputs(context, spec, record, bucket).await
 }
 
-fn build_task_spec(
+pub(super) struct PreparedTask {
+    inputs: Vec<TaskInput>,
+    mounts: Vec<S3Mount>,
+    secrets: BTreeMap<String, Secret>,
+    staging: StagingMode,
+}
+
+pub(super) fn job_bucket(record: &JobRecord) -> String {
+    match (&record.workspace_bucket, record.workspace_mode) {
+        (Some(bucket), _) => bucket.clone(),
+        (None, WorkspaceMode::None) => String::new(),
+        (None, _) => JobRecord::workspace_bucket_name(record.job_id),
+    }
+}
+
+async fn mounted_task(
+    context: &DriverContext,
+    spec: &ExecutionSpec,
+    record: &JobRecord,
+    node_id: NodeId,
+) -> Result<PreparedTask, JobError> {
+    let mounts = prepare_mounts(context, spec, record, node_id).await?;
+    let mut secrets = BTreeMap::new();
+    if !mounts.is_empty() {
+        let buckets = mounts
+            .iter()
+            .map(|mount| mount.bucket.clone())
+            .collect::<BTreeSet<_>>();
+        let credential = mint_input_credential(context, spec, record, node_id, &buckets).await?;
+        secrets.insert(
+            "access_key_id".to_string(),
+            Secret::new(credential.access_key),
+        );
+        secrets.insert(
+            "secret_access_key".to_string(),
+            Secret::new(credential.secret),
+        );
+    }
+    Ok(PreparedTask {
+        inputs: Vec::new(),
+        mounts,
+        secrets,
+        staging: StagingMode::S3Mount,
+    })
+}
+
+async fn prepare_task(
+    context: &DriverContext,
+    spec: &ExecutionSpec,
+    record: &JobRecord,
+    node_id: NodeId,
+    bucket: &str,
+    token: ulid::Ulid,
+) -> Result<PreparedTask, JobError> {
+    if record.workspace_mode == WorkspaceMode::None {
+        return mounted_task(context, spec, record, node_id).await;
+    }
+    Ok(PreparedTask {
+        inputs: prepare_workspace(context, spec, record, node_id, bucket, token).await?,
+        mounts: Vec::new(),
+        secrets: BTreeMap::new(),
+        staging: StagingMode::Files,
+    })
+}
+
+pub(super) async fn reload_task(
+    context: &DriverContext,
+    spec: &ExecutionSpec,
+    record: &JobRecord,
+    node_id: NodeId,
+    bucket: &str,
+) -> Result<PreparedTask, JobError> {
+    if record.workspace_mode == WorkspaceMode::None {
+        return mounted_task(context, spec, record, node_id).await;
+    }
+    Ok(PreparedTask {
+        inputs: load_inputs(context, spec, record, bucket).await?,
+        mounts: Vec::new(),
+        secrets: BTreeMap::new(),
+        staging: StagingMode::Files,
+    })
+}
+
+pub(super) fn build_task_spec(
     spec: &ExecutionSpec,
     attempt: &AttemptRef,
     pinned_image: &str,
-    inputs: Vec<TaskInput>,
+    prepared: PreparedTask,
     run_as: UserSpec,
 ) -> TaskSpec {
+    let PreparedTask {
+        inputs,
+        mounts,
+        secrets,
+        staging,
+    } = prepared;
     let resources = ResourceRequest {
         cpu_cores: spec.resources.cpu_cores,
         ram_bytes: spec.resources.ram_bytes,
@@ -377,7 +464,7 @@ fn build_task_spec(
         command: spec.command.clone(),
         workdir: spec.workdir.clone(),
         env: spec.env.clone(),
-        secret_env: std::collections::BTreeMap::new(),
+        secret_env: secrets,
         resources,
         workspace: None,
         security: SecurityContext {
@@ -395,8 +482,8 @@ fn build_task_spec(
         },
         log_limits: Default::default(),
         inputs,
-        s3_mounts: Vec::new(),
-        staging_mode: StagingMode::Files,
+        s3_mounts: mounts,
+        staging_mode: staging,
         output_paths: spec
             .file_outputs
             .iter()
@@ -580,7 +667,12 @@ async fn retry_same_submit(
     record: &JobRecord,
     cancel: &CancellationToken,
 ) -> Result<AttemptStatus, BackendError> {
-    let inputs = load_inputs(context, spec, record, bucket)
+    let node_id = context
+        .net_handle
+        .as_ref()
+        .map(|net| net.node_id())
+        .ok_or_else(|| BackendError::Unavailable("execution needs a net handle".to_string()))?;
+    let prepared = reload_task(context, spec, record, node_id, bucket)
         .await
         .map_err(|error| BackendError::Unavailable(error.message))?;
     let pinned_image = record
@@ -593,7 +685,7 @@ async fn retry_same_submit(
         spec,
         &fence.attempt,
         pinned_image,
-        inputs,
+        prepared,
         backend.run_identity(),
     );
     backend.submit(fence, &task_spec, cancel).await
@@ -1369,10 +1461,7 @@ fn execution_result(
     exit_code: Option<i32>,
     outputs: Vec<OutputObject>,
 ) -> JobResultPayload {
-    let bucket = record
-        .workspace_bucket
-        .clone()
-        .unwrap_or_else(|| JobRecord::workspace_bucket_name(record.job_id));
+    let bucket = job_bucket(record);
     execution_result_for(&bucket, exit_code, outputs, LogTails::default())
 }
 
@@ -1384,7 +1473,7 @@ fn execution_result_for(
 ) -> JobResultPayload {
     JobResultPayload::Execution {
         exit_code,
-        workspace_bucket: bucket.to_string(),
+        workspace_bucket: (!bucket.is_empty()).then(|| bucket.to_string()),
         outputs,
         stdout: log_tail(logs.stdout, logs.stdout_truncated),
         stderr: log_tail(logs.stderr, logs.stderr_truncated),
@@ -2044,7 +2133,12 @@ mod tests {
             &execution_spec(),
             &AttemptRef::new("job", 1),
             "alpine@sha256:digest",
-            Vec::new(),
+            PreparedTask {
+                inputs: Vec::new(),
+                mounts: Vec::new(),
+                secrets: BTreeMap::new(),
+                staging: StagingMode::Files,
+            },
             NOBODY,
         );
 
@@ -2065,7 +2159,12 @@ mod tests {
             &execution_spec(),
             &AttemptRef::new("job", 1),
             "alpine@sha256:digest",
-            Vec::new(),
+            PreparedTask {
+                inputs: Vec::new(),
+                mounts: Vec::new(),
+                secrets: BTreeMap::new(),
+                staging: StagingMode::Files,
+            },
             run_as,
         );
 
@@ -2082,7 +2181,12 @@ mod tests {
             &execution,
             &AttemptRef::new("job", 1),
             "alpine@sha256:digest",
-            Vec::new(),
+            PreparedTask {
+                inputs: Vec::new(),
+                mounts: Vec::new(),
+                secrets: BTreeMap::new(),
+                staging: StagingMode::Files,
+            },
             NOBODY,
         );
 

--- a/operations/src/jobs/workflow/reconcile.rs
+++ b/operations/src/jobs/workflow/reconcile.rs
@@ -16,10 +16,10 @@ use super::super::store::{
     read_job_record, record_attempt_started, record_attempt_tombstone, release_job,
     transition_external_to_running,
 };
-use super::workspace::load_inputs;
 use super::{
     DEFAULT_WALLTIME, build_task_spec, fail_and_crate, finalize_attempt, finalize_cancel,
-    requeue_after_tombstone, supervise_and_finalize, with_execution_heartbeat,
+    job_bucket, reload_task, requeue_after_tombstone, supervise_and_finalize,
+    with_execution_heartbeat,
 };
 use crate::driver::DriverContext;
 
@@ -100,11 +100,10 @@ impl ExternalReconciler for ComputeReconciler {
             return;
         };
 
-        let bucket = adopted
-            .workspace_bucket
-            .clone()
-            .unwrap_or_else(|| JobRecord::workspace_bucket_name(job_id));
-        spec.resolve_outputs(&bucket);
+        let bucket = job_bucket(&adopted);
+        if !bucket.is_empty() {
+            spec.resolve_outputs(&bucket);
+        }
         let attempt = AttemptRef::new(job_id.to_string().to_lowercase(), intent.attempt_no);
         let fence = FenceContext {
             attempt: attempt.clone(),
@@ -384,8 +383,19 @@ pub(super) async fn resume_attempt(
             token,
             cancel.clone(),
             async {
-                let inputs = match load_inputs(&context, &spec, &record, &bucket).await {
-                    Ok(inputs) => inputs,
+                let Some(node_id) = context.net_handle.as_ref().map(|net| net.node_id()) else {
+                    fail_or_park(
+                        &context,
+                        job_id,
+                        token,
+                        &record,
+                        JobError::permanent("execution needs a net handle"),
+                    )
+                    .await;
+                    return false;
+                };
+                let prepared = match reload_task(&context, &spec, &record, node_id, &bucket).await {
+                    Ok(prepared) => prepared,
                     Err(error) => {
                         fail_or_park(&context, job_id, token, &record, error).await;
                         return false;
@@ -411,7 +421,7 @@ pub(super) async fn resume_attempt(
                     &spec,
                     &fence.attempt,
                     pinned_image,
-                    inputs,
+                    prepared,
                     backend.run_identity(),
                 );
                 let status = match backend.submit(&fence, &task_spec, &cancel).await {

--- a/operations/src/jobs/workflow/run_crate.rs
+++ b/operations/src/jobs/workflow/run_crate.rs
@@ -6,11 +6,12 @@ use aruna_core::structs::{
 use serde_json::json;
 use ulid::Ulid;
 
-/// Workflow Run RO-Crate "Process Run Crate" profile identifiers (0.5).
+/// Process Run Crate profile identifiers (0.5).
 const CRATE_CONTEXT: &str = "https://w3id.org/ro/crate/1.2/context";
 const WORKFLOW_RUN_CONTEXT: &str = "https://w3id.org/ro/terms/workflow-run/context";
 const CRATE_PROFILE: &str = "https://w3id.org/ro/crate/1.2";
 const PROCESS_PROFILE: &str = "https://w3id.org/ro/wfrun/process/0.5";
+const WORKSPACE_PROPERTY: &str = "https://w3id.org/aruna/terms/workspace-bucket";
 
 use super::super::executor::{JobContext, JobRunOutcome};
 use super::super::store::{put_run_crate_status, read_job_record, read_run_crate_status};
@@ -189,42 +190,54 @@ fn is_transient(error: &MetadataWriteError) -> bool {
     )
 }
 
-/// RO-Crate 1.2 JSON-LD conforming to the Workflow Run RO-Crate "Process Run
-/// Crate" profile: a metadata descriptor, the run `Dataset` (conforming to the
-/// crate and process profiles and mentioning the action), a `CreateAction`
-/// binding agent/instrument/object/result/status/times, the instrument
-/// `SoftwareApplication`, and the input/output `File` entities. No secrets
-/// (spec 16.10).
+/// RO-Crate 1.2 JSON-LD conforming to the Process Run Crate 0.5 profile. No
+/// secrets are included (spec 16.10).
 fn build_run_crate_jsonld(record: &JobRecord, spec: &ExecutionSpec, document_id: Ulid) -> String {
     let root = format!("https://w3id.org/aruna/{document_id}");
     let action_id = format!("#run-{}", record.job_id);
     let agent_id = format!("#agent-{}", record.created_by);
     let software_id = format!("#software-{}", record.job_id);
-    let bucket = super::job_bucket(record);
-    let description = (!bucket.is_empty()).then_some(bucket).map_or_else(
-        || format!("Aruna execution run for job {}", record.job_id),
-        |workspace| {
-            format!(
-                "Aruna execution run for job {} in workspace {}",
-                record.job_id, workspace
-            )
-        },
-    );
+    let container_id = format!("#container-{}", record.job_id);
+    let image = record
+        .attempt_intent
+        .as_ref()
+        .map(|intent| intent.pinned_image.as_str())
+        .unwrap_or(spec.image.as_str());
+    let (repository, pinned_tag, digest) = split_image(image);
+    let (_, submitted_tag, _) = split_image(&spec.image);
+    let (registry, image_name) = split_registry(&repository);
+    let application_name = image_name.rsplit('/').next().unwrap_or(image_name.as_str());
+    let run_name = spec
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Run {application_name}"));
+    let run_description = spec
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|description| !description.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Container execution using {application_name}"));
 
-    let (exit_code, outputs) = match &record.result {
+    let (exit_code, result_workspace, outputs) = match &record.result {
         Some(JobResultPayload::Execution {
-            exit_code, outputs, ..
-        }) => (*exit_code, outputs.clone()),
-        _ => (None, Vec::new()),
+            exit_code,
+            workspace_bucket,
+            outputs,
+            ..
+        }) => (*exit_code, workspace_bucket.clone(), outputs.clone()),
+        _ => (None, None, Vec::new()),
     };
+    let workspace = record.workspace_bucket.clone().or(result_workspace);
     let action_status = if record.state == JobState::Succeeded {
         "http://schema.org/CompletedActionStatus"
     } else {
         "http://schema.org/FailedActionStatus"
     };
-
-    let mut command = spec.entrypoint.clone().unwrap_or_default();
-    command.extend(spec.command.iter().cloned());
+    let command = command_line(spec);
 
     // Inputs are the action `object`, keyed by their S3 source URL.
     let mut object_ids = Vec::with_capacity(spec.inputs.len());
@@ -257,18 +270,37 @@ fn build_run_crate_jsonld(record: &JobRecord, spec: &ExecutionSpec, document_id:
         .map(|id| json!({ "@id": id.clone() }))
         .collect();
 
+    let workspace_property = workspace.as_deref().map(|bucket| {
+        json!({
+            "@id": "#workspace-bucket",
+            "@type": "PropertyValue",
+            "name": "Workspace bucket",
+            "propertyID": WORKSPACE_PROPERTY,
+            "value": bucket
+        })
+    });
+
     let mut action = json!({
         "@id": action_id.clone(),
         "@type": "CreateAction",
-        "name": format!("execution of {}", spec.image),
+        "name": run_name.clone(),
         "agent": {"@id": agent_id.clone()},
         "instrument": {"@id": software_id.clone()},
+        "containerImage": {"@id": container_id.clone()},
         "object": object_ids,
         "result": result_ids,
-        "actionStatus": {"@id": action_status},
-        "command": command
+        "actionStatus": {"@id": action_status}
     });
     if let Some(map) = action.as_object_mut() {
+        if workspace_property.is_some() {
+            map.insert(
+                "additionalProperty".to_string(),
+                json!([{"@id": "#workspace-bucket"}]),
+            );
+        }
+        if !command.is_empty() {
+            map.insert("description".to_string(), json!(command));
+        }
         if let Some(started) = record.started_at_ms {
             map.insert("startTime".to_string(), json!(rfc3339(started)));
         }
@@ -280,17 +312,43 @@ fn build_run_crate_jsonld(record: &JobRecord, spec: &ExecutionSpec, document_id:
         }
     }
 
-    // A digest-pinned image reference is not a valid IRI, so the node keeps a
-    // minted @id and carries the raw reference as `identifier`.
-    let (image_name, image_version) = split_image(&spec.image);
     let mut software = json!({
         "@id": software_id,
         "@type": "SoftwareApplication",
-        "name": image_name,
-        "identifier": spec.image.clone()
+        "name": application_name,
+        "identifier": image
     });
-    if let (Some(map), Some(version)) = (software.as_object_mut(), image_version) {
+    let image_url = image_url(&registry, &image_name);
+    if let Some(map) = software.as_object_mut()
+        && let Some(version) = submitted_tag
+            .as_ref()
+            .or(pinned_tag.as_ref())
+            .or(digest.as_ref())
+    {
         map.insert("softwareVersion".to_string(), json!(version));
+    }
+
+    let mut container = json!({
+        "@id": container_id,
+        "@type": "https://w3id.org/ro/terms/workflow-run#ContainerImage",
+        "additionalType": {"@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"},
+        "identifier": image,
+        "registry": registry,
+        "name": image_name
+    });
+    if let Some(map) = container.as_object_mut() {
+        if let Some(tag) = submitted_tag.as_ref().or(pinned_tag.as_ref()) {
+            map.insert("tag".to_string(), json!(tag));
+        }
+        if let Some(sha256) = digest
+            .as_deref()
+            .and_then(|value| value.strip_prefix("sha256:"))
+        {
+            map.insert("sha256".to_string(), json!(sha256));
+        }
+        if let Some(url) = image_url {
+            map.insert("url".to_string(), json!(url));
+        }
     }
 
     let mut graph = vec![
@@ -303,11 +361,11 @@ fn build_run_crate_jsonld(record: &JobRecord, spec: &ExecutionSpec, document_id:
         json!({
             "@id": root,
             "@type": "Dataset",
-            "name": format!("Run {}", record.job_id),
-            "description": description,
+            "name": run_name,
+            "description": run_description,
             "datePublished": rfc3339(record.created_at_ms),
             "license": {"@id": "https://creativecommons.org/licenses/by/4.0/"},
-            "conformsTo": [{"@id": CRATE_PROFILE}, {"@id": PROCESS_PROFILE}],
+            "conformsTo": {"@id": PROCESS_PROFILE},
             "hasPart": has_part,
             "mentions": {"@id": action_id}
         }),
@@ -318,29 +376,100 @@ fn build_run_crate_jsonld(record: &JobRecord, spec: &ExecutionSpec, document_id:
             "identifier": record.created_by.to_string()
         }),
         software,
+        container,
+        json!({
+            "@id": PROCESS_PROFILE,
+            "@type": ["CreativeWork", "http://www.w3.org/ns/dx/prof/Profile"],
+            "name": "Process Run Crate",
+            "version": "0.5"
+        }),
     ];
     graph.extend(files);
+    if let Some(property) = workspace_property {
+        graph.push(property);
+    }
 
     json!({
-        "@context": [CRATE_CONTEXT, WORKFLOW_RUN_CONTEXT],
+        "@context": [
+            CRATE_CONTEXT,
+            WORKFLOW_RUN_CONTEXT,
+            {
+                "containerImage": "https://w3id.org/ro/terms/workflow-run#containerImage",
+                "registry": "https://w3id.org/ro/terms/workflow-run#registry",
+                "tag": "https://w3id.org/ro/terms/workflow-run#tag",
+                "sha256": "https://w3id.org/ro/terms/workflow-run#sha256"
+            }
+        ],
         "@graph": graph
     })
     .to_string()
 }
 
-/// Split a container image reference into a `SoftwareApplication` name and
-/// optional version: a digest after `@`, otherwise a trailing `:tag` that holds
-/// no path separator (so a `host:port/image` registry prefix is not a version).
-fn split_image(image: &str) -> (String, Option<String>) {
-    if let Some((name, digest)) = image.split_once('@') {
-        return (name.to_string(), Some(digest.to_string()));
+fn command_line(spec: &ExecutionSpec) -> String {
+    spec.entrypoint
+        .iter()
+        .flatten()
+        .chain(spec.command.iter())
+        .map(|argument| quote_argument(argument.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_argument(argument: &str) -> String {
+    if !argument.is_empty()
+        && argument
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"%+,-./:=@_".contains(&byte))
+    {
+        return argument.to_string();
     }
-    if let Some((name, tag)) = image.rsplit_once(':')
+    format!("'{}'", argument.replace('\'', "'\"'\"'"))
+}
+
+fn split_image(image: &str) -> (String, Option<String>, Option<String>) {
+    let (name, digest) = image
+        .split_once('@')
+        .map_or((image, None), |(name, digest)| (name, Some(digest)));
+    if let Some((repository, tag)) = name.rsplit_once(':')
         && !tag.contains('/')
     {
-        return (name.to_string(), Some(tag.to_string()));
+        return (
+            repository.to_string(),
+            Some(tag.to_string()),
+            digest.map(str::to_string),
+        );
     }
-    (image.to_string(), None)
+    (name.to_string(), None, digest.map(str::to_string))
+}
+
+fn split_registry(repository: &str) -> (String, String) {
+    if let Some((registry, name)) = repository.split_once('/')
+        && (registry.contains('.') || registry.contains(':') || registry == "localhost")
+    {
+        return (registry.to_string(), name.to_string());
+    }
+    let name = if repository.contains('/') {
+        repository.to_string()
+    } else {
+        format!("library/{repository}")
+    };
+    ("docker.io".to_string(), name)
+}
+
+fn image_url(registry: &str, name: &str) -> Option<String> {
+    let valid_name = name
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || b"-._/".contains(&byte));
+    if name.is_empty() || !valid_name {
+        return None;
+    }
+    match registry {
+        "docker.io" | "index.docker.io" | "registry-1.docker.io" => {
+            Some(format!("https://hub.docker.com/r/{name}"))
+        }
+        "ghcr.io" => Some(format!("https://ghcr.io/{name}")),
+        _ => None,
+    }
 }
 
 fn rfc3339(ms: u64) -> String {
@@ -353,7 +482,8 @@ fn rfc3339(ms: u64) -> String {
 mod tests {
     use super::*;
     use aruna_core::UserId;
-    use aruna_core::structs::{InputMode, InputSelection, OutputObject, RealmId};
+    use aruna_core::structs::{AttemptIntent, InputMode, InputSelection, OutputObject, RealmId};
+    use serde_json::Value;
 
     fn execution_record() -> (JobRecord, ExecutionSpec) {
         // Succeeded run with one S3 input and one produced output.
@@ -362,12 +492,16 @@ mod tests {
         let node = iroh::SecretKey::from_bytes(&[3; 32]).public();
         let spec = ExecutionSpec {
             group_id: Ulid::from_bytes([4; 16]),
-            name: None,
-            description: None,
+            name: Some("Variant calling".to_string()),
+            description: Some("Call variants for sample one".to_string()),
             tags: Default::default(),
-            image: "busybox:1.36".to_string(),
-            entrypoint: Some(vec!["/bin/sh".to_string()]),
-            command: vec!["-c".to_string(), "true".to_string()],
+            image: "docker.io/aruna/tool:2.0".to_string(),
+            entrypoint: Some(vec!["/usr/bin/python".to_string()]),
+            command: vec![
+                "/work/script.py".to_string(),
+                "--label".to_string(),
+                "sample one".to_string(),
+            ],
             workdir: None,
             env: Default::default(),
             resources: Default::default(),
@@ -381,7 +515,7 @@ mod tests {
                 dest_key: "inputs/in.txt".to_string(),
                 mode: InputMode::Snapshot,
                 container_path: None,
-                name: None,
+                name: Some("Input sample".to_string()),
                 description: None,
             }],
             file_outputs: Vec::new(),
@@ -401,13 +535,21 @@ mod tests {
         record.state = JobState::Succeeded;
         record.started_at_ms = Some(2_000);
         record.finished_at_ms = Some(3_000);
+        record.attempt_intent = Some(AttemptIntent {
+            attempt_no: 2,
+            external_name: "aruna-task-a2".to_string(),
+            executor_kind: "kubernetes".to_string(),
+            pinned_image: format!("docker.io/aruna/tool@sha256:{}", "a".repeat(64)),
+            attempt_epoch: 7,
+        });
+        record.workspace_bucket = Some("workspace-sample-one".to_string());
         record.result = Some(JobResultPayload::Execution {
             exit_code: Some(0),
-            workspace_bucket: Some(JobRecord::workspace_bucket_name(job_id)),
+            workspace_bucket: Some("workspace-sample-one".to_string()),
             outputs: vec![OutputObject {
                 bucket: "src".to_string(),
                 key: "out.txt".to_string(),
-                container_path: "/out.txt".to_string(),
+                container_path: "/work/out.txt".to_string(),
                 size: 7,
                 digest: None,
             }],
@@ -422,27 +564,35 @@ mod tests {
         serde_json::from_str(&build_run_crate_jsonld(record, spec, doc)).unwrap()
     }
 
+    fn entity_id(value: &Value) -> Option<&str> {
+        value
+            .as_str()
+            .or_else(|| value.get("@id").and_then(Value::as_str))
+    }
+
     #[test]
     fn crate_declares_profiles() {
-        // Root Dataset must conform to both the crate and process profiles.
+        // The descriptor declares 1.2; the root declares the exact run profile.
         let (record, spec) = execution_record();
         let value = parse(&record, &spec);
         assert_eq!(value["@context"][0], CRATE_CONTEXT);
         assert_eq!(value["@context"][1], WORKFLOW_RUN_CONTEXT);
+        assert_eq!(
+            value["@context"][2]["containerImage"],
+            "https://w3id.org/ro/terms/workflow-run#containerImage"
+        );
         let graph = value["@graph"].as_array().unwrap();
         let by_id = |id: &str| graph.iter().find(|e| e["@id"] == id).expect("entity");
         let descriptor = by_id("ro-crate-metadata.json");
         assert_eq!(descriptor["conformsTo"]["@id"], CRATE_PROFILE);
         let root_id = descriptor["about"]["@id"].as_str().unwrap().to_string();
         let root = by_id(&root_id);
-        let conforms: Vec<&str> = root["conformsTo"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|c| c["@id"].as_str().unwrap())
-            .collect();
-        assert!(conforms.contains(&CRATE_PROFILE));
-        assert!(conforms.contains(&PROCESS_PROFILE));
+        assert_eq!(root["conformsTo"]["@id"], PROCESS_PROFILE);
+        let profile = by_id(PROCESS_PROFILE);
+        assert_eq!(profile["@type"][0], "CreativeWork");
+        assert_eq!(profile["@type"][1], "http://www.w3.org/ns/dx/prof/Profile");
+        assert_eq!(profile["name"], "Process Run Crate");
+        assert!(!graph.iter().any(|entity| entity["@id"] == CRATE_PROFILE));
         assert_eq!(root["mentions"]["@id"], format!("#run-{}", record.job_id));
     }
 
@@ -454,49 +604,129 @@ mod tests {
         let by_id = |id: &str| graph.iter().find(|e| e["@id"] == id).expect("entity");
         let action = by_id(&format!("#run-{}", record.job_id));
         assert_eq!(action["@type"], "CreateAction");
+        assert_eq!(action["name"], "Variant calling");
+        assert_eq!(
+            action["description"],
+            "/usr/bin/python /work/script.py --label 'sample one'"
+        );
+        assert!(action.get("command").is_none());
         let instrument = action["instrument"]["@id"].as_str().unwrap();
         assert_eq!(instrument, format!("#software-{}", record.job_id));
         let software = by_id(instrument);
         assert_eq!(software["@type"], "SoftwareApplication");
-        assert_eq!(software["name"], "busybox");
-        assert_eq!(software["identifier"], "busybox:1.36");
-        assert_eq!(software["softwareVersion"], "1.36");
+        assert_eq!(software["name"], "tool");
+        assert_eq!(
+            software["identifier"],
+            format!("docker.io/aruna/tool@sha256:{}", "a".repeat(64))
+        );
+        assert_eq!(software["softwareVersion"], "2.0");
+        let container = by_id(action["containerImage"]["@id"].as_str().unwrap());
+        assert_eq!(
+            container["@type"],
+            "https://w3id.org/ro/terms/workflow-run#ContainerImage"
+        );
+        assert_eq!(container["registry"], "docker.io");
+        assert_eq!(container["name"], "aruna/tool");
+        assert_eq!(container["tag"], "2.0");
+        assert_eq!(container["sha256"], "a".repeat(64));
+        assert_eq!(container["url"], "https://hub.docker.com/r/aruna/tool");
+        assert_eq!(
+            image_url("ghcr.io", "astral-sh/uv").as_deref(),
+            Some("https://ghcr.io/astral-sh/uv")
+        );
         assert_eq!(action["object"][0]["@id"], "s3://src/in.txt");
         assert_eq!(action["result"][0]["@id"], "s3://src/out.txt");
         assert_eq!(
             action["actionStatus"]["@id"],
             "http://schema.org/CompletedActionStatus"
         );
-        assert_eq!(action["command"][0], "/bin/sh");
         assert!(action["startTime"].is_string());
         assert!(action["endTime"].is_string());
         let agent = by_id(action["agent"]["@id"].as_str().unwrap());
         assert_eq!(agent["@type"], "Person");
-        assert_eq!(by_id("s3://src/in.txt")["@type"], "File");
-        assert_eq!(by_id("s3://src/out.txt")["contentSize"], "7");
+        let input = by_id("s3://src/in.txt");
+        assert_eq!(input["name"], "Input sample");
+        let output = by_id("s3://src/out.txt");
+        assert_eq!(output["name"], "out.txt");
+        assert_eq!(output["contentSize"], "7");
+        let workspace = by_id("#workspace-bucket");
+        assert_eq!(action["additionalProperty"][0]["@id"], "#workspace-bucket");
+        assert_eq!(workspace["propertyID"], WORKSPACE_PROPERTY);
+        assert_eq!(workspace["value"], "workspace-sample-one");
+        let descriptor = by_id("ro-crate-metadata.json");
+        let root = by_id(descriptor["about"]["@id"].as_str().unwrap());
+        assert_eq!(root["name"], "Variant calling");
+        assert_eq!(root["description"], "Call variants for sample one");
     }
 
     #[test]
-    fn digest_image_id() {
-        // A digest-pinned image keeps a valid @id and carries the raw reference.
-        let (mut record, mut spec) = execution_record();
-        let image =
-            "ubuntu@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        spec.image = image.to_string();
-        record.payload = JobPayload::Execution(spec.clone());
-        let value = parse(&record, &spec);
+    fn crate_survives_roundtrip() {
+        // Storage must retain exact profile and workflow-run terms.
+        let (record, spec) = execution_record();
+        let document_id = Ulid::from_bytes(record.job_id.to_bytes());
+        let root_id = format!("https://w3id.org/aruna/{document_id}");
+        let jsonld = build_run_crate_jsonld(&record, &spec, document_id);
+        let directory = tempfile::tempdir().unwrap();
+        let node = craqle::CraqleNode::open(directory.path()).unwrap();
+        let graph_id = craqle::GraphId::new(&root_id);
+        node.apply_rocrate_document_checked_with_policy(
+            &craqle::AllowAllAuthorizer,
+            graph_id.clone(),
+            &jsonld,
+            craqle::GraphPolicy::default(),
+        )
+        .unwrap();
+
+        let exported = node
+            .export_rocrate(&craqle::AllowAllAuthorizer, &graph_id)
+            .unwrap();
+        let value: Value = serde_json::from_str(&exported).unwrap();
         let graph = value["@graph"].as_array().unwrap();
-        let by_id = |id: &str| graph.iter().find(|e| e["@id"] == id).expect("entity");
-        let action = by_id(&format!("#run-{}", record.job_id));
-        let instrument = action["instrument"]["@id"].as_str().unwrap();
-        assert_eq!(instrument, format!("#software-{}", record.job_id));
-        let software = by_id(instrument);
-        assert_eq!(software["identifier"], image);
-        assert_eq!(software["name"], "ubuntu");
+        let by_id = |id: &str| {
+            graph
+                .iter()
+                .find(|entity| entity["@id"] == id)
+                .expect("entity")
+        };
+        let has_type = |entity: &Value, expected: &str| match &entity["@type"] {
+            Value::String(value) => value == expected,
+            Value::Array(values) => values.iter().any(|value| value == expected),
+            _ => false,
+        };
+        let root = by_id(&root_id);
+        assert_eq!(entity_id(&root["conformsTo"]), Some(PROCESS_PROFILE));
+        let action = graph
+            .iter()
+            .find(|entity| has_type(entity, "CreateAction"))
+            .expect("action");
         assert_eq!(
-            software["softwareVersion"],
-            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            action["description"],
+            "/usr/bin/python /work/script.py --label 'sample one'"
         );
+        assert_eq!(
+            entity_id(&action["additionalProperty"]),
+            Some("#workspace-bucket")
+        );
+        let container = by_id(entity_id(&action["containerImage"]).unwrap());
+        assert!(has_type(
+            container,
+            "https://w3id.org/ro/terms/workflow-run#ContainerImage"
+        ));
+        assert_eq!(container["registry"], "docker.io");
+        assert_eq!(container["sha256"], "a".repeat(64));
+        let profile = by_id(PROCESS_PROFILE);
+        assert!(has_type(profile, "http://www.w3.org/ns/dx/prof/Profile"));
+        assert!(graph.iter().any(|entity| {
+            entity["propertyID"] == WORKSPACE_PROPERTY && entity["value"] == "workspace-sample-one"
+        }));
+    }
+
+    #[test]
+    fn command_quotes_arguments() {
+        let (_, mut spec) = execution_record();
+        spec.entrypoint = Some(vec!["/bin/echo".to_string()]);
+        spec.command = vec![String::new(), "it's ready".to_string()];
+        assert_eq!(command_line(&spec), "/bin/echo '' 'it'\"'\"'s ready'");
     }
 
     #[test]

--- a/operations/src/jobs/workflow/run_crate.rs
+++ b/operations/src/jobs/workflow/run_crate.rs
@@ -200,10 +200,16 @@ fn build_run_crate_jsonld(record: &JobRecord, spec: &ExecutionSpec, document_id:
     let action_id = format!("#run-{}", record.job_id);
     let agent_id = format!("#agent-{}", record.created_by);
     let software_id = format!("#software-{}", record.job_id);
-    let workspace = record
-        .workspace_bucket
-        .clone()
-        .unwrap_or_else(|| JobRecord::workspace_bucket_name(record.job_id));
+    let bucket = super::job_bucket(record);
+    let description = (!bucket.is_empty()).then_some(bucket).map_or_else(
+        || format!("Aruna execution run for job {}", record.job_id),
+        |workspace| {
+            format!(
+                "Aruna execution run for job {} in workspace {}",
+                record.job_id, workspace
+            )
+        },
+    );
 
     let (exit_code, outputs) = match &record.result {
         Some(JobResultPayload::Execution {
@@ -298,10 +304,7 @@ fn build_run_crate_jsonld(record: &JobRecord, spec: &ExecutionSpec, document_id:
             "@id": root,
             "@type": "Dataset",
             "name": format!("Run {}", record.job_id),
-            "description": format!(
-                "Aruna execution run for job {} in workspace {}",
-                record.job_id, workspace
-            ),
+            "description": description,
             "datePublished": rfc3339(record.created_at_ms),
             "license": {"@id": "https://creativecommons.org/licenses/by/4.0/"},
             "conformsTo": [{"@id": CRATE_PROFILE}, {"@id": PROCESS_PROFILE}],
@@ -400,7 +403,7 @@ mod tests {
         record.finished_at_ms = Some(3_000);
         record.result = Some(JobResultPayload::Execution {
             exit_code: Some(0),
-            workspace_bucket: JobRecord::workspace_bucket_name(job_id),
+            workspace_bucket: Some(JobRecord::workspace_bucket_name(job_id)),
             outputs: vec![OutputObject {
                 bucket: "src".to_string(),
                 key: "out.txt".to_string(),

--- a/operations/src/jobs/workflow/workspace.rs
+++ b/operations/src/jobs/workflow/workspace.rs
@@ -1,15 +1,17 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use aruna_compute::ExecutorBackend;
-use aruna_core::compute::{BackendError, FenceContext, MAX_TRANSFER_BYTES, TaskInput};
+use aruna_core::compute::{BackendError, FenceContext, MAX_TRANSFER_BYTES, S3Mount, TaskInput};
 use aruna_core::errors::{AuthorizationError, StorageError};
 use aruna_core::stream::BackendStream;
 use aruna_core::structs::{
-    AuthContext, BackendLocation, BucketInfo, ExecutionSpec, InputSelection, InputSource, JobError,
-    JobRecord, OutputDestination, OutputObject, OutputSelection, PathRestriction, Permission,
-    UserAccess, WorkspaceMode, blob_bucket_permission_path, blob_group_permission_path,
-    blob_object_permission_path, workspace_credential_id,
+    AuthContext, BackendLocation, BucketInfo, ExecutionSpec, InputMode, InputSelection,
+    InputSource, JobError, JobRecord, OutputDestination, OutputObject, OutputSelection,
+    PathRestriction, Permission, UserAccess, WorkspaceMode, blob_bucket_permission_path,
+    blob_group_permission_path, blob_object_permission_path, ensure_confined_relative_path,
+    workspace_credential_id,
 };
 use aruna_core::types::NodeId;
 use futures_util::StreamExt;
@@ -162,6 +164,44 @@ pub async fn mint_workspace_credential(
             permission: Permission::WRITE,
         },
     ];
+    mint_credential(context, spec, record, node_id, restrictions).await
+}
+
+/// Mint one read-only credential restricted to the input buckets mounted by a job.
+pub async fn mint_input_credential(
+    context: &DriverContext,
+    spec: &ExecutionSpec,
+    record: &JobRecord,
+    node_id: NodeId,
+    buckets: &BTreeSet<String>,
+) -> Result<WorkspaceCredential, JobError> {
+    let realm_id = record.created_by.realm_id;
+    let restrictions = buckets
+        .iter()
+        .flat_map(|bucket| {
+            let path = blob_bucket_permission_path(realm_id, spec.group_id, node_id, bucket);
+            [
+                PathRestriction {
+                    pattern: path.clone(),
+                    permission: Permission::READ,
+                },
+                PathRestriction {
+                    pattern: format!("{path}/**"),
+                    permission: Permission::READ,
+                },
+            ]
+        })
+        .collect();
+    mint_credential(context, spec, record, node_id, restrictions).await
+}
+
+async fn mint_credential(
+    context: &DriverContext,
+    spec: &ExecutionSpec,
+    record: &JobRecord,
+    node_id: NodeId,
+    restrictions: Vec<PathRestriction>,
+) -> Result<WorkspaceCredential, JobError> {
     let key_id = workspace_credential_id(record.job_id);
     let access_key =
         UserAccess::build_access_key(&record.created_by, &key_id).map_err(|error| {
@@ -222,6 +262,104 @@ pub async fn mint_workspace_credential(
         access_key: access.access_key,
         secret: access.secret,
     })
+}
+
+/// Validate mounted inputs and resolve the exact S3 objects exposed to the task.
+pub async fn prepare_mounts(
+    context: &DriverContext,
+    spec: &ExecutionSpec,
+    record: &JobRecord,
+    node_id: NodeId,
+) -> Result<Vec<S3Mount>, JobError> {
+    let mut mounts = Vec::with_capacity(spec.inputs.len());
+    for input in &spec.inputs {
+        if input.mode != InputMode::Mount {
+            return Err(JobError::permanent("mounted job contains a snapshot input"));
+        }
+        let InputSource::S3 {
+            bucket,
+            key,
+            version_id,
+        } = &input.source;
+        if version_id.is_some() {
+            return Err(JobError::permanent(
+                "mounted input versions are not supported",
+            ));
+        }
+        ensure_confined_relative_path(Path::new(key))
+            .map_err(|error| JobError::permanent(format!("invalid mounted input key: {error}")))?;
+        let path = input
+            .container_path
+            .clone()
+            .ok_or_else(|| JobError::permanent("mounted input has no container path"))?;
+        let bucket_info = drive(GetBucketInfoOperation::new(bucket.clone()), context)
+            .await
+            .and_then(|result| result.transpose())
+            .map_err(|error| bucket_lookup_error("input", error))?
+            .ok_or_else(|| JobError::permanent(format!("input bucket {bucket} not found")))?;
+        if bucket_info.group_id != spec.group_id {
+            return Err(JobError::permanent(
+                "input bucket is outside the execution group",
+            ));
+        }
+        let allowed = drive(
+            CheckPermissionsOperation::new(CheckPermissionsConfig {
+                auth_context: AuthContext {
+                    user_id: record.created_by,
+                    realm_id: record.created_by.realm_id,
+                    path_restrictions: None,
+                },
+                path: blob_object_permission_path(
+                    record.created_by.realm_id,
+                    spec.group_id,
+                    node_id,
+                    bucket,
+                    key,
+                ),
+                required_permission: Permission::READ,
+            }),
+            context,
+        )
+        .await
+        .map_err(|error| authorization_error("input", error))?;
+        if !allowed {
+            return Err(JobError::permanent(format!(
+                "input {bucket}/{key} access denied"
+            )));
+        }
+        match drive(
+            HeadObjectOperation::new(HeadObjectInput {
+                bucket: bucket.clone(),
+                key: key.clone(),
+                version_id: None,
+            }),
+            context,
+        )
+        .await
+        .and_then(|result| result.transpose())
+        {
+            Ok(Some(_)) => {}
+            Ok(None)
+            | Err(
+                HeadObjectError::NoSuchKey
+                | HeadObjectError::NoSuchVersion
+                | HeadObjectError::DeleteMarker,
+            ) => {
+                return Err(JobError::permanent(format!(
+                    "input {bucket}/{key} not found"
+                )));
+            }
+            Err(error) => {
+                return Err(JobError::retryable(format!("input lookup failed: {error}")));
+            }
+        }
+        mounts.push(S3Mount {
+            bucket: bucket.clone(),
+            key: key.clone(),
+            path,
+        });
+    }
+    Ok(mounts)
 }
 
 /// Snapshot each declared input into the workspace bucket by copying resolved

--- a/operations/src/jobs/workflow/workspace.rs
+++ b/operations/src/jobs/workflow/workspace.rs
@@ -203,10 +203,9 @@ async fn mint_credential(
     restrictions: Vec<PathRestriction>,
 ) -> Result<WorkspaceCredential, JobError> {
     let key_id = workspace_credential_id(record.job_id);
-    let access_key =
-        UserAccess::build_access_key(&record.created_by, &key_id).map_err(|error| {
-            JobError::permanent(format!("workspace credential key failed: {error}"))
-        })?;
+    let access_key = UserAccess::build_access_key(&key_id).map_err(|error| {
+        JobError::permanent(format!("workspace credential key failed: {error}"))
+    })?;
     match drive(GetUserAccessOperation::new(access_key.clone()), context).await {
         Ok(Some(Ok(access))) => {
             let matches_job = access.access_key == access_key

--- a/operations/src/s3/create_user_access.rs
+++ b/operations/src/s3/create_user_access.rs
@@ -87,11 +87,10 @@ impl CreateUserAccessOperation {
 
     fn handle_init(&mut self) -> Effects {
         if let CreateUserAccessState::Init = self.state {
-            let access_key =
-                match UserAccess::build_access_key(&self.config.user_identity, &self.key_id) {
-                    Ok(access_key) => access_key,
-                    Err(err) => return self.handle_error(err.into()),
-                };
+            let access_key = match UserAccess::build_access_key(&self.key_id) {
+                Ok(access_key) => access_key,
+                Err(err) => return self.handle_error(err.into()),
+            };
             let access = UserAccess {
                 access_key: access_key.clone(),
                 user_identity: self.config.user_identity,

--- a/operations/src/s3/get_user_access.rs
+++ b/operations/src/s3/get_user_access.rs
@@ -150,8 +150,7 @@ mod test {
         let storage_handle = storage::FjallStorage::open(temp_root).unwrap();
 
         let user_identity = Default::default();
-        let access_key_id =
-            UserAccess::build_access_key(&user_identity, &Ulid::generate().to_string()).unwrap();
+        let access_key_id = UserAccess::build_access_key(&Ulid::generate().to_string()).unwrap();
         let user_access = UserAccess {
             access_key: access_key_id.clone(),
             user_identity,


### PR DESCRIPTION
## Summary

- add an S3Mount staging mode that mounts task inputs from S3 through a CSI driver instead of copying them into a workspace
- support workspace-free execution jobs and mount TES inputs directly, writing file outputs straight to their destination buckets
- make the mount CSI driver configurable per deployment and skip its readiness probe when it is unset
- fall back to snapshot staging for TES when S3 mounts are unavailable on the node
- use opaque alphanumeric access key ids and reject credentials that do not match them
- consume the Kubernetes exec status so failed staging commands surface as errors
- bump the workspace version to 3.0.0-alpha.41

## Validation

- cargo test --workspace --all-targets
- cargo +nightly fmt --all -- --check
- cargo +nightly clippy --workspace --all-targets -- -D warnings

## References

- #318
