### PR TITLE
fix: preserve portal CORS fallback

### DIFF
--- a/api/src/s3/s3_server.rs
+++ b/api/src/s3/s3_server.rs
@@ -328,34 +328,41 @@ impl Service<Request<Incoming>> for WrappingService {
             if method == Method::OPTIONS
                 && let Some(origin_header) = origin_header.as_ref()
             {
-                if let Some(config) = bucket_cors.as_ref() {
-                    let response = requested_method.as_deref().map_or_else(
-                        build_preflight_forbidden_response,
-                        |requested_method| match match_preflight_rule(
+                let bucket_rule = bucket_cors.as_ref().and_then(|config| {
+                    requested_method.as_deref().and_then(|requested_method| {
+                        match_preflight_rule(
                             config,
                             origin.as_deref().unwrap_or_default(),
                             requested_method,
                             &requested_headers,
-                        ) {
-                            Some(matched_rule) => build_preflight_response(matched_rule),
-                            None => build_preflight_forbidden_response(),
-                        },
-                    );
-                    let code = response.status().as_u16();
-                    emit_request_completed(&span, "s3", code, started);
-                    record_s3_request(&metrics, &method, code, "cors_preflight", started.elapsed());
-                    return Ok(response);
-                }
-
-                let mut response = http::Response::builder()
-                    .status(StatusCode::NO_CONTENT)
-                    .body(s3s::Body::empty())
-                    .expect("static response must build");
-                if let Some(cors_headers) =
+                        )
+                    })
+                });
+                // A stored bucket configuration EXTENDS cross-origin access for
+                // additional origins; the node's own allowlist (its portals)
+                // stays authoritative. Without this fallback a bucket whose
+                // stored rules omit e.g. PUT locks the portal out of every
+                // write on it - including the PutBucketCors call that would
+                // repair the stored rules.
+                let response = if let Some(matched_rule) = bucket_rule {
+                    build_preflight_response(matched_rule)
+                } else if let Some(cors_headers) =
                     cors.s3_preflight_headers(origin_header, requested_headers_value.as_ref())
                 {
+                    let mut response = http::Response::builder()
+                        .status(StatusCode::NO_CONTENT)
+                        .body(s3s::Body::empty())
+                        .expect("static response must build");
                     response.headers_mut().extend(cors_headers);
-                }
+                    response
+                } else if bucket_cors.is_some() {
+                    build_preflight_forbidden_response()
+                } else {
+                    http::Response::builder()
+                        .status(StatusCode::NO_CONTENT)
+                        .body(s3s::Body::empty())
+                        .expect("static response must build")
+                };
                 let code = response.status().as_u16();
                 emit_request_completed(&span, "s3", code, started);
                 record_s3_request(&metrics, &method, code, "cors_preflight", started.elapsed());
@@ -364,13 +371,17 @@ impl Service<Request<Incoming>> for WrappingService {
 
             let mut result = shared.call(s3s_request).instrument(span.clone()).await;
             if let Ok(response) = &mut result {
-                if let Some(config) = bucket_cors.as_ref() {
-                    if let Some(origin) = origin.as_deref()
-                        && let Some(matched_rule) = match_actual_rule(config, origin, &method)
-                    {
-                        inject_actual_cors_headers(response, matched_rule);
-                    }
+                let bucket_rule = bucket_cors.as_ref().and_then(|config| {
+                    origin
+                        .as_deref()
+                        .and_then(|origin| match_actual_rule(config, origin, &method))
+                });
+                if let Some(matched_rule) = bucket_rule {
+                    inject_actual_cors_headers(response, matched_rule);
                 } else {
+                    // Same fallback as the preflight: allowlisted origins keep
+                    // readable responses on buckets whose stored rules do not
+                    // cover this request.
                     cors.apply_s3_response_headers(origin_header.as_ref(), response.headers_mut());
                 }
             }

--- a/aruna/tests/cors.rs
+++ b/aruna/tests/cors.rs
@@ -1,8 +1,12 @@
 mod shared;
 
+use aws_sdk_s3::types::{CorsConfiguration, CorsRule};
 use reqwest::StatusCode;
 use reqwest::header;
-use shared::{TEST_CORS_ORIGIN, TestResult, spawn_full_seed_node, spawn_seed_node};
+use shared::{
+    TEST_CORS_ORIGIN, TestResult, create_bearer_token, create_group_via_http,
+    create_s3_credentials_via_http, s3_client, spawn_full_seed_node, spawn_seed_node,
+};
 
 const DISALLOWED_ORIGIN: &str = "http://evil.test";
 
@@ -148,4 +152,149 @@ async fn s3_preflight_succeeds_unsigned_and_responses_expose_headers() -> TestRe
 
     seed.shutdown().await;
     Ok(())
+}
+
+#[tokio::test]
+async fn s3_bucket_cors_rules_never_lock_out_allowlisted_origins() -> TestResult<()> {
+    let seed = spawn_full_seed_node().await?;
+
+    let result = async {
+        let bearer = create_bearer_token(
+            seed.context.as_ref(),
+            seed.user_id,
+            seed.realm_id,
+            seed.capabilities.clone(),
+        )
+        .await?;
+        let group = create_group_via_http(&seed.base_url, &bearer, "cors-locked").await?;
+        let endpoint = seed
+            .s3
+            .as_ref()
+            .ok_or_else(|| std::io::Error::other("seed node did not start S3 server"))?;
+        let credentials =
+            create_s3_credentials_via_http(&seed.base_url, &bearer, &group.group_id).await?;
+        let s3 = s3_client(endpoint, &credentials);
+
+        let bucket = "cors-locked-bucket";
+        let object_url = format!("{}/{}/profiles/shapes.ttl", endpoint.endpoint_url, bucket);
+        s3.create_bucket().bucket(bucket).send().await?;
+        // A stored read-only rule: the shape older portal versions wrote,
+        // which used to block every browser write on the bucket - including
+        // the PutBucketCors call that would repair it.
+        s3.put_bucket_cors()
+            .bucket(bucket)
+            .cors_configuration(
+                CorsConfiguration::builder()
+                    .cors_rules(
+                        CorsRule::builder()
+                            .allowed_methods("GET")
+                            .allowed_methods("HEAD")
+                            .allowed_origins("*")
+                            .allowed_headers("*")
+                            .build()?,
+                    )
+                    .build()?,
+            )
+            .send()
+            .await?;
+
+        let client = reqwest::Client::new();
+
+        // What the stored rule covers keeps working: public GET preflight
+        // from an arbitrary origin.
+        let public_read = client
+            .request(reqwest::Method::OPTIONS, &object_url)
+            .header(header::ORIGIN, DISALLOWED_ORIGIN)
+            .header("access-control-request-method", "GET")
+            .send()
+            .await?;
+        assert_eq!(public_read.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            public_read
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|value| value.to_str().ok()),
+            Some("*")
+        );
+
+        // A PUT preflight from the node's allowlisted origin is not covered
+        // by the stored rule; it must fall back to the node allowlist instead
+        // of answering 403.
+        let portal_put = client
+            .request(reqwest::Method::OPTIONS, &object_url)
+            .header(header::ORIGIN, TEST_CORS_ORIGIN)
+            .header("access-control-request-method", "PUT")
+            .header("access-control-request-headers", "authorization,x-amz-date")
+            .send()
+            .await?;
+        assert_eq!(portal_put.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            portal_put
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|value| value.to_str().ok()),
+            Some(TEST_CORS_ORIGIN)
+        );
+        assert!(
+            portal_put
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_METHODS)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .contains("PUT")
+        );
+
+        // A foreign origin matches neither the stored rule nor the allowlist.
+        let foreign_put = client
+            .request(reqwest::Method::OPTIONS, &object_url)
+            .header(header::ORIGIN, DISALLOWED_ORIGIN)
+            .header("access-control-request-method", "PUT")
+            .send()
+            .await?;
+        assert_eq!(foreign_put.status(), StatusCode::FORBIDDEN);
+        assert!(
+            foreign_put
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .is_none()
+        );
+
+        // Covered actual requests still answer from the stored rule.
+        let covered_get = client
+            .get(&object_url)
+            .header(header::ORIGIN, TEST_CORS_ORIGIN)
+            .send()
+            .await?;
+        assert_eq!(
+            covered_get
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|value| value.to_str().ok()),
+            Some("*")
+        );
+
+        // Actual responses the stored rule does NOT cover fall back too, so
+        // the allowlisted origin can read error bodies (here: the signature
+        // rejection of an unsigned PUT) instead of an opaque CORS failure.
+        let uncovered_put = client
+            .put(&object_url)
+            .header(header::ORIGIN, TEST_CORS_ORIGIN)
+            .body("x")
+            .send()
+            .await?;
+        assert!(!uncovered_put.status().is_success());
+        assert_eq!(
+            uncovered_put
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|value| value.to_str().ok()),
+            Some(TEST_CORS_ORIGIN)
+        );
+
+        Ok(())
+    }
+    .await;
+
+    seed.shutdown().await;
+    result
 }


### PR DESCRIPTION
## Summary

- fall back to the node CORS allowlist when bucket rules do not match
- cover preflight and actual-response behavior for allowlisted portal origins