### PR TITLE
feat: support S3 object metadata

### DIFF
--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -795,10 +795,18 @@ impl ArunaS3Service {
     fn build_object_response_fields(
         &self,
         location: Option<&aruna_core::structs::BackendLocation>,
+        metadata: Option<&std::collections::HashMap<String, String>>,
         source_metadata: Option<&aruna_core::structs::SourceMetadata>,
         last_refresh: Option<SystemTime>,
         version_created_at: Option<SystemTime>,
     ) -> ObjectResponseFields {
+        let mut response_metadata = metadata.cloned().unwrap_or_default();
+        if let Some(source_headers) = source_metadata
+            .and_then(|metadata| self.source_metadata_headers(metadata, last_refresh))
+        {
+            response_metadata.extend(source_headers);
+        }
+
         ObjectResponseFields {
             content_length: location
                 .map(|location| location.blob_size as i64)
@@ -825,8 +833,7 @@ impl ArunaS3Service {
                 .or_else(|| {
                     source_metadata.and_then(|metadata| metadata.last_modified.map(Into::into))
                 }),
-            metadata: source_metadata
-                .and_then(|metadata| self.source_metadata_headers(metadata, last_refresh)),
+            metadata: (!response_metadata.is_empty()).then_some(response_metadata),
         }
     }
 
@@ -884,6 +891,7 @@ impl ArunaS3Service {
             .map(|object| {
                 let response_fields = self.build_object_response_fields(
                     object.location.as_ref(),
+                    None,
                     object.source_metadata.as_ref(),
                     object.last_refresh,
                     object.version_created_at,
@@ -1538,8 +1546,9 @@ impl S3 for ArunaS3Service {
                 move || headers.read(Clone::clone),
             ));
         }
+        let metadata = req.input.metadata.clone().unwrap_or_default();
         let input = convert_input(req.input)?;
-        let config = PutObjectConfig {
+        let operation = PutObjectOperation::new(PutObjectConfig {
             user_id: user_access.user_identity,
             group_id,
             realm_id: self.realm_id,
@@ -1550,8 +1559,8 @@ impl S3 for ArunaS3Service {
             version_source: None,
             exists: false,
             quota_ceiling,
-        };
-        let operation = PutObjectOperation::new(config);
+        })
+        .with_metadata(metadata);
 
         let result = drive(operation, &self.state)
             .await
@@ -1658,13 +1667,11 @@ impl S3 for ArunaS3Service {
             .as_ref()
             .map(MetadataDirective::as_str)
             == Some(MetadataDirective::REPLACE);
-        if metadata_replace {
-            return Err(s3_error!(
-                NotImplemented,
-                "MetadataDirective=REPLACE is not supported until object metadata is persisted."
-            ));
-        }
-        if source_bucket == dest_bucket && source_key == dest_key && source_version_id.is_none() {
+        if source_bucket == dest_bucket
+            && source_key == dest_key
+            && source_version_id.is_none()
+            && !metadata_replace
+        {
             return Err(s3_error!(
                 InvalidRequest,
                 "This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes."
@@ -1703,6 +1710,7 @@ impl S3 for ArunaS3Service {
                 node_id: self.node_id,
                 quota_ceiling,
                 conditions,
+                metadata: metadata_replace.then(|| req.input.metadata.clone().unwrap_or_default()),
             },
         )
         .await
@@ -1781,7 +1789,8 @@ impl S3 for ArunaS3Service {
                 .unwrap_or(user_access.group_id),
             created_by: user_access.user_identity,
             checksum_hint: checksum_hint.clone(),
-        });
+        })
+        .with_metadata(req.input.metadata.clone().unwrap_or_default());
 
         let result = drive(operation, &self.state)
             .await
@@ -2188,6 +2197,7 @@ impl S3 for ArunaS3Service {
         let reference_refresh = reference_metadata_refresh(response_bucket, response_key, &result);
         let response_fields = self.build_object_response_fields(
             result.location.as_ref(),
+            Some(&result.metadata),
             result.source_metadata.as_ref(),
             result.last_refresh,
             result.version_created_at,
@@ -2318,6 +2328,7 @@ impl S3 for ArunaS3Service {
 
         let response_fields = self.build_object_response_fields(
             result.location.as_ref(),
+            None,
             result.source_metadata.as_ref(),
             None,
             result.version_created_at,
@@ -2455,6 +2466,7 @@ impl S3 for ArunaS3Service {
 
         let response_fields = self.build_object_response_fields(
             result.location.as_ref(),
+            Some(&result.metadata),
             result.source_metadata.as_ref(),
             result.last_refresh,
             result.version_created_at,
@@ -2802,6 +2814,7 @@ impl S3 for ArunaS3Service {
                 } => {
                     let response_fields = self.build_object_response_fields(
                         location.as_ref(),
+                        None,
                         source_metadata.as_ref(),
                         None,
                         Some(created_at),
@@ -4303,7 +4316,7 @@ mod tests {
                 .await
                 .unwrap_err();
             let expected = if allowed {
-                S3ErrorCode::NotImplemented
+                S3ErrorCode::InternalError
             } else {
                 S3ErrorCode::AccessDenied
             };

--- a/aruna-doctor/src/explorer.rs
+++ b/aruna-doctor/src/explorer.rs
@@ -1760,6 +1760,7 @@ mod tests {
             created_at: SystemTime::UNIX_EPOCH,
             status: MultipartUploadStatus::Open,
             checksum_hint: None,
+            metadata: HashMap::new(),
         };
 
         let decoded = decode_entry(

--- a/aruna/tests/s3_copy.rs
+++ b/aruna/tests/s3_copy.rs
@@ -146,29 +146,170 @@ async fn copy_object_with_version_id_source_copies_old_version() -> TestResult<(
 }
 
 #[tokio::test]
-async fn copy_object_metadata_replace_is_rejected_until_metadata_is_persisted() -> TestResult<()> {
+async fn metadata_roundtrip() -> TestResult<()> {
     let (seed, client) = s3_setup("s3-copy-metadata-replace").await?;
 
     let result = async {
         let bucket = "s3-copy-metadata-replace";
+        let mtime = "1753272000.123456789";
+        let md5 = "XUFAKrxLKna5cZ2REBfFkg==";
         client.create_bucket().bucket(bucket).send().await?;
         client
             .put_object()
             .bucket(bucket)
             .key("source.txt")
+            .metadata("mtime", mtime)
+            .metadata("md5chksum", md5)
             .body(ByteStream::from_static(b"metadata replacement source"))
             .send()
             .await?;
 
-        let copy = client
+        let head = client
+            .head_object()
+            .bucket(bucket)
+            .key("source.txt")
+            .send()
+            .await?;
+        assert_eq!(
+            head.metadata()
+                .and_then(|metadata| metadata.get("mtime"))
+                .map(String::as_str),
+            Some(mtime)
+        );
+        assert_eq!(
+            head.metadata()
+                .and_then(|metadata| metadata.get("md5chksum"))
+                .map(String::as_str),
+            Some(md5)
+        );
+
+        let get = client
+            .get_object()
+            .bucket(bucket)
+            .key("source.txt")
+            .send()
+            .await?;
+        assert_eq!(
+            get.metadata()
+                .and_then(|metadata| metadata.get("mtime"))
+                .map(String::as_str),
+            Some(mtime)
+        );
+
+        client
             .copy_object()
             .bucket(bucket)
             .key("dest.txt")
             .copy_source(format!("{bucket}/source.txt"))
-            .metadata_directive(MetadataDirective::Replace)
             .send()
-            .await;
-        assert_eq!(service_error_code(&copy).as_deref(), Some("NotImplemented"));
+            .await?;
+        let copied = client
+            .head_object()
+            .bucket(bucket)
+            .key("dest.txt")
+            .send()
+            .await?;
+        assert_eq!(
+            copied
+                .metadata()
+                .and_then(|metadata| metadata.get("mtime"))
+                .map(String::as_str),
+            Some(mtime)
+        );
+        assert_eq!(
+            copied
+                .metadata()
+                .and_then(|metadata| metadata.get("md5chksum"))
+                .map(String::as_str),
+            Some(md5)
+        );
+
+        let updated_mtime = "1753273000.987654321";
+        client
+            .copy_object()
+            .bucket(bucket)
+            .key("dest.txt")
+            .copy_source(format!("{bucket}/dest.txt"))
+            .metadata_directive(MetadataDirective::Replace)
+            .metadata("mtime", updated_mtime)
+            .send()
+            .await?;
+        let replaced = client
+            .head_object()
+            .bucket(bucket)
+            .key("dest.txt")
+            .send()
+            .await?;
+        assert_eq!(
+            replaced
+                .metadata()
+                .and_then(|metadata| metadata.get("mtime"))
+                .map(String::as_str),
+            Some(updated_mtime)
+        );
+        assert!(
+            replaced
+                .metadata()
+                .is_none_or(|metadata| !metadata.contains_key("md5chksum"))
+        );
+
+        let multipart = client
+            .create_multipart_upload()
+            .bucket(bucket)
+            .key("multipart.txt")
+            .metadata("mtime", mtime)
+            .metadata("md5chksum", md5)
+            .send()
+            .await?;
+        let upload_id = multipart
+            .upload_id()
+            .ok_or_else(|| std::io::Error::other("multipart upload missing upload id"))?;
+        let part = client
+            .upload_part()
+            .bucket(bucket)
+            .key("multipart.txt")
+            .upload_id(upload_id)
+            .part_number(1)
+            .body(ByteStream::from_static(b"multipart metadata"))
+            .send()
+            .await?;
+        client
+            .complete_multipart_upload()
+            .bucket(bucket)
+            .key("multipart.txt")
+            .upload_id(upload_id)
+            .multipart_upload(
+                CompletedMultipartUpload::builder()
+                    .parts(
+                        CompletedPart::builder()
+                            .part_number(1)
+                            .e_tag(part.e_tag().unwrap_or_default())
+                            .build(),
+                    )
+                    .build(),
+            )
+            .send()
+            .await?;
+        let multipart_head = client
+            .head_object()
+            .bucket(bucket)
+            .key("multipart.txt")
+            .send()
+            .await?;
+        assert_eq!(
+            multipart_head
+                .metadata()
+                .and_then(|metadata| metadata.get("mtime"))
+                .map(String::as_str),
+            Some(mtime)
+        );
+        assert_eq!(
+            multipart_head
+                .metadata()
+                .and_then(|metadata| metadata.get("md5chksum"))
+                .map(String::as_str),
+            Some(md5)
+        );
 
         Ok(())
     }

--- a/core/src/structs/blob.rs
+++ b/core/src/structs/blob.rs
@@ -477,6 +477,7 @@ pub struct BlobVersion {
     pub created_at: SystemTime,
     pub created_by: UserId,
     pub state: BlobVersionState,
+    pub metadata: HashMap<String, String>,
 }
 
 impl BlobVersion {
@@ -490,6 +491,7 @@ impl BlobVersion {
             created_at,
             created_by,
             state: BlobVersionState::Materialized { blob_hash, source },
+            metadata: HashMap::new(),
         }
     }
 
@@ -498,6 +500,7 @@ impl BlobVersion {
             created_at,
             created_by,
             state: BlobVersionState::Deleted,
+            metadata: HashMap::new(),
         }
     }
 
@@ -516,7 +519,13 @@ impl BlobVersion {
                 cached_metadata,
                 last_refresh,
             },
+            metadata: HashMap::new(),
         }
+    }
+
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = metadata;
+        self
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, ConversionError> {
@@ -808,7 +817,11 @@ mod tests {
         };
 
         let versions = vec![
-            BlobVersion::materialized([1u8; 32], created_at, created_by, Some(binding.clone())),
+            BlobVersion::materialized([1u8; 32], created_at, created_by, Some(binding.clone()))
+                .with_metadata(HashMap::from([(
+                    "mtime".to_string(),
+                    "1753272000.123456789".to_string(),
+                )])),
             BlobVersion::reference(
                 binding.clone(),
                 reference_metadata,

--- a/core/src/structs/multipart.rs
+++ b/core/src/structs/multipart.rs
@@ -45,6 +45,7 @@ pub struct MultipartUpload {
     pub created_at: SystemTime,
     pub status: MultipartUploadStatus,
     pub checksum_hint: Option<MultipartUploadChecksumHint>,
+    pub metadata: HashMap<String, String>,
 }
 
 impl MultipartUpload {

--- a/operations/src/replication/incoming_version_replication.rs
+++ b/operations/src/replication/incoming_version_replication.rs
@@ -382,7 +382,8 @@ impl IncomingVersionReplicationOperation {
             self.manifest.created_at,
             self.manifest.created_by,
             self.manifest.created_at,
-        ))
+        )
+        .with_metadata(self.manifest.metadata.clone()))
     }
 
     fn incoming_logical_bytes(&self) -> Result<u64, IncomingVersionReplicationError> {
@@ -885,7 +886,8 @@ impl IncomingVersionReplicationOperation {
                             self.manifest.created_at,
                             self.manifest.created_by,
                             self.manifest.source.clone(),
-                        ),
+                        )
+                        .with_metadata(self.manifest.metadata.clone()),
                         Some(hash),
                     )
                 }
@@ -2100,6 +2102,7 @@ mod tests {
             upstream_sources: Vec::new(),
             writer_auth_context: None,
             reference_metadata: None,
+            metadata: HashMap::new(),
         }
     }
 
@@ -2782,6 +2785,10 @@ mod tests {
         let source = make_source_binding();
         let mut manifest = make_manifest(ReplicationItemKind::Materialized);
         manifest.source = Some(source.clone());
+        manifest
+            .metadata
+            .insert("mtime".to_string(), "1753272000.123456789".to_string());
+        let expected_metadata = manifest.metadata.clone();
         manifest.current_version = false;
         let mut op = IncomingVersionReplicationOperation::new(
             Ulid::generate(),
@@ -2800,6 +2807,7 @@ mod tests {
         };
         let version = BlobVersion::from_bytes(value.as_ref()).unwrap();
         assert_eq!(version.source_binding(), Some(&source));
+        assert_eq!(version.metadata, expected_metadata);
     }
 
     #[test]

--- a/operations/src/replication/protocol.rs
+++ b/operations/src/replication/protocol.rs
@@ -33,6 +33,7 @@ pub struct VersionReplicationManifest {
     pub upstream_sources: Vec<ArunaArn>,
     pub writer_auth_context: Option<AuthContext>,
     pub reference_metadata: Option<SourceMetadata>,
+    pub metadata: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -141,9 +142,16 @@ impl VersionReplicationMessage {
         match postcard::from_bytes(payload) {
             Ok(message) => Ok(message),
             Err(postcard::Error::DeserializeUnexpectedEnd) => {
+                let empty_metadata = postcard::to_allocvec(&HashMap::<String, String>::new())?;
+                let mut current = payload.to_vec();
+                current.extend_from_slice(&empty_metadata);
+                if let Ok(message) = postcard::from_bytes(&current) {
+                    return Ok(message);
+                }
                 let reference_none = postcard::to_allocvec(&Option::<SourceMetadata>::None)?;
                 let mut current = payload.to_vec();
                 current.extend_from_slice(&reference_none);
+                current.extend_from_slice(&empty_metadata);
                 if let Ok(message) = postcard::from_bytes(&current) {
                     return Ok(message);
                 }
@@ -151,6 +159,7 @@ impl VersionReplicationMessage {
                 let mut current = payload.to_vec();
                 current.extend_from_slice(&writer_none);
                 current.extend_from_slice(&reference_none);
+                current.extend_from_slice(&empty_metadata);
                 if let Ok(message) = postcard::from_bytes(&current) {
                     return Ok(message);
                 }
@@ -159,6 +168,7 @@ impl VersionReplicationMessage {
                 origin_only.extend_from_slice(&empty_sources);
                 origin_only.extend_from_slice(&writer_none);
                 origin_only.extend_from_slice(&reference_none);
+                origin_only.extend_from_slice(&empty_metadata);
                 if let Ok(message) = postcard::from_bytes(&origin_only) {
                     return Ok(message);
                 }
@@ -167,6 +177,7 @@ impl VersionReplicationMessage {
                 previous.extend_from_slice(&empty_sources);
                 previous.extend_from_slice(&writer_none);
                 previous.extend_from_slice(&reference_none);
+                previous.extend_from_slice(&empty_metadata);
                 if let Ok(message) = postcard::from_bytes(&previous) {
                     return Ok(message);
                 }
@@ -176,6 +187,7 @@ impl VersionReplicationMessage {
                 legacy.extend_from_slice(&empty_sources);
                 legacy.extend_from_slice(&writer_none);
                 legacy.extend_from_slice(&reference_none);
+                legacy.extend_from_slice(&empty_metadata);
                 Ok(postcard::from_bytes(&legacy)?)
             }
             Err(error) => Err(error.into()),
@@ -286,6 +298,7 @@ mod tests {
             upstream_sources: Vec::new(),
             writer_auth_context: None,
             reference_metadata: None,
+            metadata: HashMap::new(),
         }
     }
 
@@ -311,6 +324,9 @@ mod tests {
             last_modified: Some(SystemTime::UNIX_EPOCH),
             source_version: None,
         });
+        manifest
+            .metadata
+            .insert("mtime".to_string(), "1753272000.123456789".to_string());
         let message = VersionReplicationMessage::VersionManifest(manifest);
         let bytes = message.to_bytes().unwrap();
 

--- a/operations/src/replication/version_replication.rs
+++ b/operations/src/replication/version_replication.rs
@@ -25,6 +25,7 @@ use aruna_core::structs::{
 use aruna_core::types::{Effects, GroupId, Key, NodeId};
 use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
+use std::collections::HashMap;
 use std::time::SystemTime;
 use thiserror::Error;
 use tracing::debug;
@@ -71,6 +72,7 @@ enum ReplicationVersion {
         created_by: aruna_core::user_id::UserId,
         location: BackendLocation,
         source: Option<VersionSourceBinding>,
+        metadata: HashMap<String, String>,
     },
     Reference {
         created_at: SystemTime,
@@ -78,6 +80,7 @@ enum ReplicationVersion {
         source: VersionSourceBinding,
         cached_metadata: SourceMetadata,
         last_refresh: SystemTime,
+        metadata: HashMap<String, String>,
     },
     Deleted {
         created_at: SystemTime,
@@ -91,6 +94,7 @@ struct PendingMaterializedReplicationVersion {
     created_by: aruna_core::user_id::UserId,
     blob_hash: [u8; 32],
     source: Option<VersionSourceBinding>,
+    metadata: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1198,6 +1202,7 @@ impl ReplicateObjectVersionOperation {
                     created_at,
                     created_by,
                     source,
+                    metadata,
                     ..
                 } = version
                 else {
@@ -1218,6 +1223,7 @@ impl ReplicateObjectVersionOperation {
                     created_by,
                     location,
                     source: Some(source),
+                    metadata,
                 });
                 self.read_current_lookup()
             }
@@ -1248,19 +1254,20 @@ impl ReplicateObjectVersionOperation {
         let current_version = current_version_pointer.is_some();
         let reference_intent =
             self.sync.as_ref().is_some_and(|sync| sync.reference_intent) || self.preserve_reference;
-        let (kind, created_at, created_by, blob, source, reference_metadata) = match version {
+        let (kind, created_at, created_by, blob, source, reference, metadata) = match version {
             ReplicationVersion::Materialized {
                 created_at,
                 created_by,
                 location,
                 source,
+                metadata,
             } => {
                 if reference_intent {
                     let sync = self
                         .sync
                         .as_ref()
                         .ok_or(ReplicateObjectVersionError::UnresolvedReferenceVersion)?;
-                    let metadata = SourceMetadata {
+                    let reference = SourceMetadata {
                         content_length: location.blob_size,
                         content_type: None,
                         etag: None,
@@ -1273,7 +1280,8 @@ impl ReplicateObjectVersionOperation {
                         created_by,
                         None,
                         Some(self.reference_binding(sync)),
-                        Some(metadata),
+                        Some(reference),
+                        metadata,
                     )
                 } else {
                     let hash = location
@@ -1294,6 +1302,7 @@ impl ReplicateObjectVersionOperation {
                         }),
                         source,
                         None,
+                        metadata,
                     )
                 }
             }
@@ -1307,11 +1316,13 @@ impl ReplicateObjectVersionOperation {
                 None,
                 None,
                 None,
+                HashMap::new(),
             ),
             ReplicationVersion::Reference {
                 created_at,
                 created_by,
                 cached_metadata,
+                metadata,
                 ..
             } => {
                 if !reference_intent {
@@ -1328,6 +1339,7 @@ impl ReplicateObjectVersionOperation {
                     None,
                     Some(self.reference_binding(sync)),
                     Some(cached_metadata),
+                    metadata,
                 )
             }
         };
@@ -1371,7 +1383,8 @@ impl ReplicateObjectVersionOperation {
                 .sync
                 .as_ref()
                 .and_then(|sync| sync.writer_auth_context.clone()),
-            reference_metadata,
+            reference_metadata: reference,
+            metadata,
         });
         if let Some(manifest) = self.manifest.as_ref() {
             debug!(
@@ -1534,6 +1547,7 @@ impl Operation for ReplicateObjectVersionOperation {
                     created_at,
                     created_by,
                     state,
+                    metadata,
                 } = version;
 
                 match state {
@@ -1544,6 +1558,7 @@ impl Operation for ReplicateObjectVersionOperation {
                                 created_by,
                                 blob_hash,
                                 source,
+                                metadata,
                             });
                         self.read_blob_location(blob_hash)
                     }
@@ -1567,6 +1582,7 @@ impl Operation for ReplicateObjectVersionOperation {
                             source,
                             cached_metadata,
                             last_refresh,
+                            metadata,
                         })
                     }
                 }
@@ -1591,6 +1607,7 @@ impl Operation for ReplicateObjectVersionOperation {
                     created_by,
                     blob_hash,
                     source,
+                    metadata,
                 }) = self.pending_materialized_version.take()
                 else {
                     return self.fail(ReplicateObjectVersionError::VersionNotFound);
@@ -1603,6 +1620,7 @@ impl Operation for ReplicateObjectVersionOperation {
                     created_by,
                     location,
                     source,
+                    metadata,
                 });
                 self.read_multipart_summary()
             }
@@ -2418,12 +2436,14 @@ mod tests {
     fn manifest_includes_source_binding_for_materialized_version() {
         let version_id = Ulid::generate();
         let source = reference_source_binding();
+        let metadata = HashMap::from([("mtime".to_string(), "1753272000.123456789".to_string())]);
         let mut op = ReplicateObjectVersionOperation::new(version_request(version_id));
         op.replication_version = Some(ReplicationVersion::Materialized {
             created_at: SystemTime::now(),
             created_by: test_user_id(),
             location: materialized_location(),
             source: Some(source.clone()),
+            metadata: metadata.clone(),
         });
 
         op.build_manifest(None).unwrap();
@@ -2434,6 +2454,7 @@ mod tests {
             aruna_core::structs::ReplicationItemKind::Materialized
         );
         assert_eq!(manifest.source, Some(source));
+        assert_eq!(manifest.metadata, metadata);
     }
 
     #[test]
@@ -2450,6 +2471,7 @@ mod tests {
             created_by: test_user_id(),
             location: location.clone(),
             source: None,
+            metadata: HashMap::new(),
         });
 
         op.build_manifest(None).unwrap();
@@ -2538,6 +2560,7 @@ mod tests {
             source,
             cached_metadata,
             last_refresh,
+            metadata: HashMap::new(),
         });
 
         assert_eq!(

--- a/operations/src/s3/complete_multipart_upload.rs
+++ b/operations/src/s3/complete_multipart_upload.rs
@@ -735,6 +735,10 @@ impl CompleteMultipartUploadOperation {
             .version_created_at
             .get_or_insert_with(SystemTime::now)
             .to_owned();
+        let Some(upload_record) = self.upload_record.as_ref() else {
+            return self
+                .schedule_error(CompleteMultipartUploadError::CompleteMultipartUploadFailed);
+        };
         let version = BlobVersion::materialized(
             match blake3_hash.try_into() {
                 Ok(hash) => hash,
@@ -746,7 +750,8 @@ impl CompleteMultipartUploadOperation {
             created_at,
             self.input.created_by,
             None,
-        );
+        )
+        .with_metadata(upload_record.metadata.clone());
         let version_key = VersionKey::new(&self.input.bucket, &self.input.key, version_id);
         let effect = match write_blob_version_effect(&version_key, &version, self.txn_id) {
             Ok(effect) => effect,
@@ -1414,6 +1419,7 @@ mod tests {
             created_at: SystemTime::now(),
             status: MultipartUploadStatus::Completing,
             checksum_hint: None,
+            metadata: HashMap::new(),
         }
     }
 

--- a/operations/src/s3/copy_object.rs
+++ b/operations/src/s3/copy_object.rs
@@ -5,6 +5,7 @@ use aruna_core::UserId;
 use aruna_core::structs::checksum::HASH_MD5;
 use aruna_core::structs::{BackendLocation, RealmId, StagingStrategy, VersionSourceBinding};
 use aruna_core::types::{GroupId, NodeId};
+use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use ulid::Ulid;
@@ -31,6 +32,7 @@ pub struct CopyObjectInput {
     pub node_id: NodeId,
     pub quota_ceiling: Option<u64>,
     pub conditions: CopySourceConditions,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -174,6 +176,7 @@ pub async fn copy_object(
                 ..binding
             })
     };
+    let metadata = input.metadata.unwrap_or(source.metadata);
 
     let put_result = drive(
         PutObjectOperation::new(PutObjectConfig {
@@ -192,7 +195,8 @@ pub async fn copy_object(
             exists: false,
             version_source,
             quota_ceiling: input.quota_ceiling,
-        }),
+        })
+        .with_metadata(metadata),
         context,
     )
     .await
@@ -416,6 +420,7 @@ mod test {
                 node_id,
                 quota_ceiling: None,
                 conditions: CopySourceConditions::default(),
+                metadata: None,
             },
         )
         .await
@@ -495,6 +500,7 @@ mod test {
                 node_id,
                 quota_ceiling: None,
                 conditions: CopySourceConditions::default(),
+                metadata: None,
             },
         )
         .await
@@ -589,6 +595,7 @@ mod test {
                 node_id,
                 quota_ceiling: None,
                 conditions: CopySourceConditions::default(),
+                metadata: None,
             },
         )
         .await
@@ -751,6 +758,7 @@ mod test {
                     if_none_match: Some("*".to_string()),
                     ..Default::default()
                 },
+                metadata: None,
             },
         )
         .await

--- a/operations/src/s3/create_multipart_upload.rs
+++ b/operations/src/s3/create_multipart_upload.rs
@@ -6,6 +6,7 @@ use aruna_core::operation::Operation;
 use aruna_core::structs::{MultipartUpload, MultipartUploadChecksumHint, MultipartUploadStatus};
 use aruna_core::types::{Effects, GroupId, TxnId, UserId};
 use smallvec::smallvec;
+use std::collections::HashMap;
 use std::time::SystemTime;
 use thiserror::Error;
 use ulid::Ulid;
@@ -58,6 +59,7 @@ pub struct CreateMultipartUploadOperation {
     state: CreateMultipartUploadState,
     txn_id: Option<TxnId>,
     record: Option<MultipartUpload>,
+    metadata: HashMap<String, String>,
     output: Option<Result<CreateMultipartUploadResult, CreateMultipartUploadError>>,
 }
 
@@ -68,8 +70,14 @@ impl CreateMultipartUploadOperation {
             state: CreateMultipartUploadState::Init,
             txn_id: None,
             record: None,
+            metadata: HashMap::new(),
             output: None,
         }
+    }
+
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = metadata;
+        self
     }
 
     fn emit_error(&mut self, error: CreateMultipartUploadError) -> Effects {
@@ -103,6 +111,7 @@ impl CreateMultipartUploadOperation {
             created_at: SystemTime::now(),
             status: MultipartUploadStatus::Open,
             checksum_hint: self.input.checksum_hint.clone(),
+            metadata: self.metadata.clone(),
         };
         let value = match record.to_bytes() {
             Ok(value) => value,

--- a/operations/src/s3/get_object.rs
+++ b/operations/src/s3/get_object.rs
@@ -144,6 +144,7 @@ pub struct GetObjectInput {
 pub struct GetObjectResult {
     pub blob: BackendStream<Result<Bytes, StreamError>>,
     pub location: Option<BackendLocation>,
+    pub metadata: HashMap<String, String>,
     pub source_metadata: Option<SourceMetadata>,
     pub source_binding: Option<VersionSourceBinding>,
     pub last_refresh: Option<SystemTime>,
@@ -164,6 +165,7 @@ pub struct GetObjectOperation {
     location: Option<BackendLocation>,
     reference_access: Option<ResolvedSourceAccess>,
     reference_stream: Option<BackendStream<Result<Bytes, StreamError>>>,
+    metadata: HashMap<String, String>,
     source_metadata: Option<SourceMetadata>,
     source_binding: Option<VersionSourceBinding>,
     last_refresh: Option<SystemTime>,
@@ -185,6 +187,7 @@ impl GetObjectOperation {
             location: None,
             reference_access: None,
             reference_stream: None,
+            metadata: HashMap::new(),
             source_metadata: None,
             source_binding: None,
             last_refresh: None,
@@ -326,6 +329,7 @@ impl GetObjectOperation {
         explicit_version_request: bool,
     ) -> Effects {
         self.resolved_version_id = Some(version_id);
+        self.metadata = version.metadata.clone();
 
         match version.state {
             BlobVersionState::Materialized { blob_hash, source } => {
@@ -573,6 +577,7 @@ impl GetObjectOperation {
             self.output = Some(Ok(GetObjectResult {
                 blob,
                 location: Some(location),
+                metadata: self.metadata.clone(),
                 source_metadata: None,
                 source_binding: self.source_binding.clone(),
                 last_refresh: None,
@@ -632,6 +637,7 @@ impl GetObjectOperation {
         self.output = Some(Ok(GetObjectResult {
             blob,
             location: None,
+            metadata: self.metadata.clone(),
             source_metadata: Some(source_metadata),
             source_binding: self.source_binding.clone(),
             last_refresh: self.last_refresh,

--- a/operations/src/s3/head_object.rs
+++ b/operations/src/s3/head_object.rs
@@ -81,6 +81,7 @@ pub struct HeadObjectInput {
 #[derive(Debug, Clone, PartialEq)]
 pub struct HeadObjectResult {
     pub location: Option<BackendLocation>,
+    pub metadata: HashMap<String, String>,
     pub source_metadata: Option<SourceMetadata>,
     pub last_refresh: Option<SystemTime>,
     pub version_created_at: Option<SystemTime>,
@@ -97,6 +98,7 @@ pub struct HeadObjectOperation {
     state: HeadObjectState,
     txn_id: Option<Ulid>,
     location: Option<BackendLocation>,
+    metadata: HashMap<String, String>,
     source_metadata: Option<SourceMetadata>,
     last_refresh: Option<SystemTime>,
     version_created_at: Option<SystemTime>,
@@ -115,6 +117,7 @@ impl HeadObjectOperation {
             state: HeadObjectState::Init,
             txn_id: None,
             location: None,
+            metadata: HashMap::new(),
             source_metadata: None,
             last_refresh: None,
             version_created_at: None,
@@ -254,6 +257,7 @@ impl HeadObjectOperation {
         explicit_version_request: bool,
     ) -> Effects {
         self.resolved_version_id = Some(version_id);
+        self.metadata = version.metadata.clone();
 
         match version.state {
             BlobVersionState::Materialized { blob_hash, .. } => {
@@ -384,6 +388,7 @@ impl HeadObjectOperation {
         self.state = HeadObjectState::CommitTransaction;
         self.output = Some(Ok(HeadObjectResult {
             location: self.location.clone(),
+            metadata: self.metadata.clone(),
             source_metadata: self.source_metadata.clone(),
             last_refresh: self.last_refresh,
             version_created_at: self.version_created_at,
@@ -444,6 +449,7 @@ impl HeadObjectOperation {
                 self.state = HeadObjectState::Finish;
                 self.output = Some(Ok(HeadObjectResult {
                     location: None,
+                    metadata: self.metadata.clone(),
                     source_metadata: self.source_metadata.clone(),
                     last_refresh: self.last_refresh,
                     version_created_at: None,

--- a/operations/src/s3/list_multipart_uploads.rs
+++ b/operations/src/s3/list_multipart_uploads.rs
@@ -388,6 +388,7 @@ mod test {
             created_at,
             status: MultipartUploadStatus::Open,
             checksum_hint: None,
+            metadata: Default::default(),
         }
     }
 

--- a/operations/src/s3/list_parts.rs
+++ b/operations/src/s3/list_parts.rs
@@ -325,6 +325,7 @@ mod test {
             created_at: SystemTime::UNIX_EPOCH,
             status: MultipartUploadStatus::Open,
             checksum_hint: None,
+            metadata: HashMap::new(),
         }
     }
 

--- a/operations/src/s3/put_object.rs
+++ b/operations/src/s3/put_object.rs
@@ -23,6 +23,7 @@ use aruna_core::structs::{
 use aruna_core::types::{Effects, GroupId, NodeId, UserId};
 use bytes::Bytes;
 use smallvec::smallvec;
+use std::collections::HashMap;
 use std::time::{Duration, UNIX_EPOCH};
 use thiserror::Error;
 use ulid::Ulid;
@@ -135,6 +136,7 @@ pub struct PutObjectOperation {
     pending_error: Option<PutObjectError>,
     output: Option<Result<BackendLocation, PutObjectError>>,
     expected_bucket: Option<BucketInfo>,
+    metadata: HashMap<String, String>,
 }
 
 impl PutObjectOperation {
@@ -154,11 +156,17 @@ impl PutObjectOperation {
             pending_error: None,
             output: None,
             expected_bucket: None,
+            metadata: HashMap::new(),
         }
     }
 
     pub fn with_bucket_guard(mut self, bucket: BucketInfo) -> Self {
         self.expected_bucket = Some(bucket);
+        self
+    }
+
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = metadata;
         self
     }
 
@@ -488,7 +496,8 @@ impl PutObjectOperation {
                 version_created_at,
                 output.created_by,
                 self.config.version_source.clone(),
-            );
+            )
+            .with_metadata(self.metadata.clone());
             let version_key = VersionKey::new(
                 self.config.request.bucket.clone(),
                 self.config.request.key.clone(),

--- a/operations/src/s3/refresh_reference_metadata.rs
+++ b/operations/src/s3/refresh_reference_metadata.rs
@@ -336,6 +336,7 @@ pub async fn refresh_reference_metadata_with_context(
                 created_at,
                 created_by,
                 state,
+                metadata,
             } = version;
             let BlobVersionState::Reference {
                 source,
@@ -357,6 +358,7 @@ pub async fn refresh_reference_metadata_with_context(
                         created_by,
                         refresh.refreshed_at,
                     )
+                    .with_metadata(metadata)
                     .to_bytes()
                     {
                         Ok(value) => value,
@@ -943,7 +945,11 @@ mod tests {
             SystemTime::UNIX_EPOCH,
             test.created_by,
             last_refresh,
-        );
+        )
+        .with_metadata(std::collections::HashMap::from([(
+            "mtime".to_string(),
+            "1753272000.123456789".to_string(),
+        )]));
         match test
             .context
             .storage_handle
@@ -986,6 +992,10 @@ mod tests {
             panic!("unexpected version read event");
         };
         let version = BlobVersion::from_bytes(value.as_ref()).unwrap();
+        assert_eq!(
+            version.metadata.get("mtime").map(String::as_str),
+            Some("1753272000.123456789")
+        );
         let BlobVersionState::Reference {
             cached_metadata,
             last_refresh,

--- a/operations/src/s3/upload_part_copy.rs
+++ b/operations/src/s3/upload_part_copy.rs
@@ -284,6 +284,7 @@ mod test {
             created_at: SystemTime::now(),
             status: MultipartUploadStatus::Open,
             checksum_hint: None,
+            metadata: HashMap::new(),
         };
         let event = context
             .storage_handle


### PR DESCRIPTION
## Summary

- persist arbitrary S3 user metadata per object version and multipart upload
- return metadata on GET and HEAD, preserving or replacing it through COPY semantics
- preserve metadata across replication and reference metadata refresh
- cover rclone-compatible `mtime` and `md5chksum` metadata round trips