### PR TITLE
fix: converge metadata ingest under sync storms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+      # The official action builds a container from Docker Hub, whose rate
+      # limited pulls time out on hosted runners; install the binary instead.
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
-          command: check
+          tool: cargo-deny@0.20.2
+
+      - name: Run cargo-deny
+        run: cargo deny check
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,13 +206,13 @@ dependencies = [
  "aruna-tasks",
  "aws-sdk-s3",
  "axum",
- "base64",
+ "base64 0.23.0",
  "blake3",
  "byteview",
  "chrono",
  "crypto_box",
  "dotenvy",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek 3.0.0",
  "flate2",
  "hex",
  "iroh",
@@ -230,7 +230,7 @@ dependencies = [
  "sha2 0.11.0",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -252,13 +252,13 @@ dependencies = [
  "aruna-tasks",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.23.0",
  "blake3",
  "bytes",
  "byteview",
  "chrono",
  "crypto_box",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek 3.0.0",
  "futures-core",
  "futures-util",
  "hex",
@@ -277,7 +277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tower-http 0.7.0",
@@ -314,7 +314,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -342,7 +342,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tower",
@@ -364,13 +364,14 @@ name = "aruna-core"
 version = "3.0.0-alpha.41"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "blake3",
  "bytes",
  "byteview",
  "craqle",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek 3.0.0",
  "futures",
+ "getrandom 0.4.3",
  "globset",
  "hex",
  "iroh",
@@ -384,7 +385,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "ulid 3.0.0",
@@ -406,7 +407,7 @@ dependencies = [
  "aruna-tasks",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.23.0",
  "blake3",
  "bytes",
  "byteview",
@@ -414,7 +415,7 @@ dependencies = [
  "clap",
  "craqle",
  "dotenvy",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek 3.0.0",
  "fjall",
  "hex",
  "iroh",
@@ -424,7 +425,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "ulid 3.0.0",
@@ -455,7 +456,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -477,13 +478,13 @@ dependencies = [
  "async-compression",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.23.0",
  "blake3",
  "bytes",
  "byteview",
  "chrono",
  "craqle",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek 3.0.0",
  "fjall",
  "futures-util",
  "globset",
@@ -506,7 +507,7 @@ dependencies = [
  "spargebra",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -528,7 +529,7 @@ dependencies = [
  "crossfire",
  "fjall",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "ulid 3.0.0",
@@ -555,7 +556,7 @@ dependencies = [
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
 ]
@@ -722,13 +723,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -781,7 +782,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http 1.4.2",
  "log",
  "url",
@@ -795,9 +796,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47712fde1909402600ccfbb26e47d482d2e58bb9e9e603d9f17e67cc435a6319"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -856,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -884,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.138.1"
+version = "1.140.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa59420755799fec8aac71f562aa37ba82263f5b1926bba8b5d3465d2f7a73f"
+checksum = "e9660cf991e512fbe6094f1041ff3d3282bc5aeeeb6184e8de437ec2de024a10"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -921,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.108.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c72b08911d8128dd360fe1b22a9fec0fa8b552dde8ec828dcf20ef5ec974e9f"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1080,19 +1081,22 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd22a6ba36e3f113cb8d5b3d1fe0ed31c76ee608ef63322d753bb8d2c9479e77"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
+ "aws-smithy-xml",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1116,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1182,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3f68eec3607f02acd24067969ce2abc6ba16aa7d5ce59ca450ed2fb5f78957"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -1194,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1322,6 +1326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,7 +1453,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -1466,7 +1476,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1501,7 +1511,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1574,9 +1584,9 @@ checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1646,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1668,14 +1678,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1705,7 +1715,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1859,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "craqle"
 version = "0.1.1"
-source = "git+https://github.com/arunaengine/craqle?branch=main#4015ae493ca4d3ace613fa193e15e69a2cefc226"
+source = "git+https://github.com/arunaengine/craqle?branch=main#115b7db566e27c09bd193cbfe80485528e2efd1f"
 dependencies = [
  "blake3",
  "chrono",
@@ -1875,7 +1885,7 @@ dependencies = [
  "spareval",
  "spargebra",
  "tantivy",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "uuid",
 ]
@@ -2031,6 +2041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2064,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
+checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -2108,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -2137,36 +2148,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2184,22 +2171,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.119",
 ]
@@ -2278,7 +2254,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2320,37 +2296,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.119",
 ]
 
@@ -2516,7 +2461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
- "serde",
  "signature 2.2.0",
 ]
 
@@ -2539,7 +2483,6 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519 2.2.3",
- "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
  "subtle",
@@ -2548,11 +2491,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 5.0.0-rc.0",
+ "curve25519-dalek 5.0.0",
  "ed25519 3.0.0",
  "rand_core 0.10.1",
  "serde",
@@ -2576,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -2760,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -3176,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.3"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -3334,7 +3277,7 @@ dependencies = [
  "jni 0.22.4",
  "rand 0.10.2",
  "rustls",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -3356,7 +3299,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "url",
@@ -3384,7 +3327,7 @@ dependencies = [
  "rustls",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -3527,9 +3470,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3549,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-named-pipe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
 dependencies = [
  "hex",
  "hyper",
@@ -3559,7 +3502,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
- "winapi",
 ]
 
 [[package]]
@@ -3598,7 +3540,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3861,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
+checksum = "460de6bc52163b41b1646931f2897e5ab986f0966ade444467fec25024751a72"
 dependencies = [
  "backon",
  "blake3",
@@ -3872,7 +3814,7 @@ dependencies = [
  "ctutils",
  "data-encoding",
  "derive_more",
- "ed25519-dalek 3.0.0-rc.0",
+ "ed25519-dalek 3.0.0",
  "futures-util",
  "getrandom 0.4.3",
  "hickory-resolver",
@@ -3912,15 +3854,15 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d"
+checksum = "6be73e16ee21c923aca9b3121aaa0db936f7c7ecc156ff47b8dac944c68d59a8"
 dependencies = [
- "curve25519-dalek 5.0.0-rc.0",
+ "curve25519-dalek 5.0.0",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "ed25519-dalek 3.0.0-rc.0",
+ "ed25519-dalek 3.0.0",
  "getrandom 0.4.3",
  "n0-error",
  "rand 0.10.2",
@@ -3931,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a"
+checksum = "46f6a9b39d18e6345f5c151afd299f2488e2cb5c520fe41b107b6bd3dc4c3349"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3995,9 +3937,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354"
+checksum = "24bd586cf927f7b700f56ec3639b53cb5fa901ce284784051ff71092bfbf8193"
 dependencies = [
  "blake3",
  "bytes",
@@ -4034,19 +3976,18 @@ dependencies = [
  "tokio-websockets",
  "tracing",
  "url",
- "vergen-gitcl",
  "webpki-roots 1.0.9",
  "ws_stream_wasm",
 ]
 
 [[package]]
 name = "irokle"
-version = "0.1.2"
-source = "git+https://github.com/arunaengine/irokle.git?branch=main#35865f5985aef3552936d9569a6d6bd2891d4ce5"
+version = "0.1.3"
+source = "git+https://github.com/arunaengine/irokle.git?branch=main#5d0e0393c3de8f6d3294bb3483165c5e31060b11"
 dependencies = [
  "blake3",
  "bytes",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek 3.0.0",
  "fjall",
  "getrandom 0.4.3",
  "iroh",
@@ -4054,7 +3995,7 @@ dependencies = [
  "postcard",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4062,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "irokle-derive"
 version = "0.1.0"
-source = "git+https://github.com/arunaengine/irokle.git?branch=main#35865f5985aef3552936d9569a6d6bd2891d4ce5"
+source = "git+https://github.com/arunaengine/irokle.git?branch=main#5d0e0393c3de8f6d3294bb3483165c5e31060b11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4092,11 +4033,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "js-sys",
@@ -4109,11 +4051,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4162,7 +4114,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -4244,20 +4196,20 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4222e00941bfe18bf81b79fa23ad933e233bfa18f3ee27254c5dd9b1543b5d5f"
+checksum = "a2dbe0623574defe58ba113596c848797f131727e8f54d4b4d10793e1fe14d40"
 dependencies = [
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4272,11 +4224,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac 0.12.1",
@@ -4300,7 +4252,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "jiff",
  "serde",
  "serde_json",
@@ -4308,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb9108095346a7096d11feeaff419c75dddcac1b2f59acb38d7bf3d13c3e146"
+checksum = "208d7fe1380066abb194812a8a8e303cb896a33bb3d7b3177b71bd03ff39bf18"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -4320,11 +4272,11 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f628e05bc2264c21fe10d3d675117dc9b43ea3bf4fb07262a222679757537b"
+checksum = "31e940a73033a7c5c7918b5ece7851d84571b58be25e937198da37fa13f116d3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "either",
  "futures",
@@ -4341,11 +4293,12 @@ dependencies = [
  "kube-core",
  "pem",
  "rustls",
+ "rustls-platform-verifier",
  "secrecy",
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -4356,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b02f5933ba06140d58c7d6727f6c319f0962ec6a344aa5e21e475e891deaa8"
+checksum = "a9d2353c118cf3462c352ee0b5bd5b0cf17990af456dfd8662d136ff9812eeb4"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -4369,14 +4322,14 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ddec66c540c7cf29a5b41fe4a657a53687f95c346e03bdf00585b70a1bab21"
+checksum = "3eb064ef71c7bea55e934a443960da9e9ec31fbb2ba63e47e4aeca32603d5cc7"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -4393,7 +4346,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4448,9 +4401,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -4482,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
+checksum = "8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1"
 
 [[package]]
 name = "linktime-proc-macro"
@@ -4845,16 +4798,17 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+checksum = "e6f7398dddf5f152d2a91a2921a134c6097056e292c0d4b9906007855e7cece6"
 dependencies = [
  "bytes",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4946,9 +4900,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89"
+checksum = "e11803df44ac03a30988d61585ea50885d5428e42da944fe1e498799da7886a2"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4959,7 +4913,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4968,9 +4922,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3"
+checksum = "334c3c9833f7b2c573cceb9896ddc7aaeb58c8807cbb63211b24d1fe88bf866e"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -4987,7 +4941,7 @@ dependencies = [
  "rustls-pki-types",
  "slab",
  "sorted-index-buffer",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4995,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
+checksum = "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5105,15 +5059,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -5286,7 +5231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f8607c90e2c963a91467f50fb49fbc7fb3d573f88cea219ca59ccd3740b309"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "http 1.4.2",
@@ -5413,7 +5358,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "313d46c9f5ae70bca26b7c3e3fbb9b639292625f28af73aa016f47e788af9deb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc32c",
  "http 1.4.2",
@@ -5460,7 +5405,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5474,7 +5419,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tonic-types",
@@ -5506,7 +5451,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -5585,7 +5530,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "ryu-js",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5599,7 +5544,7 @@ dependencies = [
  "oxsdatatypes",
  "rand 0.9.5",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5612,7 +5557,7 @@ dependencies = [
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5625,7 +5570,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5634,7 +5579,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5647,7 +5592,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5754,7 +5699,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -5784,9 +5729,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5794,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5804,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5817,9 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -5936,7 +5881,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap",
  "quick-xml 0.41.0",
  "serde",
@@ -6010,7 +5955,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "derive_more",
  "hyper-util",
@@ -6165,9 +6110,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -6305,7 +6250,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -6328,7 +6273,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6350,9 +6295,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -6521,7 +6466,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6541,7 +6486,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6608,7 +6553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514a1e0b4aa288652a3fdbda4f0a610f379cdf5374e55a37c9edd03d57ed856b"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures",
@@ -6640,7 +6585,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -6719,7 +6664,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
  "uuid",
  "walkdir",
@@ -6865,9 +6810,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6983,7 +6928,7 @@ dependencies = [
  "std-next",
  "subtle",
  "sync_wrapper",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tower",
@@ -7109,9 +7054,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7119,19 +7064,19 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.27"
+version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
  "nohash-hasher",
  "num-traits",
- "serde",
+ "serde_core",
  "smallvec",
  "zmij",
 ]
@@ -7158,29 +7103,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -7208,7 +7153,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7334,6 +7279,9 @@ name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -7374,7 +7322,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -7428,7 +7376,7 @@ dependencies = [
  "memchr",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7451,7 +7399,7 @@ dependencies = [
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7465,7 +7413,7 @@ dependencies = [
  "oxrdf",
  "peg",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7544,7 +7492,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -7566,7 +7514,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7619,7 +7567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi 2.0.0",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "bytes",
@@ -7649,7 +7597,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "whoami",
 ]
@@ -7661,7 +7609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi 2.0.0",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "crc",
@@ -7686,7 +7634,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "whoami",
 ]
@@ -7710,7 +7658,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -7728,7 +7676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04082e93ed1a06debd9148c928234b46d2cf260bc65f44e1d1d3fa594c5beebc"
 dependencies = [
  "simdutf8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7790,7 +7738,7 @@ dependencies = [
  "log",
  "pin-project",
  "rustls-pki-types",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7817,9 +7765,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7906,7 +7854,7 @@ checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -7944,7 +7892,7 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "typetag",
  "uuid",
@@ -8064,7 +8012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8081,11 +8029,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -8101,13 +8049,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8121,15 +8069,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -8144,9 +8090,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8188,9 +8134,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -8227,9 +8173,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8251,15 +8197,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -8271,7 +8218,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -8325,7 +8272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http 1.4.2",
  "http-body 1.1.0",
@@ -8391,7 +8338,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "bytes",
  "futures-util",
@@ -8561,14 +8508,14 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1 0.10.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typed-path"
@@ -8609,7 +8556,7 @@ checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8781,7 +8728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -8812,9 +8759,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd4ec1eb1d240636e354a30110a1dfcb37047169a4d9bd6d9d3469df574b5c4"
+checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
 
 [[package]]
 name = "varint-rs"
@@ -8827,43 +8774,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
-]
 
 [[package]]
 name = "version_check"
@@ -9457,7 +9367,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "windows",
  "windows-core",
 ]
@@ -9481,7 +9391,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -9520,9 +9430,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"
@@ -9549,18 +9459,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "craqle"
 version = "0.1.1"
-source = "git+https://github.com/arunaengine/craqle?branch=main#115b7db566e27c09bd193cbfe80485528e2efd1f"
+source = "git+https://github.com/arunaengine/craqle?branch=main#cce50b5e2c213bc14470593aa5a3a02cfc0477fd"
 dependencies = [
  "blake3",
  "chrono",
@@ -6526,9 +6526,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqsign-aws-v4"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9e1168fab3883ec6afed1c2e20c25b2a09f366cdb662ac3e0878ae0332d63e"
+checksum = "cc883bc56889f3e4a419265c87facea222a921debc5c6f15c7fd8b68ec4b36b2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6548,14 +6548,13 @@ dependencies = [
 
 [[package]]
 name = "reqsign-core"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514a1e0b4aa288652a3fdbda4f0a610f379cdf5374e55a37c9edd03d57ed856b"
+checksum = "7e38b44697c60a823705ccef85cb04d8e0527c9d16ed7c58bf1c6395bdd24ceb"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytes",
- "form_urlencoded",
  "futures",
  "hex",
  "hmac 0.13.0",
@@ -6570,9 +6569,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-file-read-tokio"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b472a8d1f2e5a4be8ce13bb7bdf4b59e9bee613ce124aca23959ddb42176b39"
+checksum = "688ff0ae421b8d4b92b53fdafaf53df2de28f428a9962edcf21702990b26f74b"
 dependencies = [
  "anyhow",
  "reqsign-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,3 +191,4 @@ zip = { version = "8.6.0", default-features = false }
 
 [profile.release]
 panic = "abort"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ version = "3.0.0-alpha.41"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/arunaengine/aruna"
-rust-version = "1.95.0"
+rust-version = "1.97.1"
 
 [workspace.dependencies]
 # Workspace crates
@@ -41,16 +41,16 @@ async-compression = { version = "0.4.42", default-features = false, features = [
     "tokio",
     "deflate",
 ] }
-async-trait = "0.1.89"
+async-trait = "0.1.91"
 async_zip = { package = "astral_async_zip", version = "0.0.20", features = [
     "tokio",
     "deflate",
 ] }
-aws-config = { version = "1.9.0", default-features = false, features = [
+aws-config = { version = "1.10.1", default-features = false, features = [
     "default-https-client",
     "rt-tokio",
 ] }
-aws-sdk-s3 = { version = "1.138.1", default-features = false, features = [
+aws-sdk-s3 = { version = "1.140.0", default-features = false, features = [
     "default-https-client",
     "http-1x",
     "rt-tokio",
@@ -58,13 +58,13 @@ aws-sdk-s3 = { version = "1.138.1", default-features = false, features = [
 axum = "0.8.9"
 axum-extra = { version = "0.12.6", features = ["query"] }
 bao-tree = "0.16.0"
-base64 = "0.22.1"
+base64 = "0.23.0"
 blake3 = { version = "1.8.5", features = ["serde"] }
 bollard = "0.21.0"
 byteview = "0.10.1"
 bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde"] }
-clap = { version = "4.6.2", features = ["derive"] }
+clap = { version = "4.6.4", features = ["derive"] }
 console-subscriber = "0.5.0"
 craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", features = [
     "iroh",
@@ -74,16 +74,17 @@ crossfire = "3.1.19"
 crypto_box = "0.9.1"
 data-encoding = "2.11.0"
 dotenvy = "0.15.7"
-ed25519-dalek = { version = "2.2.0", features = ["rand_core", "pem"] }
+ed25519-dalek = { version = "3.0.0", features = ["pem"] }
 fjall = "3.1.8"
 flate2 = "1.1.9"
 futures = "0.3.33"
 futures-core = "0.3.33"
 futures-util = { version = "0.3.33", features = ["io"] }
+getrandom = "0.4.3"
 globset = "0.4.19"
 hex = "0.4.3"
 http = "1.4.2"
-hyper = { version = "1.10.1", features = ["full"] }
+hyper = { version = "1.11.0", features = ["full"] }
 hyper-util = { version = "0.1.20", features = [
     "server",
     "server-auto",
@@ -92,15 +93,15 @@ hyper-util = { version = "0.1.20", features = [
     "tokio",
     "service",
 ] }
-iroh = "1.0.2"
-iroh-base = "1.0.2"
+iroh = "1.0.3"
+iroh-base = "1.0.3"
 irokle = { git = "https://github.com/arunaengine/irokle.git", branch = "main", features = [
     "fjall",
     "iroh",
 ] }
 iroh-io = "0.6.2"
 iroh-quinn = "0.16.1"
-jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
 json-patch = "4.2.0"
 lru = "0.18.1"
 md5 = "0.8.1"
@@ -139,7 +140,7 @@ reqwest = { version = "0.13.4", default-features = false, features = [
 ] }
 rustix = { version = "1.1.4", features = ["process"] }
 rustls = { version = "0.23.42", features = ["ring"] }
-kube = { version = "4.0", default-features = false, features = [
+kube = { version = "4.2.0", default-features = false, features = [
     "client",
     "jsonpatch",
     "runtime",
@@ -148,8 +149,8 @@ kube = { version = "4.0", default-features = false, features = [
 ] }
 k8s-openapi = { version = "0.28", features = ["v1_32"] }
 s3s = "0.14.1"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.150", features = ["raw_value"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = { version = "1.0.151", features = ["raw_value"] }
 sha1 = "0.11.0"
 sha2 = "0.11.0"
 smallvec = "1.15.2"
@@ -160,9 +161,9 @@ sysinfo = { version = "0.39.6", default-features = false, features = [
 ] }
 tar = "0.4.46"
 tempfile = "3.27.0"
-thiserror = "2.0.18"
-tokio = { version = "1.53.0", features = ["full", "tracing"] }
-tokio-util = { version = "0.7.18", features = ["compat", "io-util"] }
+thiserror = "2.0.19"
+tokio = { version = "1.53.1", features = ["full", "tracing"] }
+tokio-util = { version = "0.7.19", features = ["compat", "io-util"] }
 tower = { version = "0.5.3", features = ["limit"] }
 tower-http = { version = "0.7.0", features = ["cors", "fs", "timeout"] }
 tracing = "0.1.44"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,30 @@
 # Build Stage
-FROM rust:1-alpine3.24@sha256:ec9c91e77119ce498cd1e87d96d77e0f75b2cee21655a29bc2bf75a51a2b20a4 AS builder
+# glibc, not musl: musl's `cmsghdr` is 4-byte aligned, so noq-udp's receive
+# timestamp decode trips its alignment assertion and aborts the process.
+FROM rust:1.97.1-trixie@sha256:1bcff4befb740599103a2c7cb51058e14479b2e35e3a34a3f0dc4ede09927488 AS builder
 WORKDIR /build
-RUN apk update
-RUN apk upgrade
-ENV RUSTFLAGS="-C target-feature=-crt-static"
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-RUN apk add llvm cmake gcc ca-certificates libc-dev pkgconfig openssl-dev musl-dev git curl
+# mold and clang back `.cargo/config.toml`, which only applies to the gnu target.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends clang cmake mold \
+    && rm -rf /var/lib/apt/lists/*
+# .dockerignore strips local files under docker/, so the default build ships an empty portal.
+# To embed portal assets, pass --build-arg PORTAL_EMBED_DIR=<staged dir outside docker/>.
+ARG PORTAL_EMBED_DIR=docker/portal
 COPY . .
 RUN cargo build --release --locked -p aruna
 RUN cargo build --release --locked -p aruna-doctor
 RUN cargo install --locked --version 0.101.0 --root target iroh-doctor
+# The runtime image has no shell, so the portal is staged here.
+RUN mkdir -p /portal && cp -r ${PORTAL_EMBED_DIR}/. /portal/ && rm -f /portal/.gitkeep
 
-FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+FROM gcr.io/distroless/cc-debian13@sha256:ed7c407fd64eb0af9dddb9456b94cee188a40a7f53cf38c9836e1e9ae14fca02
 WORKDIR /run
-# .dockerignore strips local files under docker/, so the default build ships an empty portal.
-# To embed portal assets, pass --build-arg PORTAL_EMBED_DIR=<staged dir outside docker/>.
-ARG PORTAL_EMBED_DIR=docker/portal
 ARG PORTAL_MODE=disabled
-RUN apk update
-RUN apk upgrade
-RUN apk add libgcc gcompat ca-certificates
 COPY --from=builder /build/target/release/aruna .
 COPY --from=builder /build/target/release/aruna-doctor .
 COPY --from=builder /build/target/bin/iroh-doctor .
-COPY ${PORTAL_EMBED_DIR}/ /run/portal/
-RUN rm -f /run/portal/.gitkeep
+COPY --from=builder /portal/ /run/portal/
 ENV PORTAL_MODE=${PORTAL_MODE}
 ENV PORTAL_DIR=/run/portal
 

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -538,6 +538,7 @@ mod test {
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::handle::Handle;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::structs::OidcProviderConfig;
     use aruna_core::structs::{
@@ -559,9 +560,9 @@ mod test {
     use base64::Engine;
     use byteview::ByteView;
     use chrono::Days;
+    use ed25519_dalek::Signer;
     use ed25519_dalek::SigningKey;
     use ed25519_dalek::pkcs8::EncodePrivateKey;
-    use jsonwebtoken::signature::SignerMut;
     use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
     use serde::{Deserialize, Serialize};
     use std::sync::Arc;
@@ -815,8 +816,7 @@ mod test {
             compute_handle: None,
             blob_handle: None,
         });
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key = SigningKey::generate(&mut csprng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::generate().public();
         let user_id = UserId::local(Ulid::generate(), realm_id);
@@ -881,7 +881,7 @@ mod test {
         assert!(auth.is_none());
         assert!(carrier.is_none());
 
-        let oidc_signing_key = SigningKey::generate(&mut csprng);
+        let oidc_signing_key = generate_signing_key();
         let oidc_token = sign_oidc_token(
             "https://issuer.example",
             "aruna-api",
@@ -907,7 +907,7 @@ mod test {
         let issuer = "https://issuer.example";
         let audience = "aruna-api";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let jwks = eddsa_jwk(kid, &signing_key);
         let (discovery_url, _jwks_uri, _metrics, task) =
             spawn_oidc_provider(issuer, kid, jwks).await;
@@ -941,7 +941,7 @@ mod test {
         let issuer = "https://issuer.example";
         let audience = "aruna-api";
         let kid = "symm-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let jwks = eddsa_jwk(kid, &signing_key);
         let (discovery_url, _jwks_uri, _metrics, task) =
             spawn_oidc_provider(issuer, kid, jwks).await;
@@ -977,7 +977,7 @@ mod test {
     async fn oidc_validator_rejects_wrong_audience() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let jwks = eddsa_jwk(kid, &signing_key);
         let (discovery_url, _jwks_uri, _metrics, task) =
             spawn_oidc_provider(issuer, kid, jwks).await;
@@ -1008,7 +1008,7 @@ mod test {
         let issuer = "https://issuer.example";
         let audience = "aruna-api";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let jwks = eddsa_jwk(kid, &signing_key);
         let (discovery_url, _jwks_uri, metrics, task) =
             spawn_oidc_provider(issuer, kid, jwks).await;
@@ -1043,7 +1043,7 @@ mod test {
         let issuer = "https://issuer.example";
         let audience = "aruna-api";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let jwks = eddsa_jwk(kid, &signing_key);
         let (discovery_url, _jwks_uri, metrics, task) =
             spawn_oidc_provider(issuer, kid, jwks).await;
@@ -1090,7 +1090,7 @@ mod test {
         let issuer = "https://issuer.example";
         let audience = "aruna-api";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let jwks = eddsa_jwk(kid, &signing_key);
         let (discovery_url, _jwks_uri, _metrics, task) =
             spawn_oidc_provider(issuer, kid, jwks).await;
@@ -1142,8 +1142,8 @@ mod test {
         let audience = "aruna-api";
         let old_kid = "old-key";
         let new_kid = "new-key";
-        let old_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
-        let new_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let old_signing_key = generate_signing_key();
+        let new_signing_key = generate_signing_key();
         let (discovery_url, _jwks_uri, metrics, task) =
             spawn_oidc_provider(issuer, old_kid, eddsa_jwk(old_kid, &old_signing_key)).await;
         let provider = OidcProviderConfig {
@@ -1191,7 +1191,7 @@ mod test {
         let issuer = "https://issuer.example";
         let audience = "aruna-api";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let jwks = eddsa_jwk(kid, &signing_key);
         let (discovery_url, _jwks_uri, _metrics, task) =
             spawn_oidc_provider("https://different-issuer.example", kid, jwks).await;
@@ -1235,12 +1235,11 @@ mod test {
             blob_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let mut realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let pubkey = realm_signing_key.verifying_key().to_bytes();
         let realm_id = RealmId::from_bytes(pubkey);
 
-        let node_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let node_signing_key: SigningKey = generate_signing_key();
         let node_id =
             iroh::PublicKey::from_bytes(node_signing_key.verifying_key().as_bytes()).unwrap();
 
@@ -1321,7 +1320,7 @@ mod test {
         //
         // Test Server Nodes
         //
-        let issuer_key = SigningKey::generate(&mut csprng);
+        let issuer_key = generate_signing_key();
 
         let message = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(issuer_key.verifying_key().to_bytes());
@@ -1422,11 +1421,10 @@ mod test {
             blob_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
 
-        let node_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let node_signing_key: SigningKey = generate_signing_key();
         let node_id =
             iroh::PublicKey::from_bytes(node_signing_key.verifying_key().as_bytes()).unwrap();
 
@@ -1526,12 +1524,11 @@ mod test {
             blob_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let mut realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let pubkey = realm_signing_key.verifying_key().to_bytes();
         let realm_id = RealmId::from_bytes(pubkey);
 
-        let node_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let node_signing_key: SigningKey = generate_signing_key();
         let node_id =
             iroh::PublicKey::from_bytes(node_signing_key.verifying_key().as_bytes()).unwrap();
 
@@ -1649,7 +1646,7 @@ mod test {
         //
         // Expired server token
         //
-        let issuer_key = SigningKey::generate(&mut csprng);
+        let issuer_key = generate_signing_key();
 
         let message = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(issuer_key.verifying_key().to_bytes());
@@ -1803,8 +1800,7 @@ mod test {
             blob_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::generate().public();
 
@@ -1840,7 +1836,7 @@ mod test {
 
         let now = chrono::Utc::now().timestamp().max(0) as u64;
         for _ in 0..2048 {
-            let issuer_key = SigningKey::generate(&mut csprng);
+            let issuer_key = generate_signing_key();
             let token = sign_untrusted_direct_token(&issuer_key, now);
             assert!(handle_token(&state, &token).await.is_err());
         }
@@ -1862,8 +1858,7 @@ mod test {
             blob_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let mut realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::generate().public();
 
@@ -1885,7 +1880,7 @@ mod test {
         .await
         .unwrap();
 
-        let issuer_key = SigningKey::generate(&mut csprng);
+        let issuer_key = generate_signing_key();
         let message = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(issuer_key.verifying_key().to_bytes());
         let delegation_signature = realm_signing_key.sign(message.as_bytes()).to_string();

--- a/api/src/openapi/mod.rs
+++ b/api/src/openapi/mod.rs
@@ -59,3 +59,82 @@ impl Modify for SecurityAddon {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ApiDoc;
+    use serde_json::{Value, json};
+
+    /// Operations that serve anonymous callers but return more to an authenticated one.
+    /// They pair an empty requirement with `bearer_auth` so clients send an available
+    /// token without presenting the operation as authentication-only.
+    const OPTIONAL_AUTH: &[(&str, &str)] = &[
+        ("/metadata", "get"),
+        ("/groups/{group_id}/metadata", "get"),
+        ("/metadata/{document_id}", "get"),
+        ("/metadata/{document_id}/rocrate", "get"),
+        ("/metadata/{document_id}/sparql/query", "post"),
+        ("/metadata/sparql/query", "post"),
+        ("/metadata/search", "get"),
+        ("/info", "get"),
+        ("/info/realm", "get"),
+        ("/ga4gh/drs/v1/objects", "post"),
+        ("/ga4gh/drs/v1/objects/{object_id}", "get"),
+        ("/ga4gh/drs/v1/download", "get"),
+    ];
+
+    /// Operations that reject an anonymous caller.
+    const REQUIRED_AUTH: &[(&str, &str)] = &[
+        ("/users/register", "post"),
+        ("/metadata", "post"),
+        ("/metadata/{document_id}", "delete"),
+        ("/metadata/references", "get"),
+    ];
+
+    fn operation_security(doc: &Value, path: &str, method: &str) -> Vec<Value> {
+        doc["paths"][path][method]["security"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{method} {path} declares no security requirement"))
+            .clone()
+    }
+
+    #[test]
+    fn pins_optional_security() {
+        let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        for (path, method) in OPTIONAL_AUTH {
+            let security = operation_security(&doc, path, method);
+            assert!(
+                security.contains(&json!({ "bearer_auth": [] })),
+                "{method} {path} must offer bearer_auth so clients send a held token"
+            );
+            assert!(
+                security.contains(&json!({})),
+                "{method} {path} must keep the empty requirement that marks auth optional"
+            );
+        }
+    }
+
+    #[test]
+    fn pins_required_security() {
+        let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        for (path, method) in REQUIRED_AUTH {
+            let security = operation_security(&doc, path, method);
+            assert!(
+                security.contains(&json!({ "bearer_auth": [] })),
+                "{method} {path} must require bearer_auth"
+            );
+            assert!(
+                !security.contains(&json!({})),
+                "{method} {path} rejects anonymous callers, so auth must not read as optional"
+            );
+        }
+    }
+
+    #[test]
+    fn declares_security_schemes() {
+        let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let schemes = &doc["components"]["securitySchemes"];
+        assert_eq!(schemes["bearer_auth"]["scheme"], json!("bearer"));
+        assert_eq!(schemes["basic_auth"]["scheme"], json!("basic"));
+    }
+}

--- a/api/src/ops.rs
+++ b/api/src/ops.rs
@@ -401,7 +401,7 @@ impl QueueMetrics {
     }
 
     async fn refresh(&self, ctx: &DriverContext, reporter: &mut QueueLagReporter) {
-        let sample = reporter.sample(&ctx.storage_handle).await;
+        let sample = reporter.sample(&ctx.storage_handle.bulk()).await;
         self.apply(DOCUMENT_SYNC_OUTBOX_QUEUE, sample.document_sync_outbox);
         self.apply(
             METADATA_MATERIALIZATION_QUEUE,

--- a/api/src/ops.rs
+++ b/api/src/ops.rs
@@ -50,11 +50,13 @@ const OPS_MAX_CONCURRENT_REQUESTS: usize = 32;
 
 const DOCUMENT_SYNC_OUTBOX_QUEUE: &str = "document_sync_outbox";
 const METADATA_MATERIALIZATION_QUEUE: &str = "metadata_materialization";
+const MATERIALIZATION_DEAD_LETTER_QUEUE: &str = "metadata_materialization_dead_letters";
 const BLOB_REPLICATION_QUEUE: &str = "blob_replication";
 const REFERENCE_METADATA_REFRESH_QUEUE: &str = "reference_metadata_refresh";
-const QUEUE_NAMES: [&str; 4] = [
+const QUEUE_NAMES: [&str; 5] = [
     DOCUMENT_SYNC_OUTBOX_QUEUE,
     METADATA_MATERIALIZATION_QUEUE,
+    MATERIALIZATION_DEAD_LETTER_QUEUE,
     BLOB_REPLICATION_QUEUE,
     REFERENCE_METADATA_REFRESH_QUEUE,
 ];
@@ -400,12 +402,18 @@ impl QueueMetrics {
             .set((unix_timestamp_millis() / 1_000) as i64);
     }
 
+    // Sampled on the foreground lane: queue depth must stay observable exactly
+    // when the bulk lane is saturated.
     async fn refresh(&self, ctx: &DriverContext, reporter: &mut QueueLagReporter) {
-        let sample = reporter.sample(&ctx.storage_handle.bulk()).await;
+        let sample = reporter.sample(&ctx.storage_handle).await;
         self.apply(DOCUMENT_SYNC_OUTBOX_QUEUE, sample.document_sync_outbox);
         self.apply(
             METADATA_MATERIALIZATION_QUEUE,
             sample.metadata_materialization,
+        );
+        self.apply(
+            MATERIALIZATION_DEAD_LETTER_QUEUE,
+            sample.materialization_dead_letters,
         );
         self.apply(BLOB_REPLICATION_QUEUE, sample.blob_replication);
         self.apply(

--- a/api/src/ops.rs
+++ b/api/src/ops.rs
@@ -529,8 +529,8 @@ mod tests {
     async fn healthz_fails_dead() {
         // A dropped receiver latches the storage channel-closed flag once an
         // effect is dispatched; liveness must then fail so k8s restarts the pod.
-        let (storage, receiver) = StorageHandle::new();
-        drop(receiver);
+        let (storage, receivers) = StorageHandle::new();
+        drop(receivers);
         let _ = storage
             .send_storage_effect(StorageEffect::Read {
                 key_space: NODE_STATE_KEYSPACE.to_string(),
@@ -569,8 +569,8 @@ mod tests {
 
     #[tokio::test]
     async fn readyz_reports_storage_failure() {
-        let (storage, receiver) = StorageHandle::new();
-        drop(receiver);
+        let (storage, receivers) = StorageHandle::new();
+        drop(receivers);
         let readiness = Readiness::new();
         readiness.set_ready();
         let ops = OpsState::new(

--- a/api/src/portal.rs
+++ b/api/src/portal.rs
@@ -164,6 +164,7 @@ mod tests {
     use crate::server::{DEFAULT_MAX_HTTP_BODY_SIZE, Server, ServerConfig};
     use crate::server_state::{PortalStatus, ServerState};
     use aruna_core::UserId;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::structs::{Actor, NodeCapabilities, OidcProviderConfig, RealmId};
     use aruna_operations::create_realm::{CreateRealmConfig, CreateRealmOperation};
     use aruna_operations::driver::{DriverContext, drive};
@@ -174,7 +175,6 @@ mod tests {
     use axum::http::{Method, StatusCode, header};
     use axum::routing::get;
     use axum::{Json, Router};
-    use ed25519_dalek::SigningKey;
     use std::sync::Arc;
     use tempfile::{TempDir, tempdir};
     use tokio::net::TcpListener;
@@ -193,8 +193,7 @@ mod tests {
             compute_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key = SigningKey::generate(&mut csprng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::generate().public();
 

--- a/api/src/routes/drs.rs
+++ b/api/src/routes/drs.rs
@@ -251,6 +251,7 @@ pub async fn get_authorizations(
     get,
     path = "/ga4gh/drs/v1/objects/{object_id}",
     tag = "drs",
+    description = "Authentication is optional and changes the result: an anonymous caller only resolves objects readable by the public role.",
     params(("object_id" = String, Path, description = "Aruna data W3ID, content-hash ch ARN, or versioned s3 ARN locator")),
     responses(
         (status = 200, body = DrsObjectResponse),
@@ -258,7 +259,7 @@ pub async fn get_authorizations(
         (status = 403, body = DrsErrorPayload),
         (status = 404, body = DrsErrorPayload)
     ),
-    security((),("bearer_auth" = []))
+    security((), ("bearer_auth" = []))
 )]
 pub async fn get_object(
     State(state): State<Arc<ServerState>>,
@@ -286,11 +287,13 @@ pub async fn get_object(
     post,
     path = "/ga4gh/drs/v1/objects",
     tag = "drs",
+    description = "Authentication is optional and changes the result: an anonymous caller only resolves objects readable by the public role.",
     request_body = DrsBulkObjectsRequestBody,
     responses(
         (status = 200, body = DrsBulkObjectsResponse),
         (status = 400, body = DrsErrorPayload)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn post_objects(
     State(state): State<Arc<ServerState>>,
@@ -329,12 +332,14 @@ pub async fn post_objects(
     get,
     path = "/ga4gh/drs/v1/download",
     tag = "drs",
+    description = "Authentication is optional and changes the result: an anonymous caller only downloads objects readable by the public role.",
     params(("object_id" = String, Query, description = "Aruna data W3ID, content-hash ch ARN, or versioned s3 ARN locator")),
     responses(
         (status = 200, description = "Object bytes"),
         (status = 400, body = DrsErrorPayload),
         (status = 404, body = DrsErrorPayload)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn download_object(
     State(state): State<Arc<ServerState>>,

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -1388,6 +1388,7 @@ mod tests {
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::handle::Handle;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::keyspaces::{
         AUTH_KEYSPACE, BLOB_HEAD_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, BLOB_VERSIONS_KEYSPACE,
         GROUP_KEYSPACE, S3_BUCKET_KEYSPACE, USER_KEYSPACE,
@@ -1404,7 +1405,6 @@ mod tests {
     use axum::http::StatusCode;
     use axum::{Extension, Json};
     use byteview::ByteView;
-    use ed25519_dalek::SigningKey;
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -1502,8 +1502,7 @@ mod tests {
             task_handle: None,
             compute_handle: None,
         });
-        let realm_signing_key =
-            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let state = Arc::new(
             ServerState::new(

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1579,6 +1579,7 @@ mod tests {
     use aruna_core::UserId;
     use aruna_core::effects::StorageEffect;
     use aruna_core::errors::StorageError;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::structs::{Actor, AuthContext, NodeCapabilities, QuotaConfig, RealmId};
     use aruna_operations::claim_initial_realm_admin::{
         ClaimInitialRealmAdminInput, ClaimInitialRealmAdminOperation,
@@ -1593,7 +1594,6 @@ mod tests {
     use axum::extract::{FromRequest, State};
     use axum::http::StatusCode;
     use axum::{Extension, Json};
-    use ed25519_dalek::SigningKey;
     use std::sync::Arc;
     use tempfile::{TempDir, tempdir};
     use tower::ServiceExt;
@@ -1611,8 +1611,7 @@ mod tests {
             compute_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key = SigningKey::generate(&mut csprng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::generate().public();
 
@@ -2022,8 +2021,7 @@ mod tests {
             compute_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key = SigningKey::generate(&mut csprng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let user_id = UserId::local(Ulid::generate(), realm_id);
         let node_id = iroh::SecretKey::generate().public();

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -15,6 +15,7 @@ use aruna_operations::check_permissions::{CheckPermissionsConfig, CheckPermissio
 use aruna_operations::driver::drive;
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::get_realm_nodes::GetRealmNodesOperation;
+use aruna_operations::metadata::stats::count_realm_documents;
 use aruna_operations::mutate_realm_placement::{
     MutateRealmPlacementConfig, MutateRealmPlacementError, RealmPlacementMutation,
     drive_realm_placement_mutation,
@@ -1127,6 +1128,13 @@ pub struct UsageResponse {
     pub logical_bytes: u64,
     pub referenced_bytes: u64,
     pub realm: UsageTotals,
+    /// Realm-wide total of live metadata documents, excluding lifecycle-deleted
+    /// ones. This is the realm's document volume, not a count of what the
+    /// calling principal may read, so it is not filtered per caller. Absent on
+    /// the group usage endpoint and on nodes without a metadata subsystem, so
+    /// an absent count never reads as zero documents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_documents: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quota: Option<GroupQuotaStatus>,
 }
@@ -1205,6 +1213,7 @@ impl UsageResponse {
             logical_bytes: local.logical_bytes,
             referenced_bytes: local.referenced_bytes,
             realm: realm.into(),
+            metadata_documents: None,
             quota: None,
         }
     }
@@ -1243,7 +1252,18 @@ pub async fn get_usage(
     require_realm_auth(&state, auth)?;
     let local = load_usage_counters(&state, USAGE_GLOBAL_KEY.to_vec()).await?;
     let realm = load_realm_usage(&state, RealmUsageScope::Global).await?;
-    Ok((StatusCode::OK, Json(UsageResponse::new(local, realm))))
+    let mut response = UsageResponse::new(local, realm);
+    // Best effort: storage counters stay reportable when the metadata
+    // subsystem cannot answer, and the omitted field never reads as zero.
+    response.metadata_documents =
+        match count_realm_documents(&state.get_ctx(), state.get_realm_id()).await {
+            Ok(count) => count,
+            Err(error) => {
+                warn!(error = %error, "metadata document count unavailable for usage response");
+                None
+            }
+        };
+    Ok((StatusCode::OK, Json(response)))
 }
 
 fn map_realm_nodes(
@@ -1931,6 +1951,104 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response.buckets, 2, "flat fields report local total");
         assert_eq!(response.realm.buckets, 5, "realm sums local and remote");
+        assert_eq!(
+            response.metadata_documents, None,
+            "a node without a metadata subsystem omits the count"
+        );
+        let body = serde_json::to_value(&response).unwrap();
+        assert!(!body.as_object().unwrap().contains_key("metadata_documents"));
+    }
+
+    /// The reported total covers every live document in the realm, including
+    /// the private ones the caller holds no role for.
+    #[tokio::test]
+    async fn usage_counts_documents() {
+        use aruna_core::storage_entries::metadata_registry_write_entries;
+        use aruna_core::structs::{MetadataRegistryRecord, PlacementRef};
+
+        let storage_dir = tempdir().unwrap();
+        let metadata_dir = tempdir().unwrap();
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().unwrap()).unwrap();
+        let node_id = iroh::SecretKey::generate().public();
+        let metadata_handle = aruna_operations::metadata::MetadataHandle::new(
+            metadata_dir.path(),
+            node_id,
+            storage_handle.clone(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let realm_signing_key = generate_signing_key();
+        let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
+        let driver_ctx = Arc::new(DriverContext {
+            storage_handle: storage_handle.clone(),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: Some(metadata_handle),
+            task_handle: None,
+            compute_handle: None,
+        });
+        let state = Arc::new(
+            ServerState::new(
+                driver_ctx,
+                realm_id,
+                node_id,
+                NodeCapabilities::local_node(realm_id).unwrap(),
+                false,
+                None,
+                aruna_operations::jobs::runtime::JobsRuntime::new(),
+            )
+            .await,
+        );
+
+        let group_id = Ulid::generate();
+        let mut writes = Vec::new();
+        for (index, public) in [(0u8, true), (1, true), (2, false)] {
+            let document_id = Ulid::from_parts(index.into(), index.into());
+            let path = format!("datasets/{index}");
+            let record = MetadataRegistryRecord {
+                realm_id,
+                group_id,
+                document_id,
+                document_path: path.clone(),
+                graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+                public,
+                permission_path: MetadataRegistryRecord::permission_path_for(
+                    &realm_id,
+                    group_id,
+                    &path,
+                    document_id,
+                ),
+                placement: PlacementRef::NIL,
+                holder_node_ids: Vec::new(),
+                created_at_ms: 1,
+                updated_at_ms: 1,
+                last_event_id: Ulid::nil(),
+            };
+            writes.extend(metadata_registry_write_entries(&record).unwrap());
+        }
+        assert!(matches!(
+            state
+                .get_ctx()
+                .storage_handle
+                .send_storage_effect(StorageEffect::BatchWrite {
+                    writes,
+                    txn_id: None,
+                })
+                .await,
+            aruna_core::events::Event::Storage(
+                aruna_core::events::StorageEvent::BatchWriteResult { .. }
+            )
+        ));
+
+        let auth = test_auth_context(&state);
+        let (_, Json(response)) = get_usage(State(state), Extension(Some(auth)))
+            .await
+            .unwrap();
+
+        assert_eq!(response.metadata_documents, Some(3));
     }
 
     #[test]

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -1911,6 +1911,7 @@ pub(crate) fn map_search_hit(hit: MetadataSearchHit) -> MetadataSearchHitRespons
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aruna_core::keys::generate_signing_key;
 
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
@@ -5054,8 +5055,7 @@ mod tests {
     }
 
     fn test_realm_signing_key() -> SigningKey {
-        let mut rng = jsonwebtoken::signature::rand_core::OsRng;
-        SigningKey::generate(&mut rng)
+        generate_signing_key()
     }
 
     fn test_realm_id(seed: u8) -> RealmId {

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -23,7 +23,7 @@ use aruna_operations::get_metadata_document::load_metadata_record_by_document as
 use aruna_operations::jobs::service::submit_export_job;
 use aruna_operations::metadata::api::{
     ExportMetadataRoCrateRequest, ExportMetadataRoCrateResult, GetVisibleMetadataDocumentRequest,
-    ListVisibleMetadataDocumentsRequest, MetadataApiError, MetadataApiQueryMode,
+    ListVisibleMetadataDocumentsRequest, MetadataApiError, MetadataApiQueryMode, MetadataListOrder,
     MetadataDocumentQueryRequest, MetadataFanoutStats, MetadataQueryRequest,
     MetadataReferenceEntry, MetadataReferencesExecution, MetadataReferencesRequest,
     MetadataRoCrateExportView as OperationMetadataRoCrateExportView, MetadataSearchRequest,
@@ -228,6 +228,8 @@ pub struct ListMetadataQuery {
     pub limit: Option<usize>,
     #[serde(default)]
     pub offset: Option<usize>,
+    #[serde(default)]
+    pub order: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -673,7 +675,8 @@ pub async fn create_metadata_document(
         ("path_prefix" = Option<String>, Query, description = "Normalized metadata path prefix, for example profiles/"),
         ("include" = Option<String>, Query, description = "Comma-separated includes. Currently supports summary"),
         ("limit" = Option<usize>, Query, description = "Maximum documents to return"),
-        ("offset" = Option<usize>, Query, description = "Number of filtered documents to skip")
+        ("offset" = Option<usize>, Query, description = "Number of filtered documents to skip"),
+        ("order" = Option<String>, Query, description = "Page order: created (default, ascending document id) or recent (descending updated_at, tie-broken by descending document id). Any other value is rejected with 400")
     ),
     responses(
         (status = 200, description = "Visible metadata documents", body = ListMetadataResponse),
@@ -703,7 +706,8 @@ pub async fn list_all_metadata_documents(
         ("path_prefix" = Option<String>, Query, description = "Normalized metadata path prefix, for example profiles/"),
         ("include" = Option<String>, Query, description = "Comma-separated includes. Currently supports summary"),
         ("limit" = Option<usize>, Query, description = "Maximum documents to return"),
-        ("offset" = Option<usize>, Query, description = "Number of filtered documents to skip")
+        ("offset" = Option<usize>, Query, description = "Number of filtered documents to skip"),
+        ("order" = Option<String>, Query, description = "Page order: created (default, ascending document id) or recent (descending updated_at, tie-broken by descending document id). Any other value is rejected with 400")
     ),
     responses(
         (status = 200, description = "Visible metadata documents", body = ListMetadataResponse),
@@ -1497,6 +1501,7 @@ async fn run_list_metadata_documents(
     group_id: Option<Ulid>,
 ) -> ServerResult<ListMetadataResponse> {
     let include = parse_metadata_include_flags(query.include.as_deref())?;
+    let order = parse_metadata_order(query.order.as_deref())?;
     let ctx = state.get_ctx();
     let result = run_list_visible_metadata_documents(
         ctx.as_ref(),
@@ -1507,6 +1512,7 @@ async fn run_list_metadata_documents(
             include_summary: include.summary,
             limit: query.limit,
             offset: query.offset,
+            order,
             auth,
         },
     )
@@ -1548,6 +1554,16 @@ fn parse_metadata_include_flags(include: Option<&str>) -> ServerResult<MetadataI
         }
     }
     Ok(flags)
+}
+
+fn parse_metadata_order(order: Option<&str>) -> ServerResult<MetadataListOrder> {
+    match order.map(str::trim) {
+        None | Some("") | Some("created") => Ok(MetadataListOrder::Created),
+        Some("recent") => Ok(MetadataListOrder::Recent),
+        Some(_) => Err(ServerError::BadRequestMessage(
+            "order must be created or recent".to_string(),
+        )),
+    }
 }
 
 fn format_timestamp_ms(timestamp_ms: u64) -> String {
@@ -2031,6 +2047,28 @@ mod tests {
         assert_eq!(
             mapped.into_response().status(),
             axum::http::StatusCode::CONFLICT
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_order() {
+        use axum::response::IntoResponse;
+        assert!(matches!(
+            parse_metadata_order(None),
+            Ok(MetadataListOrder::Created)
+        ));
+        assert!(matches!(
+            parse_metadata_order(Some("created")),
+            Ok(MetadataListOrder::Created)
+        ));
+        assert!(matches!(
+            parse_metadata_order(Some("recent")),
+            Ok(MetadataListOrder::Recent)
+        ));
+        let rejected = parse_metadata_order(Some("updated")).expect_err("unknown order rejected");
+        assert_eq!(
+            rejected.into_response().status(),
+            axum::http::StatusCode::BAD_REQUEST
         );
     }
 

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -193,6 +193,12 @@ pub struct ListMetadataResponse {
     pub limit: usize,
     pub offset: usize,
     pub total_returned: usize,
+    /// Approximate total across all pages: it can over-count when a
+    /// per-document DENY subtracts from a group-wide grant, and under-count
+    /// when a grant is narrower than a group. Absent on targeted lookups, whose
+    /// limit is too small to be worth the scan.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_estimate: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -1509,6 +1515,7 @@ async fn run_list_metadata_documents(
         limit: result.limit,
         offset: result.offset,
         total_returned: result.total_returned,
+        total_estimate: result.total_estimate,
     })
 }
 

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -5326,8 +5326,8 @@ mod tests {
     }
 
     async fn setup_state_with_closed_storage() -> Arc<ServerState> {
-        let (storage_handle, receiver) = storage::StorageHandle::new();
-        drop(receiver);
+        let (storage_handle, receivers) = storage::StorageHandle::new();
+        drop(receivers);
 
         let realm_id = test_realm_id(3);
         let node_id = iroh::SecretKey::from_bytes(&[14u8; 32]).public();

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -2182,6 +2182,7 @@ mod tests {
                 .map(|digest| digest.try_into().unwrap()),
             state: MetadataMaterializationState::Failed,
             attempts: 1,
+            failures: 0,
             last_error: Some("projection failed".to_string()),
             updated_at_ms: 1,
         };

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -193,10 +193,9 @@ pub struct ListMetadataResponse {
     pub limit: usize,
     pub offset: usize,
     pub total_returned: usize,
-    /// Approximate total across all pages: it can over-count when a
-    /// per-document DENY subtracts from a group-wide grant, and under-count
-    /// when a grant is narrower than a group. Absent on targeted lookups, whose
-    /// limit is too small to be worth the scan.
+    /// Exact total of documents visible to the caller across all pages,
+    /// evaluated per document against the caller's permission rules. Absent
+    /// on targeted lookups, whose limit is too small to be worth the scan.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_estimate: Option<usize>,
 }

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -4,7 +4,7 @@ use crate::auth::{
 };
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
-use aruna_core::errors::AuthorizationError;
+use aruna_core::errors::{AuthorizationError, StorageError};
 use aruna_core::metadata::{
     MetadataError, MetadataQueryResults, MetadataRoCratePage, MetadataSearchHit,
 };
@@ -569,7 +569,8 @@ impl MetadataDocumentListItem {
         ),
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
-        (status = 403, description = "Forbidden", body = ErrorResponse)
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 409, description = "Concurrent create conflict; retry", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -1572,6 +1573,9 @@ fn map_create_metadata_error(error: CreateMetadataDocumentError) -> ServerError 
         CreateMetadataDocumentError::MetadataError(metadata_error) => {
             map_metadata_error(metadata_error)
         }
+        CreateMetadataDocumentError::StorageError(StorageError::TransactionConflict) => {
+            ServerError::Conflict("concurrent metadata create conflict; retry".to_string())
+        }
         other => ServerError::InternalError(other.to_string()),
     }
 }
@@ -1993,6 +1997,19 @@ mod tests {
             metadata_handle, ..
         } = context;
         metadata_handle.as_ref().expect("metadata handle installed")
+    }
+
+    #[test]
+    fn maps_conflict_409() {
+        use axum::response::IntoResponse;
+        let mapped = map_create_metadata_error(CreateMetadataDocumentError::StorageError(
+            StorageError::TransactionConflict,
+        ));
+        assert!(matches!(mapped, ServerError::Conflict(_)));
+        assert_eq!(
+            mapped.into_response().status(),
+            axum::http::StatusCode::CONFLICT
+        );
     }
 
     #[tokio::test]

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -667,6 +667,7 @@ pub async fn create_metadata_document(
     get,
     path = "/metadata",
     tag = "metadata",
+    description = "Authentication is optional and changes the result: an authenticated caller sees every document their identity may read, an anonymous caller sees only public documents.",
     params(
         ("group_id" = Option<String>, Query, description = "Optional group id filter"),
         ("path_prefix" = Option<String>, Query, description = "Normalized metadata path prefix, for example profiles/"),
@@ -677,7 +678,8 @@ pub async fn create_metadata_document(
     responses(
         (status = 200, description = "Visible metadata documents", body = ListMetadataResponse),
         (status = 400, description = "Invalid query", body = ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn list_all_metadata_documents(
     State(state): State<Arc<ServerState>>,
@@ -695,6 +697,7 @@ pub async fn list_all_metadata_documents(
     get,
     path = "/groups/{group_id}/metadata",
     tag = "metadata",
+    description = "Authentication is optional and changes the result: an authenticated caller sees every document of the group their identity may read, an anonymous caller sees only public documents.",
     params(
         ("group_id" = String, Path, description = "Group id"),
         ("path_prefix" = Option<String>, Query, description = "Normalized metadata path prefix, for example profiles/"),
@@ -705,7 +708,8 @@ pub async fn list_all_metadata_documents(
     responses(
         (status = 200, description = "Visible metadata documents", body = ListMetadataResponse),
         (status = 400, description = "Invalid group id", body = ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn list_metadata_documents(
     State(state): State<Arc<ServerState>>,
@@ -724,6 +728,7 @@ pub async fn list_metadata_documents(
     get,
     path = "/metadata/{document_id}",
     tag = "metadata",
+    description = "Authentication is optional and changes the result: a document that is not public is only returned to a caller whose identity may read it.",
     params(("document_id" = String, Path, description = "Metadata document id")),
     responses(
         (status = 200, description = "Metadata document summary", body = MetadataDocumentSummary),
@@ -731,7 +736,8 @@ pub async fn list_metadata_documents(
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn get_metadata_document(
     State(state): State<Arc<ServerState>>,
@@ -796,6 +802,7 @@ pub async fn delete_metadata_document(
     get,
     path = "/metadata/{document_id}/rocrate",
     tag = "metadata",
+    description = "Authentication is optional and changes the result: a document that is not public is only exported to a caller whose identity may read it.",
     params(
         ("document_id" = String, Path, description = "Metadata document id"),
         ("view" = Option<MetadataRoCrateView>, Query, description = "Export view: full, summary, page, or raw"),
@@ -852,7 +859,8 @@ pub async fn delete_metadata_document(
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse),
         (status = 503, description = "Requested view is not available", body = ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn export_metadata_rocrate(
     State(state): State<Arc<ServerState>>,
@@ -1227,6 +1235,7 @@ pub async fn add_metadata_contextual_entity(
     post,
     path = "/metadata/{document_id}/sparql/query",
     tag = "metadata",
+    description = "Authentication is optional and changes the result: the document is only queried for a caller whose identity may read it.",
     params(("document_id" = String, Path, description = "Metadata document id")),
     request_body(
         content = SparqlQueryRequest,
@@ -1257,7 +1266,8 @@ pub async fn add_metadata_contextual_entity(
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn query_metadata_document(
     State(state): State<Arc<ServerState>>,
@@ -1293,6 +1303,7 @@ pub async fn query_metadata_document(
     post,
     path = "/metadata/sparql/query",
     tag = "metadata",
+    description = "Authentication is optional and changes the result: the queried graph union only contains metadata the caller may read.",
     request_body(
         content = SparqlQueryRequest,
         description = "Run a SPARQL `SELECT` or `ASK` query across all visible metadata. `mode=local` evaluates the current node's authorized graph union. `mode=distributed` accepts only union-safe `ASK` or `SELECT DISTINCT` single-pattern queries and merges partition sets. Distributed mode is best-effort by default; set `allow_partial=false` to fail if any partition is unavailable.",
@@ -1320,7 +1331,8 @@ pub async fn query_metadata_document(
         (status = 200, description = "SPARQL query result", body = MetadataQueryResponse),
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 501, description = "Unsupported query mode", body = ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn query_all_metadata(
     State(state): State<Arc<ServerState>>,
@@ -1355,6 +1367,7 @@ pub async fn query_all_metadata(
     get,
     path = "/metadata/search",
     tag = "metadata",
+    description = "Authentication is optional and changes the result: hits are restricted to metadata the caller may read, so an anonymous request returns fewer documents.",
     params(
         ("q" = Option<String>, Query, description = "Search query; optional when conforms_to is set"),
         ("conforms_to" = Option<String>, Query, description = "Exact RO-Crate conformsTo profile IRI"),
@@ -1367,7 +1380,8 @@ pub async fn query_all_metadata(
         (status = 200, description = "Metadata search hits", body = MetadataSearchResponse),
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 501, description = "Unsupported query mode", body = ErrorResponse)
-    )
+    ),
+    security((), ("bearer_auth" = []))
 )]
 pub async fn search_metadata(
     State(state): State<Arc<ServerState>>,

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -23,8 +23,8 @@ use aruna_operations::get_metadata_document::load_metadata_record_by_document as
 use aruna_operations::jobs::service::submit_export_job;
 use aruna_operations::metadata::api::{
     ExportMetadataRoCrateRequest, ExportMetadataRoCrateResult, GetVisibleMetadataDocumentRequest,
-    ListVisibleMetadataDocumentsRequest, MetadataApiError, MetadataApiQueryMode, MetadataListOrder,
-    MetadataDocumentQueryRequest, MetadataFanoutStats, MetadataQueryRequest,
+    ListVisibleMetadataDocumentsRequest, MetadataApiError, MetadataApiQueryMode,
+    MetadataDocumentQueryRequest, MetadataFanoutStats, MetadataListOrder, MetadataQueryRequest,
     MetadataReferenceEntry, MetadataReferencesExecution, MetadataReferencesRequest,
     MetadataRoCrateExportView as OperationMetadataRoCrateExportView, MetadataSearchRequest,
     export_metadata_rocrate as run_export_metadata_rocrate,

--- a/api/src/routes/onboarding.rs
+++ b/api/src/routes/onboarding.rs
@@ -595,6 +595,7 @@ mod tests {
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::handle::Handle;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, REALM_CONFIG_KEYSPACE};
     use aruna_core::onboarding::{
         BootstrapOnboardingRequest, CreateOnboardingSecretRequest, OnboardingMode,
@@ -663,8 +664,7 @@ mod tests {
             compute_handle: None,
         });
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key = SigningKey::generate(&mut csprng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let user_id = UserId::local(Ulid::generate(), realm_id);
         let node_id = net_handle.node_id();
@@ -750,7 +750,7 @@ mod tests {
         .await
         .unwrap();
 
-        let issuer_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let issuer_key = generate_signing_key();
         let issuer_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(issuer_key.verifying_key().to_bytes());
         let onboarding_secret = created.onboarding_secret;
@@ -997,7 +997,7 @@ mod tests {
             ))
             .to_string();
 
-        let issuer_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let issuer_key = generate_signing_key();
         let issuer_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(issuer_key.verifying_key().to_bytes());
         let onboarding_secret = created.onboarding_secret;

--- a/api/src/routes/tes.rs
+++ b/api/src/routes/tes.rs
@@ -4,7 +4,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use aruna_core::compute::paths_overlap;
+use aruna_core::compute::{
+    has_wildcard, literal_prefix, output_glob, output_suffix, paths_overlap,
+};
 use aruna_core::errors::AuthorizationError;
 use aruna_core::structs::{
     AuthContext, ComputeResources, ExecutionSpec, InputMode, InputSelection, InputSource, JobId,
@@ -146,10 +148,17 @@ pub struct TesOutput {
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Destination URL; a directory prefix when `path` contains wildcards.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Absolute container path, optionally with POSIX (IEEE Std 1003.1-2017,
+    /// 12.13) wildcards `*`, `?`, and `[...]` selecting several files.
     #[serde(default)]
     pub path: String,
+    /// Literal ancestor stripped from every matched path before it is appended
+    /// to `url`. Required when `path` has wildcards, ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_prefix: Option<String>,
     #[serde(rename = "type", default)]
     pub kind: TesFileType,
 }
@@ -796,9 +805,23 @@ fn map_task_to_spec(
         file_outputs.push(output);
     }
     for output in &file_outputs {
-        let parent = FilePath::new(&output.container_path)
-            .parent()
-            .and_then(FilePath::to_str)
+        // A pattern is captured under its literal prefix, which is the directory
+        // the container must be able to write.
+        let pattern = has_wildcard(&output.container_path)
+            .then(|| output_glob(&output.container_path))
+            .transpose()
+            .map_err(|_| TesError::bad_request("invalid output path"))?;
+        let parent = if pattern.is_some() {
+            literal_prefix(&output.container_path)
+                .map_err(|_| TesError::bad_request("invalid output parent path"))?
+        } else {
+            FilePath::new(&output.container_path)
+                .parent()
+                .ok_or_else(|| TesError::bad_request("invalid output parent path"))?
+                .to_path_buf()
+        };
+        let parent = parent
+            .to_str()
             .ok_or_else(|| TesError::bad_request("invalid output parent path"))?;
         if parent == "/" {
             return Err(TesError::bad_request("root output parent is forbidden"));
@@ -806,6 +829,7 @@ fn map_task_to_spec(
         for input in &inputs {
             if let Some(path) = input.container_path.as_deref()
                 && (path == output.container_path
+                    || pattern.as_ref().is_some_and(|glob| glob.is_match(path))
                     || paths_overlap(path, parent)
                         .map_err(|_| TesError::bad_request("invalid input or output path"))?)
             {
@@ -892,6 +916,12 @@ fn map_input(input: &TesInput, s3_mounts: bool) -> Result<InputSelection, TesErr
         .ok_or_else(|| TesError::bad_request("input url is required"))?;
     let (bucket, key) = parse_s3_url(url, "input")?;
     validate_path(&input.path, "input path", false)?;
+    // TES 1.1 defines wildcards for outputs only; an input path is one file.
+    if has_wildcard(&input.path) {
+        return Err(TesError::bad_request(
+            "input path must not contain wildcards",
+        ));
+    }
     Ok(InputSelection {
         source: InputSource::S3 {
             bucket,
@@ -915,6 +945,7 @@ fn map_output(output: &TesOutput) -> Result<OutputSelection, TesError> {
         return Err(TesError::bad_request("directory outputs are not supported"));
     }
     validate_path(&output.path, "output path", false)?;
+    let path_prefix = output_prefix(output)?;
     let url = output
         .url
         .as_deref()
@@ -922,10 +953,39 @@ fn map_output(output: &TesOutput) -> Result<OutputSelection, TesError> {
     let (bucket, key) = parse_s3_url(url, "output")?;
     Ok(OutputSelection {
         container_path: output.path.clone(),
+        path_prefix,
         destination: OutputDestination::S3 { bucket, key },
         name: output.name.clone(),
         description: output.description.clone(),
     })
+}
+
+/// TES 1.1 makes `path_prefix` required when `path` carries POSIX wildcards and
+/// ignored otherwise, so a wildcard-free output drops any prefix it was sent.
+fn output_prefix(output: &TesOutput) -> Result<Option<String>, TesError> {
+    if !has_wildcard(&output.path) {
+        return Ok(None);
+    }
+    output_glob(&output.path).map_err(|error| {
+        TesError::bad_request(format!(
+            "output path `{}` is not a valid pattern: {error}",
+            output.path
+        ))
+    })?;
+    let prefix = output.path_prefix.as_deref().ok_or_else(|| {
+        TesError::bad_request(format!(
+            "output path `{}` contains wildcards and requires path_prefix",
+            output.path
+        ))
+    })?;
+    validate_path(prefix, "output path_prefix", false)?;
+    if has_wildcard(prefix) || output_suffix(&output.path, prefix).is_none() {
+        return Err(TesError::bad_request(format!(
+            "output path_prefix `{prefix}` must be a literal ancestor of `{}`",
+            output.path
+        )));
+    }
+    Ok(Some(prefix.to_string()))
 }
 
 fn parse_s3_url(url: &str, role: &str) -> Result<(String, String), TesError> {
@@ -1057,6 +1117,7 @@ fn project_task(record: &JobRecord, view: TesView, base_url: &str) -> TesTask {
                 description: output.description.clone(),
                 url: Some(format!("s3://{bucket}/{key}")),
                 path: output.container_path.clone(),
+                path_prefix: output.path_prefix.clone(),
                 kind: TesFileType::File,
             }
         })
@@ -1911,6 +1972,83 @@ mod tests {
             .zones
             .push("zone-a".to_string());
         assert!(map_task_to_spec(&task, None, true).is_err());
+    }
+
+    #[test]
+    fn maps_wildcard_output() {
+        let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
+        task.outputs[0].path = "/out/*.txt".to_string();
+        task.outputs[0].path_prefix = Some("/out".to_string());
+        task.outputs[0].url = Some("s3://dest/results".to_string());
+
+        let (spec, _) = map_task_to_spec(&task, None, true).unwrap();
+
+        assert_eq!(spec.file_outputs[0].container_path, "/out/*.txt");
+        assert_eq!(spec.file_outputs[0].path_prefix.as_deref(), Some("/out"));
+    }
+
+    #[test]
+    fn rejects_input_match() {
+        // An input the pattern would select must not be captured as an output.
+        let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
+        task.inputs[0].path = "/in/data.csv".to_string();
+        task.outputs[0].path = "/in/*.csv".to_string();
+        task.outputs[0].path_prefix = Some("/in".to_string());
+
+        let error = map_task_to_spec(&task, None, true).unwrap_err();
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rejects_missing_prefix() {
+        let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
+        task.outputs[0].path = "/out/*.txt".to_string();
+
+        let error = map_task_to_spec(&task, None, true).unwrap_err();
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert!(error.message.contains("/out/*.txt"), "{}", error.message);
+    }
+
+    #[test]
+    fn rejects_foreign_prefix() {
+        let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
+        task.outputs[0].path = "/out/sub/*.txt".to_string();
+        for prefix in ["/other", "/out/s", "/out/*", "out"] {
+            task.outputs[0].path_prefix = Some(prefix.to_string());
+            let error = map_task_to_spec(&task, None, true).unwrap_err();
+            assert_eq!(error.status, StatusCode::BAD_REQUEST, "{prefix}");
+        }
+        // The pattern itself must still compile.
+        task.outputs[0].path = "/out/[a.txt".to_string();
+        task.outputs[0].path_prefix = Some("/out".to_string());
+        assert_eq!(
+            map_task_to_spec(&task, None, true).unwrap_err().status,
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn ignores_unused_prefix() {
+        // TES 1.1 ignores path_prefix unless the path carries wildcards.
+        let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
+        task.outputs[0].path_prefix = Some("/out".to_string());
+
+        let (spec, _) = map_task_to_spec(&task, None, true).unwrap();
+
+        assert!(spec.file_outputs[0].path_prefix.is_none());
+    }
+
+    #[test]
+    fn rejects_wildcard_input() {
+        // TES 1.1 defines wildcards for outputs only.
+        let mut task = sample_task(Ulid::from_bytes([5u8; 16]));
+        task.inputs[0].path = "/in/*.csv".to_string();
+
+        let error = map_task_to_spec(&task, None, true).unwrap_err();
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -1002,6 +1002,7 @@ mod tests {
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::handle::Handle;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::keyspaces::{REALM_CONFIG_KEYSPACE, USER_KEYSPACE};
     use aruna_core::onboarding::{OnboardingMode, OnboardingSecret, OnboardingSecretRecord};
     use aruna_core::structs::{
@@ -1242,8 +1243,7 @@ mod tests {
         )
         .await;
 
-        let realm_signing_key =
-            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = net_handle.node_id();
         let realm_admin_id = UserId::local(Ulid::generate(), realm_id);
@@ -1422,7 +1422,7 @@ mod tests {
     async fn get_user_for_regular_registered_user_returns_forbidden() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
@@ -1457,7 +1457,7 @@ mod tests {
     async fn issued_user_token_carries_bounded_expiry() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
@@ -1490,7 +1490,7 @@ mod tests {
     async fn bootstrap_registration_consumes_secret() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, false).await;
 
@@ -1534,7 +1534,7 @@ mod tests {
     async fn get_user_for_missing_user_without_admin_permissions_returns_forbidden() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
@@ -1571,7 +1571,7 @@ mod tests {
     async fn get_user_requires_authentication() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
@@ -1596,12 +1596,11 @@ mod tests {
     async fn get_user_returns_unimplemented_for_foreign_realm_token() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
-        let foreign_realm_signing_key =
-            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let foreign_realm_signing_key = generate_signing_key();
         let foreign_realm_id =
             RealmId::from_bytes(foreign_realm_signing_key.verifying_key().to_bytes());
         node.state.add_trusted_realm(foreign_realm_id).await;
@@ -1670,7 +1669,7 @@ mod tests {
     async fn get_token_returns_aruna_token_for_registered_oidc_user() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
@@ -1706,7 +1705,7 @@ mod tests {
     async fn get_token_rejects_scoped_aruna_token() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
@@ -1741,7 +1740,7 @@ mod tests {
     async fn get_token_rejects_alias_aruna_token() {
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
         let node = spawn_test_node(provider, true).await;
 
@@ -1809,12 +1808,12 @@ mod resolve_tests {
     use crate::error::ServerError;
     use crate::server_state::ServerState;
     use aruna_core::UserId;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::structs::{AuthContext, NodeCapabilities, RealmId};
     use aruna_operations::driver::DriverContext;
     use aruna_storage::FjallStorage;
     use axum::extract::State;
     use axum::{Extension, Json};
-    use ed25519_dalek::SigningKey;
     use std::sync::Arc;
     use tempfile::{TempDir, tempdir};
     use ulid::Ulid;
@@ -1830,8 +1829,7 @@ mod resolve_tests {
             task_handle: None,
             compute_handle: None,
         });
-        let realm_signing_key =
-            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let state = Arc::new(
             ServerState::new(

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -515,13 +515,15 @@ async fn register_admin(
     post,
     path = "/users/register",
     tag = "users",
+    description = "Requires an OIDC bearer token from a configured issuer, not an Aruna access token.",
     request_body = RegisterUserRequest,
     responses(
         (status = 201, description = "User registered", body = RegisterUserResponse),
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse)
-    )
+    ),
+    security(("bearer_auth" = []))
 )]
 async fn register_user(
     State(state): State<Arc<ServerState>>,

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -238,6 +238,7 @@ mod tests {
     use aruna::config::load;
     use aruna_api::server::{Server, ServerConfig};
     use aruna_api::server_state::ServerState;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::structs::{NodeCapabilities, RealmId};
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
     use aruna_operations::announce_realm_presence::{
@@ -248,7 +249,6 @@ mod tests {
     use aruna_operations::incoming::initialize_net_incoming;
     use aruna_operations::task_incoming::initialize_task_incoming;
     use aruna_tasks::TaskHandle;
-    use ed25519_dalek::SigningKey;
     use std::sync::Arc;
     use tempfile::tempdir;
     use tokio::net::TcpListener;
@@ -347,8 +347,7 @@ mod tests {
         )
         .await;
 
-        let realm_signing_key =
-            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let capabilities = NodeCapabilities::management_node(realm_signing_key).unwrap();
         let bootstrap_user = aruna_core::UserId::local(Ulid::generate(), realm_id);

--- a/aruna-doctor/src/tokens.rs
+++ b/aruna-doctor/src/tokens.rs
@@ -450,6 +450,7 @@ mod tests {
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::handle::Handle;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::keyspaces::{REALM_CONFIG_KEYSPACE, USER_KEYSPACE};
     use aruna_core::structs::{
         Actor, NodeCapabilities, OidcProviderConfig, RealmConfigDocument, RealmId, TokenClaims,
@@ -736,8 +737,7 @@ mod tests {
         )
         .await;
 
-        let realm_signing_key =
-            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let realm_signing_key = generate_signing_key();
         let realm_id =
             aruna_core::structs::RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let capabilities = NodeCapabilities::management_node(realm_signing_key).unwrap();
@@ -880,7 +880,7 @@ mod tests {
     }
 
     fn aruna_token_fixture() -> (SigningKey, RealmId, UserId) {
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
         let user_id = UserId::local(Ulid::generate(), realm_id);
         (signing_key, realm_id, user_id)
@@ -969,8 +969,7 @@ mod tests {
     #[tokio::test]
     async fn delegated_server_token_view_is_valid_for_trusted_realm() {
         let (realm_signing_key, realm_id, user_id) = aruna_token_fixture();
-        let issuer_signing_key =
-            SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let issuer_signing_key = generate_signing_key();
         let issuer_pubkey = public_key_base64(&issuer_signing_key);
         let mut claims = aruna_token_claims(realm_id, user_id);
         claims.issuer_pubkey = Some(issuer_pubkey.clone());
@@ -1127,7 +1126,7 @@ mod tests {
         let _guard = env_lock().lock().await;
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let oidc_token = sign_oidc_token(issuer, kid, &signing_key, "subject-123", Some("Alice"));
         let (provider, oidc_task) =
             spawn_oidc_provider(issuer, kid, &signing_key, oidc_token).await;
@@ -1161,7 +1160,7 @@ mod tests {
         let _guard = env_lock().lock().await;
         let issuer = "https://issuer.example";
         let kid = "main-key";
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let oidc_token = sign_oidc_token(issuer, kid, &signing_key, "subject-admin", Some("Admin"));
         let (provider, oidc_task) =
             spawn_oidc_provider(issuer, kid, &signing_key, oidc_token).await;

--- a/aruna/src/config.rs
+++ b/aruna/src/config.rs
@@ -3,6 +3,7 @@ use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
+use aruna_core::keys::generate_signing_key;
 use aruna_core::keyspaces::{NODE_STATE_KEYSPACE, REALM_CONFIG_KEYSPACE};
 use aruna_core::onboarding::{
     BootstrapOnboardingRequest, BootstrapOnboardingResponse, OnboardingMode, OnboardingPhase,
@@ -841,9 +842,8 @@ fn node_capabilities_from_state(
 }
 
 fn generate_initialized_node_state() -> Result<PersistedNodeState, SetupError> {
-    let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-    let realm_signing_key = SigningKey::generate(&mut csprng);
-    let node_signing_key = SigningKey::generate(&mut csprng);
+    let realm_signing_key = generate_signing_key();
+    let node_signing_key = generate_signing_key();
 
     Ok(PersistedNodeState {
         boot_origin: BootOrigin::InitializedRealm,
@@ -872,13 +872,12 @@ async fn bootstrap_onboarded_node_state(
     node_labels: BTreeMap<String, String>,
 ) -> Result<BootstrappedNodeState, SetupError> {
     let decoded_secret = OnboardingSecret::decode(onboarding_secret)?;
-    let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-    let node_signing_key = SigningKey::generate(&mut csprng);
+    let node_signing_key = generate_signing_key();
     let net_secret_key = node_signing_key.to_bytes();
     let node_id = iroh::SecretKey::from_bytes(&net_secret_key).public();
 
     let issuer_signing_key = if matches!(decoded_secret.mode, OnboardingMode::Server) {
-        Some(SigningKey::generate(&mut csprng))
+        Some(generate_signing_key())
     } else {
         None
     };
@@ -1400,13 +1399,13 @@ mod tests {
         fjall_persist_policy_env, load, load_oidc_providers_from_env, parse_node_labels_env,
         persist_node_state, portal_config_env, rocrate_limits_env, validate_public_url,
     };
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::structs::{
         DynamicDiscoveryMethod, RealmConfigDocument, RealmDiscoveryConfig, RealmId, RelayPolicy,
         RoCrateLimits, StaticRealmEndpoint,
     };
     use aruna_net::{DiscoveryMethod, RelayMethod, endpoint_addr_to_config_string};
     use aruna_storage::{FjallPersistPolicy, FjallStorage};
-    use ed25519_dalek::SigningKey;
     use std::sync::OnceLock;
     use tempfile::tempdir;
     use tokio::sync::Mutex;
@@ -2068,9 +2067,8 @@ mod tests {
         let tempdir = tempdir().unwrap();
         let storage = FjallStorage::open(tempdir.path().to_str().unwrap()).unwrap();
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key = SigningKey::generate(&mut csprng);
-        let net_signing_key = SigningKey::generate(&mut csprng);
+        let realm_signing_key = generate_signing_key();
+        let net_signing_key = generate_signing_key();
         let node_state = PersistedNodeState {
             boot_origin: BootOrigin::Onboarded,
             status: PersistedNodeStatus::Complete,
@@ -2134,9 +2132,8 @@ mod tests {
         let tempdir = tempdir().unwrap();
         let storage = FjallStorage::open(tempdir.path().to_str().unwrap()).unwrap();
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key = SigningKey::generate(&mut csprng);
-        let net_signing_key = SigningKey::generate(&mut csprng);
+        let realm_signing_key = generate_signing_key();
+        let net_signing_key = generate_signing_key();
         let node_state = PersistedNodeState {
             boot_origin: BootOrigin::Onboarded,
             status: PersistedNodeStatus::PendingOnboarding,

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -899,7 +899,8 @@ mod tests {
         let readiness = Readiness::new();
         readiness.set_ready();
         let observed_readiness = readiness.clone();
-        let (storage_handle, receiver) = StorageHandle::new();
+        let (storage_handle, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         let worker = thread::spawn(move || {
             let (effect, response_tx, _span, _queued_at, _in_flight) = receiver
                 .recv()
@@ -952,7 +953,8 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_usage_counters_returns_probe_errors() {
-        let (storage_handle, receiver) = StorageHandle::new();
+        let (storage_handle, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         let worker = thread::spawn(move || {
             let (effect, response_tx, _span, _queued_at, _in_flight) = receiver
                 .recv()
@@ -975,7 +977,8 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_usage_counters_rejects_unexpected_probe_events() {
-        let (storage_handle, receiver) = StorageHandle::new();
+        let (storage_handle, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         let worker = thread::spawn(move || {
             let (effect, response_tx, _span, _queued_at, _in_flight) = receiver
                 .recv()

--- a/aruna/tests/compute_execution.rs
+++ b/aruna/tests/compute_execution.rs
@@ -268,6 +268,7 @@ async fn execution_end_to_end() -> TestResult<()> {
     spec.inputs[0].container_path = Some("/input/input.txt".to_string());
     spec.file_outputs = vec![OutputSelection {
         container_path: "/output/result.txt".to_string(),
+        path_prefix: None,
         destination: OutputDestination::S3 {
             bucket: fixture.source_bucket.clone(),
             key: "outputs/result.txt".to_string(),

--- a/aruna/tests/oidc_registration.rs
+++ b/aruna/tests/oidc_registration.rs
@@ -6,6 +6,7 @@ use aruna_core::UserId;
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
+use aruna_core::keys::generate_signing_key;
 use aruna_core::keyspaces::{USER_KEYSPACE, USER_SUBJECT_INDEX_KEYSPACE};
 use aruna_core::structs::{Actor, NodeCapabilities, OidcProviderConfig, User, oidc_subject_key};
 use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
@@ -207,7 +208,7 @@ async fn spawn_test_node(provider: OidcProviderConfig) -> TestNode {
     )
     .await;
 
-    let realm_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+    let realm_signing_key = generate_signing_key();
     let realm_id =
         aruna_core::structs::RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
     let bootstrap_user = UserId::local(Ulid::generate(), realm_id);
@@ -298,7 +299,7 @@ async fn spawn_test_node(provider: OidcProviderConfig) -> TestNode {
 async fn oidc_registration_route_creates_user_indexes_and_token() {
     let issuer = "https://issuer.example";
     let kid = "main-key";
-    let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+    let signing_key = generate_signing_key();
     let (provider, oidc_task) = spawn_oidc_provider(issuer, kid, &signing_key).await;
     let node = spawn_test_node(provider).await;
 

--- a/aruna/tests/shared.rs
+++ b/aruna/tests/shared.rs
@@ -16,6 +16,7 @@ use aruna_api::server::{Server, ServerConfig};
 use aruna_api::server_state::ServerState;
 use aruna_blob::blob::BlobHandler;
 use aruna_core::UserId;
+use aruna_core::keys::generate_signing_key;
 use aruna_core::metrics::NodeMetrics;
 use aruna_core::onboarding::{
     CreateOnboardingSecretRequest, CreateOnboardingSecretResponse, OnboardingMode, OnboardingPhase,
@@ -44,7 +45,6 @@ use aruna_storage::{FjallStorage, StorageHandle};
 use aruna_tasks::TaskHandle;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
-use ed25519_dalek::SigningKey;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::StatusCode;
 use std::collections::HashMap;
@@ -575,7 +575,7 @@ async fn spawn_seed_node_with_mode(mode: NodeServiceMode) -> TestResult<SeedNode
         .to_str()
         .ok_or_else(|| std::io::Error::other("invalid temp path"))?;
     let storage = FjallStorage::open(storage_path)?;
-    let realm_signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+    let realm_signing_key = generate_signing_key();
     let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
     let user_id = UserId::new(Ulid::generate(), realm_id);
     let net = NetHandle::new(

--- a/blob/src/opendal.rs
+++ b/blob/src/opendal.rs
@@ -322,6 +322,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn builds_unsigned_s3() {
+        // `skip_signature` must stay a valid S3 config key across opendal upgrades.
+        build_service::<services::S3>(HashMap::from([
+            ("bucket".to_string(), "public-data".to_string()),
+            ("endpoint".to_string(), "https://s3.example.org".to_string()),
+            ("region".to_string(), "eu-central-1".to_string()),
+            ("skip_signature".to_string(), "true".to_string()),
+        ]))
+        .unwrap();
+
+        build_service::<services::S3>(HashMap::from([
+            ("bucket".to_string(), "public-data".to_string()),
+            ("endpoint".to_string(), "https://s3.example.org".to_string()),
+            ("region".to_string(), "eu-central-1".to_string()),
+            ("skip_signature".to_string(), "nope".to_string()),
+        ]))
+        .unwrap_err();
+    }
+
+    #[tokio::test]
     async fn check_reports_success() {
         let dir = tempdir().unwrap();
         let operator = build_service::<services::Fs>(HashMap::from([(

--- a/compute/src/executor/apptainer/mod.rs
+++ b/compute/src/executor/apptainer/mod.rs
@@ -58,13 +58,12 @@ impl ApptainerBackend {
             return Ok(to_status(&directory, status));
         }
         if let Some(payload) = read_optional::<PayloadRecord>(&directory.join("payload.json"))? {
-            if runtime::process_live(&payload.process)? {
-                return Ok(running_status(&directory));
+            let running = running_status(&directory, payload.started_at_ms);
+            if runtime::process_live(&payload.process)? || !runtime::cgroup_empty(&payload.cgroup)?
+            {
+                return Ok(running);
             }
-            if !runtime::cgroup_empty(&payload.cgroup)? {
-                return Ok(running_status(&directory));
-            }
-            return settle_status(&directory, running_status(&directory));
+            return settle_status(&directory, running);
         }
         if directory.join("supervisor.json").exists() {
             return settle_status(&directory, submitted_status(&directory));
@@ -1029,11 +1028,11 @@ fn submitted_status(directory: &Path) -> AttemptStatus {
     }
 }
 
-fn running_status(directory: &Path) -> AttemptStatus {
+fn running_status(directory: &Path, started_at_ms: Option<u64>) -> AttemptStatus {
     AttemptStatus {
         phase: AttemptPhase::Running,
         backend_ref: directory.display().to_string(),
-        started_at_ms: None,
+        started_at_ms,
         finished_at_ms: None,
     }
 }
@@ -1303,6 +1302,7 @@ mod tests {
             &PayloadRecord {
                 process: dead_record(),
                 cgroup: backend.cgroup_path(context),
+                started_at_ms: Some(1),
             },
         )
         .unwrap();
@@ -1363,7 +1363,7 @@ mod tests {
         )
         .unwrap();
 
-        let status = settle_status(root.path(), running_status(root.path())).unwrap();
+        let status = settle_status(root.path(), running_status(root.path(), Some(1))).unwrap();
 
         assert!(matches!(status.phase, AttemptPhase::Exited { code: 0 }));
     }

--- a/compute/src/executor/apptainer/mod.rs
+++ b/compute/src/executor/apptainer/mod.rs
@@ -9,9 +9,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use aruna_core::compute::{
     AdoptableEvidence, ArtifactEvidence, AttemptPhase, AttemptStatus, BackendError, CancelEvidence,
-    ExecutorKind, FenceContext, LogLimits, LogStream, LogTails, MAX_TRANSFER_BYTES, NetworkAccess,
-    ReconcileEvidence, ResumePoint, StagingMode, TaskOutput, TaskSpec, TombstoneEvidence,
-    TombstoneSpec, UserSpec, normalize_container_path,
+    ExecutorKind, FenceContext, LogLimits, LogStream, LogTails, MAX_OUTPUT_MATCHES,
+    MAX_TRANSFER_BYTES, NetworkAccess, OutputMatcher, ReconcileEvidence, ResumePoint, StagingMode,
+    TaskOutput, TaskSpec, TombstoneEvidence, TombstoneSpec, UserSpec, literal_prefix,
+    normalize_container_path,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -452,7 +453,7 @@ impl ExecutorBackend for ApptainerBackend {
         }
         let directory = self.state.attempt_dir(context);
         let attempt: AttemptRecord = read_json(&directory.join("attempt.json"))?;
-        if !attempt.output_paths.iter().any(|output| output == path) {
+        if !declared_outputs(&attempt)?.is_match(path) {
             return Err(BackendError::InvalidSpec(
                 "output path was not declared".to_string(),
             ));
@@ -482,6 +483,33 @@ impl ExecutorBackend for ApptainerBackend {
             size,
             chunks: Box::pin(ChannelStream(rx)),
         })
+    }
+
+    async fn list_outputs(
+        &self,
+        context: &FenceContext,
+        pattern: &str,
+    ) -> Result<Vec<String>, BackendError> {
+        let status = self.attempt_status(context)?;
+        if !status.is_terminal() {
+            return Err(BackendError::InvalidSpec(
+                "attempt is not terminal".to_string(),
+            ));
+        }
+        let directory = self.state.attempt_dir(context);
+        let attempt: AttemptRecord = read_json(&directory.join("attempt.json"))?;
+        if !attempt.output_paths.iter().any(|output| output == pattern) {
+            return Err(BackendError::InvalidSpec(
+                "output path was not declared".to_string(),
+            ));
+        }
+        let glob = OutputMatcher::new([pattern]).map_err(BackendError::InvalidSpec)?;
+        let prefix = literal_prefix(pattern).map_err(BackendError::InvalidSpec)?;
+        let root = directory
+            .join("workspace/root")
+            .canonicalize()
+            .map_err(io_error)?;
+        list_workspace(&root, &host_path(&root, &prefix), &glob)
     }
 
     async fn reconcile(&self, context: &FenceContext) -> ReconcileEvidence {
@@ -1108,6 +1136,58 @@ fn io_error(error: std::io::Error) -> BackendError {
     BackendError::Api(format!("Apptainer backend: {error}"))
 }
 
+fn declared_outputs(attempt: &AttemptRecord) -> Result<OutputMatcher, BackendError> {
+    OutputMatcher::new(attempt.output_paths.iter().map(String::as_str))
+        .map_err(BackendError::InvalidSpec)
+}
+
+/// Regular files below `start` whose container path the pattern selects.
+/// Symlinks are skipped, so a listing can never leave the workspace root.
+fn list_workspace(
+    root: &Path,
+    start: &Path,
+    glob: &OutputMatcher,
+) -> Result<Vec<String>, BackendError> {
+    let mut matched = Vec::new();
+    let mut pending = vec![start.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(io_error(error)),
+        };
+        for entry in entries {
+            let entry = entry.map_err(io_error)?;
+            let file_type = entry.file_type().map_err(io_error)?;
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                pending.push(entry.path());
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            let relative = path.strip_prefix(root).map_err(|_| {
+                BackendError::InvalidSpec("listing escaped the workspace".to_string())
+            })?;
+            let absolute = format!("/{}", relative.display());
+            if glob.is_match(&absolute) {
+                if matched.len() >= MAX_OUTPUT_MATCHES {
+                    return Err(BackendError::InvalidSpec(
+                        "pattern matches too many files".to_string(),
+                    ));
+                }
+                matched.push(absolute);
+            }
+        }
+    }
+    matched.sort();
+    Ok(matched)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1132,6 +1212,28 @@ mod tests {
         };
 
         backend.cleanup(&context).await.unwrap();
+    }
+
+    #[test]
+    fn lists_matching_files() {
+        let root = tempdir().unwrap();
+        let root = root.path();
+        std::fs::create_dir_all(root.join("out/sub")).unwrap();
+        for path in ["out/a.txt", "out/b.csv", "out/sub/c.txt"] {
+            std::fs::write(root.join(path), b"x").unwrap();
+        }
+        std::os::unix::fs::symlink(root.join("out/a.txt"), root.join("out/link.txt")).unwrap();
+        let glob = OutputMatcher::new(["/out/*.txt"]).unwrap();
+
+        let matched = list_workspace(root, &root.join("out"), &glob).unwrap();
+
+        // Symlinks never resolve, and `*` stops at the separator.
+        assert_eq!(matched, vec!["/out/a.txt".to_string()]);
+        assert!(
+            list_workspace(root, &root.join("absent"), &glob)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/compute/src/executor/apptainer/mod.rs
+++ b/compute/src/executor/apptainer/mod.rs
@@ -3,7 +3,7 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::process::{Command, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -230,18 +230,17 @@ impl ApptainerBackend {
             .arg(&temp)
             .arg(format!("docker://{image}"))
             .kill_on_drop(true);
-        let status = tokio::select! {
+        let output = tokio::select! {
             _ = cancel.cancelled() => return Err(BackendError::Cancelled),
-            result = tokio::time::timeout(self.config.pull_deadline, command.status()) => {
+            result = tokio::time::timeout(self.config.pull_deadline, command.output()) => {
                 result
                     .map_err(|_| BackendError::Timeout("Apptainer image pull timed out".to_string()))?
                     .map_err(io_error)?
             }
         };
-        if !status.success() {
-            return Err(BackendError::Api(format!(
-                "Apptainer image pull failed with {status}"
-            )));
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(pull_error(&stderr, output.status));
         }
         File::open(&temp)
             .and_then(|file| file.sync_all())
@@ -852,6 +851,29 @@ async fn resolve_digest(
     Ok(format!("{}@{digest}", repository_name(image)))
 }
 
+/// A pull that can never succeed must be permanent, or the attempt is requeued
+/// until the park budget runs out instead of failing with the registry cause.
+fn pull_error(stderr: &str, status: ExitStatus) -> BackendError {
+    let detail = format!(
+        "Apptainer image pull failed with {status}: {}",
+        stderr.trim()
+    );
+    if image_missing(stderr) {
+        BackendError::ImageNotFound(detail)
+    } else if image_denied(stderr) {
+        BackendError::ImageUnauthorized(detail)
+    } else {
+        BackendError::Unavailable(detail)
+    }
+}
+
+fn image_denied(stderr: &str) -> bool {
+    let stderr = stderr.to_ascii_lowercase();
+    ["unauthorized", "denied", "forbidden", "authentication"]
+        .iter()
+        .any(|message| stderr.contains(message))
+}
+
 fn image_missing(stderr: &str) -> bool {
     let stderr = stderr.to_ascii_lowercase();
     ["image not found", "manifest unknown", "name unknown"]
@@ -1342,6 +1364,20 @@ mod tests {
     fn classifies_registry_failure() {
         assert!(image_missing("MANIFEST_UNKNOWN: manifest unknown"));
         assert!(!image_missing("dial tcp: connection timed out"));
+    }
+
+    #[test]
+    fn classifies_pull_error() {
+        // A hopeless pull must be permanent; only a blip may be retried.
+        use std::os::unix::process::ExitStatusExt;
+        let status = ExitStatus::from_raw(256);
+        let missing = pull_error("FATAL: manifest unknown", status);
+        let denied = pull_error("FATAL: unauthorized: authentication required", status);
+        let blip = pull_error("dial tcp: connection timed out", status);
+        assert!(matches!(missing, BackendError::ImageNotFound(_)));
+        assert!(matches!(denied, BackendError::ImageUnauthorized(_)));
+        assert!(matches!(blip, BackendError::Unavailable(_)));
+        assert!(!missing.retryable() && !denied.retryable() && blip.retryable());
     }
 
     #[tokio::test]

--- a/compute/src/executor/apptainer/mod.rs
+++ b/compute/src/executor/apptainer/mod.rs
@@ -1172,7 +1172,15 @@ fn list_workspace(
             let relative = path.strip_prefix(root).map_err(|_| {
                 BackendError::InvalidSpec("listing escaped the workspace".to_string())
             })?;
-            let absolute = format!("/{}", relative.display());
+            // A lossy name would address a file that does not exist, so skip it.
+            let Some(relative) = relative.to_str() else {
+                tracing::warn!(
+                    path = %relative.display(),
+                    "skipping output path that is not UTF-8"
+                );
+                continue;
+            };
+            let absolute = format!("/{relative}");
             if glob.is_match(&absolute) {
                 if matched.len() >= MAX_OUTPUT_MATCHES {
                     return Err(BackendError::InvalidSpec(
@@ -1233,6 +1241,25 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn skips_invalid_name() {
+        // A lossy name matches the pattern but addresses no file, so the fetch
+        // that follows would fail forever.
+        use std::os::unix::ffi::OsStrExt;
+
+        let root = tempdir().unwrap();
+        let root = root.path();
+        std::fs::create_dir_all(root.join("out")).unwrap();
+        std::fs::write(root.join("out/a.txt"), b"x").unwrap();
+        let invalid = std::ffi::OsStr::from_bytes(b"\xff\xfe.txt");
+        std::fs::write(root.join("out").join(invalid), b"y").unwrap();
+        let glob = OutputMatcher::new(["/out/*.txt"]).unwrap();
+
+        let matched = list_workspace(root, &root.join("out"), &glob).unwrap();
+
+        assert_eq!(matched, vec!["/out/a.txt".to_string()]);
     }
 
     #[test]

--- a/compute/src/executor/apptainer/runtime.rs
+++ b/compute/src/executor/apptainer/runtime.rs
@@ -53,14 +53,17 @@ pub fn supervisor(attempt_dir: &Path) -> Result<(), BackendError> {
             "invalid launcher readiness byte".to_string(),
         ));
     }
+    // Recorded before the launcher is released so a poll can report the start
+    // without waiting for the terminal status record.
+    let started_at_ms = now_ms();
     write_json(
         &attempt_dir.join("payload.json"),
         &PayloadRecord {
             process,
             cgroup: launch.cgroup.clone(),
+            started_at_ms: Some(started_at_ms),
         },
     )?;
-    let started_at_ms = now_ms();
     stream.write_all(&[1]).map_err(io_error)?;
     drop(stream);
 

--- a/compute/src/executor/apptainer/state.rs
+++ b/compute/src/executor/apptainer/state.rs
@@ -61,6 +61,8 @@ pub struct ProcessRecord {
 pub struct PayloadRecord {
     pub process: ProcessRecord,
     pub cgroup: PathBuf,
+    #[serde(default)]
+    pub started_at_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -255,4 +257,30 @@ pub fn sync_dir(path: &Path) -> Result<(), BackendError> {
 
 fn state_error(error: std::io::Error) -> BackendError {
     BackendError::Api(format!("Apptainer state: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_start_optional() {
+        // A payload written before the start time existed must still decode.
+        let record = PayloadRecord {
+            process: ProcessRecord {
+                pid: 7,
+                start_ticks: 9,
+            },
+            cgroup: PathBuf::from("/sys/fs/cgroup/attempt"),
+            started_at_ms: Some(1_700_000_000_000),
+        };
+        let encoded = serde_json::to_vec(&record).expect("encode payload");
+
+        let decoded: PayloadRecord = serde_json::from_slice(&encoded).expect("decode payload");
+        assert_eq!(decoded.started_at_ms, Some(1_700_000_000_000));
+
+        let legacy = br#"{"process":{"pid":7,"start_ticks":9},"cgroup":"/c"}"#;
+        let decoded: PayloadRecord = serde_json::from_slice(legacy).expect("decode legacy payload");
+        assert_eq!(decoded.started_at_ms, None);
+    }
 }

--- a/compute/src/executor/docker/mod.rs
+++ b/compute/src/executor/docker/mod.rs
@@ -45,6 +45,10 @@ const GENERATION_LABEL: &str = "aruna-engine.org/controller-generation";
 const DIRECTORY_MODE: u32 = 1 << 31;
 const NON_REGULAR_MODES: u32 =
     DIRECTORY_MODE | (1 << 27) | (1 << 26) | (1 << 25) | (1 << 24) | (1 << 21) | (1 << 19);
+/// A wildcard listing streams the whole prefix archive to read its headers and
+/// uploads none of it, so the per-file transfer cap must not apply. This bound
+/// only stops an archive that never ends.
+const MAX_LISTING_SCAN_BYTES: u64 = 1024 * MAX_TRANSFER_BYTES;
 
 mod control;
 
@@ -958,7 +962,13 @@ fn list_archive(
         {
             return Err(output_spec("archive entry path is unsafe"));
         }
-        let Some(absolute) = base.join(path).to_str().map(str::to_string) else {
+        // A lossy name would address a file that does not exist, so skip it.
+        let joined = base.join(path);
+        let Some(absolute) = joined.to_str().map(str::to_string) else {
+            tracing::warn!(
+                path = %joined.display(),
+                "skipping output path that is not UTF-8"
+            );
             continue;
         };
         if glob.is_match(&absolute) {
@@ -1431,7 +1441,7 @@ impl ExecutorBackend for DockerBackend {
             .docker
             .download_from_container(container_id, Some(options))
             .map(|chunk| chunk.map_err(|error| io::Error::other(classify_archive(&error))));
-        let counted = Box::pin(count_limited(raw, MAX_TRANSFER_BYTES));
+        let counted = Box::pin(count_limited(raw, MAX_LISTING_SCAN_BYTES));
         let reader = SyncIoBridge::new_with_handle(StreamReader::new(counted), Handle::current());
         let listed = tokio::task::spawn_blocking(move || list_archive(reader, &base, &glob))
             .await
@@ -2399,6 +2409,57 @@ mod tests {
             parse_bytes(bytes, Path::new("output.txt"), limit).await,
             Err(BackendError::InvalidSpec(_))
         ));
+    }
+
+    #[test]
+    fn lists_past_transfer() {
+        // Name collection streams the whole prefix archive but uploads nothing,
+        // so scratch payload must not be charged to the transfer cap.
+        let scratch = vec![b'x'; 256 * 1024];
+        let bytes = make_archive(&[
+            ("out/a.txt", tar::EntryType::Regular, b"1"),
+            ("out/scratch.bin", tar::EntryType::Regular, &scratch),
+            ("out/b.txt", tar::EntryType::Regular, b"2"),
+        ]);
+        let glob = OutputMatcher::new(["/out/*.txt"]).unwrap();
+
+        let matched = list_archive(io::Cursor::new(bytes), Path::new("/"), &glob).unwrap();
+
+        assert_eq!(matched, vec!["/out/a.txt", "/out/b.txt"]);
+        assert!(MAX_LISTING_SCAN_BYTES > MAX_TRANSFER_BYTES);
+    }
+
+    #[test]
+    fn skips_invalid_listing() {
+        // A file whose name is not UTF-8 cannot be addressed as an output, but
+        // it must not fail the capture of the files that can be.
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o644);
+        header.set_size(1);
+        header.as_mut_bytes()[..12].copy_from_slice(b"out/\xff\xfe.txt");
+        header.set_cksum();
+        let mut builder = tar::Builder::new(Vec::new());
+        builder.append(&header, &b"x"[..]).unwrap();
+        builder
+            .append_data(
+                &mut {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_entry_type(tar::EntryType::Regular);
+                    header.set_mode(0o644);
+                    header.set_size(1);
+                    header
+                },
+                "out/a.txt",
+                &b"1"[..],
+            )
+            .unwrap();
+        let bytes = builder.into_inner().unwrap();
+        let glob = OutputMatcher::new(["/out/*.txt"]).unwrap();
+
+        let matched = list_archive(io::Cursor::new(bytes), Path::new("/"), &glob).unwrap();
+
+        assert_eq!(matched, vec!["/out/a.txt"]);
     }
 
     #[test]

--- a/compute/src/executor/docker/mod.rs
+++ b/compute/src/executor/docker/mod.rs
@@ -2437,7 +2437,7 @@ mod tests {
         header.set_entry_type(tar::EntryType::Regular);
         header.set_mode(0o644);
         header.set_size(1);
-        header.as_mut_bytes()[..12].copy_from_slice(b"out/\xff\xfe.txt");
+        header.as_mut_bytes()[..10].copy_from_slice(b"out/\xff\xfe.txt");
         header.set_cksum();
         let mut builder = tar::Builder::new(Vec::new());
         builder.append(&header, &b"x"[..]).unwrap();

--- a/compute/src/executor/docker/mod.rs
+++ b/compute/src/executor/docker/mod.rs
@@ -2426,7 +2426,7 @@ mod tests {
         let matched = list_archive(io::Cursor::new(bytes), Path::new("/"), &glob).unwrap();
 
         assert_eq!(matched, vec!["/out/a.txt", "/out/b.txt"]);
-        assert!(MAX_LISTING_SCAN_BYTES > MAX_TRANSFER_BYTES);
+        const { assert!(MAX_LISTING_SCAN_BYTES > MAX_TRANSFER_BYTES) };
     }
 
     #[test]

--- a/compute/src/executor/docker/mod.rs
+++ b/compute/src/executor/docker/mod.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 use aruna_core::compute::{
     AdoptableEvidence, ArtifactEvidence, AttemptPhase, AttemptRef, AttemptStatus, BackendError,
     CancelEvidence, ExecutorKind, FenceContext, InputStream, LogLimits, LogStream, LogTails,
-    MAX_TRANSFER_BYTES, NOBODY, NetworkAccess, ReconcileEvidence, ResumePoint, StagingMode,
-    TaskInput, TaskOutput, TaskSpec, TombstoneEvidence, TombstoneSpec, UserSpec,
+    MAX_OUTPUT_MATCHES, MAX_TRANSFER_BYTES, NOBODY, NetworkAccess, OutputMatcher,
+    ReconcileEvidence, ResumePoint, StagingMode, TaskInput, TaskOutput, TaskSpec,
+    TombstoneEvidence, TombstoneSpec, UserSpec, literal_prefix,
 };
 use async_trait::async_trait;
 use bollard::models::{
@@ -936,6 +937,41 @@ fn stream_output(
     }
 }
 
+/// Collect the regular files of a directory archive that the pattern selects.
+/// Entry payloads are skipped; only the headers are inspected.
+fn list_archive(
+    archive: impl Read,
+    base: &Path,
+    glob: &OutputMatcher,
+) -> Result<Vec<String>, BackendError> {
+    let mut archive = tar::Archive::new(archive);
+    let mut matched = Vec::new();
+    for entry in archive.entries().map_err(archive_error)? {
+        let entry = entry.map_err(archive_error)?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let path = entry.path().map_err(archive_api)?;
+        if path
+            .components()
+            .any(|part| !matches!(part, std::path::Component::Normal(_)))
+        {
+            return Err(output_spec("archive entry path is unsafe"));
+        }
+        let Some(absolute) = base.join(path).to_str().map(str::to_string) else {
+            continue;
+        };
+        if glob.is_match(&absolute) {
+            if matched.len() >= MAX_OUTPUT_MATCHES {
+                return Err(output_spec("pattern matches too many files"));
+            }
+            matched.push(absolute);
+        }
+    }
+    matched.sort();
+    Ok(matched)
+}
+
 fn build_config(
     config: &DockerConfig,
     context: &FenceContext,
@@ -1363,6 +1399,47 @@ impl ExecutorBackend for DockerBackend {
             Err(_) => Err(BackendError::Api(
                 "output parse stopped before the tar header".to_string(),
             )),
+        }
+    }
+
+    async fn list_outputs(
+        &self,
+        context: &FenceContext,
+        pattern: &str,
+    ) -> Result<Vec<String>, BackendError> {
+        let _guard = self.control_guard(context).await?;
+        let attempt = &context.attempt;
+        attempt.validate().map_err(BackendError::InvalidSpec)?;
+        let glob = OutputMatcher::new([pattern]).map_err(BackendError::InvalidSpec)?;
+        let prefix = literal_prefix(pattern).map_err(BackendError::InvalidSpec)?;
+        // Entries of a directory archive are relative to the requested directory.
+        let base = prefix
+            .parent()
+            .ok_or_else(|| output_spec("pattern has no literal parent"))?
+            .to_path_buf();
+        let inspect = self.inspect_matching_attempt(attempt).await?;
+        if !inspect_to_status(inspect.clone()).is_terminal() {
+            return Err(output_spec("attempt is not terminal"));
+        }
+        let container_id = inspect.id.as_deref().ok_or_else(|| {
+            BackendError::Api("Docker inspect response omitted the container ID".to_string())
+        })?;
+        let options = DownloadFromContainerOptionsBuilder::new()
+            .path(&prefix.to_string_lossy())
+            .build();
+        let raw = self
+            .docker
+            .download_from_container(container_id, Some(options))
+            .map(|chunk| chunk.map_err(|error| io::Error::other(classify_archive(&error))));
+        let counted = Box::pin(count_limited(raw, MAX_TRANSFER_BYTES));
+        let reader = SyncIoBridge::new_with_handle(StreamReader::new(counted), Handle::current());
+        let listed = tokio::task::spawn_blocking(move || list_archive(reader, &base, &glob))
+            .await
+            .map_err(|error| BackendError::Api(format!("output listing stopped: {error}")))?;
+        match listed {
+            // An absent output directory selects nothing rather than failing.
+            Err(BackendError::NotFound(_)) => Ok(Vec::new()),
+            other => other,
         }
     }
 

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -1570,21 +1570,19 @@ fn job_pending(job: &Job) -> bool {
         .is_some_and(|status| status.active.unwrap_or(0) > 0 && status.ready.unwrap_or(0) == 0)
 }
 
-/// Kubelet reasons for a container that cannot start without outside help.
-fn stuck_wait(reason: &str) -> bool {
+/// Reasons the kubelet reports only after repeated failed attempts. A bare
+/// `ErrImagePull` is a single try, so it never proves a stuck container.
+fn repeated_wait(reason: &str) -> bool {
     matches!(
         reason,
-        "InvalidImageName"
-            | "ErrImagePull"
-            | "ImagePullBackOff"
-            | "CreateContainerConfigError"
-            | "CreateContainerError"
+        "ImagePullBackOff" | "CreateContainerConfigError" | "CreateContainerError"
     )
 }
 
 /// Kubernetes retries a failing image pull forever, so the Job counts such a
 /// Pod as active and never reports a terminal condition. A malformed reference
-/// fails at once; a retryable reason fails once it outlives `deadline`.
+/// fails at once; a repeated failure fails once it outlives `deadline`, which
+/// is anchored at the Pod start and so also covers scheduling.
 fn pod_stuck_reason(pod: &Pod, deadline: Duration, now: Timestamp) -> Option<String> {
     let status = pod.status.as_ref()?;
     let waited = status
@@ -1601,7 +1599,7 @@ fn pod_stuck_reason(pod: &Pod, deadline: Duration, now: Timestamp) -> Option<Str
         .find_map(|container| {
             let waiting = container.state.as_ref()?.waiting.as_ref()?;
             let reason = waiting.reason.as_deref()?;
-            if !stuck_wait(reason) || (reason != "InvalidImageName" && waited <= deadline) {
+            if reason != "InvalidImageName" && !(repeated_wait(reason) && waited > deadline) {
                 return None;
             }
             let detail = waiting.message.as_deref().unwrap_or("no detail reported");
@@ -2588,11 +2586,30 @@ mod tests {
 
     #[test]
     fn fails_stalled_pull() {
-        let pod = waiting_pod("ImagePullBackOff", POD_START);
-        let reason = pod_stuck_reason(&pod, Duration::from_secs(30), probe_now(120))
-            .expect("reject stalled pull");
-        assert!(reason.contains("ImagePullBackOff"), "{reason}");
-        assert!(reason.contains("pull access failed"), "{reason}");
+        // Only a reason implying repeated failures may end the attempt, and
+        // then only past the deadline.
+        for reason in [
+            "ImagePullBackOff",
+            "CreateContainerConfigError",
+            "CreateContainerError",
+        ] {
+            let pod = waiting_pod(reason, POD_START);
+            let stuck = pod_stuck_reason(&pod, Duration::from_secs(30), probe_now(120))
+                .expect("reject stalled pull");
+            assert!(stuck.contains(reason), "{stuck}");
+            assert!(stuck.contains("pull access failed"), "{stuck}");
+        }
+    }
+
+    #[test]
+    fn waits_single_pull() {
+        // The deadline starts at the Pod, so scheduling and volume attach time
+        // count against it; one observed ErrImagePull is not repeated failure.
+        let pod = waiting_pod("ErrImagePull", POD_START);
+        assert_eq!(
+            pod_stuck_reason(&pod, Duration::from_secs(30), probe_now(9_000)),
+            None
+        );
     }
 
     #[test]

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -1603,7 +1603,7 @@ fn pod_stuck_reason(pod: &Pod, deadline: Duration, now: Timestamp) -> Option<Str
     let waited = status
         .start_time
         .as_ref()
-        .or_else(|| pod.metadata.creation_timestamp.as_ref())
+        .or(pod.metadata.creation_timestamp.as_ref())
         .map(|since| Duration::try_from(now.duration_since(since.0)).unwrap_or_default())
         .unwrap_or_default();
     status

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -18,10 +18,12 @@ use json_patch::Patch as JsonPatch;
 use k8s_openapi::api::authorization::v1::SelfSubjectAccessReview;
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{
-    ConfigMap, Namespace, PersistentVolume, PersistentVolumeClaim, Pod, Secret, ServiceAccount,
+    ConfigMap, ContainerState, Namespace, PersistentVolume, PersistentVolumeClaim, Pod, Secret,
+    ServiceAccount,
 };
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use k8s_openapi::api::storage::v1::{CSIDriver, StorageClass};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
 use k8s_openapi::jiff::Timestamp;
 use kube::api::{
     Api, AttachParams, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams,
@@ -606,23 +608,34 @@ impl KubernetesBackend {
         let mut status = job_status(job);
         if status.is_terminal() {
             let pods = self.task_pods(context).await?;
-            if let Some(terminated) = pods.iter().find_map(|pod| {
-                pod.status
-                    .as_ref()
-                    .and_then(|status| status.container_statuses.as_ref())
-                    .and_then(|statuses| statuses.iter().find(|status| status.name == "task"))
-                    .and_then(|status| status.state.as_ref())
-                    .and_then(|state| state.terminated.as_ref())
-            }) {
+            if let Some(terminated) = pods
+                .iter()
+                .find_map(|pod| task_state(pod)?.terminated.as_ref())
+            {
                 status.phase = AttemptPhase::Exited {
                     code: terminated.exit_code,
                 };
+                // A failed Job carries no completionTime, so the container is the
+                // only terminal timing evidence.
+                status.started_at_ms = status
+                    .started_at_ms
+                    .or_else(|| time_ms(terminated.started_at.as_ref()));
+                status.finished_at_ms = status
+                    .finished_at_ms
+                    .or_else(|| time_ms(terminated.finished_at.as_ref()));
             }
-        } else if job_pending(job) {
+            return Ok(status);
+        }
+        let pending = job_pending(job);
+        if !pending && status.started_at_ms.is_some() {
+            return Ok(status);
+        }
+        // Costs one extra Pod list per poll until a start time is observed: the
+        // Job reports startTime only once its controller has processed the Job.
+        let pods = self.task_pods(context).await?;
+        if pending {
             let now = Timestamp::now();
-            if let Some(reason) = self
-                .task_pods(context)
-                .await?
+            if let Some(reason) = pods
                 .iter()
                 .find_map(|pod| pod_stuck_reason(pod, self.config.pull_deadline, now))
             {
@@ -632,8 +645,12 @@ impl KubernetesBackend {
                     "failing attempt whose container cannot start"
                 );
                 status.phase = AttemptPhase::Failed { reason };
+                return Ok(status);
             }
         }
+        status.started_at_ms = status
+            .started_at_ms
+            .or_else(|| pods.iter().find_map(pod_started));
         Ok(status)
     }
 
@@ -1546,12 +1563,17 @@ fn job_status(job: &Job) -> AttemptStatus {
     } else {
         AttemptPhase::Submitted
     };
+    let times = job.status.as_ref();
     AttemptStatus {
         phase,
         backend_ref: job.metadata.uid.clone().unwrap_or_else(|| job.name_any()),
-        started_at_ms: None,
-        finished_at_ms: None,
+        started_at_ms: time_ms(times.and_then(|status| status.start_time.as_ref())),
+        finished_at_ms: time_ms(times.and_then(|status| status.completion_time.as_ref())),
     }
+}
+
+fn time_ms(time: Option<&Time>) -> Option<u64> {
+    u64::try_from(time?.0.as_millisecond()).ok()
 }
 
 /// Active but unready Pods are the only ones that can hold a stuck container.
@@ -1605,12 +1627,28 @@ fn pod_stuck_reason(pod: &Pod, deadline: Duration, now: Timestamp) -> Option<Str
 
 /// Log reads only succeed once the task container has left its waiting state.
 fn task_started(pod: &Pod) -> bool {
+    task_state(pod).is_some_and(|state| state.running.is_some() || state.terminated.is_some())
+}
+
+fn task_state(pod: &Pod) -> Option<&ContainerState> {
     pod.status
+        .as_ref()?
+        .container_statuses
+        .as_ref()?
+        .iter()
+        .find(|status| status.name == "task")?
+        .state
         .as_ref()
-        .and_then(|status| status.container_statuses.as_ref())
-        .and_then(|statuses| statuses.iter().find(|status| status.name == "task"))
-        .and_then(|status| status.state.as_ref())
-        .is_some_and(|state| state.running.is_some() || state.terminated.is_some())
+}
+
+/// The container start survives its exit, so both states carry the evidence.
+fn pod_started(pod: &Pod) -> Option<u64> {
+    let state = task_state(pod)?;
+    match (state.running.as_ref(), state.terminated.as_ref()) {
+        (Some(running), _) => time_ms(running.started_at.as_ref()),
+        (None, Some(terminated)) => time_ms(terminated.started_at.as_ref()),
+        (None, None) => None,
+    }
 }
 
 fn job_epoch(job: &Job) -> Result<u64, BackendError> {
@@ -2462,6 +2500,70 @@ mod tests {
             None
         );
         assert!(task_started(&pod));
+    }
+
+    #[test]
+    fn maps_job_times() {
+        // Without these the task log has no duration and the walltime cap has
+        // no anchor.
+        let job: Job = serde_json::from_value(json!({
+            "apiVersion":"batch/v1","kind":"Job",
+            "metadata":{"name":"aruna-job-a1","namespace":"compute","uid":"job-uid"},
+            "status":{
+                "startTime":POD_START,
+                "completionTime":"2027-01-01T00:01:00Z",
+                "conditions":[{"type":"Complete","status":"True"}]
+            }
+        }))
+        .expect("build job");
+
+        let status = job_status(&job);
+
+        assert_eq!(status.phase, AttemptPhase::Exited { code: 0 });
+        assert_eq!(
+            status.started_at_ms,
+            u64::try_from(probe_now(0).as_millisecond()).ok()
+        );
+        assert_eq!(
+            status.finished_at_ms,
+            u64::try_from(probe_now(60).as_millisecond()).ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn status_uses_pod_start() {
+        // The Job publishes startTime only once its controller processed it, so
+        // the running container is the earlier evidence.
+        let client = fake_client(|method, path| match (method, path) {
+            ("GET", "/apis/batch/v1/namespaces/compute/jobs/aruna-job-a1") => {
+                let mut job = job_json("running");
+                job["status"] = json!({"active": 1, "ready": 1});
+                (200, job)
+            }
+            ("GET", "/api/v1/namespaces/compute/pods") => {
+                let pod = task_pod(json!({"running":{"startedAt":POD_START}}), POD_START);
+                (
+                    200,
+                    json!({
+                        "apiVersion":"v1","kind":"PodList","metadata":{},
+                        "items":[serde_json::to_value(pod).expect("encode running pod")]
+                    }),
+                )
+            }
+            _ => (404, status_json(404)),
+        });
+        let backend = KubernetesBackend {
+            client,
+            config: test_config(),
+        };
+
+        let status = backend.status(&context()).await.unwrap();
+
+        assert_eq!(status.phase, AttemptPhase::Running);
+        assert_eq!(
+            status.started_at_ms,
+            u64::try_from(probe_now(0).as_millisecond()).ok()
+        );
     }
 
     fn stuck_list() -> Value {

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -6,9 +6,10 @@ use std::time::{Duration, Instant};
 
 use aruna_core::compute::{
     AdoptableEvidence, ArtifactEvidence, AttemptPhase, AttemptStatus, BackendError, CancelEvidence,
-    ExecutorKind, FenceContext, LogLimits, LogStream, LogTails, MAX_TRANSFER_BYTES, NOBODY,
-    ReconcileEvidence, ResumePoint, StagingMode, TaskOutput, TaskSpec, TombstoneEvidence,
-    TombstoneSpec, UserSpec, normalize_container_path,
+    ExecutorKind, FenceContext, LogLimits, LogStream, LogTails, MAX_OUTPUT_MATCHES,
+    MAX_TRANSFER_BYTES, NOBODY, OutputMatcher, ReconcileEvidence, ResumePoint, StagingMode,
+    TaskOutput, TaskSpec, TombstoneEvidence, TombstoneSpec, UserSpec, literal_prefix,
+    normalize_container_path,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -42,9 +43,9 @@ use super::{BackendCaps, ExecutorBackend, digest_pinned};
 mod manifest;
 
 use manifest::{
-    HELPER_PATH, StageMarker, WORKLOAD_SA, helper_pod, job_manifest, marker_manifest, marker_name,
-    mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest, needs_workspace,
-    network_policies, pvc_manifest, secret_manifest, secret_name, workspace_name,
+    HELPER_PATH, StageMarker, WORKLOAD_SA, WORKSPACE_PATH, helper_pod, job_manifest,
+    marker_manifest, marker_name, mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest,
+    needs_workspace, network_policies, pvc_manifest, secret_manifest, secret_name, workspace_name,
 };
 
 pub const EPOCH_ANNOTATION: &str = "aruna-engine.org/attempt-epoch";
@@ -52,6 +53,8 @@ pub const GENERATION_ANNOTATION: &str = "aruna-engine.org/controller-generation"
 pub const STATE_ANNOTATION: &str = "aruna-engine.org/state";
 pub const ROLE_LABEL: &str = "aruna-engine.org/role";
 const DEFAULT_WORKSPACE_BYTES: u64 = 10 * 1024 * 1024 * 1024;
+/// Bounds one helper listing response.
+const MAX_LISTING_BYTES: u64 = 16 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct KubernetesBackend {
@@ -688,6 +691,72 @@ impl KubernetesBackend {
         Ok(())
     }
 
+    /// Enumerate the workspace below `prefix` through a helper Pod and keep the
+    /// paths the pattern selects. The helper emits NUL-terminated paths.
+    async fn list_archive(
+        &self,
+        context: &FenceContext,
+        prefix: &str,
+        glob: &OutputMatcher,
+    ) -> Result<Vec<String>, BackendError> {
+        let pod = self
+            .create_helper(context, "fetch", &CancellationToken::new())
+            .await?;
+        let params = AttachParams::default()
+            .container("helper")
+            .stdin(false)
+            .stdout(true)
+            .stderr(false);
+        let listed = async {
+            let mut attached = self
+                .pods()
+                .exec(
+                    &pod.name_any(),
+                    [
+                        HELPER_PATH,
+                        "list",
+                        "--workspace",
+                        WORKSPACE_PATH,
+                        "--prefix",
+                        prefix,
+                    ],
+                    &params,
+                )
+                .await
+                .map_err(kube_error)?;
+            let stdout = attached.stdout().ok_or_else(|| {
+                BackendError::Api("list exec did not expose standard output".to_string())
+            })?;
+            let mut listing = Vec::new();
+            stdout
+                .take(MAX_LISTING_BYTES)
+                .read_to_end(&mut listing)
+                .await
+                .map_err(io_error)?;
+            join_exec(attached).await?;
+            let mut matched = Vec::new();
+            for path in listing.split(|byte| *byte == 0) {
+                let Ok(path) = std::str::from_utf8(path) else {
+                    return Err(BackendError::Api("listing is not UTF-8".to_string()));
+                };
+                if path.is_empty() || !glob.is_match(path) {
+                    continue;
+                }
+                if matched.len() >= MAX_OUTPUT_MATCHES {
+                    return Err(BackendError::InvalidSpec(
+                        "pattern matches too many files".to_string(),
+                    ));
+                }
+                matched.push(path.to_string());
+            }
+            matched.sort();
+            Ok(matched)
+        }
+        .await;
+        let _ = self.delete_pod(&pod).await;
+        listed
+    }
+
     async fn fetch_archive(
         &self,
         context: &FenceContext,
@@ -1063,6 +1132,28 @@ impl ExecutorBackend for KubernetesBackend {
         self.fetch_archive(context, path).await
     }
 
+    async fn list_outputs(
+        &self,
+        context: &FenceContext,
+        pattern: &str,
+    ) -> Result<Vec<String>, BackendError> {
+        let job = self.get_job(context).await?;
+        if !job_status(&job).is_terminal() {
+            return Err(BackendError::InvalidSpec(
+                "attempt is not terminal".to_string(),
+            ));
+        }
+        validate_output(&job, pattern)?;
+        let glob = OutputMatcher::new([pattern]).map_err(BackendError::InvalidSpec)?;
+        let prefix = literal_prefix(pattern).map_err(BackendError::InvalidSpec)?;
+        // The listing helper needs the workspace claim, which the task pods hold
+        // until they are reaped.
+        self.save_logs(context).await?;
+        self.delete_tasks(context).await?;
+        self.list_archive(context, &prefix.to_string_lossy(), &glob)
+            .await
+    }
+
     async fn reconcile(&self, context: &FenceContext) -> ReconcileEvidence {
         match self.jobs().get_opt(&context.attempt.external_name()).await {
             Ok(Some(job)) => {
@@ -1392,6 +1483,7 @@ fn validate_marker(
     Ok(marker)
 }
 
+/// A path is valid when it was declared literally or matches a declared pattern.
 fn validate_output(job: &Job, path: &str) -> Result<(), BackendError> {
     normalize_container_path(path).map_err(BackendError::InvalidSpec)?;
     let outputs = job
@@ -1402,7 +1494,9 @@ fn validate_output(job: &Job, path: &str) -> Result<(), BackendError> {
         .ok_or_else(|| BackendError::Conflict("Job output declarations are missing".to_string()))?;
     let outputs: Vec<String> = serde_json::from_str(outputs)
         .map_err(|error| BackendError::Conflict(format!("invalid Job outputs: {error}")))?;
-    if !outputs.iter().any(|output| output == path) {
+    let declared = OutputMatcher::new(outputs.iter().map(String::as_str))
+        .map_err(BackendError::InvalidSpec)?;
+    if !declared.is_match(path) {
         return Err(BackendError::InvalidSpec(
             "output path was not declared".to_string(),
         ));
@@ -1997,6 +2091,25 @@ mod tests {
                 }
             }]
         })
+    }
+
+    #[test]
+    fn accepts_pattern_output() {
+        // A declared wildcard output authorizes every path it selects.
+        let job: Job = serde_json::from_value(json!({
+            "apiVersion": "batch/v1", "kind": "Job",
+            "metadata": {
+                "name": "aruna-job-a1", "namespace": "compute",
+                "annotations": {"aruna-engine.org/output-paths": r#"["/out/*.txt","/log/run.txt"]"#}
+            }
+        }))
+        .expect("build job");
+
+        assert!(validate_output(&job, "/out/a.txt").is_ok());
+        assert!(validate_output(&job, "/out/*.txt").is_ok());
+        assert!(validate_output(&job, "/log/run.txt").is_ok());
+        assert!(validate_output(&job, "/out/sub/a.txt").is_err());
+        assert!(validate_output(&job, "/out/a.csv").is_err());
     }
 
     #[tokio::test]

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -21,6 +21,7 @@ use k8s_openapi::api::core::v1::{
 };
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use k8s_openapi::api::storage::v1::{CSIDriver, StorageClass};
+use k8s_openapi::jiff::Timestamp;
 use kube::api::{
     Api, AttachParams, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams,
     Preconditions,
@@ -614,6 +615,21 @@ impl KubernetesBackend {
                     code: terminated.exit_code,
                 };
             }
+        } else if job_pending(job) {
+            let now = Timestamp::now();
+            if let Some(reason) = self
+                .task_pods(context)
+                .await?
+                .iter()
+                .find_map(|pod| pod_stuck_reason(pod, self.config.pull_deadline, now))
+            {
+                tracing::warn!(
+                    attempt = %context.attempt.external_name(),
+                    %reason,
+                    "failing attempt whose container cannot start"
+                );
+                status.phase = AttemptPhase::Failed { reason };
+            }
         }
         Ok(status)
     }
@@ -1001,6 +1017,11 @@ impl ExecutorBackend for KubernetesBackend {
             let Some(pod) = pods.first() else {
                 return Ok(LogTails::default());
             };
+            // A container that never started rejects log reads, which must not
+            // block the terminal handling that reaps the attempt.
+            if !task_started(pod) {
+                return Ok(LogTails::default());
+            }
             self.pods()
                 .logs(
                     &pod.name_any(),
@@ -1439,6 +1460,65 @@ fn job_status(job: &Job) -> AttemptStatus {
     }
 }
 
+/// Active but unready Pods are the only ones that can hold a stuck container.
+fn job_pending(job: &Job) -> bool {
+    job.status
+        .as_ref()
+        .is_some_and(|status| status.active.unwrap_or(0) > 0 && status.ready.unwrap_or(0) == 0)
+}
+
+/// Kubelet reasons for a container that cannot start without outside help.
+fn stuck_wait(reason: &str) -> bool {
+    matches!(
+        reason,
+        "InvalidImageName"
+            | "ErrImagePull"
+            | "ImagePullBackOff"
+            | "CreateContainerConfigError"
+            | "CreateContainerError"
+    )
+}
+
+/// Kubernetes retries a failing image pull forever, so the Job counts such a
+/// Pod as active and never reports a terminal condition. A malformed reference
+/// fails at once; a retryable reason fails once it outlives `deadline`.
+fn pod_stuck_reason(pod: &Pod, deadline: Duration, now: Timestamp) -> Option<String> {
+    let status = pod.status.as_ref()?;
+    let waited = status
+        .start_time
+        .as_ref()
+        .or_else(|| pod.metadata.creation_timestamp.as_ref())
+        .map(|since| Duration::try_from(now.duration_since(since.0)).unwrap_or_default())
+        .unwrap_or_default();
+    status
+        .init_container_statuses
+        .iter()
+        .chain(status.container_statuses.iter())
+        .flatten()
+        .find_map(|container| {
+            let waiting = container.state.as_ref()?.waiting.as_ref()?;
+            let reason = waiting.reason.as_deref()?;
+            if !stuck_wait(reason) || (reason != "InvalidImageName" && waited <= deadline) {
+                return None;
+            }
+            let detail = waiting.message.as_deref().unwrap_or("no detail reported");
+            Some(format!(
+                "container `{}` cannot start ({reason}): {detail}",
+                container.name
+            ))
+        })
+}
+
+/// Log reads only succeed once the task container has left its waiting state.
+fn task_started(pod: &Pod) -> bool {
+    pod.status
+        .as_ref()
+        .and_then(|status| status.container_statuses.as_ref())
+        .and_then(|statuses| statuses.iter().find(|status| status.name == "task"))
+        .and_then(|status| status.state.as_ref())
+        .is_some_and(|state| state.running.is_some() || state.terminated.is_some())
+}
+
 fn job_epoch(job: &Job) -> Result<u64, BackendError> {
     annotation_u64(job, EPOCH_ANNOTATION)
 }
@@ -1825,6 +1905,7 @@ mod tests {
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
     use super::*;
+    use crate::executor::logs::NullSink;
 
     fn context() -> FenceContext {
         FenceContext {
@@ -2198,5 +2279,129 @@ mod tests {
                 .iter()
                 .any(|path| path.contains("csidrivers"))
         );
+    }
+
+    const POD_START: &str = "2027-01-01T00:00:00Z";
+
+    fn probe_now(after: i64) -> Timestamp {
+        let start: Timestamp = POD_START.parse().expect("parse pod start");
+        Timestamp::from_second(start.as_second() + after).expect("build probe time")
+    }
+
+    fn task_pod(state: Value, started: &str) -> Pod {
+        serde_json::from_value(json!({
+            "apiVersion":"v1","kind":"Pod",
+            "metadata":{
+                "name":"task-pod","namespace":"compute","uid":"pod-uid",
+                "labels":{ROLE_LABEL:"task"}
+            },
+            "status":{
+                "phase":"Pending","startTime":started,
+                "containerStatuses":[{
+                    "name":"task","image":"registry.example/task:1","imageID":"",
+                    "ready":false,"restartCount":0,"state":state
+                }]
+            }
+        }))
+        .expect("build task pod")
+    }
+
+    fn waiting_pod(reason: &str, started: &str) -> Pod {
+        task_pod(
+            json!({"waiting":{"reason":reason,"message":"pull access failed"}}),
+            started,
+        )
+    }
+
+    #[test]
+    fn fails_invalid_image() {
+        // A malformed reference is permanent, so the deadline must not apply.
+        let pod = waiting_pod("InvalidImageName", POD_START);
+        let reason = pod_stuck_reason(&pod, Duration::from_secs(300), probe_now(1))
+            .expect("reject invalid image");
+        assert!(reason.contains("InvalidImageName"), "{reason}");
+    }
+
+    #[test]
+    fn waits_pull_backoff() {
+        // A registry blip inside the deadline must stay Running.
+        let pod = waiting_pod("ImagePullBackOff", POD_START);
+        assert_eq!(
+            pod_stuck_reason(&pod, Duration::from_secs(30), probe_now(5)),
+            None
+        );
+    }
+
+    #[test]
+    fn fails_stalled_pull() {
+        let pod = waiting_pod("ImagePullBackOff", POD_START);
+        let reason = pod_stuck_reason(&pod, Duration::from_secs(30), probe_now(120))
+            .expect("reject stalled pull");
+        assert!(reason.contains("ImagePullBackOff"), "{reason}");
+        assert!(reason.contains("pull access failed"), "{reason}");
+    }
+
+    #[test]
+    fn ignores_running_pod() {
+        let pod = task_pod(json!({"running":{"startedAt":POD_START}}), POD_START);
+        assert_eq!(
+            pod_stuck_reason(&pod, Duration::from_secs(30), probe_now(9_000)),
+            None
+        );
+        assert!(task_started(&pod));
+    }
+
+    fn stuck_list() -> Value {
+        let pod = waiting_pod("ImagePullBackOff", "2020-01-01T00:00:00Z");
+        json!({
+            "apiVersion":"v1","kind":"PodList","metadata":{},
+            "items":[serde_json::to_value(pod).expect("encode stuck pod")]
+        })
+    }
+
+    fn stuck_client() -> Client {
+        fake_client(|method, path| match (method, path) {
+            ("GET", "/apis/batch/v1/namespaces/compute/jobs/aruna-job-a1") => {
+                (200, job_json("running"))
+            }
+            ("GET", "/api/v1/namespaces/compute/pods") => (200, stuck_list()),
+            _ => (404, status_json(404)),
+        })
+    }
+
+    #[tokio::test]
+    async fn status_fails_stuck() {
+        // The Job stays active forever, so the stuck Pod must drive the phase.
+        let backend = KubernetesBackend {
+            client: stuck_client(),
+            config: test_config(),
+        };
+
+        let status = backend.status(&context()).await.unwrap();
+
+        match status.phase {
+            AttemptPhase::Failed { reason } => {
+                assert!(reason.contains("ImagePullBackOff"), "{reason}");
+            }
+            other => panic!("unexpected phase: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn skips_unstarted_logs() {
+        // Terminal handling parks the job when log capture errors, so a Pod
+        // that never started must report empty logs instead of failing.
+        let backend = KubernetesBackend {
+            client: stuck_client(),
+            config: test_config(),
+        };
+
+        let tails = backend
+            .fetch_logs(&context(), &LogLimits::default(), &NullSink)
+            .await
+            .unwrap();
+
+        assert!(tails.stdout.is_empty());
+        assert_eq!(tails.stdout_total, 0);
     }
 }

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -748,11 +748,14 @@ impl KubernetesBackend {
                 BackendError::Api("list exec did not expose standard output".to_string())
             })?;
             let mut listing = Vec::new();
-            stdout
-                .take(MAX_LISTING_BYTES)
-                .read_to_end(&mut listing)
-                .await
-                .map_err(io_error)?;
+            // A helper wedged mid-listing must not stall the capture forever.
+            tokio::time::timeout(
+                EXEC_JOIN_TIMEOUT,
+                stdout.take(MAX_LISTING_BYTES).read_to_end(&mut listing),
+            )
+            .await
+            .map_err(|_| BackendError::Timeout("output listing read timed out".to_string()))?
+            .map_err(io_error)?;
             join_exec(attached).await?;
             select_listed(&listing, glob)
         }

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -55,8 +55,10 @@ pub const GENERATION_ANNOTATION: &str = "aruna-engine.org/controller-generation"
 pub const STATE_ANNOTATION: &str = "aruna-engine.org/state";
 pub const ROLE_LABEL: &str = "aruna-engine.org/role";
 const DEFAULT_WORKSPACE_BYTES: u64 = 10 * 1024 * 1024 * 1024;
-/// Bounds one helper listing response.
+/// Bounds one helper listing response; the helper enforces the same bound.
 const MAX_LISTING_BYTES: u64 = 16 * 1024 * 1024;
+/// Bounds the wait for an exec status so a stalled helper cannot hang a capture.
+const EXEC_JOIN_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Clone)]
 pub struct KubernetesBackend {
@@ -709,7 +711,8 @@ impl KubernetesBackend {
     }
 
     /// Enumerate the workspace below `prefix` through a helper Pod and keep the
-    /// paths the pattern selects. The helper emits NUL-terminated paths.
+    /// paths the pattern selects. The helper emits NUL-terminated paths closed
+    /// by an empty record and the decimal path count.
     async fn list_archive(
         &self,
         context: &FenceContext,
@@ -751,23 +754,7 @@ impl KubernetesBackend {
                 .await
                 .map_err(io_error)?;
             join_exec(attached).await?;
-            let mut matched = Vec::new();
-            for path in listing.split(|byte| *byte == 0) {
-                let Ok(path) = std::str::from_utf8(path) else {
-                    return Err(BackendError::Api("listing is not UTF-8".to_string()));
-                };
-                if path.is_empty() || !glob.is_match(path) {
-                    continue;
-                }
-                if matched.len() >= MAX_OUTPUT_MATCHES {
-                    return Err(BackendError::InvalidSpec(
-                        "pattern matches too many files".to_string(),
-                    ));
-                }
-                matched.push(path.to_string());
-            }
-            matched.sort();
-            Ok(matched)
+            select_listed(&listing, glob)
         }
         .await;
         let _ = self.delete_pod(&pod).await;
@@ -1929,6 +1916,55 @@ impl Write for ArchiveWriter {
     }
 }
 
+/// Split a helper listing into its path records, rejecting a stream whose
+/// terminator is missing or whose count disagrees: a short read must fail the
+/// capture instead of silently dropping matches.
+fn listed_paths(listing: &[u8]) -> Result<Vec<&[u8]>, BackendError> {
+    let truncated = || BackendError::InvalidSpec("output listing is truncated".to_string());
+    let body = listing.strip_suffix(&[0]).ok_or_else(truncated)?;
+    let mut records: Vec<&[u8]> = body.split(|byte| *byte == 0).collect();
+    let count = records.pop().ok_or_else(truncated)?;
+    if records.pop() != Some(&b""[..]) {
+        return Err(truncated());
+    }
+    let count = std::str::from_utf8(count)
+        .ok()
+        .and_then(|count| count.parse::<usize>().ok())
+        .ok_or_else(truncated)?;
+    if count != records.len() || records.iter().any(|path| path.is_empty()) {
+        return Err(BackendError::InvalidSpec(
+            "output listing is inconsistent".to_string(),
+        ));
+    }
+    Ok(records)
+}
+
+/// Listed paths the pattern selects. A path that is not UTF-8 cannot be
+/// addressed as an output, so it is skipped instead of failing the capture.
+fn select_listed(listing: &[u8], glob: &OutputMatcher) -> Result<Vec<String>, BackendError> {
+    let mut matched = Vec::new();
+    for path in listed_paths(listing)? {
+        let Ok(path) = std::str::from_utf8(path) else {
+            tracing::warn!(
+                path = %String::from_utf8_lossy(path),
+                "skipping output path that is not UTF-8"
+            );
+            continue;
+        };
+        if !glob.is_match(path) {
+            continue;
+        }
+        if matched.len() >= MAX_OUTPUT_MATCHES {
+            return Err(BackendError::InvalidSpec(
+                "pattern matches too many files".to_string(),
+            ));
+        }
+        matched.push(path.to_string());
+    }
+    matched.sort();
+    Ok(matched)
+}
+
 async fn stream_output<R: AsyncRead + Unpin>(
     mut stdout: R,
     attached: kube::api::AttachedProcess,
@@ -1976,10 +2012,16 @@ async fn join_exec(mut attached: kube::api::AttachedProcess) -> Result<(), Backe
     let status = attached.take_status().ok_or_else(|| {
         BackendError::Api("Kubernetes exec status stream is unavailable".to_string())
     })?;
-    attached.join().await.map_err(remote_error)?;
-    let status = status
+    let joined = async {
+        attached.join().await.map_err(remote_error)?;
+        status
+            .await
+            .ok_or_else(|| BackendError::Api("Kubernetes exec returned no status".to_string()))
+    };
+    // A helper that stops writing must not hold the capture open forever.
+    let status = tokio::time::timeout(EXEC_JOIN_TIMEOUT, joined)
         .await
-        .ok_or_else(|| BackendError::Api("Kubernetes exec returned no status".to_string()))?;
+        .map_err(|_| BackendError::Timeout("Kubernetes exec did not finish".to_string()))??;
     if status.status.as_deref() == Some("Success") {
         return Ok(());
     }
@@ -2148,6 +2190,67 @@ mod tests {
         assert!(validate_output(&job, "/log/run.txt").is_ok());
         assert!(validate_output(&job, "/out/sub/a.txt").is_err());
         assert!(validate_output(&job, "/out/a.csv").is_err());
+    }
+
+    fn listing(paths: &[&[u8]]) -> Vec<u8> {
+        let mut listing = Vec::new();
+        for path in paths {
+            listing.extend_from_slice(path);
+            listing.push(0);
+        }
+        listing.push(0);
+        listing.extend_from_slice(paths.len().to_string().as_bytes());
+        listing.push(0);
+        listing
+    }
+
+    #[test]
+    fn rejects_cut_listing() {
+        // Without the terminator a capped read would upload a partial listing
+        // while the job still reported success.
+        let glob = OutputMatcher::new(["/out/*.txt"]).expect("build matcher");
+        let full = listing(&[b"/out/a.txt", b"/out/b.txt"]);
+        assert_eq!(
+            select_listed(&full, &glob).expect("accept full listing"),
+            vec!["/out/a.txt".to_string(), "/out/b.txt".to_string()]
+        );
+
+        for cut in [full.len() - 1, full.len() - 4, 11, 0] {
+            assert!(
+                matches!(
+                    select_listed(&full[..cut], &glob),
+                    Err(BackendError::InvalidSpec(_))
+                ),
+                "listing cut at {cut} was accepted"
+            );
+        }
+        // A terminator that disagrees with the records is equally unusable.
+        let mut miscounted = listing(&[b"/out/a.txt"]);
+        miscounted.pop();
+        miscounted.pop();
+        miscounted.extend_from_slice(b"2\0");
+        assert!(matches!(
+            select_listed(&miscounted, &glob),
+            Err(BackendError::InvalidSpec(_))
+        ));
+        assert!(
+            select_listed(&listing(&[]), &glob)
+                .expect("accept empty listing")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn skips_invalid_listing() {
+        // A file whose name is not UTF-8 cannot be addressed, but it must not
+        // fail the capture of the files that can be.
+        let glob = OutputMatcher::new(["/out/*.txt"]).expect("build matcher");
+        let listing = listing(&[b"/out/a.txt", b"/out/\xff\xfe.txt", b"/out/b.txt"]);
+
+        assert_eq!(
+            select_listed(&listing, &glob).expect("accept mixed listing"),
+            vec!["/out/a.txt".to_string(), "/out/b.txt".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/compute/src/executor/mod.rs
+++ b/compute/src/executor/mod.rs
@@ -152,6 +152,18 @@ pub trait ExecutorBackend: Send + Sync {
         path: &str,
     ) -> Result<TaskOutput, BackendError>;
 
+    /// Resolve a declared POSIX output pattern against the terminal attempt's
+    /// filesystem. Zero matches is an empty list, never an error.
+    async fn list_outputs(
+        &self,
+        _context: &FenceContext,
+        _pattern: &str,
+    ) -> Result<Vec<String>, BackendError> {
+        Err(BackendError::InvalidSpec(
+            "backend does not support wildcard outputs".to_string(),
+        ))
+    }
+
     /// Query by deterministic name after restart / lease loss. Never mutates.
     async fn reconcile(&self, context: &FenceContext) -> ReconcileEvidence;
 

--- a/compute/src/executor/staging.rs
+++ b/compute/src/executor/staging.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use aruna_core::compute::{
-    BackendError, InputStream, StagingMode, TaskSpec, normalize_container_path, paths_overlap,
+    BackendError, InputStream, StagingMode, TaskSpec, has_wildcard, literal_prefix,
+    normalize_container_path, paths_overlap,
 };
 use aruna_core::structs::ensure_confined_relative_path;
 
@@ -133,15 +134,23 @@ impl StageLayout {
                     "duplicate output path `{output}`"
                 )));
             }
-            let parent = path.parent().ok_or_else(|| {
-                BackendError::InvalidSpec(format!("output path `{output}` has no parent"))
-            })?;
+            // A pattern is captured under its literal prefix; the wildcard
+            // components must never be created as directories.
+            let parent = if has_wildcard(output) {
+                literal_prefix(output).map_err(BackendError::InvalidSpec)?
+            } else {
+                path.parent()
+                    .ok_or_else(|| {
+                        BackendError::InvalidSpec(format!("output path `{output}` has no parent"))
+                    })?
+                    .to_path_buf()
+            };
             if parent == std::path::Path::new("/") {
                 return Err(BackendError::InvalidSpec(
                     "root output parent is forbidden".to_string(),
                 ));
             }
-            output_parents.insert(parent.to_path_buf());
+            output_parents.insert(parent);
         }
         for input in files
             .iter()
@@ -270,6 +279,22 @@ mod tests {
         spec.inputs = vec![TaskInput::from_bytes("/work/.command.sh", "data")];
         spec.output_paths = vec!["/work/out.txt".to_string()];
         assert!(StageLayout::from_spec(&spec).is_ok());
+    }
+
+    #[test]
+    fn plans_wildcard_parent() {
+        // Only the literal prefix of a pattern becomes a real directory.
+        let mut spec = TaskSpec::new(AttemptRef::new("job", 0), "image");
+        spec.output_paths = vec!["/output/*/result.txt".to_string()];
+        let layout = StageLayout::from_spec(&spec).unwrap();
+        assert_eq!(
+            layout.output_parents,
+            BTreeSet::from([PathBuf::from("/output")])
+        );
+
+        let mut spec = TaskSpec::new(AttemptRef::new("job", 0), "image");
+        spec.output_paths = vec!["/*.txt".to_string()];
+        assert!(StageLayout::from_spec(&spec).is_err());
     }
 
     #[test]

--- a/compute/tests/docker_backend.rs
+++ b/compute/tests/docker_backend.rs
@@ -49,6 +49,11 @@ trait DockerTestExt {
         attempt: &AttemptRef,
         path: &str,
     ) -> Result<TaskOutput, BackendError>;
+    async fn list_outputs(
+        &self,
+        attempt: &AttemptRef,
+        pattern: &str,
+    ) -> Result<Vec<String>, BackendError>;
     async fn reconcile(&self, attempt: &AttemptRef) -> ReconcileEvidence;
     async fn cleanup(&self, attempt: &AttemptRef) -> Result<(), BackendError>;
 }
@@ -130,6 +135,14 @@ impl DockerTestExt for DockerBackend {
         path: &str,
     ) -> Result<TaskOutput, BackendError> {
         aruna_compute::ExecutorBackend::fetch_output(self, &fence(attempt), path).await
+    }
+
+    async fn list_outputs(
+        &self,
+        attempt: &AttemptRef,
+        pattern: &str,
+    ) -> Result<Vec<String>, BackendError> {
+        aruna_compute::ExecutorBackend::list_outputs(self, &fence(attempt), pattern).await
     }
 
     async fn reconcile(&self, attempt: &AttemptRef) -> ReconcileEvidence {
@@ -285,6 +298,40 @@ async fn file_transfer() {
     assert_eq!(
         read_output(&backend, &attempt, "/output/aruna.txt").await,
         b"hello from aruna"
+    );
+
+    let _ = backend.cleanup(&attempt).await;
+}
+
+#[tokio::test]
+async fn wildcard_outputs() {
+    // A pattern selects the matching files of the terminal container only.
+    let backend = backend_or_skip!();
+    let cancel = CancellationToken::new();
+    let mut spec = sh(
+        &unique("wildcard"),
+        "mkdir -p /output/sub && echo a > /output/a.txt && echo b > /output/b.txt \
+         && echo c > /output/report.csv && echo d > /output/sub/deep.txt",
+    );
+    spec.output_paths.push("/output/*.txt".to_string());
+    let attempt = spec.attempt.clone();
+
+    backend.submit(&spec, &cancel).await.unwrap();
+    let status = backend.wait(&attempt, &cancel).await.unwrap();
+    assert_eq!(status.phase, AttemptPhase::Exited { code: 0 });
+
+    let matched = backend
+        .list_outputs(&attempt, "/output/*.txt")
+        .await
+        .unwrap();
+    assert_eq!(matched, vec!["/output/a.txt", "/output/b.txt"]);
+    assert_eq!(read_output(&backend, &attempt, &matched[0]).await, b"a\n");
+    assert!(
+        backend
+            .list_outputs(&attempt, "/absent/*.txt")
+            .await
+            .unwrap()
+            .is_empty()
     );
 
     let _ = backend.cleanup(&attempt).await;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ irokle = { workspace = true }
 futures = { workspace = true }
 prometheus-client = { workspace = true }
 ed25519-dalek = { workspace = true }
+getrandom = { workspace = true }
 globset = { workspace = true }
 oxrdf = { workspace = true }
 percent-encoding = { workspace = true }

--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -450,9 +450,33 @@ fn collapse_stars(pattern: &str) -> String {
     collapsed
 }
 
+/// POSIX 12.13 has no brace alternation, so `{` and `}` stay literal file name
+/// characters instead of expanding into alternates the caller never declared.
+fn escape_braces(pattern: &str) -> String {
+    let mut escaped = String::with_capacity(pattern.len());
+    let (mut skip, mut class) = (false, false);
+    for character in pattern.chars() {
+        match character {
+            _ if skip => skip = false,
+            '\\' => skip = true,
+            '[' if !class => class = true,
+            ']' if class => class = false,
+            '{' | '}' if !class => {
+                escaped.push('[');
+                escaped.push(character);
+                escaped.push(']');
+                continue;
+            }
+            _ => {}
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
 fn build_glob(pattern: &str) -> Result<Glob, String> {
     // `literal_separator` keeps `*` and `?` inside one path component, as POSIX requires.
-    GlobBuilder::new(&collapse_stars(pattern))
+    GlobBuilder::new(&escape_braces(&collapse_stars(pattern)))
         .literal_separator(true)
         .build()
         .map_err(|error| error.to_string())
@@ -698,6 +722,26 @@ mod tests {
         // A repeated `*` stays one POSIX wildcard instead of recursing.
         assert_eq!(matched("/out/**/*.txt"), vec!["/out/sub/c.txt"]);
         assert!(output_glob("/out/[a.txt").is_err());
+    }
+
+    #[test]
+    fn braces_stay_literal() {
+        // Brace alternation is undeclared, so `{a,b}` names one directory.
+        let glob = output_glob("/out/{a,b}/x.txt").unwrap();
+        assert!(glob.is_match("/out/{a,b}/x.txt"));
+        assert!(!glob.is_match("/out/a/x.txt"));
+        assert!(!glob.is_match("/out/b/x.txt"));
+        assert!(!has_wildcard("/out/{a,b}/x.txt"));
+        assert_eq!(
+            literal_prefix("/out/{a,b}/x.txt").unwrap(),
+            Path::new("/out/{a,b}/x.txt")
+        );
+
+        let matcher = OutputMatcher::new(["/out/{a,b}.csv", "/out/[ab]{x}.txt"]).unwrap();
+        assert!(matcher.is_match("/out/{a,b}.csv"));
+        assert!(!matcher.is_match("/out/a.csv"));
+        assert!(matcher.is_match("/out/a{x}.txt"));
+        assert!(!matcher.is_match("/out/ax.txt"));
     }
 
     #[test]

--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -8,11 +8,19 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::Stream;
+use globset::{Glob, GlobBuilder, GlobMatcher, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::Zeroize;
 
 pub const MAX_TRANSFER_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Pattern characters of IEEE Std 1003.1-2017 (POSIX) 12.13, the only wildcards
+/// TES 1.1 allows in `tesOutput.path`.
+const WILDCARDS: [char; 3] = ['*', '?', '['];
+
+/// Upper bound on the files a single wildcard output may expand to.
+pub const MAX_OUTPUT_MATCHES: usize = 1024;
 
 pub type InputStream = Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send>>;
 pub type OutputChunks = Pin<Box<dyn Stream<Item = Result<Bytes, BackendError>> + Send + Sync>>;
@@ -419,6 +427,100 @@ pub fn paths_overlap(input: &str, output_parent: &str) -> Result<bool, String> {
     Ok(input == output_parent || output_parent.starts_with(&input))
 }
 
+/// True when a container path carries a POSIX 12.13 wildcard.
+pub fn has_wildcard(path: &str) -> bool {
+    path.contains(WILDCARDS)
+}
+
+/// POSIX gives a run of `*` the meaning of a single `*`, so `**` must not turn
+/// into the recursive wildcard of the glob engine.
+fn collapse_stars(pattern: &str) -> String {
+    let mut collapsed = String::with_capacity(pattern.len());
+    let (mut escaped, mut star) = (false, false);
+    for character in pattern.chars() {
+        match character {
+            _ if escaped => (escaped, star) = (false, false),
+            '\\' => (escaped, star) = (true, false),
+            '*' if star => continue,
+            '*' => star = true,
+            _ => star = false,
+        }
+        collapsed.push(character);
+    }
+    collapsed
+}
+
+fn build_glob(pattern: &str) -> Result<Glob, String> {
+    // `literal_separator` keeps `*` and `?` inside one path component, as POSIX requires.
+    GlobBuilder::new(&collapse_stars(pattern))
+        .literal_separator(true)
+        .build()
+        .map_err(|error| error.to_string())
+}
+
+/// Compile one output pattern into a matcher anchored at the absolute pattern.
+pub fn output_glob(pattern: &str) -> Result<GlobMatcher, String> {
+    normalize_container_path(pattern)?;
+    Ok(build_glob(pattern)?.compile_matcher())
+}
+
+/// Deepest wildcard-free ancestor of a pattern, which is the directory a backend
+/// enumerates. A wildcard-free path yields itself.
+pub fn literal_prefix(pattern: &str) -> Result<PathBuf, String> {
+    let normalized = normalize_container_path(pattern)?;
+    let mut prefix = PathBuf::from("/");
+    for component in normalized.components() {
+        let Component::Normal(part) = component else {
+            continue;
+        };
+        if part.to_string_lossy().contains(WILDCARDS) {
+            break;
+        }
+        prefix.push(part);
+    }
+    Ok(prefix)
+}
+
+/// The part of `path` below `prefix`, split on a path-component boundary.
+/// `None` when `prefix` is not a strict ancestor of `path`.
+pub fn output_suffix(path: &str, prefix: &str) -> Option<String> {
+    let path = normalize_container_path(path).ok()?;
+    let prefix = normalize_container_path(prefix).ok()?;
+    let suffix = path.strip_prefix(&prefix).ok()?.to_str()?;
+    (!suffix.is_empty()).then(|| suffix.to_string())
+}
+
+/// The declared outputs of one attempt: a wildcard path selects every file it
+/// matches, a wildcard-free path only itself.
+#[derive(Debug)]
+pub struct OutputMatcher {
+    literals: Vec<String>,
+    patterns: GlobSet,
+}
+
+impl OutputMatcher {
+    pub fn new<'a>(declared: impl IntoIterator<Item = &'a str>) -> Result<Self, String> {
+        let mut literals = Vec::new();
+        let mut builder = GlobSetBuilder::new();
+        for path in declared {
+            normalize_container_path(path)?;
+            if has_wildcard(path) {
+                builder.add(build_glob(path)?);
+            } else {
+                literals.push(path.to_string());
+            }
+        }
+        Ok(Self {
+            literals,
+            patterns: builder.build().map_err(|error| error.to_string())?,
+        })
+    }
+
+    pub fn is_match(&self, path: &str) -> bool {
+        self.literals.iter().any(|literal| literal == path) || self.patterns.is_match(path)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AttemptPhase {
     Submitted,
@@ -559,4 +661,88 @@ pub struct TombstoneSpec {
 pub struct TombstoneEvidence {
     pub backend_ref: String,
     pub attempt_epoch: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LISTING: [&str; 6] = [
+        "/out/a.txt",
+        "/out/b.txt",
+        "/out/ab.txt",
+        "/out/report.csv",
+        "/out/sub/c.txt",
+        "/out/sub/deep/d.txt",
+    ];
+
+    fn matched(pattern: &str) -> Vec<&'static str> {
+        let glob = output_glob(pattern).unwrap();
+        LISTING
+            .into_iter()
+            .filter(|path| glob.is_match(path))
+            .collect()
+    }
+
+    #[test]
+    fn expands_posix_pattern() {
+        // `*` and `?` must stay inside one path component; `[..]` is a class.
+        assert_eq!(
+            matched("/out/*.txt"),
+            vec!["/out/a.txt", "/out/b.txt", "/out/ab.txt"]
+        );
+        assert_eq!(matched("/out/?.txt"), vec!["/out/a.txt", "/out/b.txt"]);
+        assert_eq!(matched("/out/[ab].txt"), vec!["/out/a.txt", "/out/b.txt"]);
+        assert_eq!(matched("/out/sub/*.txt"), vec!["/out/sub/c.txt"]);
+        assert!(matched("/out/*.md").is_empty());
+        // A repeated `*` stays one POSIX wildcard instead of recursing.
+        assert_eq!(matched("/out/**/*.txt"), vec!["/out/sub/c.txt"]);
+        assert!(output_glob("/out/[a.txt").is_err());
+    }
+
+    #[test]
+    fn detects_wildcards() {
+        assert!(has_wildcard("/out/*.txt"));
+        assert!(has_wildcard("/out/?.txt"));
+        assert!(has_wildcard("/out/[ab].txt"));
+        assert!(!has_wildcard("/out/report.txt"));
+    }
+
+    #[test]
+    fn finds_literal_prefix() {
+        assert_eq!(literal_prefix("/out/*.txt").unwrap(), Path::new("/out"));
+        assert_eq!(literal_prefix("/out/*/x.txt").unwrap(), Path::new("/out"));
+        assert_eq!(literal_prefix("/*.txt").unwrap(), Path::new("/"));
+        assert_eq!(
+            literal_prefix("/out/report.txt").unwrap(),
+            Path::new("/out/report.txt")
+        );
+        assert!(literal_prefix("out/*.txt").is_err());
+    }
+
+    #[test]
+    fn strips_output_prefix() {
+        assert_eq!(output_suffix("/out/a.txt", "/out").unwrap(), "a.txt");
+        assert_eq!(
+            output_suffix("/out/sub/deep/d.txt", "/out").unwrap(),
+            "sub/deep/d.txt"
+        );
+        assert_eq!(
+            output_suffix("/out/sub/c.txt", "/out/sub").unwrap(),
+            "c.txt"
+        );
+        // A prefix must end on a component boundary and stay a strict ancestor.
+        assert!(output_suffix("/output/a.txt", "/out").is_none());
+        assert!(output_suffix("/out", "/out").is_none());
+        assert!(output_suffix("/other/a.txt", "/out").is_none());
+    }
+
+    #[test]
+    fn matches_declared_outputs() {
+        let matcher = OutputMatcher::new(["/out/report.txt", "/out/*.csv"]).unwrap();
+        assert!(matcher.is_match("/out/report.txt"));
+        assert!(matcher.is_match("/out/report.csv"));
+        assert!(!matcher.is_match("/out/sub/report.csv"));
+        assert!(!matcher.is_match("/out/other.txt"));
+    }
 }

--- a/core/src/effects.rs
+++ b/core/src/effects.rs
@@ -192,6 +192,15 @@ pub enum StorageEffect {
     },
 }
 
+/// Dispatch lane for a storage effect. Foreground is always served before Bulk,
+/// so sync traffic is never starved by background materialization work.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StoragePriority {
+    #[default]
+    Foreground,
+    Bulk,
+}
+
 /// Lower bound for a [`StorageEffect::Iter`] scan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IterStart {

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -114,7 +114,7 @@ pub enum SourceConnectorResolutionError {
     ResolveFailed,
 }
 
-#[derive(Debug, Error, PartialEq, Clone)]
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
 pub enum StorageError {
     #[error("Key not found")]
     KeyNotFound,

--- a/core/src/keys.rs
+++ b/core/src/keys.rs
@@ -1,5 +1,19 @@
+use ed25519_dalek::SigningKey;
+
 use crate::id::{DhtKeyId, NodeId};
 use crate::structs::RealmId;
+
+/// Fresh Ed25519 signing key from operating-system randomness.
+///
+/// `SigningKey::generate` needs an infallible `rand_core` generator, and no
+/// `OsRng` implements that trait, so the entropy is drawn directly. A failing
+/// system generator is not recoverable.
+#[must_use]
+pub fn generate_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("operating system random number generator failed");
+    SigningKey::from_bytes(&bytes)
+}
 
 /// Derive a DHT key from arbitrary bytes using BLAKE3.
 #[must_use]

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -20,6 +20,7 @@ pub const METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE: &str =
     "metadata_materialization_document_jobs";
 pub const METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE: &str =
     "metadata_materialization_dead_letters";
+pub const METADATA_MATERIALIZATION_PRUNE_KEYSPACE: &str = "metadata_materialization_prunes";
 pub const ADMIN_DOCUMENT_STATE_KEYSPACE: &str = "admin_document_state";
 pub const ADMIN_DOCUMENT_CONFLICT_KEYSPACE: &str = "admin_document_conflicts";
 pub const DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE: &str = "document_sync_applied_ops";

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -18,6 +18,8 @@ pub const METADATA_RAW_REVISION_KEYSPACE: &str = "metadata_raw_revisions";
 pub const METADATA_MATERIALIZATION_JOB_KEYSPACE: &str = "metadata_materialization_jobs";
 pub const METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE: &str =
     "metadata_materialization_document_jobs";
+pub const METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE: &str =
+    "metadata_materialization_dead_letters";
 pub const ADMIN_DOCUMENT_STATE_KEYSPACE: &str = "admin_document_state";
 pub const ADMIN_DOCUMENT_CONFLICT_KEYSPACE: &str = "admin_document_conflicts";
 pub const DOCUMENT_SYNC_APPLIED_OPS_KEYSPACE: &str = "document_sync_applied_ops";

--- a/core/src/metadata.rs
+++ b/core/src/metadata.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use ulid::Ulid;
 
 use crate::NodeId;
+use crate::errors::StorageError;
 use crate::structs::{AuthContext, MetadataAuditOperation, MetadataRegistryRecord, RealmId};
 use crate::types::{GroupId, UserId};
 
@@ -876,6 +877,10 @@ pub enum MetadataError {
     /// document: retrying it is always valid.
     #[error("metadata persist failed: {0}")]
     Persist(String),
+    /// Storage adapter failure, kept typed so callers can tell an overloaded
+    /// node from a payload the backend will never accept.
+    #[error("metadata storage error: {0}")]
+    Storage(#[from] StorageError),
     #[error("metadata backend error: {0}")]
     Backend(String),
 }

--- a/core/src/metadata.rs
+++ b/core/src/metadata.rs
@@ -469,6 +469,9 @@ pub struct MetadataMaterializationStatusRecord {
     pub dataset_digest: Option<[u8; 32]>,
     pub state: MetadataMaterializationState,
     pub attempts: u32,
+    /// Application-level failures only; infrastructure errors retry without
+    /// counting so an overloaded node never gives up on a document.
+    pub failures: u32,
     pub last_error: Option<String>,
     pub updated_at_ms: u64,
 }
@@ -492,6 +495,7 @@ impl MetadataMaterializationStatusRecord {
             dataset_digest: None,
             state: MetadataMaterializationState::Pending,
             attempts: 0,
+            failures: 0,
             last_error: None,
             updated_at_ms,
         }
@@ -503,7 +507,23 @@ pub struct MetadataMaterializationJobRecord {
     pub document_id: Ulid,
     pub event_id: Ulid,
     pub due_at_ms: u64,
+    /// Total tries; drives retry backoff and stale-duplicate detection.
     pub attempts: u32,
+    /// Application-level failures only; the attempt cap tests this counter so a
+    /// storm of timeouts cannot park a job.
+    pub failures: u32,
+}
+
+/// A job that exhausted its failure budget. Kept so the queue drain can pick it
+/// up again later: parking must never silently drop a document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetadataMaterializationDeadLetterRecord {
+    pub job: MetadataMaterializationJobRecord,
+    pub last_error: String,
+    pub parked_at_ms: u64,
+    /// How often this job has been parked; drives the requeue backoff.
+    pub parks: u32,
+    pub requeue_at_ms: u64,
 }
 
 impl MetadataMaterializationJobRecord {
@@ -513,6 +533,7 @@ impl MetadataMaterializationJobRecord {
             event_id: event.event_id,
             due_at_ms,
             attempts: 0,
+            failures: 0,
         }
     }
 }

--- a/core/src/metadata.rs
+++ b/core/src/metadata.rs
@@ -513,6 +513,9 @@ pub struct MetadataMaterializationJobRecord {
     /// Application-level failures only; the attempt cap tests this counter so a
     /// storm of timeouts cannot park a job.
     pub failures: u32,
+    /// How often this job was already parked. Carried across requeue so the
+    /// dead-letter backoff of a poison document keeps growing.
+    pub parks: u32,
 }
 
 /// A job that exhausted its failure budget. Kept so the queue drain can pick it
@@ -535,6 +538,7 @@ impl MetadataMaterializationJobRecord {
             due_at_ms,
             attempts: 0,
             failures: 0,
+            parks: 0,
         }
     }
 }

--- a/core/src/metadata.rs
+++ b/core/src/metadata.rs
@@ -872,6 +872,10 @@ pub enum MetadataError {
     Validation(Vec<MetadataValidationViolation>),
     #[error("metadata graph not found")]
     GraphNotFound,
+    /// Durability failure while persisting backend state. Infrastructure, not the
+    /// document: retrying it is always valid.
+    #[error("metadata persist failed: {0}")]
+    Persist(String),
     #[error("metadata backend error: {0}")]
     Backend(String),
 }

--- a/core/src/operation.rs
+++ b/core/src/operation.rs
@@ -11,6 +11,16 @@ pub trait Operation: Send + std::fmt::Debug + PartialEq {
     fn is_complete(&self) -> bool;
     fn finalize(self) -> Result<Self::Output, Self::Error>;
     fn abort(&mut self) -> Effects;
+
+    /// Whether an error is an ordinary client-visible outcome (not found, denied)
+    /// rather than an operational failure. Expected errors are logged at debug so
+    /// polling clients cannot flood the error stream and its span exporter.
+    fn expected_error(_error: &Self::Error) -> bool
+    where
+        Self: Sized,
+    {
+        false
+    }
 }
 
 pub trait SubOperation: Send + std::fmt::Debug {

--- a/core/src/storage_entries.rs
+++ b/core/src/storage_entries.rs
@@ -17,11 +17,11 @@ use crate::keyspaces::{
     METADATA_GRAPH_LIFECYCLE_KEYSPACE, METADATA_GRAPH_PRUNE_JOB_KEYSPACE,
     METADATA_HOLDERS_KEYSPACE, METADATA_INDEX_KEYSPACE, METADATA_IRI_REFERENCE_INDEX_KEYSPACE,
     METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE, METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE,
-    METADATA_MATERIALIZATION_JOB_KEYSPACE, METADATA_MATERIALIZATION_STATUS_KEYSPACE,
-    METADATA_PENDING_PROJECTION_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE,
-    NOTIFICATION_INBOX_PRUNE_INDEX_KEYSPACE, NOTIFICATION_OUTBOX_KEYSPACE,
-    NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE, SHARD_MANIFEST_KEYSPACE,
-    USER_SUBJECT_INDEX_KEYSPACE,
+    METADATA_MATERIALIZATION_JOB_KEYSPACE, METADATA_MATERIALIZATION_PRUNE_KEYSPACE,
+    METADATA_MATERIALIZATION_STATUS_KEYSPACE, METADATA_PENDING_PROJECTION_KEYSPACE,
+    NOTIFICATION_INBOX_KEYSPACE, NOTIFICATION_INBOX_PRUNE_INDEX_KEYSPACE,
+    NOTIFICATION_OUTBOX_KEYSPACE, NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE,
+    SHARD_MANIFEST_KEYSPACE, USER_SUBJECT_INDEX_KEYSPACE,
 };
 use crate::metadata::{
     MetadataCreateEventRecord, MetadataDocumentLifecycleRecord, MetadataGraphLifecycleRecord,
@@ -550,6 +550,23 @@ pub fn dead_letter_entry(
         dead_letter_key(record.job.document_id, record.job.event_id),
         postcard::to_allocvec(record)?.into(),
     ))
+}
+
+/// A document whose superseded IRI index rows still have to be dropped. Kept
+/// durable so cleanup survives the batch that scheduled it.
+pub fn materialization_prune_entry(
+    document_id: Ulid,
+    cursor: Ulid,
+) -> Result<(KeySpace, Key, Value), ConversionError> {
+    Ok((
+        METADATA_MATERIALIZATION_PRUNE_KEYSPACE.to_string(),
+        materialization_prune_key(document_id),
+        postcard::to_allocvec(&cursor)?.into(),
+    ))
+}
+
+pub fn materialization_prune_key(document_id: Ulid) -> Key {
+    ByteView::from(document_id.to_bytes().to_vec())
 }
 
 pub fn metadata_graph_prune_job_write_entry(

--- a/core/src/storage_entries.rs
+++ b/core/src/storage_entries.rs
@@ -16,15 +16,17 @@ use crate::keyspaces::{
     METADATA_DOCUMENT_LIFECYCLE_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE,
     METADATA_GRAPH_LIFECYCLE_KEYSPACE, METADATA_GRAPH_PRUNE_JOB_KEYSPACE,
     METADATA_HOLDERS_KEYSPACE, METADATA_INDEX_KEYSPACE, METADATA_IRI_REFERENCE_INDEX_KEYSPACE,
-    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE, METADATA_MATERIALIZATION_JOB_KEYSPACE,
-    METADATA_MATERIALIZATION_STATUS_KEYSPACE, METADATA_PENDING_PROJECTION_KEYSPACE,
-    NOTIFICATION_INBOX_KEYSPACE, NOTIFICATION_INBOX_PRUNE_INDEX_KEYSPACE,
-    NOTIFICATION_OUTBOX_KEYSPACE, NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE,
-    SHARD_MANIFEST_KEYSPACE, USER_SUBJECT_INDEX_KEYSPACE,
+    METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE, METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE,
+    METADATA_MATERIALIZATION_JOB_KEYSPACE, METADATA_MATERIALIZATION_STATUS_KEYSPACE,
+    METADATA_PENDING_PROJECTION_KEYSPACE, NOTIFICATION_INBOX_KEYSPACE,
+    NOTIFICATION_INBOX_PRUNE_INDEX_KEYSPACE, NOTIFICATION_OUTBOX_KEYSPACE,
+    NOTIFICATION_WATCH_SUBSCRIPTIONS_KEYSPACE, SHARD_MANIFEST_KEYSPACE,
+    USER_SUBJECT_INDEX_KEYSPACE,
 };
 use crate::metadata::{
     MetadataCreateEventRecord, MetadataDocumentLifecycleRecord, MetadataGraphLifecycleRecord,
-    MetadataGraphPruneJobRecord, MetadataIriReferenceIndexRecord, MetadataMaterializationJobRecord,
+    MetadataGraphPruneJobRecord, MetadataIriReferenceIndexRecord,
+    MetadataMaterializationDeadLetterRecord, MetadataMaterializationJobRecord,
     MetadataMaterializationStatusRecord,
 };
 use crate::structs::{
@@ -214,6 +216,10 @@ pub fn metadata_materialization_document_job_key(document_id: Ulid, event_id: Ul
     bytes.extend_from_slice(&document_id.to_bytes());
     bytes.extend_from_slice(&event_id.to_bytes());
     ByteView::from(bytes)
+}
+
+pub fn dead_letter_key(document_id: Ulid, event_id: Ulid) -> Key {
+    metadata_materialization_document_job_key(document_id, event_id)
 }
 
 pub fn metadata_materialization_job_key(record: &MetadataMaterializationJobRecord) -> Key {
@@ -530,6 +536,18 @@ pub fn metadata_materialization_document_job_write_entry(
     Ok((
         METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
         metadata_materialization_document_job_key(record.document_id, record.event_id),
+        postcard::to_allocvec(record)?.into(),
+    ))
+}
+
+/// Parked job kept for later requeue; the drain rearm loop retries these so a
+/// node converges without an operator or a restart.
+pub fn dead_letter_entry(
+    record: &MetadataMaterializationDeadLetterRecord,
+) -> Result<(KeySpace, Key, Value), ConversionError> {
+    Ok((
+        METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
+        dead_letter_key(record.job.document_id, record.job.event_id),
         postcard::to_allocvec(record)?.into(),
     ))
 }

--- a/core/src/storage_entries.rs
+++ b/core/src/storage_entries.rs
@@ -509,16 +509,21 @@ pub fn metadata_iri_reference_write_entry(
     ))
 }
 
+/// Due-index row for the materialization queue. The value is empty: the sidecar
+/// row is authoritative. Both rows MUST be written and deleted in one batch/txn
+/// so the index never references a document job that does not exist.
 pub fn metadata_materialization_job_write_entry(
     record: &MetadataMaterializationJobRecord,
 ) -> Result<(KeySpace, Key, Value), ConversionError> {
     Ok((
         METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
         metadata_materialization_job_key(record),
-        postcard::to_allocvec(record)?.into(),
+        ByteView::from(Vec::new()),
     ))
 }
 
+/// Authoritative sidecar row for the materialization queue, paired with the due
+/// index row above; the two MUST be written and deleted together.
 pub fn metadata_materialization_document_job_write_entry(
     record: &MetadataMaterializationJobRecord,
 ) -> Result<(KeySpace, Key, Value), ConversionError> {

--- a/core/src/structs/job.rs
+++ b/core/src/structs/job.rs
@@ -161,7 +161,11 @@ pub enum OutputDestination {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OutputSelection {
+    /// Absolute container path, which may carry POSIX 12.13 wildcards.
     pub container_path: String,
+    /// Literal ancestor stripped from every matched path to build the
+    /// destination key. Required with wildcards, absent otherwise.
+    pub path_prefix: Option<String>,
     pub destination: OutputDestination,
     pub name: Option<String>,
     pub description: Option<String>,
@@ -497,6 +501,7 @@ impl ExecutionSpec {
         for output in std::mem::take(&mut self.workspace_outputs) {
             self.file_outputs.push(OutputSelection {
                 container_path: output.container_path,
+                path_prefix: None,
                 destination: OutputDestination::S3 {
                     bucket: bucket.to_string(),
                     key: output.dest_key,
@@ -1495,6 +1500,7 @@ mod tests {
             spec.file_outputs,
             vec![OutputSelection {
                 container_path: "/out/report.txt".to_string(),
+                path_prefix: None,
                 destination: OutputDestination::S3 {
                     bucket: "ws-job".to_string(),
                     key: "outputs/report.txt".to_string(),

--- a/deny.toml
+++ b/deny.toml
@@ -13,9 +13,6 @@ ignore = [
     "RUSTSEC-2025-0052", # async-std discontinued (transitive)
     "RUSTSEC-2026-0194", # quick-xml quadratic parse via RDF stack (upstream craqle)
     "RUSTSEC-2026-0195", # quick-xml namespace allocation via RDF stack (upstream craqle)
-    # Yanked for a macOS-only build break (apache/opendal#7923); Linux is
-    # unaffected and 0.57 lacks the raw APIs we use. Drop this on 0.58.1.
-    { crate = "opendal@0.58.0", reason = "yanked for a macOS-only issue, apache/opendal#7923" },
 ]
 
 [licenses]

--- a/docs/compute-executors.md
+++ b/docs/compute-executors.md
@@ -60,6 +60,11 @@ Input files may share a directory with outputs. Exact input/output collisions,
 input-file ancestors, duplicate paths, and root output parents are rejected.
 Paths are normalized by components, so `/out` and `/output` remain distinct.
 
+An output path may carry the POSIX wildcards `*`, `?`, and `[...]`, which never
+cross `/`. Each match is uploaded below the declared destination with the
+required `path_prefix` stripped, and a pattern that matches nothing captures
+nothing. A declared path without wildcards must still exist when the task ends.
+
 ## Docker
 
 Required configuration:
@@ -199,8 +204,9 @@ release fallback.
 ## Helper image
 
 The helper source is in `scripts/compute-helper`. It provides only `stage`,
-`fetch`, and `probe`: safe tar staging, tar output fetch, marker comparison, and
-probe installation. It contains no AWS SDK or credential input.
+`fetch`, `list`, and `probe`: safe tar staging, tar output fetch, workspace
+listing for wildcard outputs, marker comparison, and probe installation. It
+contains no AWS SDK or credential input.
 
 Build the plain local image from the repository root with:
 

--- a/net/src/dht/driver.rs
+++ b/net/src/dht/driver.rs
@@ -2874,7 +2874,8 @@ mod tests {
 
     #[tokio::test]
     async fn replay_skips_write() {
-        let (storage, receiver) = StorageHandle::new();
+        let (storage, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         let key = DhtKeyId::from_data(b"unchanged-replay");
         let entry = make_entry(1, key, now_unix_secs().saturating_add(200));
         let encoded = encode_entries(std::slice::from_ref(&entry)).expect("encode entry");

--- a/net/src/irokle.rs
+++ b/net/src/irokle.rs
@@ -104,9 +104,10 @@ struct PendingMetadataCreateApply {
     lifecycle_revision: Option<DocumentSyncChange>,
 }
 
-struct MetadataPlacementFence {
-    config_write: Option<(String, ByteView, Value)>,
-}
+/// Placement fence outcome. The transactional read of the realm config is the
+/// whole fence: a concurrent config mutation conflicts the commit. The config
+/// row is never written back, which would only conflict its readers.
+struct MetadataPlacementFence;
 
 enum MetadataPlacementOutcome<T> {
     Accepted(T),
@@ -2622,19 +2623,18 @@ impl DocumentSyncService {
 
         let txn_id = start_storage_transaction(&self.storage).await?;
         let mut writes = Vec::with_capacity(candidates.len() * 3 + cursor_writes.len());
-        let mut config_writes = BTreeMap::new();
         let mut accepted = Vec::with_capacity(candidates.len());
         let mut accepted_candidates = Vec::with_capacity(candidates.len());
         let mut deferred_cursor_topics = BTreeSet::new();
         for (apply, entries) in candidates {
-            let fence = match metadata_placement_fence_in_transaction(
+            match metadata_placement_fence_in_transaction(
                 &self.storage,
                 &apply.record.record,
                 txn_id,
             )
             .await
             {
-                Ok(MetadataPlacementOutcome::Accepted(fence)) => fence,
+                Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence)) => {}
                 Ok(MetadataPlacementOutcome::Deferred(dependency)) => {
                     warn!(
                         topic_id = %apply.topic_id,
@@ -2674,19 +2674,15 @@ impl DocumentSyncService {
                     return Err(error);
                 }
             };
-            accepted_candidates.push((apply, entries, fence.config_write));
+            accepted_candidates.push((apply, entries));
         }
-        for (apply, entries, config_write) in accepted_candidates {
+        for (apply, entries) in accepted_candidates {
             if deferred_cursor_topics.contains(&apply.topic_id) {
                 continue;
-            }
-            if let Some(config_write) = config_write {
-                config_writes.insert(apply.record.record.realm_id, config_write);
             }
             writes.extend(entries);
             accepted.push(apply);
         }
-        writes.extend(config_writes.into_values());
         writes.extend(cursor_writes.into_iter().filter_map(|(topic_id, write)| {
             (!deferred_cursor_topics.contains(&topic_id)).then_some(write)
         }));
@@ -3292,8 +3288,8 @@ async fn apply_metadata_registry_upsert_to_storage(
     };
     for _ in 0..2 {
         let txn_id = start_storage_transaction(storage).await?;
-        let fence = match metadata_placement_fence_in_transaction(storage, &record, txn_id).await {
-            Ok(MetadataPlacementOutcome::Accepted(fence)) => fence,
+        match metadata_placement_fence_in_transaction(storage, &record, txn_id).await {
+            Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence)) => {}
             Ok(MetadataPlacementOutcome::Deferred(dependency)) => {
                 let _ = storage
                     .send_storage_effect(StorageEffect::AbortTransaction { txn_id })
@@ -3351,10 +3347,7 @@ async fn apply_metadata_registry_upsert_to_storage(
             return Ok(MetadataPlacementOutcome::Accepted(()));
         }
 
-        let mut entries = base_entries.clone();
-        if let Some(config_write) = fence.config_write {
-            entries.push(config_write);
-        }
+        let entries = base_entries.clone();
         match storage_batch_delete_and_write_in_transaction(storage, txn_id, Vec::new(), entries)
             .await
         {
@@ -4472,9 +4465,7 @@ async fn metadata_placement_fence_in_transaction(
     .await?;
     let Some(value) = value else {
         return if record.placement == PlacementRef::NIL {
-            Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence {
-                config_write: None,
-            }))
+            Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence))
         } else {
             Ok(MetadataPlacementOutcome::Deferred(dependency))
         };
@@ -4489,13 +4480,7 @@ async fn metadata_placement_fence_in_transaction(
     {
         return Ok(MetadataPlacementOutcome::Deferred(dependency));
     }
-    Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence {
-        config_write: Some((
-            REALM_CONFIG_KEYSPACE.to_string(),
-            target.storage_key(),
-            value,
-        )),
-    }))
+    Ok(MetadataPlacementOutcome::Accepted(MetadataPlacementFence))
 }
 
 async fn storage_read_from(
@@ -9726,6 +9711,64 @@ mod tests {
             .await
             .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn upsert_keeps_config() {
+        // The placement fence reads the realm config inside its transaction and
+        // must not write it back: an identical write only conflicts the config's
+        // readers, which is how inbound sync used to stall concurrent creates.
+        let (_dir, storage) = test_storage();
+        let group_id = Ulid::from_parts(2_130, 1);
+        let document_id = Ulid::from_parts(2_131, 1);
+        let record = registry_record(
+            group_id,
+            document_id,
+            "datasets/config-untouched",
+            100,
+            Ulid::from_parts(2_132, 1),
+        );
+        let actor = test_actor(1, UserId::nil(record.realm_id), record.realm_id);
+        let mut config = RealmConfigDocument::default_for_realm(record.realm_id, Vec::new());
+        config.seed_default_placement();
+        let config_target = DocumentSyncTarget::RealmConfig {
+            realm_id: record.realm_id,
+        };
+        storage_batch_write_to(
+            &storage,
+            vec![(
+                config_target.storage_keyspace().to_string(),
+                config_target.storage_key(),
+                config
+                    .to_bytes(&actor)
+                    .expect("realm config serializes")
+                    .into(),
+            )],
+        )
+        .await
+        .expect("realm config writes");
+        let before = storage.snapshot_metrics().requests_total;
+
+        apply_metadata_registry_upsert_to_storage(
+            &storage,
+            record.clone(),
+            postcard::to_allocvec(&record).expect("registry serializes"),
+        )
+        .await
+        .expect("registry upsert applies");
+
+        assert!(
+            read_storage_value(
+                &storage,
+                METADATA_INDEX_KEYSPACE,
+                metadata_registry_key(group_id, document_id),
+            )
+            .await
+            .is_some(),
+            "the upsert still lands"
+        );
+        assert_eq!(storage.snapshot_metrics().conflicts_total, 0);
+        assert!(storage.snapshot_metrics().requests_total > before);
     }
 
     #[tokio::test]

--- a/operations/src/auth.rs
+++ b/operations/src/auth.rs
@@ -239,6 +239,7 @@ impl IssuerKeyCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aruna_core::keys::generate_signing_key;
     use base64::Engine;
     use ed25519_dalek::SigningKey;
 
@@ -249,9 +250,8 @@ mod tests {
     #[tokio::test]
     async fn issuer_key_cache_evicts_beyond_capacity() {
         let cache = IssuerKeyCache::with_capacity_and_ttl(2, ISSUER_KEY_CACHE_TTL);
-        let mut rng = jsonwebtoken::signature::rand_core::OsRng;
         for _ in 0..5 {
-            let key = SigningKey::generate(&mut rng);
+            let key = generate_signing_key();
             cache.get_or_insert(&pubkey_b64(&key)).await.unwrap();
         }
         assert_eq!(cache.len().await, 2);
@@ -277,7 +277,7 @@ mod tests {
     async fn issuer_key_cache_refreshes_expired_entries() {
         let ttl = Duration::from_secs(3600);
         let cache = IssuerKeyCache::with_capacity_and_ttl(4, ttl);
-        let key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let key = generate_signing_key();
         let pubkey = pubkey_b64(&key);
         cache.get_or_insert(&pubkey).await.unwrap();
 

--- a/operations/src/check_permissions.rs
+++ b/operations/src/check_permissions.rs
@@ -1,15 +1,10 @@
-use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::AuthorizationError;
-use aruna_core::events::{Event, StorageEvent};
-use aruna_core::keyspaces::AUTH_KEYSPACE;
+use aruna_core::events::Event;
 use aruna_core::operation::Operation;
-use aruna_core::structs::{
-    AuthContext, GroupAuthorizationDocument, Permission, RealmAuthorizationDocument, RealmId, Role,
-};
-use aruna_core::types::{Effects, GroupId, TxnId};
-use globset::Glob;
-use smallvec::smallvec;
-use ulid::Ulid;
+use aruna_core::structs::{AuthContext, Permission};
+use aruna_core::types::Effects;
+
+use crate::permission_rules::{PermissionRulesConfig, PermissionRulesOperation};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CheckPermissionsConfig {
@@ -18,355 +13,26 @@ pub struct CheckPermissionsConfig {
     pub required_permission: Permission,
 }
 
+/// Decides a single path. Rule collection and evaluation live in
+/// `permission_rules`, so read paths that filter many paths at once share
+/// exactly these semantics.
 #[derive(Debug, PartialEq)]
 pub struct CheckPermissionsOperation {
-    config: CheckPermissionsConfig,
-    txn_id: Option<TxnId>,
-    group_id: Option<Ulid>,
-    realm_auth_doc: Option<RealmAuthorizationDocument>,
-    group_auth_doc: Option<GroupAuthorizationDocument>,
-    output: Option<Result<bool, AuthorizationError>>,
-    state: CheckPermissionsState,
-}
-
-struct CollectedRole {
-    role: Role,
-    direct: bool,
-    public: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum CheckPermissionsState {
-    Init,
-    StartTransaction,
-    GetRealmAuthDoc,
-    GetGroupAuthDoc,
-    CheckPermissions,
-    Finish,
-    Error,
-}
-
-impl std::fmt::Display for CheckPermissionsState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                CheckPermissionsState::Init => "CheckPermissionsState::Init",
-                CheckPermissionsState::StartTransaction =>
-                    "CheckPermissionsState::StartTransaction",
-                CheckPermissionsState::GetRealmAuthDoc => "CheckPermissionsState::GetRealmAuthDoc",
-                CheckPermissionsState::GetGroupAuthDoc => "CheckPermissionsState::GetGroupAuthDoc",
-                CheckPermissionsState::CheckPermissions =>
-                    "CheckPermissionsState::CheckPermissions",
-                CheckPermissionsState::Finish => "CheckPermissionsState::Finish",
-                CheckPermissionsState::Error => "CheckPermissionsState::Error",
-            }
-        )
-    }
+    rules: PermissionRulesOperation,
+    path: String,
+    required_permission: Permission,
 }
 
 impl CheckPermissionsOperation {
     pub fn new(config: CheckPermissionsConfig) -> Self {
         CheckPermissionsOperation {
-            config,
-            txn_id: None,
-            realm_auth_doc: None,
-            group_id: None,
-            group_auth_doc: None,
-            output: None,
-            state: CheckPermissionsState::Init,
+            rules: PermissionRulesOperation::new(PermissionRulesConfig {
+                auth_context: config.auth_context,
+                path: config.path.clone(),
+            }),
+            path: config.path,
+            required_permission: config.required_permission,
         }
-    }
-
-    fn handle_start_transaction(&mut self, event: Event) -> Effects {
-        let got = format!("{event:?}");
-        if let (
-            CheckPermissionsState::StartTransaction,
-            Event::Storage(StorageEvent::TransactionStarted { txn_id }),
-        ) = (self.state, event)
-        {
-            self.txn_id = Some(txn_id);
-            let effects = self.get_realm_auth_doc();
-            match effects {
-                Ok(effects) => effects,
-                Err(err) => self.fail(err),
-            }
-        } else {
-            self.unexpected_event(
-                self.state,
-                "Event::Storage(StorageEvent::TransactionStart)",
-                got,
-            )
-        }
-    }
-
-    fn handle_realm_auth(&mut self, event: Event) -> Effects {
-        let got = format!("{event:?}");
-        if let (
-            CheckPermissionsState::GetRealmAuthDoc,
-            Event::Storage(StorageEvent::ReadResult { value, .. }),
-        ) = (self.state, event)
-        {
-            match self.emit_realm_auth_doc(value) {
-                Ok(effects) => effects,
-                Err(err) => self.fail(err),
-            }
-        } else {
-            self.unexpected_event(self.state, "Event::Storage(StorageEvent::ReadResult)", got)
-        }
-    }
-
-    fn handle_group_auth(&mut self, event: Event) -> Effects {
-        let got = format!("{event:?}");
-        if let (
-            CheckPermissionsState::GetGroupAuthDoc,
-            Event::Storage(StorageEvent::ReadResult { value, .. }),
-        ) = (self.state, event)
-        {
-            match self.emit_group_auth_doc(value) {
-                Ok(effects) => effects,
-                Err(err) => self.fail(err),
-            }
-        } else {
-            self.unexpected_event(self.state, "Event::Storage(StorageEvent::ReadResult)", got)
-        }
-    }
-
-    fn handle_check_permissions(&mut self, event: Event) -> Effects {
-        let got = format!("{event:?}");
-        if let (
-            CheckPermissionsState::CheckPermissions,
-            Event::Storage(StorageEvent::TransactionCommitted { .. }),
-        ) = (self.state, event)
-        {
-            match self.emit_check_permissions() {
-                Ok(effects) => effects,
-                Err(err) => self.fail(err),
-            }
-        } else {
-            self.unexpected_event(
-                self.state,
-                "Event::Storage(StorageEvent::TransactionCommitted)",
-                got,
-            )
-        }
-    }
-
-    fn parse_path(path: &str) -> Result<(RealmId, Option<GroupId>), AuthorizationError> {
-        let mut levels = path.split("/");
-        levels.next();
-        let realm = levels
-            .next()
-            .and_then(|rid| RealmId::from_base64(rid).ok())
-            .ok_or_else(|| AuthorizationError::InvalidRealmId)?;
-
-        let separator = levels.next();
-
-        let group = if separator == Some("g") {
-            levels.next().and_then(|g| Ulid::from_string(g).ok())
-        } else {
-            None
-        };
-
-        Ok((realm, group))
-    }
-
-    fn get_realm_auth_doc(&mut self) -> Result<Effects, AuthorizationError> {
-        self.state = CheckPermissionsState::GetRealmAuthDoc;
-        let (realm, group) = CheckPermissionsOperation::parse_path(&self.config.path)?;
-        self.group_id = group;
-        Ok(smallvec![Effect::Storage(StorageEffect::Read {
-            key_space: AUTH_KEYSPACE.to_string(),
-            key: (*realm.as_bytes()).into(),
-            txn_id: self.txn_id
-        })])
-    }
-
-    fn emit_realm_auth_doc(
-        &mut self,
-        value: Option<byteview::ByteView>,
-    ) -> Result<Effects, AuthorizationError> {
-        self.realm_auth_doc = Some(RealmAuthorizationDocument::from_bytes(
-            &value.ok_or_else(|| AuthorizationError::AuthDocNotFound)?,
-        )?);
-
-        match self.group_id {
-            Some(group) => {
-                self.state = CheckPermissionsState::GetGroupAuthDoc;
-                Ok(smallvec![Effect::Storage(StorageEffect::Read {
-                    txn_id: self.txn_id,
-                    key_space: AUTH_KEYSPACE.to_string(),
-                    key: group.to_bytes().into(),
-                })])
-            }
-            None => {
-                self.state = CheckPermissionsState::CheckPermissions;
-                Ok(smallvec![Effect::Storage(
-                    StorageEffect::CommitTransaction {
-                        txn_id: self
-                            .txn_id
-                            .ok_or_else(|| AuthorizationError::NoTransactionFound)?
-                    }
-                )])
-            }
-        }
-    }
-
-    fn emit_group_auth_doc(
-        &mut self,
-        value: Option<byteview::ByteView>,
-    ) -> Result<Effects, AuthorizationError> {
-        self.state = CheckPermissionsState::CheckPermissions;
-        self.group_auth_doc = Some(GroupAuthorizationDocument::from_bytes(
-            &value.ok_or_else(|| AuthorizationError::AuthDocNotFound)?,
-        )?);
-
-        Ok(smallvec![Effect::Storage(
-            StorageEffect::CommitTransaction {
-                txn_id: self
-                    .txn_id
-                    .ok_or_else(|| AuthorizationError::NoTransactionFound)?
-            }
-        )])
-    }
-
-    fn emit_check_permissions(&mut self) -> Result<Effects, AuthorizationError> {
-        self.state = CheckPermissionsState::Finish;
-        let roles = self.collect_roles()?;
-        let allowed = self.check_permissions(roles)?;
-        let allowed = if allowed {
-            self.check_path_restrictions()?
-        } else {
-            false
-        };
-        self.output = Some(Ok(allowed));
-        Ok(smallvec![])
-    }
-
-    fn collect_roles(&mut self) -> Result<Vec<CollectedRole>, AuthorizationError> {
-        let realm_auth_doc = self
-            .realm_auth_doc
-            .as_ref()
-            .ok_or_else(|| AuthorizationError::AuthDocNotFound)?;
-        let realm_id = realm_auth_doc.realm_id;
-        let auth_user = self.config.auth_context.user_id;
-        let mut roles = realm_auth_doc.roles.clone();
-        if let Some(group) = &self.group_auth_doc {
-            roles.extend(group.roles.clone());
-        }
-        Ok(roles
-            .into_values()
-            .filter_map(|role| {
-                // Public roles apply by assigning this realm's exact Everyone
-                // principal. Other nil user ids are not public for this realm.
-                let public = role.is_public(realm_id);
-                let direct = !auth_user.is_nil() && role.assigned_users.contains(&auth_user);
-                (public || direct).then_some(CollectedRole {
-                    role,
-                    direct,
-                    public,
-                })
-            })
-            .collect())
-    }
-
-    fn check_permissions(&mut self, roles: Vec<CollectedRole>) -> Result<bool, AuthorizationError> {
-        let mut allowed = false;
-        for CollectedRole {
-            role,
-            direct,
-            public,
-        } in roles
-        {
-            for (path, permission) in role.permissions {
-                let glob = Glob::new(&path)?.compile_matcher();
-                if glob.is_match(&self.config.path) {
-                    if public
-                        && permission == Permission::READ
-                        && self.config.required_permission == Permission::READ
-                    {
-                        allowed = true;
-                    }
-
-                    if direct {
-                        match permission {
-                            Permission::DENY => {
-                                return Ok(false);
-                            }
-                            Permission::READ => {
-                                if self.config.required_permission == Permission::READ {
-                                    allowed = true;
-                                }
-                            }
-                            Permission::WRITE => allowed = true,
-                        }
-                    }
-                }
-            }
-        }
-        Ok(allowed)
-    }
-
-    fn check_path_restrictions(&self) -> Result<bool, AuthorizationError> {
-        let Some(restrictions) = self.config.auth_context.path_restrictions.as_ref() else {
-            return Ok(true);
-        };
-
-        let mut allowed = false;
-        for restriction in restrictions {
-            let glob = Glob::new(&restriction.pattern)?.compile_matcher();
-            if glob.is_match(&self.config.path) {
-                match restriction.permission {
-                    Permission::DENY => return Ok(false),
-                    Permission::READ => {
-                        if self.config.required_permission == Permission::READ {
-                            allowed = true;
-                        }
-                    }
-                    Permission::WRITE => allowed = true,
-                }
-            }
-        }
-
-        Ok(allowed)
-    }
-
-    fn fail(&mut self, err: AuthorizationError) -> Effects {
-        self.state = CheckPermissionsState::Error;
-        self.output = Some(Err(err));
-        self.abort()
-    }
-
-    fn fail_with_cleanup(&mut self, err: AuthorizationError, cleanup_effects: Effects) -> Effects {
-        self.state = CheckPermissionsState::Error;
-        self.output = Some(Err(err));
-        cleanup_effects
-    }
-
-    fn unexpected_event(
-        &mut self,
-        state: CheckPermissionsState,
-        expected: &'static str,
-        got: String,
-    ) -> Effects {
-        let cleanup_effects = self.abort();
-        self.fail_with_cleanup(
-            AuthorizationError::UnexpectedEvent {
-                state: state.to_string(),
-                expected,
-                got,
-            },
-            cleanup_effects,
-        )
-    }
-
-    fn fail_on_storage_error(&mut self, event: Event) -> Result<Event, Effects> {
-        if let Event::Storage(StorageEvent::Error { error }) = event {
-            return Err(self.fail(error.into()));
-        }
-
-        Ok(event)
     }
 }
 
@@ -375,63 +41,41 @@ impl Operation for CheckPermissionsOperation {
 
     type Error = AuthorizationError;
 
-    fn start(&mut self) -> aruna_core::types::Effects {
-        self.state = CheckPermissionsState::StartTransaction;
-
-        smallvec![Effect::Storage(StorageEffect::StartTransaction {
-            read: true
-        })]
+    fn start(&mut self) -> Effects {
+        self.rules.start()
     }
 
-    fn step(&mut self, event: Event) -> aruna_core::types::Effects {
-        let event = match self.fail_on_storage_error(event) {
-            Ok(event) => event,
-            Err(effects) => return effects,
-        };
-
-        match self.state {
-            CheckPermissionsState::StartTransaction => self.handle_start_transaction(event),
-            CheckPermissionsState::GetRealmAuthDoc => self.handle_realm_auth(event),
-            CheckPermissionsState::GetGroupAuthDoc => self.handle_group_auth(event),
-            CheckPermissionsState::CheckPermissions => self.handle_check_permissions(event),
-            CheckPermissionsState::Finish
-            | CheckPermissionsState::Init
-            | CheckPermissionsState::Error => smallvec![],
-        }
+    fn step(&mut self, event: Event) -> Effects {
+        self.rules.step(event)
     }
 
     fn is_complete(&self) -> bool {
-        matches!(
-            self.state,
-            CheckPermissionsState::Finish | CheckPermissionsState::Error
-        )
+        self.rules.is_complete()
     }
 
     fn finalize(self) -> Result<Self::Output, Self::Error> {
-        self.output.ok_or_else(|| AuthorizationError::NotFinished)?
+        let CheckPermissionsOperation {
+            rules,
+            path,
+            required_permission,
+        } = self;
+        Ok(rules.finalize()?.allows(&path, &required_permission))
     }
 
-    fn abort(&mut self) -> aruna_core::types::Effects {
-        match self.txn_id {
-            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
-            None => smallvec![],
-        }
+    fn abort(&mut self) -> Effects {
+        self.rules.abort()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use aruna_core::keys::generate_signing_key;
     use std::collections::{HashMap, HashSet};
 
     use aruna_core::UserId;
-    use aruna_core::structs::{
-        Actor, AuthContext, PathRestriction, Permission, RealmAuthorizationDocument, RealmId, Role,
-    };
+    use aruna_core::structs::{Actor, AuthContext, Permission, RealmId};
     use aruna_net::{DiscoveryMethod, NetConfig, NetHandle, RelayMethod};
     use aruna_storage::storage;
     use aruna_tasks::TaskHandle;
-    use ed25519_dalek::SigningKey;
     use tempfile::tempdir;
     use ulid::Ulid;
 
@@ -445,198 +89,6 @@ mod test {
     use crate::create_group::{CreateGroupConfig, CreateGroupOperation};
     use crate::create_realm::{CreateRealmConfig, CreateRealmOperation};
     use crate::driver::{DriverContext, drive};
-
-    #[tokio::test]
-    pub async fn test_path_parsing() {
-        let realm_signing_key: SigningKey = generate_signing_key();
-        let pubkey = realm_signing_key.verifying_key().to_bytes();
-        let realm_id = RealmId::from_bytes(pubkey);
-        let group_id = Ulid::generate();
-        let path = format!("/{}/g/{}", realm_id, group_id.to_string());
-        let (parsed_realm_id, parsed_group_id) =
-            CheckPermissionsOperation::parse_path(&path).unwrap();
-
-        assert_eq!(realm_id, parsed_realm_id);
-        assert_eq!(group_id, parsed_group_id.unwrap());
-
-        let path = format!("/{}/admin", realm_id);
-        let (parsed_realm_id, parsed_group_id) =
-            CheckPermissionsOperation::parse_path(&path).unwrap();
-
-        assert_eq!(realm_id, parsed_realm_id);
-        assert!(parsed_group_id.is_none());
-
-        let path = format!("/abcd/g/{}", Ulid::generate().to_string());
-        assert!(CheckPermissionsOperation::parse_path(&path).is_err());
-    }
-
-    #[test]
-    fn path_restrictions_enforce_whitelist_and_required_permission() {
-        let realm_id = RealmId([0u8; 32]);
-        let group_id = Ulid::generate();
-        let pattern = format!("/{realm_id}/g/{group_id}/meta/**");
-        let mut operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
-            auth_context: AuthContext {
-                user_id: UserId::local(Ulid::generate(), realm_id),
-                realm_id,
-                path_restrictions: Some(vec![PathRestriction {
-                    pattern: pattern.clone(),
-                    permission: Permission::READ,
-                }]),
-            },
-            path: format!("/{realm_id}/g/{group_id}/meta/document"),
-            required_permission: Permission::READ,
-        });
-
-        assert!(operation.check_path_restrictions().unwrap());
-
-        operation.config.path = format!("/{realm_id}/g/{group_id}/data/document");
-        assert!(!operation.check_path_restrictions().unwrap());
-
-        operation.config.path = format!("/{realm_id}/g/{group_id}/meta/document");
-        operation.config.required_permission = Permission::WRITE;
-        assert!(!operation.check_path_restrictions().unwrap());
-
-        operation.config.required_permission = Permission::READ;
-        operation.config.auth_context.path_restrictions = Some(vec![PathRestriction {
-            pattern,
-            permission: Permission::DENY,
-        }]);
-        assert!(!operation.check_path_restrictions().unwrap());
-    }
-
-    #[test]
-    fn collect_roles_only_treats_same_realm_nil_as_public() {
-        let realm_id = RealmId([1u8; 32]);
-        let other_realm_id = RealmId([2u8; 32]);
-        let group_id = Ulid::generate();
-        let role = Role {
-            role_id: Ulid::generate(),
-            name: "foreign-nil".to_string(),
-            permissions: HashMap::from([(
-                format!("/{realm_id}/g/{group_id}/data/**"),
-                Permission::READ,
-            )]),
-            assigned_users: HashSet::from([UserId::nil(other_realm_id)]),
-        };
-        let mut operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
-            auth_context: AuthContext::anonymous(realm_id),
-            path: format!("/{realm_id}/g/{group_id}/data/object"),
-            required_permission: Permission::READ,
-        });
-        operation.realm_auth_doc = Some(RealmAuthorizationDocument {
-            realm_id,
-            roles: HashMap::from([(role.role_id, role)]),
-            operation_restrictions: HashMap::new(),
-        });
-
-        assert!(operation.collect_roles().unwrap().is_empty());
-    }
-
-    #[test]
-    fn public_grants_are_read_only_when_evaluating_permissions() {
-        let realm_id = RealmId([2u8; 32]);
-        let group_id = Ulid::generate();
-        let user_id = UserId::local(Ulid::generate(), realm_id);
-        let path = format!("/{realm_id}/g/{group_id}/data/object");
-
-        let public_write = Role {
-            role_id: Ulid::generate(),
-            name: "public-write".to_string(),
-            permissions: HashMap::from([(path.clone(), Permission::WRITE)]),
-            assigned_users: HashSet::from([UserId::nil(realm_id)]),
-        };
-        let mut write_operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
-            auth_context: AuthContext::anonymous(realm_id),
-            path: path.clone(),
-            required_permission: Permission::WRITE,
-        });
-        assert!(
-            !write_operation
-                .check_permissions(vec![super::CollectedRole {
-                    role: public_write,
-                    direct: false,
-                    public: true,
-                }])
-                .unwrap()
-        );
-
-        let public_direct_write = Role {
-            role_id: Ulid::generate(),
-            name: "public-direct-write".to_string(),
-            permissions: HashMap::from([(path.clone(), Permission::WRITE)]),
-            assigned_users: HashSet::from([UserId::nil(realm_id), user_id]),
-        };
-        assert!(
-            write_operation
-                .check_permissions(vec![super::CollectedRole {
-                    role: public_direct_write,
-                    direct: true,
-                    public: true,
-                }])
-                .unwrap()
-        );
-
-        let public_deny = Role {
-            role_id: Ulid::generate(),
-            name: "public-deny".to_string(),
-            permissions: HashMap::from([(path.clone(), Permission::DENY)]),
-            assigned_users: HashSet::from([UserId::nil(realm_id)]),
-        };
-        let direct_read = Role {
-            role_id: Ulid::generate(),
-            name: "direct-read".to_string(),
-            permissions: HashMap::from([(path.clone(), Permission::READ)]),
-            assigned_users: HashSet::from([user_id]),
-        };
-        let public_direct_deny = Role {
-            role_id: Ulid::generate(),
-            name: "public-direct-deny".to_string(),
-            permissions: HashMap::from([(path.clone(), Permission::DENY)]),
-            assigned_users: HashSet::from([UserId::nil(realm_id), user_id]),
-        };
-        let mut read_operation = CheckPermissionsOperation::new(CheckPermissionsConfig {
-            auth_context: AuthContext {
-                user_id,
-                realm_id,
-                path_restrictions: None,
-            },
-            path,
-            required_permission: Permission::READ,
-        });
-        assert!(
-            read_operation
-                .check_permissions(vec![
-                    super::CollectedRole {
-                        role: public_deny,
-                        direct: false,
-                        public: true,
-                    },
-                    super::CollectedRole {
-                        role: direct_read.clone(),
-                        direct: true,
-                        public: false,
-                    },
-                ])
-                .unwrap()
-        );
-        assert!(
-            !read_operation
-                .check_permissions(vec![
-                    super::CollectedRole {
-                        role: public_direct_deny,
-                        direct: true,
-                        public: true,
-                    },
-                    super::CollectedRole {
-                        role: direct_read,
-                        direct: true,
-                        public: false,
-                    },
-                ])
-                .unwrap()
-        );
-    }
 
     #[tokio::test]
     pub async fn public_roles_apply_to_everyone_and_are_read_only() {

--- a/operations/src/check_permissions.rs
+++ b/operations/src/check_permissions.rs
@@ -421,6 +421,7 @@ impl Operation for CheckPermissionsOperation {
 
 #[cfg(test)]
 mod test {
+    use aruna_core::keys::generate_signing_key;
     use std::collections::{HashMap, HashSet};
 
     use aruna_core::UserId;
@@ -447,8 +448,7 @@ mod test {
 
     #[tokio::test]
     pub async fn test_path_parsing() {
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let pubkey = realm_signing_key.verifying_key().to_bytes();
         let realm_id = RealmId::from_bytes(pubkey);
         let group_id = Ulid::generate();

--- a/operations/src/claim_initial_realm_admin.rs
+++ b/operations/src/claim_initial_realm_admin.rs
@@ -601,6 +601,7 @@ mod tests {
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::errors::StorageError;
     use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, DOCUMENT_SYNC_OUTBOX_KEYSPACE};
     use aruna_core::operation::Operation;
     use aruna_core::structs::{Actor, RealmAuthorizationDocument, RealmId, Role};
@@ -630,8 +631,7 @@ mod tests {
         .unwrap();
         let task_handle = TaskHandle::new();
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let realm_id = RealmId::from_bytes(realm_signing_key.verifying_key().to_bytes());
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();
 

--- a/operations/src/connectors/validation.rs
+++ b/operations/src/connectors/validation.rs
@@ -35,7 +35,13 @@ pub enum ValidationError {
     EmptyPublicValue { key: String },
     #[error("secret config key `{key}` must not be empty")]
     EmptySecretValue { key: String },
+    #[error("public config key `{key}` must be `true` or `false`")]
+    InvalidBoolValue { key: String },
+    #[error("credentials must not be set when `skip_signature` is enabled")]
+    CredentialsWithSkipSignature,
 }
+
+pub const S3_SKIP_SIGNATURE: &str = "skip_signature";
 
 pub fn validate_connector_input(
     name: &str,
@@ -94,6 +100,17 @@ pub fn validate_connector_input(
         }
     }
 
+    if let Some(value) = public_config.get(S3_SKIP_SIGNATURE) {
+        if value != "true" && value != "false" {
+            return Err(ValidationError::InvalidBoolValue {
+                key: S3_SKIP_SIGNATURE.to_string(),
+            });
+        }
+        if value == "true" && !secret_config.is_empty() {
+            return Err(ValidationError::CredentialsWithSkipSignature);
+        }
+    }
+
     Ok(())
 }
 
@@ -106,7 +123,7 @@ pub const fn rules_for_kind(kind: SourceConnectorKind) -> SourceConnectorValidat
         },
         SourceConnectorKind::S3 => SourceConnectorValidationRules {
             required_public_keys: &["bucket", "endpoint"],
-            allowed_public_keys: &["bucket", "endpoint", "region", "root"],
+            allowed_public_keys: &["bucket", "endpoint", "region", "root", S3_SKIP_SIGNATURE],
             allowed_secret_keys: &["access_key_id", "secret_access_key"],
         },
         SourceConnectorKind::Webdav => SourceConnectorValidationRules {
@@ -225,6 +242,65 @@ mod tests {
             ]),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn accepts_skip_signature() {
+        // A public bucket needs no credentials at all.
+        validate_connector_input(
+            "public-s3",
+            SourceConnectorKind::S3,
+            &HashMap::from([
+                ("bucket".to_string(), "ngi-igenomes".to_string()),
+                (
+                    "endpoint".to_string(),
+                    "https://s3.amazonaws.com".to_string(),
+                ),
+                (S3_SKIP_SIGNATURE.to_string(), "true".to_string()),
+            ]),
+            &HashMap::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn skip_forbids_credentials() {
+        // Unsigned requests would silently ignore the stored secrets.
+        let err = validate_connector_input(
+            "public-s3",
+            SourceConnectorKind::S3,
+            &HashMap::from([
+                ("bucket".to_string(), "reads".to_string()),
+                ("endpoint".to_string(), "https://s3.example.org".to_string()),
+                (S3_SKIP_SIGNATURE.to_string(), "true".to_string()),
+            ]),
+            &HashMap::from([("access_key_id".to_string(), "AKIA".to_string())]),
+        )
+        .unwrap_err();
+
+        assert_eq!(err, ValidationError::CredentialsWithSkipSignature);
+    }
+
+    #[test]
+    fn rejects_bad_skip() {
+        let err = validate_connector_input(
+            "public-s3",
+            SourceConnectorKind::S3,
+            &HashMap::from([
+                ("bucket".to_string(), "reads".to_string()),
+                ("endpoint".to_string(), "https://s3.example.org".to_string()),
+                (S3_SKIP_SIGNATURE.to_string(), "yes".to_string()),
+            ]),
+            &HashMap::new(),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            ValidationError::InvalidBoolValue {
+                key: S3_SKIP_SIGNATURE.to_string(),
+            }
+        );
     }
 
     #[test]

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -377,7 +377,7 @@ impl CreateMetadataDocumentOperation {
         smallvec![self.graph_validation_effect()]
     }
 
-    fn read_realm_config_effect(&mut self) -> Effects {
+    fn realm_config_effect(&mut self) -> Effects {
         self.state = CreateMetadataDocumentState::ReadRealmConfig;
         let realm_target = DocumentSyncTarget::RealmConfig {
             realm_id: self.config.actor.realm_id,
@@ -585,7 +585,7 @@ impl Operation for CreateMetadataDocumentOperation {
             CreateMetadataDocumentState::ValidateGraph => match event {
                 Event::Metadata(MetadataEvent::ValidationResult { .. }) => {
                     if self.skip_existing_check {
-                        return self.read_realm_config_effect();
+                        return self.realm_config_effect();
                     }
                     self.state = CreateMetadataDocumentState::CheckExisting;
                     smallvec![read_registry_by_document_effect(
@@ -602,7 +602,7 @@ impl Operation for CreateMetadataDocumentOperation {
                 match crate::metadata::repository::parse_registry_read(event) {
                     Ok(Some(_)) => self
                         .fail_without_cleanup(CreateMetadataDocumentError::DocumentAlreadyExists),
-                    Ok(None) => self.read_realm_config_effect(),
+                    Ok(None) => self.realm_config_effect(),
                     Err(crate::metadata::repository::StorageReadError::Storage(error)) => {
                         self.fail_without_cleanup(error.into())
                     }
@@ -796,7 +796,7 @@ mod tests {
         })
     }
 
-    fn assert_create_fence_read(effects: &[Effect]) {
+    fn assert_fence_read(effects: &[Effect]) {
         let [
             Effect::Storage(StorageEffect::BatchRead {
                 reads,
@@ -960,7 +960,7 @@ mod tests {
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted {
             txn_id: retry_txn,
         }));
-        assert_create_fence_read(effects.as_slice());
+        assert_fence_read(effects.as_slice());
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
                 (
@@ -1008,7 +1008,7 @@ mod tests {
         let effects = operation.step(validation_result(document_id));
         let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_create_fence_read(effects.as_slice());
+        assert_fence_read(effects.as_slice());
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
                 (metadata_create_acceptance_key(document_id), None),
@@ -1206,13 +1206,13 @@ mod tests {
         let effects = operation.step(validation_result(document_id));
         let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_create_fence_read(effects.as_slice());
+        assert_fence_read(effects.as_slice());
         let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         assert_create_event_append(effects.as_slice(), document_id, &actor);
     }
 
     #[test]
-    fn config_read_precedes_txn() {
+    fn config_precedes_txn() {
         // The realm config only steers placement, so it is read outside the
         // transaction: a config edit must never conflict a create.
         let realm_id = RealmId([22u8; 32]);
@@ -1241,7 +1241,7 @@ mod tests {
 
         let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_create_fence_read(effects.as_slice());
+        assert_fence_read(effects.as_slice());
     }
 
     #[test]
@@ -1306,7 +1306,7 @@ mod tests {
         }));
         let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_create_fence_read(effects.as_slice());
+        assert_fence_read(effects.as_slice());
         let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         assert_eq!(
@@ -1348,7 +1348,7 @@ mod tests {
         let effects = operation.step(validation_result(document_id));
         let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_create_fence_read(effects.as_slice());
+        assert_fence_read(effects.as_slice());
         let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
@@ -1410,7 +1410,7 @@ mod tests {
         }));
         let config_read = supply_realm_config(&mut operation, config_read.as_slice(), None, &actor);
         let fence_read = begin_transaction(&mut operation, config_read.as_slice());
-        assert_create_fence_read(fence_read.as_slice());
+        assert_fence_read(fence_read.as_slice());
         let append = operation.step(create_fence_read(&actor, group_id, document_id));
         assert_create_event_append(append.as_slice(), document_id, &actor);
 

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -705,10 +705,13 @@ impl Operation for CreateMetadataDocumentOperation {
 mod tests {
     use super::{
         CreateMetadataDocumentConfig, CreateMetadataDocumentError, CreateMetadataDocumentOperation,
-        CreateMetadataDocumentPayload,
+        CreateMetadataDocumentPayload, create_metadata_document,
     };
 
+    use std::sync::Arc;
+
     use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::errors::StorageError;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::{
         METADATA_CREATE_ACCEPTANCE_KEYSPACE, METADATA_DOCUMENT_INDEX_KEYSPACE,
@@ -727,8 +730,12 @@ mod tests {
         Actor, MetadataRegistryRecord, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind,
     };
     use aruna_core::types::{Effects, GroupId, Key};
+    use aruna_storage::storage::EffectReceiver;
+    use aruna_storage::{FjallStorage, StorageHandle};
     use ulid::Ulid;
 
+    use crate::driver::DriverContext;
+    use crate::metadata::MetadataHandle;
     use crate::placement::resolve_shard_holders;
 
     fn actor(realm_id: RealmId, key_byte: u8) -> Actor {
@@ -1345,5 +1352,123 @@ mod tests {
                 aruna_core::errors::StorageError::WriteError,
             ))
         );
+    }
+
+    // Answers each storage effect of the create flow; the first `conflict_commits`
+    // commits fail with a conflict and the rest succeed. Returns StartTransaction
+    // count so tests can prove a retry occurred.
+    fn scripted_conflict_actor(
+        receiver: EffectReceiver,
+        conflict_commits: u32,
+    ) -> std::thread::JoinHandle<u32> {
+        std::thread::spawn(move || {
+            let mut starts = 0u32;
+            let mut commits = 0u32;
+            while let Ok((effect, response_tx, _span, _at, _guard)) = receiver.recv() {
+                let event = match effect {
+                    StorageEffect::StartTransaction { .. } => {
+                        starts += 1;
+                        StorageEvent::TransactionStarted {
+                            txn_id: Ulid::from_parts(u64::from(starts), 1),
+                        }
+                    }
+                    StorageEffect::BatchRead { .. } => StorageEvent::BatchReadResult {
+                        values: vec![
+                            (Key::from(vec![0u8]), None),
+                            (Key::from(vec![1u8]), None),
+                            (Key::from(vec![2u8]), None),
+                        ],
+                    },
+                    StorageEffect::BatchWrite { .. } => {
+                        StorageEvent::BatchWriteResult { entries: Vec::new() }
+                    }
+                    StorageEffect::CommitTransaction { txn_id } => {
+                        commits += 1;
+                        if commits <= conflict_commits {
+                            StorageEvent::Error {
+                                error: StorageError::TransactionConflict,
+                            }
+                        } else {
+                            StorageEvent::TransactionCommitted { txn_id }
+                        }
+                    }
+                    StorageEffect::AbortTransaction { txn_id } => {
+                        StorageEvent::TransactionAborted { txn_id }
+                    }
+                    StorageEffect::Write { key, .. } => StorageEvent::WriteResult { key },
+                    other => panic!("unexpected storage effect: {other:?}"),
+                };
+                response_tx.send(event);
+            }
+            starts
+        })
+    }
+
+    fn conflict_test_context(storage: StorageHandle, temp: &std::path::Path) -> Arc<DriverContext> {
+        let node_id = iroh::SecretKey::from_bytes(&[9u8; 32]).public();
+        let metadata_storage =
+            FjallStorage::open(temp.join("meta-store").to_str().unwrap()).unwrap();
+        let metadata_handle =
+            MetadataHandle::new(temp.join("meta"), node_id, metadata_storage, None, None, None)
+                .unwrap();
+        Arc::new(DriverContext {
+            storage_handle: storage,
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: Some(metadata_handle),
+            task_handle: None,
+            compute_handle: None,
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_recovers_conflict() {
+        // A commit conflict on the first drive is retried; the fresh transaction
+        // then commits, so the wrapper returns Ok.
+        let temp = tempfile::tempdir().unwrap();
+        let (storage, receivers) = StorageHandle::new();
+        let actor_thread = scripted_conflict_actor(receivers.foreground, 1);
+        let context = conflict_test_context(storage, temp.path());
+
+        let realm_id = RealmId([61u8; 32]);
+        let operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
+            actor(realm_id, 9),
+            GroupId::generate(),
+            Ulid::generate(),
+        ));
+        let result = create_metadata_document(operation, context.clone()).await;
+        assert!(result.is_ok(), "retry recovers conflict: {result:?}");
+
+        drop(context);
+        let starts = actor_thread.join().unwrap();
+        assert_eq!(starts, 3, "attempt 1 opens two txns, the retry opens one");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_exhausts_conflict() {
+        // Every commit conflicts, so the wrapper exhausts its retries and returns
+        // the conflict; each drive opens two txns via the internal recheck.
+        let temp = tempfile::tempdir().unwrap();
+        let (storage, receivers) = StorageHandle::new();
+        let actor_thread = scripted_conflict_actor(receivers.foreground, u32::MAX);
+        let context = conflict_test_context(storage, temp.path());
+
+        let realm_id = RealmId([62u8; 32]);
+        let operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
+            actor(realm_id, 9),
+            GroupId::generate(),
+            Ulid::generate(),
+        ));
+        let result = create_metadata_document(operation, context.clone()).await;
+        assert!(matches!(
+            result,
+            Err(CreateMetadataDocumentError::StorageError(
+                StorageError::TransactionConflict
+            ))
+        ));
+
+        drop(context);
+        let starts = actor_thread.join().unwrap();
+        assert_eq!(starts, 8, "four drive attempts each open two txns");
     }
 }

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -1389,9 +1389,9 @@ mod tests {
                             (Key::from(vec![2u8]), None),
                         ],
                     },
-                    StorageEffect::BatchWrite { .. } => {
-                        StorageEvent::BatchWriteResult { entries: Vec::new() }
-                    }
+                    StorageEffect::BatchWrite { .. } => StorageEvent::BatchWriteResult {
+                        entries: Vec::new(),
+                    },
                     StorageEffect::CommitTransaction { txn_id } => {
                         commits += 1;
                         if commits <= conflict_commits {
@@ -1418,9 +1418,15 @@ mod tests {
         let node_id = iroh::SecretKey::from_bytes(&[9u8; 32]).public();
         let metadata_storage =
             FjallStorage::open(temp.join("meta-store").to_str().unwrap()).unwrap();
-        let metadata_handle =
-            MetadataHandle::new(temp.join("meta"), node_id, metadata_storage, None, None, None)
-                .unwrap();
+        let metadata_handle = MetadataHandle::new(
+            temp.join("meta"),
+            node_id,
+            metadata_storage,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         Arc::new(DriverContext {
             storage_handle: storage,
             net_handle: None,

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -1448,7 +1448,9 @@ mod tests {
         assert!(ms >= base && ms < base.saturating_mul(2));
     }
 
-    #[tokio::test(start_paused = true)]
+    // Real timers: the scripted storage runs on an OS thread, so a paused clock
+    // would auto-advance the storage request timeout before it can respond.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn retry_recovers_conflict() {
         // A commit conflict on the first drive is retried; the fresh transaction
         // then commits, so the wrapper returns Ok.
@@ -1471,7 +1473,7 @@ mod tests {
         assert_eq!(starts, 3, "attempt 1 opens two txns, the retry opens one");
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn retry_exhausts_conflict() {
         // Every commit conflicts, so the wrapper exhausts its retries and returns
         // the conflict; each drive opens two txns via the internal recheck.

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -864,9 +864,11 @@ mod tests {
             panic!("expected transactional create append");
         };
         assert_eq!(*write_txn, txn_id);
-        assert!(!writes.iter().any(|(key_space, _, _)| {
-            key_space == REALM_CONFIG_KEYSPACE
-        }));
+        assert!(
+            !writes
+                .iter()
+                .any(|(key_space, _, _)| { key_space == REALM_CONFIG_KEYSPACE })
+        );
         assert!(
             writes
                 .iter()

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -84,6 +84,9 @@ pub struct CreateMetadataDocumentOperation {
     conflict_recheck: bool,
     txn_id: Option<TxnId>,
     state: CreateMetadataDocumentState,
+    /// Realm config read outside the transaction; it only steers placement, so
+    /// keeping it out of the read set means a config edit cannot conflict a create.
+    placement_config: Option<RealmConfigDocument>,
     record: Option<MetadataRegistryRecord>,
     create_event: Option<MetadataCreateEventRecord>,
     output: Option<Result<CreateMetadataDocumentResult, CreateMetadataDocumentError>>,
@@ -94,6 +97,7 @@ enum CreateMetadataDocumentState {
     Init,
     ValidateGraph,
     CheckExisting,
+    ReadRealmConfig,
     StartTransaction,
     ReadCreateFence,
     AppendCreateEvent,
@@ -137,6 +141,7 @@ impl CreateMetadataDocumentOperation {
             conflict_recheck: false,
             txn_id: None,
             state: CreateMetadataDocumentState::Init,
+            placement_config: None,
             record: None,
             create_event: None,
             output: None,
@@ -171,6 +176,7 @@ impl CreateMetadataDocumentOperation {
             conflict_recheck: false,
             txn_id: None,
             state: CreateMetadataDocumentState::Init,
+            placement_config: None,
             record: None,
             create_event: None,
             output: None,
@@ -371,6 +377,18 @@ impl CreateMetadataDocumentOperation {
         smallvec![self.graph_validation_effect()]
     }
 
+    fn read_realm_config_effect(&mut self) -> Effects {
+        self.state = CreateMetadataDocumentState::ReadRealmConfig;
+        let realm_target = DocumentSyncTarget::RealmConfig {
+            realm_id: self.config.actor.realm_id,
+        };
+        smallvec![Effect::Storage(StorageEffect::Read {
+            key_space: realm_target.storage_keyspace().to_string(),
+            key: realm_target.storage_key(),
+            txn_id: None,
+        })]
+    }
+
     fn start_transaction_effect(&mut self) -> Effects {
         self.state = CreateMetadataDocumentState::StartTransaction;
         smallvec![Effect::Storage(StorageEffect::StartTransaction {
@@ -381,9 +399,6 @@ impl CreateMetadataDocumentOperation {
     fn read_create_fence_effect(&mut self, txn_id: TxnId) -> Effects {
         self.txn_id = Some(txn_id);
         self.state = CreateMetadataDocumentState::ReadCreateFence;
-        let realm_target = DocumentSyncTarget::RealmConfig {
-            realm_id: self.config.actor.realm_id,
-        };
         smallvec![Effect::Storage(StorageEffect::BatchRead {
             reads: vec![
                 (
@@ -397,10 +412,6 @@ impl CreateMetadataDocumentOperation {
                         self.config.group_id,
                         &self.config.document_path,
                     ),
-                ),
-                (
-                    realm_target.storage_keyspace().to_string(),
-                    realm_target.storage_key(),
                 ),
             ],
             txn_id: Some(txn_id),
@@ -433,7 +444,6 @@ impl CreateMetadataDocumentOperation {
         &mut self,
         acceptance_value: Option<Value>,
         path_value: Option<Value>,
-        realm_config_value: Option<Value>,
     ) -> Effects {
         if let Some(bytes) = acceptance_value {
             let event: MetadataCreateEventRecord = match postcard::from_bytes(&bytes) {
@@ -465,14 +475,7 @@ impl CreateMetadataDocumentOperation {
             return self.fail(StorageError::TransactionConflict.into());
         }
 
-        let config = match realm_config_value.as_ref() {
-            Some(bytes) => match RealmConfigDocument::from_bytes(bytes) {
-                Ok(config) => Some(config),
-                Err(error) => return self.fail(error.into()),
-            },
-            None => None,
-        };
-        match self.choose_placement(config.as_ref()) {
+        match self.choose_placement(self.placement_config.as_ref()) {
             Ok(placement) => self.append_create_event_effect(placement),
             Err(error) => self.fail(error),
         }
@@ -582,7 +585,7 @@ impl Operation for CreateMetadataDocumentOperation {
             CreateMetadataDocumentState::ValidateGraph => match event {
                 Event::Metadata(MetadataEvent::ValidationResult { .. }) => {
                     if self.skip_existing_check {
-                        return self.start_transaction_effect();
+                        return self.read_realm_config_effect();
                     }
                     self.state = CreateMetadataDocumentState::CheckExisting;
                     smallvec![read_registry_by_document_effect(
@@ -599,7 +602,7 @@ impl Operation for CreateMetadataDocumentOperation {
                 match crate::metadata::repository::parse_registry_read(event) {
                     Ok(Some(_)) => self
                         .fail_without_cleanup(CreateMetadataDocumentError::DocumentAlreadyExists),
-                    Ok(None) => self.start_transaction_effect(),
+                    Ok(None) => self.read_realm_config_effect(),
                     Err(crate::metadata::repository::StorageReadError::Storage(error)) => {
                         self.fail_without_cleanup(error.into())
                     }
@@ -608,6 +611,25 @@ impl Operation for CreateMetadataDocumentOperation {
                     }
                 }
             }
+            CreateMetadataDocumentState::ReadRealmConfig => match event {
+                Event::Storage(StorageEvent::ReadResult { value, .. }) => {
+                    match value
+                        .as_ref()
+                        .map(|bytes| RealmConfigDocument::from_bytes(bytes))
+                    {
+                        Some(Ok(config)) => {
+                            self.placement_config = Some(config);
+                            self.start_transaction_effect()
+                        }
+                        Some(Err(error)) => self.fail_without_cleanup(error.into()),
+                        None => self.start_transaction_effect(),
+                    }
+                }
+                Event::Storage(StorageEvent::Error { error }) => {
+                    self.fail_without_cleanup(error.into())
+                }
+                other => self.unexpected_event("realm config read result", format!("{other:?}")),
+            },
             CreateMetadataDocumentState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
                     self.read_create_fence_effect(txn_id)
@@ -619,27 +641,18 @@ impl Operation for CreateMetadataDocumentOperation {
             },
             CreateMetadataDocumentState::ReadCreateFence => match event {
                 Event::Storage(StorageEvent::BatchReadResult { values }) => {
-                    let [
-                        (_, acceptance_value),
-                        (_, path_value),
-                        (_, realm_config_value),
-                    ] = values.as_slice()
-                    else {
+                    let [(_, acceptance_value), (_, path_value)] = values.as_slice() else {
                         return self.unexpected_event(
                             "metadata create fence read",
                             format!("batch read with {} values", values.len()),
                         );
                     };
-                    self.apply_create_fence(
-                        acceptance_value.clone(),
-                        path_value.clone(),
-                        realm_config_value.clone(),
-                    )
+                    self.apply_create_fence(acceptance_value.clone(), path_value.clone())
                 }
                 Event::Storage(StorageEvent::Error { error }) => {
                     self.fail_without_cleanup(error.into())
                 }
-                other => self.unexpected_event("realm config read result", format!("{other:?}")),
+                other => self.unexpected_event("create fence read result", format!("{other:?}")),
             },
             CreateMetadataDocumentState::AppendCreateEvent => match event {
                 Event::Storage(StorageEvent::BatchWriteResult { .. }) => {
@@ -771,12 +784,7 @@ mod tests {
         config
     }
 
-    fn realm_config_read(
-        config: Option<&RealmConfigDocument>,
-        actor: &Actor,
-        group_id: GroupId,
-        document_id: Ulid,
-    ) -> Event {
+    fn create_fence_read(actor: &Actor, group_id: GroupId, document_id: Ulid) -> Event {
         Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
                 (metadata_create_acceptance_key(document_id), None),
@@ -784,21 +792,11 @@ mod tests {
                     metadata_path_key(&actor.realm_id, group_id, "datasets/fast-create"),
                     None,
                 ),
-                (
-                    actor.realm_id.as_bytes().to_vec().into(),
-                    config.map(|config| {
-                        config
-                            .to_bytes(actor)
-                            .expect("realm config encodes")
-                            .to_vec()
-                            .into()
-                    }),
-                ),
             ],
         })
     }
 
-    fn assert_realm_config_read(effects: &[Effect]) {
+    fn assert_create_fence_read(effects: &[Effect]) {
         let [
             Effect::Storage(StorageEffect::BatchRead {
                 reads,
@@ -807,12 +805,42 @@ mod tests {
             }),
         ] = effects
         else {
-            panic!("expected realm config read");
+            panic!("expected create fence read");
         };
-        assert_eq!(reads.len(), 3);
+        assert_eq!(reads.len(), 2);
         assert_eq!(reads[0].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
         assert_eq!(reads[1].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
-        assert_eq!(reads[2].0, REALM_CONFIG_KEYSPACE);
+    }
+
+    // Answers the non-transactional realm config read that precedes the create
+    // transaction and returns the effects it produces.
+    fn supply_realm_config(
+        operation: &mut CreateMetadataDocumentOperation,
+        effects: &[Effect],
+        config: Option<&RealmConfigDocument>,
+        actor: &Actor,
+    ) -> Effects {
+        let [
+            Effect::Storage(StorageEffect::Read {
+                key_space,
+                key,
+                txn_id: None,
+            }),
+        ] = effects
+        else {
+            panic!("expected non-transactional realm config read, got {effects:?}");
+        };
+        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
+        operation.step(Event::Storage(StorageEvent::ReadResult {
+            key: key.clone(),
+            value: config.map(|config| {
+                config
+                    .to_bytes(actor)
+                    .expect("realm config encodes")
+                    .to_vec()
+                    .into()
+            }),
+        }))
     }
 
     fn begin_transaction(
@@ -842,6 +870,12 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
+        let effects = supply_realm_config(
+            &mut operation,
+            effects.as_slice(),
+            Some(&realm_config),
+            &actor,
+        );
         let [Effect::Storage(StorageEffect::StartTransaction { read: false })] = effects.as_slice()
         else {
             panic!("expected create transaction start");
@@ -857,20 +891,14 @@ mod tests {
             }),
         ] = effects.as_slice()
         else {
-            panic!("expected transactional realm config read");
+            panic!("expected transactional create fence read");
         };
-        assert_eq!(reads.len(), 3);
+        assert_eq!(reads.len(), 2);
         assert_eq!(reads[0].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
         assert_eq!(reads[1].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
-        assert_eq!(reads[2].0, REALM_CONFIG_KEYSPACE);
         assert_eq!(*read_txn, txn_id);
 
-        let effects = operation.step(realm_config_read(
-            Some(&realm_config),
-            &actor,
-            group_id,
-            document_id,
-        ));
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         let [
             Effect::Storage(StorageEffect::BatchWrite {
                 writes,
@@ -932,7 +960,7 @@ mod tests {
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted {
             txn_id: retry_txn,
         }));
-        assert_realm_config_read(effects.as_slice());
+        assert_create_fence_read(effects.as_slice());
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
                 (
@@ -943,7 +971,6 @@ mod tests {
                     metadata_path_key(&actor.realm_id, group_id, "datasets/fast-create"),
                     Some(postcard::to_allocvec(&winner).unwrap().into()),
                 ),
-                (actor.realm_id.as_bytes().to_vec().into(), None),
             ],
         }));
         assert!(matches!(
@@ -979,8 +1006,9 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
+        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_realm_config_read(effects.as_slice());
+        assert_create_fence_read(effects.as_slice());
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
                 (metadata_create_acceptance_key(document_id), None),
@@ -988,7 +1016,6 @@ mod tests {
                     metadata_path_key(&realm_id, group_id, "datasets/fast-create"),
                     Some(postcard::to_allocvec(&winner).unwrap().into()),
                 ),
-                (realm_id.as_bytes().to_vec().into(), None),
             ],
         }));
 
@@ -1016,6 +1043,7 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
+        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         begin_transaction(&mut operation, effects.as_slice());
         operation.conflict_recheck = true;
 
@@ -1176,10 +1204,44 @@ mod tests {
         let effects = operation.start();
         assert_validation_effect(effects.as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
+        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_realm_config_read(effects.as_slice());
-        let effects = operation.step(realm_config_read(None, &actor, group_id, document_id));
+        assert_create_fence_read(effects.as_slice());
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         assert_create_event_append(effects.as_slice(), document_id, &actor);
+    }
+
+    #[test]
+    fn config_read_precedes_txn() {
+        // The realm config only steers placement, so it is read outside the
+        // transaction: a config edit must never conflict a create.
+        let realm_id = RealmId([22u8; 32]);
+        let actor = actor(realm_id, 5);
+        let group_id = GroupId::generate();
+        let document_id = Ulid::generate();
+        let mut operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
+            actor.clone(),
+            group_id,
+            document_id,
+        ));
+
+        operation.start();
+        let effects = operation.step(validation_result(document_id));
+        let [
+            Effect::Storage(StorageEffect::Read {
+                key_space,
+                txn_id: None,
+                ..
+            }),
+        ] = effects.as_slice()
+        else {
+            panic!("expected non-transactional realm config read, got {effects:?}");
+        };
+        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
+
+        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
+        let effects = begin_transaction(&mut operation, effects.as_slice());
+        assert_create_fence_read(effects.as_slice());
     }
 
     #[test]
@@ -1199,13 +1261,14 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
-        begin_transaction(&mut operation, effects.as_slice());
-        let effects = operation.step(realm_config_read(
+        let effects = supply_realm_config(
+            &mut operation,
+            effects.as_slice(),
             Some(&realm_config),
             &actor,
-            group_id,
-            document_id,
-        ));
+        );
+        begin_transaction(&mut operation, effects.as_slice());
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         let [Effect::Storage(StorageEffect::BatchWrite { writes, .. })] = effects.as_slice() else {
             panic!("expected transactional create append");
         };
@@ -1241,9 +1304,10 @@ mod tests {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
+        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_realm_config_read(effects.as_slice());
-        let effects = operation.step(realm_config_read(None, &actor, group_id, document_id));
+        assert_create_fence_read(effects.as_slice());
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         assert_eq!(
             operation
@@ -1282,9 +1346,10 @@ mod tests {
 
         assert_validation_effect(operation.start().as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
+        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
-        assert_realm_config_read(effects.as_slice());
-        let effects = operation.step(realm_config_read(None, &actor, group_id, document_id));
+        assert_create_fence_read(effects.as_slice());
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![(METADATA_EVENT_LOG_KEYSPACE.to_string(), create_event_key)],
@@ -1343,9 +1408,10 @@ mod tests {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
-        let config_read = begin_transaction(&mut operation, config_read.as_slice());
-        assert_realm_config_read(config_read.as_slice());
-        let append = operation.step(realm_config_read(None, &actor, group_id, document_id));
+        let config_read = supply_realm_config(&mut operation, config_read.as_slice(), None, &actor);
+        let fence_read = begin_transaction(&mut operation, config_read.as_slice());
+        assert_create_fence_read(fence_read.as_slice());
+        let append = operation.step(create_fence_read(&actor, group_id, document_id));
         assert_create_event_append(append.as_slice(), document_id, &actor);
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
@@ -1382,12 +1448,11 @@ mod tests {
                             txn_id: Ulid::from_parts(u64::from(starts), 1),
                         }
                     }
+                    StorageEffect::Read { key, .. } => {
+                        StorageEvent::ReadResult { key, value: None }
+                    }
                     StorageEffect::BatchRead { .. } => StorageEvent::BatchReadResult {
-                        values: vec![
-                            (Key::from(vec![0u8]), None),
-                            (Key::from(vec![1u8]), None),
-                            (Key::from(vec![2u8]), None),
-                        ],
+                        values: vec![(Key::from(vec![0u8]), None), (Key::from(vec![1u8]), None)],
                     },
                     StorageEffect::BatchWrite { .. } => StorageEvent::BatchWriteResult {
                         entries: Vec::new(),

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -84,9 +84,6 @@ pub struct CreateMetadataDocumentOperation {
     conflict_recheck: bool,
     txn_id: Option<TxnId>,
     state: CreateMetadataDocumentState,
-    /// Realm config read outside the transaction; it only steers placement, so
-    /// keeping it out of the read set means a config edit cannot conflict a create.
-    placement_config: Option<RealmConfigDocument>,
     record: Option<MetadataRegistryRecord>,
     create_event: Option<MetadataCreateEventRecord>,
     output: Option<Result<CreateMetadataDocumentResult, CreateMetadataDocumentError>>,
@@ -97,7 +94,6 @@ enum CreateMetadataDocumentState {
     Init,
     ValidateGraph,
     CheckExisting,
-    ReadRealmConfig,
     StartTransaction,
     ReadCreateFence,
     AppendCreateEvent,
@@ -141,7 +137,6 @@ impl CreateMetadataDocumentOperation {
             conflict_recheck: false,
             txn_id: None,
             state: CreateMetadataDocumentState::Init,
-            placement_config: None,
             record: None,
             create_event: None,
             output: None,
@@ -176,7 +171,6 @@ impl CreateMetadataDocumentOperation {
             conflict_recheck: false,
             txn_id: None,
             state: CreateMetadataDocumentState::Init,
-            placement_config: None,
             record: None,
             create_event: None,
             output: None,
@@ -377,18 +371,6 @@ impl CreateMetadataDocumentOperation {
         smallvec![self.graph_validation_effect()]
     }
 
-    fn realm_config_effect(&mut self) -> Effects {
-        self.state = CreateMetadataDocumentState::ReadRealmConfig;
-        let realm_target = DocumentSyncTarget::RealmConfig {
-            realm_id: self.config.actor.realm_id,
-        };
-        smallvec![Effect::Storage(StorageEffect::Read {
-            key_space: realm_target.storage_keyspace().to_string(),
-            key: realm_target.storage_key(),
-            txn_id: None,
-        })]
-    }
-
     fn start_transaction_effect(&mut self) -> Effects {
         self.state = CreateMetadataDocumentState::StartTransaction;
         smallvec![Effect::Storage(StorageEffect::StartTransaction {
@@ -396,9 +378,15 @@ impl CreateMetadataDocumentOperation {
         })]
     }
 
+    /// The realm config joins the fence read set read-only: it is never written
+    /// back, so concurrent creates stay conflict-free, while a real config change
+    /// conflicts the commit and makes the retry re-choose its placement.
     fn read_create_fence_effect(&mut self, txn_id: TxnId) -> Effects {
         self.txn_id = Some(txn_id);
         self.state = CreateMetadataDocumentState::ReadCreateFence;
+        let realm_target = DocumentSyncTarget::RealmConfig {
+            realm_id: self.config.actor.realm_id,
+        };
         smallvec![Effect::Storage(StorageEffect::BatchRead {
             reads: vec![
                 (
@@ -412,6 +400,10 @@ impl CreateMetadataDocumentOperation {
                         self.config.group_id,
                         &self.config.document_path,
                     ),
+                ),
+                (
+                    realm_target.storage_keyspace().to_string(),
+                    realm_target.storage_key(),
                 ),
             ],
             txn_id: Some(txn_id),
@@ -444,6 +436,7 @@ impl CreateMetadataDocumentOperation {
         &mut self,
         acceptance_value: Option<Value>,
         path_value: Option<Value>,
+        realm_config_value: Option<Value>,
     ) -> Effects {
         if let Some(bytes) = acceptance_value {
             let event: MetadataCreateEventRecord = match postcard::from_bytes(&bytes) {
@@ -475,7 +468,14 @@ impl CreateMetadataDocumentOperation {
             return self.fail(StorageError::TransactionConflict.into());
         }
 
-        match self.choose_placement(self.placement_config.as_ref()) {
+        let config = match realm_config_value.as_ref() {
+            Some(bytes) => match RealmConfigDocument::from_bytes(bytes) {
+                Ok(config) => Some(config),
+                Err(error) => return self.fail(error.into()),
+            },
+            None => None,
+        };
+        match self.choose_placement(config.as_ref()) {
             Ok(placement) => self.append_create_event_effect(placement),
             Err(error) => self.fail(error),
         }
@@ -585,7 +585,7 @@ impl Operation for CreateMetadataDocumentOperation {
             CreateMetadataDocumentState::ValidateGraph => match event {
                 Event::Metadata(MetadataEvent::ValidationResult { .. }) => {
                     if self.skip_existing_check {
-                        return self.realm_config_effect();
+                        return self.start_transaction_effect();
                     }
                     self.state = CreateMetadataDocumentState::CheckExisting;
                     smallvec![read_registry_by_document_effect(
@@ -602,7 +602,7 @@ impl Operation for CreateMetadataDocumentOperation {
                 match crate::metadata::repository::parse_registry_read(event) {
                     Ok(Some(_)) => self
                         .fail_without_cleanup(CreateMetadataDocumentError::DocumentAlreadyExists),
-                    Ok(None) => self.realm_config_effect(),
+                    Ok(None) => self.start_transaction_effect(),
                     Err(crate::metadata::repository::StorageReadError::Storage(error)) => {
                         self.fail_without_cleanup(error.into())
                     }
@@ -611,25 +611,6 @@ impl Operation for CreateMetadataDocumentOperation {
                     }
                 }
             }
-            CreateMetadataDocumentState::ReadRealmConfig => match event {
-                Event::Storage(StorageEvent::ReadResult { value, .. }) => {
-                    match value
-                        .as_ref()
-                        .map(|bytes| RealmConfigDocument::from_bytes(bytes))
-                    {
-                        Some(Ok(config)) => {
-                            self.placement_config = Some(config);
-                            self.start_transaction_effect()
-                        }
-                        Some(Err(error)) => self.fail_without_cleanup(error.into()),
-                        None => self.start_transaction_effect(),
-                    }
-                }
-                Event::Storage(StorageEvent::Error { error }) => {
-                    self.fail_without_cleanup(error.into())
-                }
-                other => self.unexpected_event("realm config read result", format!("{other:?}")),
-            },
             CreateMetadataDocumentState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
                     self.read_create_fence_effect(txn_id)
@@ -641,13 +622,22 @@ impl Operation for CreateMetadataDocumentOperation {
             },
             CreateMetadataDocumentState::ReadCreateFence => match event {
                 Event::Storage(StorageEvent::BatchReadResult { values }) => {
-                    let [(_, acceptance_value), (_, path_value)] = values.as_slice() else {
+                    let [
+                        (_, acceptance_value),
+                        (_, path_value),
+                        (_, realm_config_value),
+                    ] = values.as_slice()
+                    else {
                         return self.unexpected_event(
                             "metadata create fence read",
                             format!("batch read with {} values", values.len()),
                         );
                     };
-                    self.apply_create_fence(acceptance_value.clone(), path_value.clone())
+                    self.apply_create_fence(
+                        acceptance_value.clone(),
+                        path_value.clone(),
+                        realm_config_value.clone(),
+                    )
                 }
                 Event::Storage(StorageEvent::Error { error }) => {
                     self.fail_without_cleanup(error.into())
@@ -784,13 +774,28 @@ mod tests {
         config
     }
 
-    fn create_fence_read(actor: &Actor, group_id: GroupId, document_id: Ulid) -> Event {
+    fn create_fence_read(
+        actor: &Actor,
+        group_id: GroupId,
+        document_id: Ulid,
+        config: Option<&RealmConfigDocument>,
+    ) -> Event {
         Event::Storage(StorageEvent::BatchReadResult {
             values: vec![
                 (metadata_create_acceptance_key(document_id), None),
                 (
                     metadata_path_key(&actor.realm_id, group_id, "datasets/fast-create"),
                     None,
+                ),
+                (
+                    actor.realm_id.as_bytes().to_vec().into(),
+                    config.map(|config| {
+                        config
+                            .to_bytes(actor)
+                            .expect("realm config encodes")
+                            .to_vec()
+                            .into()
+                    }),
                 ),
             ],
         })
@@ -807,40 +812,10 @@ mod tests {
         else {
             panic!("expected create fence read");
         };
-        assert_eq!(reads.len(), 2);
+        assert_eq!(reads.len(), 3);
         assert_eq!(reads[0].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
         assert_eq!(reads[1].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
-    }
-
-    // Answers the non-transactional realm config read that precedes the create
-    // transaction and returns the effects it produces.
-    fn supply_realm_config(
-        operation: &mut CreateMetadataDocumentOperation,
-        effects: &[Effect],
-        config: Option<&RealmConfigDocument>,
-        actor: &Actor,
-    ) -> Effects {
-        let [
-            Effect::Storage(StorageEffect::Read {
-                key_space,
-                key,
-                txn_id: None,
-            }),
-        ] = effects
-        else {
-            panic!("expected non-transactional realm config read, got {effects:?}");
-        };
-        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
-        operation.step(Event::Storage(StorageEvent::ReadResult {
-            key: key.clone(),
-            value: config.map(|config| {
-                config
-                    .to_bytes(actor)
-                    .expect("realm config encodes")
-                    .to_vec()
-                    .into()
-            }),
-        }))
+        assert_eq!(reads[2].0, REALM_CONFIG_KEYSPACE);
     }
 
     fn begin_transaction(
@@ -870,12 +845,6 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
-        let effects = supply_realm_config(
-            &mut operation,
-            effects.as_slice(),
-            Some(&realm_config),
-            &actor,
-        );
         let [Effect::Storage(StorageEffect::StartTransaction { read: false })] = effects.as_slice()
         else {
             panic!("expected create transaction start");
@@ -883,9 +852,9 @@ mod tests {
 
         let txn_id = Ulid::from_bytes([32; 16]);
         let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
+        assert_fence_read(effects.as_slice());
         let [
             Effect::Storage(StorageEffect::BatchRead {
-                reads,
                 txn_id: Some(read_txn),
                 ..
             }),
@@ -893,12 +862,14 @@ mod tests {
         else {
             panic!("expected transactional create fence read");
         };
-        assert_eq!(reads.len(), 2);
-        assert_eq!(reads[0].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
-        assert_eq!(reads[1].0, METADATA_CREATE_ACCEPTANCE_KEYSPACE);
         assert_eq!(*read_txn, txn_id);
 
-        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
+        let effects = operation.step(create_fence_read(
+            &actor,
+            group_id,
+            document_id,
+            Some(&realm_config),
+        ));
         let [
             Effect::Storage(StorageEffect::BatchWrite {
                 writes,
@@ -971,6 +942,7 @@ mod tests {
                     metadata_path_key(&actor.realm_id, group_id, "datasets/fast-create"),
                     Some(postcard::to_allocvec(&winner).unwrap().into()),
                 ),
+                (actor.realm_id.as_bytes().to_vec().into(), None),
             ],
         }));
         assert!(matches!(
@@ -1006,7 +978,6 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
-        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_fence_read(effects.as_slice());
         let effects = operation.step(Event::Storage(StorageEvent::BatchReadResult {
@@ -1016,6 +987,7 @@ mod tests {
                     metadata_path_key(&realm_id, group_id, "datasets/fast-create"),
                     Some(postcard::to_allocvec(&winner).unwrap().into()),
                 ),
+                (realm_id.as_bytes().to_vec().into(), None),
             ],
         }));
 
@@ -1043,7 +1015,6 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
-        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         begin_transaction(&mut operation, effects.as_slice());
         operation.conflict_recheck = true;
 
@@ -1204,42 +1175,29 @@ mod tests {
         let effects = operation.start();
         assert_validation_effect(effects.as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
-        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_fence_read(effects.as_slice());
-        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id, None));
         assert_create_event_append(effects.as_slice(), document_id, &actor);
     }
 
     #[test]
-    fn config_precedes_txn() {
-        // The realm config only steers placement, so it is read outside the
-        // transaction: a config edit must never conflict a create.
+    fn config_joins_fence() {
+        // The stamped bucket decides the document's sync topic, so the config it
+        // came from must be in the commit's read set: no read precedes the
+        // transaction, and the fence read carries the realm config.
         let realm_id = RealmId([22u8; 32]);
         let actor = actor(realm_id, 5);
         let group_id = GroupId::generate();
         let document_id = Ulid::generate();
         let mut operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
-            actor.clone(),
+            actor,
             group_id,
             document_id,
         ));
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
-        let [
-            Effect::Storage(StorageEffect::Read {
-                key_space,
-                txn_id: None,
-                ..
-            }),
-        ] = effects.as_slice()
-        else {
-            panic!("expected non-transactional realm config read, got {effects:?}");
-        };
-        assert_eq!(key_space, REALM_CONFIG_KEYSPACE);
-
-        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_fence_read(effects.as_slice());
     }
@@ -1261,14 +1219,13 @@ mod tests {
 
         operation.start();
         let effects = operation.step(validation_result(document_id));
-        let effects = supply_realm_config(
-            &mut operation,
-            effects.as_slice(),
-            Some(&realm_config),
-            &actor,
-        );
         begin_transaction(&mut operation, effects.as_slice());
-        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
+        let effects = operation.step(create_fence_read(
+            &actor,
+            group_id,
+            document_id,
+            Some(&realm_config),
+        ));
         let [Effect::Storage(StorageEffect::BatchWrite { writes, .. })] = effects.as_slice() else {
             panic!("expected transactional create append");
         };
@@ -1304,10 +1261,9 @@ mod tests {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
-        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_fence_read(effects.as_slice());
-        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id, None));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         assert_eq!(
             operation
@@ -1346,10 +1302,9 @@ mod tests {
 
         assert_validation_effect(operation.start().as_slice(), document_id);
         let effects = operation.step(validation_result(document_id));
-        let effects = supply_realm_config(&mut operation, effects.as_slice(), None, &actor);
         let effects = begin_transaction(&mut operation, effects.as_slice());
         assert_fence_read(effects.as_slice());
-        let effects = operation.step(create_fence_read(&actor, group_id, document_id));
+        let effects = operation.step(create_fence_read(&actor, group_id, document_id, None));
         let create_event_key = assert_create_event_append(effects.as_slice(), document_id, &actor);
         let effects = operation.step(Event::Storage(StorageEvent::BatchWriteResult {
             entries: vec![(METADATA_EVENT_LOG_KEYSPACE.to_string(), create_event_key)],
@@ -1404,14 +1359,13 @@ mod tests {
 
         assert_validation_effect(operation.start().as_slice(), document_id);
         assert_existing_read(operation.step(validation_result(document_id)).as_slice());
-        let config_read = operation.step(Event::Storage(StorageEvent::ReadResult {
+        let existing_read = operation.step(Event::Storage(StorageEvent::ReadResult {
             key: document_id.to_bytes().to_vec().into(),
             value: None,
         }));
-        let config_read = supply_realm_config(&mut operation, config_read.as_slice(), None, &actor);
-        let fence_read = begin_transaction(&mut operation, config_read.as_slice());
+        let fence_read = begin_transaction(&mut operation, existing_read.as_slice());
         assert_fence_read(fence_read.as_slice());
-        let append = operation.step(create_fence_read(&actor, group_id, document_id));
+        let append = operation.step(create_fence_read(&actor, group_id, document_id, None));
         assert_create_event_append(append.as_slice(), document_id, &actor);
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
@@ -1452,7 +1406,11 @@ mod tests {
                         StorageEvent::ReadResult { key, value: None }
                     }
                     StorageEffect::BatchRead { .. } => StorageEvent::BatchReadResult {
-                        values: vec![(Key::from(vec![0u8]), None), (Key::from(vec![1u8]), None)],
+                        values: vec![
+                            (Key::from(vec![0u8]), None),
+                            (Key::from(vec![1u8]), None),
+                            (Key::from(vec![2u8]), None),
+                        ],
                     },
                     StorageEffect::BatchWrite { .. } => StorageEvent::BatchWriteResult {
                         entries: Vec::new(),

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -458,16 +458,12 @@ impl CreateMetadataDocumentOperation {
             None => None,
         };
         match self.choose_placement(config.as_ref()) {
-            Ok(placement) => self.append_create_event_effect(placement, realm_config_value),
+            Ok(placement) => self.append_create_event_effect(placement),
             Err(error) => self.fail(error),
         }
     }
 
-    fn append_create_event_effect(
-        &mut self,
-        placement: PlacementRef,
-        realm_config_value: Option<Value>,
-    ) -> Effects {
+    fn append_create_event_effect(&mut self, placement: PlacementRef) -> Effects {
         let Some(txn_id) = self.txn_id else {
             return self.fail(CreateMetadataDocumentError::MissingTransaction);
         };
@@ -483,17 +479,7 @@ impl CreateMetadataDocumentOperation {
                 Ok(writes)
             });
         match writes {
-            Ok(mut writes) => {
-                if let Some(value) = realm_config_value {
-                    let target = DocumentSyncTarget::RealmConfig {
-                        realm_id: self.config.actor.realm_id,
-                    };
-                    writes.push((
-                        target.storage_keyspace().to_string(),
-                        target.storage_key(),
-                        value,
-                    ));
-                }
+            Ok(writes) => {
                 smallvec![Effect::Storage(StorageEffect::BatchWrite {
                     writes,
                     txn_id: Some(txn_id),
@@ -848,8 +834,8 @@ mod tests {
             panic!("expected transactional create append");
         };
         assert_eq!(*write_txn, txn_id);
-        assert!(writes.iter().any(|(key_space, key, _)| {
-            key_space == REALM_CONFIG_KEYSPACE && key.as_ref() == actor.realm_id.as_bytes()
+        assert!(!writes.iter().any(|(key_space, _, _)| {
+            key_space == REALM_CONFIG_KEYSPACE
         }));
         assert!(
             writes
@@ -1140,12 +1126,20 @@ mod tests {
         operation.start();
         let effects = operation.step(validation_result(document_id));
         begin_transaction(&mut operation, effects.as_slice());
-        operation.step(realm_config_read(
+        let effects = operation.step(realm_config_read(
             Some(&realm_config),
             &actor,
             group_id,
             document_id,
         ));
+        let [Effect::Storage(StorageEffect::BatchWrite { writes, .. })] = effects.as_slice() else {
+            panic!("expected transactional create append");
+        };
+        assert!(
+            !writes
+                .iter()
+                .any(|(key_space, _, _)| key_space == REALM_CONFIG_KEYSPACE)
+        );
 
         let placement = operation
             .record

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -162,6 +162,21 @@ impl CreateMetadataDocumentOperation {
         &self.config
     }
 
+    /// A pristine operation with the same inputs, for a conflict retry.
+    fn fresh_copy(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            skip_existing_check: self.skip_existing_check,
+            forwarded: self.forwarded,
+            conflict_recheck: false,
+            txn_id: None,
+            state: CreateMetadataDocumentState::Init,
+            record: None,
+            create_event: None,
+            output: None,
+        }
+    }
+
     fn graph_iri(&self) -> String {
         MetadataRegistryRecord::graph_iri_for(self.config.document_id)
     }
@@ -518,11 +533,26 @@ impl CreateMetadataDocumentOperation {
     }
 }
 
+const CREATE_CONFLICT_RETRIES: usize = 3;
+
 pub async fn create_metadata_document(
-    operation: CreateMetadataDocumentOperation,
+    template: CreateMetadataDocumentOperation,
     context: Arc<DriverContext>,
 ) -> Result<CreateMetadataDocumentResult, CreateMetadataDocumentError> {
-    let created = drive(operation, context.as_ref()).await?;
+    let mut attempt = 0usize;
+    let created = loop {
+        match drive(template.fresh_copy(), context.as_ref()).await {
+            Ok(created) => break created,
+            Err(CreateMetadataDocumentError::StorageError(StorageError::TransactionConflict))
+                if attempt < CREATE_CONFLICT_RETRIES =>
+            {
+                let backoff = crate::queue_backoff::retry_after_ms(attempt as u32, 25, 250);
+                tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    };
     schedule_pending_metadata_projection_drain(context.as_ref(), std::time::Duration::ZERO)
         .await
         .map_err(|error| MetadataError::Backend(error.to_string()))?;
@@ -951,6 +981,31 @@ mod tests {
             operation.finalize(),
             Err(CreateMetadataDocumentError::DocumentAlreadyExists)
         );
+    }
+
+    #[test]
+    fn fresh_copy_resets() {
+        let realm_id = RealmId([41u8; 32]);
+        let actor = actor(realm_id, 11);
+        let group_id = GroupId::generate();
+        let document_id = Ulid::from_bytes([41; 16]);
+        let mut operation = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
+            actor.clone(),
+            group_id,
+            document_id,
+        ));
+
+        operation.start();
+        let effects = operation.step(validation_result(document_id));
+        begin_transaction(&mut operation, effects.as_slice());
+        operation.conflict_recheck = true;
+
+        let expected = CreateMetadataDocumentOperation::new_for_generated_document_id(config(
+            actor,
+            group_id,
+            document_id,
+        ));
+        assert_eq!(operation.fresh_copy(), expected);
     }
 
     fn config(actor: Actor, group_id: GroupId, document_id: Ulid) -> CreateMetadataDocumentConfig {

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -535,6 +535,16 @@ impl CreateMetadataDocumentOperation {
 
 const CREATE_CONFLICT_RETRIES: usize = 3;
 
+// Deterministic per-document jitter decorrelates overlapping create retries so a
+// genuine realm-config mutation does not make them all retry in lockstep.
+fn create_retry_backoff(attempt: usize, document_id: Ulid) -> std::time::Duration {
+    let base = crate::queue_backoff::retry_after_ms(attempt as u32, 25, 250);
+    let mut head = [0u8; 8];
+    head.copy_from_slice(&document_id.to_bytes()[..8]);
+    let jitter = u64::from_le_bytes(head) % base;
+    std::time::Duration::from_millis(base.saturating_add(jitter))
+}
+
 pub async fn create_metadata_document(
     template: CreateMetadataDocumentOperation,
     context: Arc<DriverContext>,
@@ -546,8 +556,8 @@ pub async fn create_metadata_document(
             Err(CreateMetadataDocumentError::StorageError(StorageError::TransactionConflict))
                 if attempt < CREATE_CONFLICT_RETRIES =>
             {
-                let backoff = crate::queue_backoff::retry_after_ms(attempt as u32, 25, 250);
-                tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
+                tokio::time::sleep(create_retry_backoff(attempt, template.config.document_id))
+                    .await;
                 attempt += 1;
             }
             Err(error) => return Err(error),
@@ -705,7 +715,7 @@ impl Operation for CreateMetadataDocumentOperation {
 mod tests {
     use super::{
         CreateMetadataDocumentConfig, CreateMetadataDocumentError, CreateMetadataDocumentOperation,
-        CreateMetadataDocumentPayload, create_metadata_document,
+        CreateMetadataDocumentPayload, create_metadata_document, create_retry_backoff,
     };
 
     use std::sync::Arc;
@@ -1419,6 +1429,17 @@ mod tests {
             task_handle: None,
             compute_handle: None,
         })
+    }
+
+    #[test]
+    fn backoff_jitters() {
+        // Backoff is deterministic per document and stays within [base, 2*base).
+        let id = Ulid::from_bytes([7u8; 16]);
+        let base = crate::queue_backoff::retry_after_ms(0, 25, 250);
+        let first = create_retry_backoff(0, id);
+        assert_eq!(first, create_retry_backoff(0, id));
+        let ms = first.as_millis() as u64;
+        assert!(ms >= base && ms < base.saturating_mul(2));
     }
 
     #[tokio::test(start_paused = true)]

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -494,6 +494,7 @@ fn seed_placement_defaults(config: &mut RealmConfigDocument) {
 
 #[cfg(test)]
 mod test {
+    use aruna_core::keys::generate_signing_key;
     use std::time::Duration;
 
     use aruna_core::UserId;
@@ -960,8 +961,7 @@ mod test {
             compute_handle: None,
         };
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let realm_signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let realm_signing_key: SigningKey = generate_signing_key();
         let pubkey = realm_signing_key.verifying_key().to_bytes();
         let realm_id = RealmId::from_bytes(pubkey);
         let node_id = iroh::SecretKey::from_bytes(&[1u8; 32]).public();

--- a/operations/src/create_token.rs
+++ b/operations/src/create_token.rs
@@ -171,6 +171,7 @@ mod test {
     use crate::create_token::{CreateTokenConfig, CreateTokenOperation};
     use crate::driver::{DriverContext, drive};
     use aruna_core::UserId;
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::structs::{NodeCapabilities, RealmId};
     use aruna_storage::storage;
     use ed25519_dalek::SigningKey;
@@ -192,8 +193,7 @@ mod test {
             compute_handle: None,
         };
 
-        let mut csprng = jsonwebtoken::signature::rand_core::OsRng;
-        let signing_key: SigningKey = SigningKey::generate(&mut csprng);
+        let signing_key: SigningKey = generate_signing_key();
         let pubkey = signing_key.verifying_key().to_bytes();
         let realm_id = RealmId::from_bytes(pubkey);
         let capabilities = NodeCapabilities::management_node(signing_key).unwrap();

--- a/operations/src/delete_metadata_document.rs
+++ b/operations/src/delete_metadata_document.rs
@@ -893,6 +893,17 @@ mod tests {
     fn delete_rides_stored_bucket() {
         let actor = actor();
         let mut record = record(&actor);
+        // Deterministic identity so the placement collision check cannot flake on
+        // the timestamp bytes of a freshly generated document id.
+        record.group_id = Ulid::from_bytes([3; 16]);
+        record.document_id = Ulid::from_bytes([5; 16]);
+        record.graph_iri = MetadataRegistryRecord::graph_iri_for(record.document_id);
+        record.permission_path = MetadataRegistryRecord::permission_path_for(
+            &record.realm_id,
+            record.group_id,
+            &record.document_path,
+            record.document_id,
+        );
         let mut config = RealmConfigDocument::new(record.realm_id, Vec::new(), 3);
         let strategy = PlacementStrategy {
             strategy_id: Ulid::from_bytes([1; 16]),

--- a/operations/src/driver.rs
+++ b/operations/src/driver.rs
@@ -13,7 +13,7 @@ use std::any::{type_name, type_name_of_val};
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
-use tracing::{Instrument, debug_span, error, trace, warn};
+use tracing::{Instrument, debug, debug_span, error, trace, warn};
 
 use crate::metadata::MetadataHandle;
 use crate::task_persistence::persist_task_effect;
@@ -324,6 +324,12 @@ pub async fn drive<O: Operation>(
             event = "operation.completed",
             operation = %operation_name,
             "Completed operation"
+        ),
+        Err(error) if O::expected_error(error) => debug!(
+            event = "operation.rejected",
+            operation = %operation_name,
+            error = ?error,
+            "Operation rejected"
         ),
         Err(error) => error!(
             event = "operation.failed",

--- a/operations/src/get_metadata_document.rs
+++ b/operations/src/get_metadata_document.rs
@@ -200,6 +200,16 @@ impl Operation for GetMetadataDocumentOperation {
         self.output.expect("metadata get operation must set output")
     }
 
+    // A read of a document that does not exist yet, or whose graph has not
+    // materialized, is a 404 for the caller, not a node failure.
+    fn expected_error(error: &Self::Error) -> bool {
+        matches!(
+            error,
+            GetMetadataDocumentError::DocumentNotFound
+                | GetMetadataDocumentError::MetadataError(MetadataError::GraphNotFound)
+        )
+    }
+
     fn abort(&mut self) -> Effects {
         smallvec![]
     }

--- a/operations/src/jobs/import/consortium.rs
+++ b/operations/src/jobs/import/consortium.rs
@@ -132,8 +132,10 @@ async fn validates_corpus() {
         Some("https://w3id.org/ro/crate/1.2/context")
     );
     assert_eq!(elabftw.wrapper.as_deref(), Some("2025-09-16-103731-export"));
-    let image = "./Demo - Gold-master-experiment - 4af4da4e/example.jpg";
-    let json = "./Molecular-biology - Facilis-illum-sed-reprehenderit - a7658b02/autesse.json";
+    // eLabFTW writes identifiers with literal spaces; validation encodes them.
+    let image = "./Demo%20-%20Gold-master-experiment%20-%204af4da4e/example.jpg";
+    let json =
+        "./Molecular-biology%20-%20Facilis-illum-sed-reprehenderit%20-%20a7658b02/autesse.json";
     assert_eq!(
         elabftw.file_ids.iter().cloned().collect::<BTreeSet<_>>(),
         BTreeSet::from([image.to_string(), json.to_string()])
@@ -150,8 +152,16 @@ async fn validates_corpus() {
             "fd/fdedffebcfbbdc8eb9a554d54951783ced67e23ac0c38445f67112bfb81543147d8960561fcd7745e3e3ec098ded2d5f86730ad635520319e502c11c5260ba2c.json"
         )
     );
-    assert!(elabftw.paths.contains(image.trim_start_matches("./")));
-    assert!(elabftw.paths.contains(json.trim_start_matches("./")));
+    assert!(
+        elabftw
+            .paths
+            .contains("Demo - Gold-master-experiment - 4af4da4e/example.jpg")
+    );
+    assert!(
+        elabftw.paths.contains(
+            "Molecular-biology - Facilis-illum-sed-reprehenderit - a7658b02/autesse.json"
+        )
+    );
 
     let pasta = read_fixture(handle, PASTA, 2).await;
     assert_eq!(

--- a/operations/src/jobs/import/mod.rs
+++ b/operations/src/jobs/import/mod.rs
@@ -29,7 +29,7 @@ use aruna_core::effects::{BlobEffect, StorageEffect};
 use aruna_core::errors::{BlobError, SourceConnectorResolutionError, StagingSourceError};
 use aruna_core::events::{BlobEvent, Event, StorageEvent};
 use aruna_core::keyspaces::{JOB_ENTRY_KEYSPACE, ROCRATE_JOB_STATE_KEYSPACE};
-use aruna_core::metadata::MetadataValidationViolation;
+use aruna_core::metadata::{MetadataError, MetadataValidationViolation};
 use aruna_core::stream::BackendStream;
 use aruna_core::structs::checksum::{ChecksumAlgorithm, ExpectedChecksum};
 use aruna_core::structs::{
@@ -47,6 +47,7 @@ use futures_util::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, BufReader, SeekFrom};
 use tokio::sync::mpsc;
+use tracing::info;
 use ulid::Ulid;
 
 use self::archive::{
@@ -70,6 +71,8 @@ use crate::metadata::forward::{MetadataWriteError, create_metadata_document_rout
 use crate::replication::queue::{
     QueueLiveVersionReplicationInput, QueueLiveVersionReplicationOperation,
 };
+use crate::s3::delete_object::DeleteObjectError;
+use crate::s3::delete_objects::{DeleteObjectsEntry, DeleteObjectsInput, delete_objects};
 use crate::s3::get_bucket_info::{GetBucketInfoError, GetBucketInfoOperation};
 use crate::s3::get_object::{GetObjectError, GetObjectInput, GetObjectOperation};
 use crate::s3::put_object::{PutObjectConfig, PutObjectError, PutObjectInput, PutObjectOperation};
@@ -107,6 +110,9 @@ struct ImportEntryPlan {
     target_key: String,
     described_id: Option<String>,
     code: ReasonCode,
+    /// Minted while planning so the rewritten identifiers can be validated
+    /// before the first write, and so a rollback knows what to delete.
+    version_id: Ulid,
     data_offset: u64,
     compressed_size: u64,
     uncompressed_size: u64,
@@ -134,6 +140,7 @@ struct ImportCheckpoint {
     failed: u64,
     rewritten_json: Option<String>,
     created: bool,
+    rolled_back: u64,
     failure: Option<String>,
     cancelled: bool,
 }
@@ -153,6 +160,7 @@ impl Default for ImportCheckpoint {
             failed: 0,
             rewritten_json: None,
             created: false,
+            rolled_back: 0,
             failure: None,
             cancelled: false,
         }
@@ -209,43 +217,44 @@ pub async fn run_rocrate_import(ctx: &JobContext, spec: &ImportRoCrateSpec) -> J
             }
         }
 
-        let result =
-            match checkpoint.phase {
-                ImportPhase::Acquire => acquire_source(ctx, spec).await.map(|input| {
-                    checkpoint.refs.hidden_locations = vec![input.location.clone()];
-                    checkpoint.input = Some(input);
-                    checkpoint.phase = ImportPhase::Inspect;
-                }),
-                ImportPhase::Inspect => inspect_source(ctx, spec, &checkpoint).await.map(
-                    |(inspection, metadata_json)| {
+        let result = match checkpoint.phase {
+            ImportPhase::Acquire => acquire_source(ctx, spec).await.map(|input| {
+                checkpoint.refs.hidden_locations = vec![input.location.clone()];
+                checkpoint.input = Some(input);
+                checkpoint.phase = ImportPhase::Inspect;
+            }),
+            ImportPhase::Inspect => {
+                inspect_source(ctx, spec, &checkpoint)
+                    .await
+                    .map(|(inspection, metadata_json)| {
                         checkpoint.inspection = Some(inspection);
                         checkpoint.metadata_json = Some(metadata_json);
                         checkpoint.phase = ImportPhase::Validate;
-                    },
-                ),
-                ImportPhase::Validate => match validate_source(ctx, spec, &mut checkpoint).await {
-                    Ok(validated) => {
-                        plan = Some(validated);
-                        Ok(())
-                    }
-                    Err(error) => Err(error),
-                },
-                ImportPhase::Write => match plan.as_ref() {
-                    Some(plan) => write_next(ctx, spec, &mut checkpoint, plan).await,
-                    None => Err(ImportFailure::Permanent(
-                        "import plan is missing".to_string(),
-                    )),
-                },
-                ImportPhase::Rewrite => match plan.as_ref() {
-                    Some(plan) => rewrite_crate(ctx, spec, &mut checkpoint, plan).await,
-                    None => Err(ImportFailure::Permanent(
-                        "import plan is missing".to_string(),
-                    )),
-                },
-                ImportPhase::Create => create_document(ctx, spec, &mut checkpoint).await,
-                ImportPhase::Cleanup => cleanup_source(ctx, &mut checkpoint).await,
-                ImportPhase::Done => return import_outcome(&checkpoint, spec),
-            };
+                    })
+            }
+            ImportPhase::Validate => match validate_source(ctx, spec, &mut checkpoint).await {
+                Ok(validated) => {
+                    plan = Some(validated);
+                    Ok(())
+                }
+                Err(error) => Err(error),
+            },
+            ImportPhase::Write => match plan.as_ref() {
+                Some(plan) => write_next(ctx, spec, &mut checkpoint, plan).await,
+                None => Err(ImportFailure::Permanent(
+                    "import plan is missing".to_string(),
+                )),
+            },
+            ImportPhase::Rewrite => match plan.as_ref() {
+                Some(plan) => rewrite_crate(ctx, spec, &mut checkpoint, plan).await,
+                None => Err(ImportFailure::Permanent(
+                    "import plan is missing".to_string(),
+                )),
+            },
+            ImportPhase::Create => create_document(ctx, spec, &mut checkpoint).await,
+            ImportPhase::Cleanup => cleanup_source(ctx, spec, plan.as_ref(), &mut checkpoint).await,
+            ImportPhase::Done => return import_outcome(&checkpoint, spec),
+        };
 
         match result {
             Ok(()) => {
@@ -300,7 +309,10 @@ pub async fn run_rocrate_import(ctx: &JobContext, spec: &ImportRoCrateSpec) -> J
     }
 }
 
-pub(crate) async fn cleanup_after_panic(ctx: &JobContext) -> JobRunOutcome {
+pub(crate) async fn cleanup_after_panic(
+    ctx: &JobContext,
+    spec: &ImportRoCrateSpec,
+) -> JobRunOutcome {
     const PANIC_MESSAGE: &str = "job payload panicked";
 
     let mut checkpoint = match read_checkpoint(ctx).await {
@@ -314,31 +326,34 @@ pub(crate) async fn cleanup_after_panic(ctx: &JobContext) -> JobRunOutcome {
         cleanup_errors.push(error);
     }
     checkpoint.failure = Some(PANIC_MESSAGE.to_string());
-    if phase == ImportPhase::Write {
-        match read_plan(ctx).await {
-            Ok(plan) => {
-                if let Err(error) = mark_write_failure(ctx, plan.as_ref(), &mut checkpoint).await {
-                    cleanup_errors.push(error);
-                }
-            }
-            Err(error) => cleanup_errors.push(error),
+    let plan = match read_plan(ctx).await {
+        Ok(plan) => plan,
+        Err(error) => {
+            cleanup_errors.push(error);
+            None
         }
+    };
+    if phase == ImportPhase::Write
+        && let Err(error) = mark_write_failure(ctx, plan.as_ref(), &mut checkpoint).await
+    {
+        cleanup_errors.push(error);
     }
     checkpoint.phase = ImportPhase::Cleanup;
     if let Err(error) = persist_checkpoint(ctx, &checkpoint).await {
         cleanup_errors.push(error);
     }
-    if let Err(error) = cleanup_source(ctx, &mut checkpoint).await {
+    if let Err(error) = cleanup_source(ctx, spec, plan.as_ref(), &mut checkpoint).await {
         cleanup_errors.push(failure_message(error));
     }
     if let Err(error) = persist_checkpoint(ctx, &checkpoint).await {
         cleanup_errors.push(error);
     }
     let message = if cleanup_errors.is_empty() {
-        PANIC_MESSAGE.to_string()
+        format!("{PANIC_MESSAGE}; {}", write_state(&checkpoint))
     } else {
         format!(
-            "{PANIC_MESSAGE}; cleanup errors: {}",
+            "{PANIC_MESSAGE}; {}; cleanup errors: {}",
+            write_state(&checkpoint),
             cleanup_errors.join("; ")
         )
     };
@@ -680,6 +695,7 @@ async fn validate_source(
                 ReasonCode::Unlisted
             },
             described_id,
+            version_id: Ulid::generate(),
             data_offset: entry.data_offset,
             compressed_size: entry.compressed_size,
             uncompressed_size: entry.uncompressed_size,
@@ -688,6 +704,7 @@ async fn validate_source(
         });
     }
     entries.sort_by(|left, right| left.path.cmp(&right.path));
+    preflight_crate(spec, ctx.owner_node_id, validated.value, &entries)?;
     if let Some(signature) = signature_entry(inspection) {
         let row = ImportReportRow {
             entry_key: format!("signature/{}", signature.path),
@@ -719,6 +736,51 @@ async fn validate_source(
     checkpoint.phase = ImportPhase::Write;
     ctx.progress.set_total(checkpoint.entries_total);
     Ok(plan)
+}
+
+/// Rejects a crate that would fail validation before anything is written.
+///
+/// Every rewritten identifier is already known here. The placeholder content
+/// hash is a literal value rather than a reference, so it cannot change the
+/// graph the validator walks.
+fn preflight_crate(
+    spec: &ImportRoCrateSpec,
+    node_id: aruna_core::NodeId,
+    value: serde_json::Value,
+    entries: &[ImportEntryPlan],
+) -> Result<(), ImportFailure> {
+    let mut targets = HashMap::new();
+    for entry in entries {
+        let Some(file_id) = entry.described_id.clone() else {
+            continue;
+        };
+        targets.insert(
+            file_id,
+            RewriteTarget {
+                w3id: entry_arn(spec, node_id, entry)?.to_w3id(),
+                hash_w3id: format!("{ARUNA_DATA_PREFIX}{}", hex::encode([0u8; 32])),
+                local_path: entry.path.clone(),
+            },
+        );
+    }
+    rewrite_document(value, &targets)
+        .map(|_| ())
+        .map_err(validation_failure)
+}
+
+fn entry_arn(
+    spec: &ImportRoCrateSpec,
+    node_id: aruna_core::NodeId,
+    entry: &ImportEntryPlan,
+) -> Result<VersionedObjectArn, ImportFailure> {
+    VersionedObjectArn::new(
+        spec.auth_context.realm_id,
+        node_id,
+        spec.target.bucket.clone(),
+        entry.target_key.clone(),
+        entry.version_id,
+    )
+    .map_err(|error| ImportFailure::Permanent(error.to_string()))
 }
 
 async fn write_next(
@@ -755,13 +817,9 @@ async fn write_next(
         .await?
         .unwrap_or_else(|| entry_report(entry));
     if row.detail.version_id.is_none() {
-        row.detail.version_id = Some(Ulid::generate());
+        row.detail.version_id = Some(entry.version_id);
         write_report(ctx, &row).await?;
     }
-    let version_id = row
-        .detail
-        .version_id
-        .ok_or_else(|| ImportFailure::Permanent("import version fence is missing".to_string()))?;
     let body = payload_stream(
         ctx,
         &input.location,
@@ -798,7 +856,7 @@ async fn write_next(
             checksum_type: None,
             exists: false,
             version_source: None,
-            preassigned_version_id: Some(version_id),
+            preassigned_version_id: Some(entry.version_id),
             quota_ceiling: quota,
         })
         .with_bucket_guard(bucket_info)
@@ -819,14 +877,7 @@ async fn write_next(
         .get_blake3()
         .and_then(|hash| hash.try_into().ok())
         .ok_or_else(|| ImportFailure::Retryable("written object has no BLAKE3 hash".to_string()))?;
-    let arn = VersionedObjectArn::new(
-        spec.auth_context.realm_id,
-        ctx.owner_node_id,
-        spec.target.bucket.clone(),
-        entry.target_key.clone(),
-        result.version_id,
-    )
-    .map_err(|error| ImportFailure::Permanent(error.to_string()))?;
+    let arn = entry_arn(spec, ctx.owner_node_id, entry)?;
     row.detail.version_id = Some(result.version_id);
     row.detail.blake3 = Some(hex::encode(hash));
     row.detail.size = Some(result.location.blob_size);
@@ -870,10 +921,6 @@ async fn rewrite_crate(
         let report = reports
             .get(&entry.path)
             .ok_or_else(|| ImportFailure::Permanent("import report row is missing".to_string()))?;
-        let version_id = report
-            .detail
-            .version_id
-            .ok_or_else(|| ImportFailure::Permanent("imported version is missing".to_string()))?;
         let hash: [u8; 32] = report
             .detail
             .blake3
@@ -885,18 +932,10 @@ async fn rewrite_crate(
                     .and_then(|hash| hash.try_into().ok())
                     .ok_or_else(|| ImportFailure::Permanent("imported hash is invalid".to_string()))
             })?;
-        let arn = VersionedObjectArn::new(
-            spec.auth_context.realm_id,
-            ctx.owner_node_id,
-            spec.target.bucket.clone(),
-            entry.target_key.clone(),
-            version_id,
-        )
-        .map_err(|error| ImportFailure::Permanent(error.to_string()))?;
         targets.insert(
             file_id.clone(),
             RewriteTarget {
-                w3id: arn.to_w3id(),
+                w3id: entry_arn(spec, ctx.owner_node_id, entry)?.to_w3id(),
                 hash_w3id: format!("{ARUNA_DATA_PREFIX}{}", hex::encode(hash)),
                 local_path: entry.path.clone(),
             },
@@ -968,17 +1007,19 @@ async fn create_document(
             checkpoint.phase = ImportPhase::Cleanup;
             Ok(())
         }
-        Err(error) if metadata_is_transient(&error) => {
-            Err(ImportFailure::Retryable(error.to_string()))
-        }
-        Err(error) => Err(ImportFailure::Permanent(error.to_string())),
+        Err(error) => Err(classify_metadata(error)),
     }
 }
 
 async fn cleanup_source(
     ctx: &JobContext,
+    spec: &ImportRoCrateSpec,
+    plan: Option<&ImportPlan>,
     checkpoint: &mut ImportCheckpoint,
 ) -> Result<(), ImportFailure> {
+    if let Some(plan) = plan.filter(|_| rollback_required(checkpoint)) {
+        checkpoint.rolled_back = rollback_writes(ctx, spec, plan, checkpoint).await?;
+    }
     let Some(input) = checkpoint.input.as_ref() else {
         checkpoint.refs.hidden_locations.clear();
         checkpoint.phase = ImportPhase::Done;
@@ -995,6 +1036,88 @@ async fn cleanup_source(
     checkpoint.refs.hidden_locations.clear();
     checkpoint.phase = ImportPhase::Done;
     Ok(())
+}
+
+/// A failed import must leave nothing behind. A cancelled one keeps what it
+/// already committed, which its report rows state entry by entry.
+fn rollback_required(checkpoint: &ImportCheckpoint) -> bool {
+    !checkpoint.created && checkpoint.failure.is_some()
+}
+
+/// Deletes exactly the object versions this import wrote.
+///
+/// Every version id is minted by this job, so a version another writer owns can
+/// never be removed, even where the import landed on an existing key.
+async fn rollback_writes(
+    ctx: &JobContext,
+    spec: &ImportRoCrateSpec,
+    plan: &ImportPlan,
+    checkpoint: &ImportCheckpoint,
+) -> Result<u64, ImportFailure> {
+    // The entry at `next_entry` may have landed before the failure was seen.
+    let attempted = plan
+        .entries
+        .len()
+        .min(checkpoint.next_entry.saturating_add(1));
+    let written = checkpoint.next_entry.min(plan.entries.len());
+    if attempted == 0 {
+        return Ok(0);
+    }
+    let bucket = match load_bucket(ctx, &spec.target.bucket).await {
+        Ok(bucket) => bucket,
+        Err(ImportFailure::Permanent(_)) => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    let outcomes = delete_objects(
+        &ctx.driver,
+        DeleteObjectsInput {
+            bucket: spec.target.bucket.clone(),
+            entries: plan.entries[..attempted]
+                .iter()
+                .map(|entry| DeleteObjectsEntry {
+                    key: entry.target_key.clone(),
+                    version_id: Some(entry.version_id),
+                })
+                .collect(),
+            group_id: bucket.group_id,
+            realm_id: spec.auth_context.realm_id,
+            node_id: ctx.owner_node_id,
+            deleted_by: spec.auth_context.user_id,
+        },
+    )
+    .await;
+    let mut removed = 0;
+    for outcome in outcomes {
+        match outcome.result {
+            Ok(_) => removed += 1,
+            Err(DeleteObjectError::NoSuchVersion) => {}
+            Err(error) => {
+                return Err(ImportFailure::Retryable(format!(
+                    "rollback of `{}` failed: {error}",
+                    outcome.key
+                )));
+            }
+        }
+    }
+    for entry in &plan.entries[..written] {
+        let mut row = read_report(ctx, &entry.path)
+            .await?
+            .unwrap_or_else(|| entry_report(entry));
+        row.code = ReasonCode::Failed;
+        row.message = Some("written object was removed after the import failed".to_string());
+        row.detail.version_id = None;
+        row.detail.blake3 = None;
+        row.detail.size = None;
+        row.detail.arn = None;
+        row.detail.w3id = None;
+        write_report(ctx, &row).await?;
+    }
+    info!(
+        job_id = %ctx.job_id,
+        removed,
+        "Rolled back objects written by a failed RO-Crate import"
+    );
+    Ok(removed)
 }
 
 async fn ensure_targets(ctx: &JobContext, spec: &ImportRoCrateSpec) -> Result<(), ImportFailure> {
@@ -1624,6 +1747,21 @@ fn permanent_staging(error: &StagingSourceError) -> bool {
     )
 }
 
+/// A rejected document never becomes acceptable by retrying, so it is reported
+/// as violations and rolled back instead of burning the remaining attempts.
+fn classify_metadata(error: MetadataWriteError) -> ImportFailure {
+    match error {
+        MetadataWriteError::Create(CreateMetadataDocumentError::MetadataError(
+            MetadataError::Validation(violations),
+        )) => ImportFailure::Validation(violations),
+        MetadataWriteError::Create(CreateMetadataDocumentError::MetadataError(
+            MetadataError::InvalidInput(message),
+        )) => ImportFailure::Permanent(message),
+        error if metadata_is_transient(&error) => ImportFailure::Retryable(error.to_string()),
+        error => ImportFailure::Permanent(error.to_string()),
+    }
+}
+
 fn metadata_is_transient(error: &MetadataWriteError) -> bool {
     matches!(
         error,
@@ -1659,7 +1797,10 @@ fn import_outcome(checkpoint: &ImportCheckpoint, spec: &ImportRoCrateSpec) -> Jo
         return JobRunOutcome::Cancelled;
     }
     if let Some(error) = &checkpoint.failure {
-        return JobRunOutcome::Failed(JobError::permanent(error.clone()));
+        return JobRunOutcome::Failed(JobError::permanent(format!(
+            "{error}; {}",
+            write_state(checkpoint)
+        )));
     }
     JobRunOutcome::Succeeded(JobResultPayload::ImportRoCrate(ImportRoCrateResult {
         document_id: checkpoint.created.then_some(spec.document_id),
@@ -1669,6 +1810,19 @@ fn import_outcome(checkpoint: &ImportCheckpoint, spec: &ImportRoCrateSpec) -> Jo
         failed: checkpoint.failed,
         report_digest: [0; 32],
     }))
+}
+
+/// States what a failed import left behind, so the report never leaves the
+/// caller guessing whether data landed.
+fn write_state(checkpoint: &ImportCheckpoint) -> String {
+    if checkpoint.created {
+        return "the metadata document was created".to_string();
+    }
+    match checkpoint.rolled_back {
+        0 => "no objects were written".to_string(),
+        1 => "1 written object was removed".to_string(),
+        removed => format!("{removed} written objects were removed"),
+    }
 }
 
 fn failure_message(error: ImportFailure) -> String {
@@ -1820,27 +1974,28 @@ mod tests {
         .unwrap();
 
         let node_id = iroh::SecretKey::from_bytes(&[6; 32]).public();
+        let spec = ImportRoCrateSpec {
+            auth_context: AuthContext {
+                user_id: owner,
+                realm_id,
+                path_restrictions: None,
+            },
+            source: ImportRoCrateSource::Upload { upload_id },
+            target: ImportRoCrateTarget {
+                bucket: "target".to_string(),
+                prefix: "crate".to_string(),
+            },
+            metadata: ImportMetadataTarget {
+                group_id: Ulid::from_bytes([7; 16]),
+                path: "crate".to_string(),
+                public: false,
+            },
+            limits: Default::default(),
+            document_id: Ulid::from_bytes([8; 16]),
+        };
         let mut record = JobRecord::new(
             job_id,
-            JobPayload::ImportRoCrate(ImportRoCrateSpec {
-                auth_context: AuthContext {
-                    user_id: owner,
-                    realm_id,
-                    path_restrictions: None,
-                },
-                source: ImportRoCrateSource::Upload { upload_id },
-                target: ImportRoCrateTarget {
-                    bucket: "target".to_string(),
-                    prefix: "crate".to_string(),
-                },
-                metadata: ImportMetadataTarget {
-                    group_id: Ulid::from_bytes([7; 16]),
-                    path: "crate".to_string(),
-                    public: false,
-                },
-                limits: Default::default(),
-                document_id: Ulid::from_bytes([8; 16]),
-            }),
+            JobPayload::ImportRoCrate(spec.clone()),
             owner,
             node_id,
             1,
@@ -1884,7 +2039,7 @@ mod tests {
         .await
         .unwrap();
 
-        let JobRunOutcome::Failed(error) = cleanup_after_panic(&ctx).await else {
+        let JobRunOutcome::Failed(error) = cleanup_after_panic(&ctx, &spec).await else {
             panic!("panic cleanup must fail the job")
         };
         assert_eq!(error.kind, aruna_core::structs::JobErrorKind::Permanent);

--- a/operations/src/jobs/import/mod.rs
+++ b/operations/src/jobs/import/mod.rs
@@ -872,6 +872,12 @@ async fn write_next(
         Err(error) => return Err(classify_put(error)),
     }
     .ok_or_else(|| ImportFailure::Retryable("object write returned no result".to_string()))?;
+    // The preflight validated identifiers built from the planned version.
+    if result.version_id != entry.version_id {
+        return Err(ImportFailure::Permanent(
+            "written object version does not match the planned version".to_string(),
+        ));
+    }
     let hash: [u8; 32] = result
         .location
         .get_blake3()

--- a/operations/src/jobs/import/mod.rs
+++ b/operations/src/jobs/import/mod.rs
@@ -200,7 +200,9 @@ pub async fn run_rocrate_import(ctx: &JobContext, spec: &ImportRoCrateSpec) -> J
             Ok(plan) => plan,
             Err(error) => return retryable_error(error),
         },
-        _ => None,
+        ImportPhase::Acquire | ImportPhase::Inspect | ImportPhase::Validate | ImportPhase::Done => {
+            None
+        }
     };
 
     loop {

--- a/operations/src/jobs/import/mod.rs
+++ b/operations/src/jobs/import/mod.rs
@@ -184,19 +184,23 @@ pub async fn run_rocrate_import(ctx: &JobContext, spec: &ImportRoCrateSpec) -> J
     if let Err(error) = persist_checkpoint(ctx, &checkpoint).await {
         return retryable_error(error);
     }
-    let mut plan = if matches!(
-        checkpoint.phase,
-        ImportPhase::Write | ImportPhase::Rewrite | ImportPhase::Create
-    ) {
-        match read_plan(ctx).await {
-            Ok(Some(plan)) => Some(plan),
-            Ok(None) => {
-                return JobRunOutcome::Failed(JobError::permanent("import plan is missing"));
+    let mut plan = match checkpoint.phase {
+        ImportPhase::Write | ImportPhase::Rewrite | ImportPhase::Create => {
+            match read_plan(ctx).await {
+                Ok(Some(plan)) => Some(plan),
+                Ok(None) => {
+                    return JobRunOutcome::Failed(JobError::permanent("import plan is missing"));
+                }
+                Err(error) => return retryable_error(error),
             }
-            Err(error) => return retryable_error(error),
         }
-    } else {
-        None
+        // A resumed cleanup rolls back with the plan; a failure before
+        // planning simply has none.
+        ImportPhase::Cleanup => match read_plan(ctx).await {
+            Ok(plan) => plan,
+            Err(error) => return retryable_error(error),
+        },
+        _ => None,
     };
 
     loop {
@@ -874,6 +878,7 @@ async fn write_next(
     .ok_or_else(|| ImportFailure::Retryable("object write returned no result".to_string()))?;
     // The preflight validated identifiers built from the planned version.
     if result.version_id != entry.version_id {
+        report_divergent(ctx, entry, result.version_id).await?;
         return Err(ImportFailure::Permanent(
             "written object version does not match the planned version".to_string(),
         ));
@@ -1044,6 +1049,26 @@ async fn cleanup_source(
     Ok(())
 }
 
+/// Name a version the store returned instead of the planned one. Rollback only
+/// removes versions this job minted, so an unplanned version must not be
+/// deleted blindly; the system row keeps it findable.
+async fn report_divergent(
+    ctx: &JobContext,
+    entry: &ImportEntryPlan,
+    written: Ulid,
+) -> Result<(), ImportFailure> {
+    let mut row = entry_report(entry);
+    row.entry_key = format!("divergent/{}", entry.path);
+    row.code = ReasonCode::Failed;
+    row.message = Some(format!(
+        "object write returned version {written} instead of the planned {}; \
+         the written version was left in place",
+        entry.version_id
+    ));
+    row.detail.version_id = Some(written);
+    write_system_report(ctx, &row).await
+}
+
 /// A failed import must leave nothing behind. A cancelled one keeps what it
 /// already committed, which its report rows state entry by entry.
 fn rollback_required(checkpoint: &ImportCheckpoint) -> bool {
@@ -1065,15 +1090,20 @@ async fn rollback_writes(
         .entries
         .len()
         .min(checkpoint.next_entry.saturating_add(1));
-    let written = checkpoint.next_entry.min(plan.entries.len());
     if attempted == 0 {
         return Ok(0);
     }
-    let bucket = match load_bucket(ctx, &spec.target.bucket).await {
-        Ok(bucket) => bucket,
-        Err(ImportFailure::Permanent(_)) => return Ok(0),
-        Err(error) => return Err(error),
-    };
+    // An unreachable bucket leaves the rollback unfinished, so it must requeue
+    // instead of reporting a clean one.
+    let bucket = load_bucket(ctx, &spec.target.bucket)
+        .await
+        .map_err(|error| {
+            ImportFailure::Retryable(format!(
+                "rollback cannot read bucket `{}`: {}",
+                spec.target.bucket,
+                failure_message(error)
+            ))
+        })?;
     let outcomes = delete_objects(
         &ctx.driver,
         DeleteObjectsInput {
@@ -1093,10 +1123,12 @@ async fn rollback_writes(
     )
     .await;
     let mut removed = 0;
-    for outcome in outcomes {
+    // Only a version that was really removed loses its report detail, so the
+    // entry that failed before writing keeps its own failure message.
+    for (entry, outcome) in plan.entries[..attempted].iter().zip(outcomes) {
         match outcome.result {
             Ok(_) => removed += 1,
-            Err(DeleteObjectError::NoSuchVersion) => {}
+            Err(DeleteObjectError::NoSuchVersion) => continue,
             Err(error) => {
                 return Err(ImportFailure::Retryable(format!(
                     "rollback of `{}` failed: {error}",
@@ -1104,8 +1136,6 @@ async fn rollback_writes(
                 )));
             }
         }
-    }
-    for entry in &plan.entries[..written] {
         let mut row = read_report(ctx, &entry.path)
             .await?
             .unwrap_or_else(|| entry_report(entry));

--- a/operations/src/jobs/import/rewrite.rs
+++ b/operations/src/jobs/import/rewrite.rs
@@ -4,6 +4,7 @@ use aruna_core::metadata::MetadataValidationViolation;
 use craqle::{CrateViolation, RoCrateError, UpdateError};
 use oxrdf::{NamedOrBlankNode, Term};
 use oxttl::NQuadsParser;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use serde_json::{Map, Value, json};
 use thiserror::Error;
 use url::Url;
@@ -13,6 +14,19 @@ use crate::jobs::rocrate_jsonld::{JsonLdKeywords, RDF_TYPE_IRI, is_file_type};
 const JSONLD_BASE_IRI: &str = "https://craqle.invalid/";
 const SCHEMA_CONTENT_IRI: &str = "http://schema.org/contentUrl";
 const LOCAL_PATH_IRI: &str = "https://w3id.org/ro/terms#localPath";
+/// ASCII characters an IRI cannot carry literally. `%` is excluded so an already
+/// encoded identifier normalizes to itself.
+const ID_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'\\')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
 
 #[derive(Debug, Error)]
 pub enum CrateValidationError {
@@ -41,16 +55,20 @@ pub struct RewriteOutcome {
     pub warnings: Vec<String>,
 }
 
+/// Validates a crate and returns it with every identifier IRI-encoded.
+///
+/// Normalization happens on the document itself: an identifier that only a
+/// normalized copy makes valid would be dropped by the JSON-LD parser once the
+/// crate reaches the create path, orphaning everything behind it.
 pub fn validate_document(jsonld: &str) -> Result<ValidatedDocument, CrateValidationError> {
-    let value: Value = serde_json::from_str(jsonld)
+    let mut value: Value = serde_json::from_str(jsonld)
         .map_err(|error| CrateValidationError::Invalid(error.to_string()))?;
-    let mut validation = value.clone();
-    normalize_ids(&mut validation);
-    let validation = serde_json::to_string(&validation)
-        .map_err(|error| CrateValidationError::Invalid(error.to_string()))?;
-    let canonical = craqle::validate_rocrate_jsonld(&validation).map_err(map_validation_error)?;
-    let file_subjects = file_subjects(&canonical.nquads)?;
     let keywords = JsonLdKeywords::new(&value);
+    normalize_ids(&mut value, &keywords);
+    let normalized = serde_json::to_string(&value)
+        .map_err(|error| CrateValidationError::Invalid(error.to_string()))?;
+    let canonical = craqle::validate_rocrate_jsonld(&normalized).map_err(map_validation_error)?;
+    let file_subjects = file_subjects(&canonical.nquads)?;
     let mut file_ids = Vec::new();
     collect_file_ids(&value, &file_subjects, &keywords, &mut file_ids)?;
     Ok(ValidatedDocument { value, file_ids })
@@ -61,6 +79,7 @@ pub fn rewrite_document(
     targets: &HashMap<String, RewriteTarget>,
 ) -> Result<RewriteOutcome, CrateValidationError> {
     let keywords = JsonLdKeywords::new(&value);
+    let targets = expanded_targets(targets)?;
     let compact_content = keywords.term_matches(
         "contentUrl",
         &[
@@ -73,7 +92,7 @@ pub fn rewrite_document(
     let mut warnings = HashSet::new();
     rewrite_value(
         &mut value,
-        targets,
+        &targets,
         &keywords,
         compact_content,
         compact_path,
@@ -144,17 +163,48 @@ fn collect_file_ids(
     Ok(())
 }
 
-fn normalize_ids(value: &mut Value) {
+fn normalize_ids(value: &mut Value, keywords: &JsonLdKeywords) {
     match value {
-        Value::Array(values) => values.iter_mut().for_each(normalize_ids),
+        Value::Array(values) => values
+            .iter_mut()
+            .for_each(|value| normalize_ids(value, keywords)),
         Value::Object(object) => {
-            if let Some(Value::String(id)) = object.get_mut("@id") {
-                *id = id.replace(' ', "%20");
+            for (key, value) in object.iter_mut() {
+                if let Value::String(id) = value
+                    && keywords.is_id(key)
+                    && let Some(canonical) = canonical_id(id)
+                {
+                    *id = canonical;
+                }
+                normalize_ids(value, keywords);
             }
-            object.values_mut().for_each(normalize_ids);
         }
         _ => {}
     }
+}
+
+fn canonical_id(id: &str) -> Option<String> {
+    let canonical = utf8_percent_encode(id, ID_ENCODE_SET).to_string();
+    (canonical != id).then_some(canonical)
+}
+
+/// Keys every target by its resolved IRI, so an entity and the references to it
+/// still meet when they differ in `./` prefix or percent-encoding.
+fn expanded_targets(
+    targets: &HashMap<String, RewriteTarget>,
+) -> Result<HashMap<String, &RewriteTarget>, CrateValidationError> {
+    let mut expanded = HashMap::with_capacity(targets.len());
+    for (id, target) in targets {
+        expanded.insert(expanded_id(id)?, target);
+    }
+    Ok(expanded)
+}
+
+fn matching_target(targets: &HashMap<String, &RewriteTarget>, id: &str) -> Option<RewriteTarget> {
+    expanded_id(id)
+        .ok()
+        .and_then(|id| targets.get(&id))
+        .map(|target| (*target).clone())
 }
 
 fn expanded_id(id: &str) -> Result<String, CrateValidationError> {
@@ -170,7 +220,7 @@ fn expanded_id(id: &str) -> Result<String, CrateValidationError> {
 
 fn rewrite_value(
     value: &mut Value,
-    targets: &HashMap<String, RewriteTarget>,
+    targets: &HashMap<String, &RewriteTarget>,
     keywords: &JsonLdKeywords,
     compact_content: bool,
     compact_path: bool,
@@ -180,7 +230,7 @@ fn rewrite_value(
         Value::Array(values) => {
             for value in values {
                 if let Value::String(raw) = value
-                    && targets.contains_key(raw)
+                    && matching_target(targets, raw).is_some()
                 {
                     warnings.insert(raw.clone());
                 }
@@ -200,7 +250,7 @@ fn rewrite_value(
                 .map(|(key, id)| (key.to_string(), id.to_string()));
             if let Some((id_key, target)) = original_id
                 .as_ref()
-                .and_then(|(key, id)| targets.get(id).cloned().map(|target| (key, target)))
+                .and_then(|(key, id)| matching_target(targets, id).map(|target| (key, target)))
             {
                 object.insert(id_key.clone(), Value::String(target.w3id.clone()));
                 if object.len() > 1 {
@@ -230,7 +280,7 @@ fn rewrite_value(
                 }
                 if !keywords.is_id(key)
                     && let Value::String(raw) = value
-                    && targets.contains_key(raw)
+                    && matching_target(targets, raw).is_some()
                 {
                     warnings.insert(raw.clone());
                 }
@@ -438,6 +488,120 @@ mod tests {
             Err(CrateValidationError::Violations(violations))
                 if violations[0].code == "unsupported_crate_version"
         ));
+    }
+
+    fn target(name: &str) -> RewriteTarget {
+        RewriteTarget {
+            w3id: format!("https://w3id.org/aruna/data/arn:{name}"),
+            hash_w3id: format!("https://w3id.org/aruna/data/{}", "a".repeat(64)),
+            local_path: format!("data/{name}"),
+        }
+    }
+
+    #[test]
+    fn matches_mixed_ids() {
+        // One entity is encoded and referenced literally; the other is reversed.
+        let document = json!({
+            "@context": "https://w3id.org/ro/crate/1.2/context",
+            "@graph": [
+                {
+                    "@id": "ro-crate-metadata.json",
+                    "@type": "CreativeWork",
+                    "about": {"@id": "./"},
+                    "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"}
+                },
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "test",
+                    "description": "test crate",
+                    "datePublished": "2026-07-27",
+                    "hasPart": [{"@id": "./data/a%20b.txt"}, {"@id": "./data/c d.txt"}]
+                },
+                {"@id": "./data/a b.txt", "@type": "File", "name": "a"},
+                {"@id": "./data/c%20d.txt", "@type": "File", "name": "c"}
+            ]
+        })
+        .to_string();
+
+        let validated = validate_document(&document).unwrap();
+        assert_eq!(
+            validated.file_ids,
+            vec![
+                "./data/a%20b.txt".to_string(),
+                "./data/c%20d.txt".to_string()
+            ]
+        );
+        let rewritten = rewrite_document(
+            validated.value,
+            &HashMap::from([
+                ("./data/a%20b.txt".to_string(), target("a")),
+                ("./data/c%20d.txt".to_string(), target("c")),
+            ]),
+        )
+        .unwrap();
+
+        let value: Value = serde_json::from_str(&rewritten.jsonld).unwrap();
+        assert_eq!(
+            value["@graph"][1]["hasPart"],
+            json!([
+                {"@id": "https://w3id.org/aruna/data/arn:a"},
+                {"@id": "https://w3id.org/aruna/data/arn:c"}
+            ])
+        );
+        assert!(craqle::validate_rocrate_jsonld(&rewritten.jsonld).is_ok());
+    }
+
+    #[test]
+    fn encodes_nested_ids() {
+        // A folder dataset whose id needs encoding must survive as written.
+        let folder = "./Demo - Experiment - abc123/";
+        let document = json!({
+            "@context": "https://w3id.org/ro/crate/1.2/context",
+            "@graph": [
+                {
+                    "@id": "ro-crate-metadata.json",
+                    "@type": "CreativeWork",
+                    "about": {"@id": "./"},
+                    "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"}
+                },
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "test",
+                    "description": "test crate",
+                    "datePublished": "2026-07-27",
+                    "hasPart": [{"@id": folder}, {"@id": "./ -  - bb8b469d/"}]
+                },
+                {
+                    "@id": folder,
+                    "@type": "Dataset",
+                    "name": "folder",
+                    "hasPart": {"@id": format!("{folder}example.txt")}
+                },
+                {"@id": "./ -  - bb8b469d/", "@type": "Dataset", "name": "empty"},
+                {"@id": format!("{folder}example.txt"), "@type": "File", "name": "example"}
+            ]
+        })
+        .to_string();
+
+        let validated = validate_document(&document).unwrap();
+        let file_id = "./Demo%20-%20Experiment%20-%20abc123/example.txt";
+        assert_eq!(validated.file_ids, vec![file_id.to_string()]);
+        let rewritten = rewrite_document(
+            validated.value,
+            &HashMap::from([(file_id.to_string(), target("example"))]),
+        )
+        .unwrap();
+
+        let value: Value = serde_json::from_str(&rewritten.jsonld).unwrap();
+        assert_eq!(
+            value["@graph"][2]["@id"],
+            "./Demo%20-%20Experiment%20-%20abc123/"
+        );
+        assert_eq!(value["@graph"][3]["@id"], "./%20-%20%20-%20bb8b469d/");
+        // The emitted bytes must validate unaided: the create path normalizes nothing.
+        assert!(craqle::validate_rocrate_jsonld(&rewritten.jsonld).is_ok());
     }
 
     #[test]

--- a/operations/src/jobs/runtime.rs
+++ b/operations/src/jobs/runtime.rs
@@ -789,10 +789,11 @@ async fn supervise(
 
 async fn handle_panic(ctx: &JobContext, record: &JobRecord) -> JobRunOutcome {
     warn!(job_id = %ctx.job_id, "Job payload panicked; failing the attempt");
-    if ctx.final_attempt && matches!(&record.payload, JobPayload::ImportRoCrate(_)) {
-        crate::jobs::import::cleanup_after_panic(ctx).await
-    } else {
-        JobRunOutcome::Failed(JobError::retryable("job payload panicked"))
+    match &record.payload {
+        JobPayload::ImportRoCrate(spec) if ctx.final_attempt => {
+            crate::jobs::import::cleanup_after_panic(ctx, spec).await
+        }
+        _ => JobRunOutcome::Failed(JobError::retryable("job payload panicked")),
     }
 }
 

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -1474,9 +1474,11 @@ pub async fn transition_external_to_running(
         if record.cancel_requested {
             return Ok(JobMutation::Skip);
         }
-        if let Some(started_at_ms) = started_at_ms {
-            record.started_at_ms.get_or_insert(started_at_ms);
-        }
+        // Running must always carry a start: it anchors the walltime cap, and a
+        // backend that reports none still started when the controller saw it.
+        record
+            .started_at_ms
+            .get_or_insert(started_at_ms.unwrap_or(now_ms));
         record.state = JobState::Running;
         record.updated_at_ms = now_ms;
         if let Some(claim) = record.claim.as_mut() {
@@ -3384,6 +3386,31 @@ mod tests {
         assert_eq!(stored.attempt_intent, committed.record.attempt_intent);
         assert!(stored.started_at_ms.is_none());
         assert!(stored.claim.is_some());
+    }
+
+    #[tokio::test]
+    async fn running_backfills_start() {
+        // Kubernetes and Apptainer accept an attempt before reporting a start
+        // time; without a start the walltime cap would have no anchor.
+        let (_dir, storage) = temp_storage();
+        let job_id = JobId::from_bytes([0xA9; 16]);
+        let token = Ulid::generate();
+        insert_job(&storage, &execution_record(job_id, token, JobState::Ready))
+            .await
+            .unwrap();
+
+        let stored = transition_external_to_running(&storage, job_id, token, None, 6_000)
+            .await
+            .unwrap();
+
+        assert_eq!(stored.state, JobState::Running);
+        assert_eq!(stored.started_at_ms, Some(6_000));
+
+        // Later evidence must not move an already anchored start.
+        let stored = transition_external_to_running(&storage, job_id, token, Some(9_000), 9_100)
+            .await
+            .unwrap();
+        assert_eq!(stored.started_at_ms, Some(6_000));
     }
 
     #[tokio::test]

--- a/operations/src/jobs/workflow/mod.rs
+++ b/operations/src/jobs/workflow/mod.rs
@@ -771,26 +771,23 @@ pub async fn supervise_and_finalize(
         .resources
         .max_walltime_ms
         .unwrap_or(DEFAULT_WALLTIME.as_millis() as u64);
-    let walltime_left = read_job_record(&storage, job_id, None)
+    // A record without start evidence anchors the cap here, so no attempt can
+    // outrun the walltime limit for want of a backend-reported start.
+    let started_at_ms = read_job_record(&storage, job_id, None)
         .await
         .ok()
         .flatten()
         .and_then(|record| record.started_at_ms)
-        .map(|started_at_ms| {
-            Duration::from_millis(
-                started_at_ms
-                    .saturating_add(walltime_ms)
-                    .saturating_sub(unix_timestamp_millis()),
-            )
-        });
+        .unwrap_or_else(unix_timestamp_millis);
+    let walltime_left = Duration::from_millis(
+        started_at_ms
+            .saturating_add(walltime_ms)
+            .saturating_sub(unix_timestamp_millis()),
+    );
     let wait_and_finalize = async {
-        let result = if let Some(walltime_left) = walltime_left {
-            tokio::select! {
-                result = backend.wait(&fence, &cancel) => Some(result),
-                _ = tokio::time::sleep(walltime_left) => None,
-            }
-        } else {
-            Some(backend.wait(&fence, &cancel).await)
+        let result = tokio::select! {
+            result = backend.wait(&fence, &cancel) => Some(result),
+            _ = tokio::time::sleep(walltime_left) => None,
         };
         if let Some(result) = result {
             finalize_attempt(
@@ -1903,7 +1900,7 @@ mod tests {
         Arc::get_mut(&mut ctx).unwrap().task_handle = None;
         let (record, token, attempt) = ready_with_intent(&storage).await;
         let job_id = record.job_id;
-        transition_external_to_running(&storage, job_id, token, None, 6)
+        transition_external_to_running(&storage, job_id, token, None, unix_timestamp_millis())
             .await
             .unwrap();
         let backend = StubBackend::new(StubReconcile::NotFound);
@@ -1960,7 +1957,7 @@ mod tests {
         Arc::get_mut(&mut ctx).unwrap().task_handle = None;
         let (record, token, attempt) = ready_with_intent(&storage).await;
         let job_id = record.job_id;
-        transition_external_to_running(&storage, job_id, token, None, 6)
+        transition_external_to_running(&storage, job_id, token, None, unix_timestamp_millis())
             .await
             .unwrap();
         let backend = StubBackend::new(StubReconcile::NotFound);
@@ -1998,6 +1995,45 @@ mod tests {
         transition_external_to_running(&storage, job_id, token, Some(1), 6)
             .await
             .unwrap();
+        let backend = StubBackend::new(StubReconcile::Waiting);
+        let mut spec = execution_spec();
+        spec.resources.max_walltime_ms = Some(0);
+
+        supervise_and_finalize(
+            ctx,
+            job_id,
+            token,
+            backend.clone(),
+            fence(&attempt),
+            spec,
+            "ws-test".to_string(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        let stored = read_job_record(&storage, job_id, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(backend.cancels.load(Ordering::Relaxed), 1);
+        assert_eq!(stored.state, JobState::Failed);
+        assert_eq!(
+            stored.last_error.unwrap().message,
+            "walltime limit exceeded"
+        );
+    }
+
+    #[tokio::test]
+    async fn arms_missing_start() {
+        // A record carrying no backend start evidence must still be capped,
+        // anchored at the moment supervision begins.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let mut ctx = context(storage.clone());
+        Arc::get_mut(&mut ctx).unwrap().task_handle = None;
+        let (record, token, attempt) = ready_with_intent(&storage).await;
+        let job_id = record.job_id;
+        assert!(record.started_at_ms.is_none());
         let backend = StubBackend::new(StubReconcile::Waiting);
         let mut spec = execution_spec();
         spec.resources.max_walltime_ms = Some(0);

--- a/operations/src/jobs/workflow/mod.rs
+++ b/operations/src/jobs/workflow/mod.rs
@@ -771,14 +771,7 @@ pub async fn supervise_and_finalize(
         .resources
         .max_walltime_ms
         .unwrap_or(DEFAULT_WALLTIME.as_millis() as u64);
-    // A record without start evidence anchors the cap here, so no attempt can
-    // outrun the walltime limit for want of a backend-reported start.
-    let started_at_ms = read_job_record(&storage, job_id, None)
-        .await
-        .ok()
-        .flatten()
-        .and_then(|record| record.started_at_ms)
-        .unwrap_or_else(unix_timestamp_millis);
+    let started_at_ms = walltime_anchor(&storage, job_id, token).await;
     let walltime_left = Duration::from_millis(
         started_at_ms
             .saturating_add(walltime_ms)
@@ -803,6 +796,32 @@ pub async fn supervise_and_finalize(
         .is_none()
     {
         info!(job_id = %job_id, "Execution supervisor superseded; abandoning");
+    }
+}
+
+/// The walltime cap needs an anchor even without backend start evidence. The
+/// first supervision pass persists the one it derives, so a restarted
+/// supervisor cannot hand the attempt a fresh window.
+async fn walltime_anchor(
+    storage: &aruna_storage::StorageHandle,
+    job_id: JobId,
+    token: ulid::Ulid,
+) -> u64 {
+    if let Some(started_at_ms) = read_job_record(storage, job_id, None)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|record| record.started_at_ms)
+    {
+        return started_at_ms;
+    }
+    let anchor = unix_timestamp_millis();
+    match record_attempt_started(storage, job_id, token, anchor).await {
+        Ok(record) => record.started_at_ms.unwrap_or(anchor),
+        Err(error) => {
+            warn!(job_id = %job_id, error = %error, "Walltime anchor write failed");
+            anchor
+        }
     }
 }
 
@@ -2060,6 +2079,31 @@ mod tests {
             stored.last_error.unwrap().message,
             "walltime limit exceeded"
         );
+    }
+
+    #[tokio::test]
+    async fn anchor_survives_restart() {
+        // A crashlooping supervisor must not keep granting the attempt a fresh
+        // pre-Running window, so the first derived anchor is the durable one.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let (record, token, _attempt) = ready_with_intent(&storage).await;
+        let job_id = record.job_id;
+        assert!(record.started_at_ms.is_none());
+
+        let first = walltime_anchor(&storage, job_id, token).await;
+
+        let stored = read_job_record(&storage, job_id, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.started_at_ms, Some(first));
+        assert_eq!(walltime_anchor(&storage, job_id, token).await, first);
+        // Backend start evidence never moves an anchor that already exists.
+        record_attempt_started(&storage, job_id, token, first.saturating_add(60_000))
+            .await
+            .unwrap();
+        assert_eq!(walltime_anchor(&storage, job_id, token).await, first);
     }
 
     #[tokio::test]

--- a/operations/src/jobs/workflow/workspace.rs
+++ b/operations/src/jobs/workflow/workspace.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use aruna_compute::ExecutorBackend;
-use aruna_core::compute::{BackendError, FenceContext, MAX_TRANSFER_BYTES, S3Mount, TaskInput};
+use aruna_core::compute::{
+    BackendError, FenceContext, MAX_OUTPUT_MATCHES, MAX_TRANSFER_BYTES, S3Mount, TaskInput,
+    has_wildcard, output_suffix,
+};
 use aruna_core::errors::{AuthorizationError, StorageError};
 use aruna_core::stream::BackendStream;
 use aruna_core::structs::{
@@ -441,11 +444,78 @@ pub async fn capture_outputs(
     node_id: NodeId,
 ) -> Result<Vec<OutputObject>, JobError> {
     let mut outputs = Vec::with_capacity(spec.file_outputs.len());
-    for output in &spec.file_outputs {
-        outputs
-            .push(put_file_output(context, backend, fence, spec, record, node_id, output).await?);
+    for declared in &spec.file_outputs {
+        for output in resolve_output(backend, fence, declared).await? {
+            outputs.push(
+                put_file_output(context, backend, fence, spec, record, node_id, &output).await?,
+            );
+        }
     }
     Ok(outputs)
+}
+
+/// Resolve one declared output into the concrete files to upload. A wildcard
+/// path is expanded against the terminal attempt; a literal path is uploaded as
+/// declared and still fails the job when it is missing.
+async fn resolve_output(
+    backend: &Arc<dyn ExecutorBackend>,
+    fence: &FenceContext,
+    output: &OutputSelection,
+) -> Result<Vec<OutputSelection>, JobError> {
+    if !has_wildcard(&output.container_path) {
+        return Ok(vec![output.clone()]);
+    }
+    let mut matched = backend
+        .list_outputs(fence, &output.container_path)
+        .await
+        .map_err(|error| output_read_error(&error))?;
+    matched.sort();
+    matched.dedup();
+    tracing::debug!(
+        pattern = %output.container_path,
+        matched = matched.len(),
+        "Expanded wildcard output"
+    );
+    expand_selection(output, matched)
+}
+
+/// One selection per matched file, keyed by the match with `path_prefix` stripped.
+/// Zero matches captures nothing, which the spec allows for a selection pattern.
+fn expand_selection(
+    output: &OutputSelection,
+    matched: Vec<String>,
+) -> Result<Vec<OutputSelection>, JobError> {
+    let prefix = output.path_prefix.as_deref().ok_or_else(|| {
+        JobError::permanent(format!(
+            "output `{}` contains wildcards without a path_prefix",
+            output.container_path
+        ))
+    })?;
+    if matched.len() > MAX_OUTPUT_MATCHES {
+        return Err(JobError::permanent(format!(
+            "output `{}` matches more than {MAX_OUTPUT_MATCHES} files",
+            output.container_path
+        )));
+    }
+    let OutputDestination::S3 { bucket, key } = &output.destination;
+    matched
+        .into_iter()
+        .map(|path| {
+            let suffix = output_suffix(&path, prefix).ok_or_else(|| {
+                JobError::permanent(format!("output `{path}` is outside path_prefix `{prefix}`"))
+            })?;
+            Ok(OutputSelection {
+                container_path: path,
+                path_prefix: None,
+                destination: OutputDestination::S3 {
+                    bucket: bucket.clone(),
+                    key: format!("{}/{suffix}", key.trim_end_matches('/')),
+                },
+                name: output.name.clone(),
+                description: output.description.clone(),
+            })
+        })
+        .collect()
 }
 
 /// Stream one declared container output into its S3 destination. When the
@@ -1193,6 +1263,76 @@ mod tests {
         assert_eq!(merged.len(), MAX_OUTPUT_MANIFEST_OBJECTS);
 
         let error = merge_outputs(inventoried, vec![output("overflow")]).unwrap_err();
+        assert_eq!(error.kind, aruna_core::structs::JobErrorKind::Permanent);
+    }
+
+    fn wildcard_output(pattern: &str) -> OutputSelection {
+        OutputSelection {
+            container_path: pattern.to_string(),
+            path_prefix: Some("/out".to_string()),
+            destination: OutputDestination::S3 {
+                bucket: "dest".to_string(),
+                key: "results/".to_string(),
+            },
+            name: Some("reports".to_string()),
+            description: None,
+        }
+    }
+
+    fn expanded_keys(output: &OutputSelection, matched: Vec<String>) -> Vec<String> {
+        expand_selection(output, matched)
+            .unwrap()
+            .iter()
+            .map(|output| {
+                let OutputDestination::S3 { key, .. } = &output.destination;
+                key.clone()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn expands_matched_keys() {
+        let output = wildcard_output("/out/*.txt");
+        let matched = vec!["/out/a.txt".to_string(), "/out/b.txt".to_string()];
+
+        let expanded = expand_selection(&output, matched).unwrap();
+
+        assert_eq!(expanded[1].container_path, "/out/b.txt");
+        assert_eq!(expanded[1].name.as_deref(), Some("reports"));
+        assert!(expanded[1].path_prefix.is_none());
+        // The suffix below path_prefix keeps every nested component.
+        assert_eq!(
+            expanded_keys(&output, vec!["/out/a.txt".to_string()]),
+            vec!["results/a.txt"]
+        );
+        assert_eq!(
+            expanded_keys(
+                &wildcard_output("/out/*/*/*.txt"),
+                vec!["/out/sub/deep/b.txt".to_string()]
+            ),
+            vec!["results/sub/deep/b.txt"]
+        );
+    }
+
+    #[test]
+    fn empty_expansion_captures() {
+        // Zero matches is a legitimate empty selection, not a job failure.
+        assert!(
+            expand_selection(&wildcard_output("/out/*.txt"), Vec::new())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn rejects_foreign_match() {
+        let output = wildcard_output("/out/*.txt");
+        let error = expand_selection(&output, vec!["/other/a.txt".to_string()]).unwrap_err();
+        assert_eq!(error.kind, aruna_core::structs::JobErrorKind::Permanent);
+
+        let mut output = output;
+        output.path_prefix = None;
+        let error = expand_selection(&output, vec!["/out/a.txt".to_string()]).unwrap_err();
         assert_eq!(error.kind, aruna_core::structs::JobErrorKind::Permanent);
     }
 

--- a/operations/src/jobs/workflow/workspace.rs
+++ b/operations/src/jobs/workflow/workspace.rs
@@ -1043,7 +1043,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_outputs_remain() {
-        let (storage_handle, _receiver) = aruna_storage::StorageHandle::new();
+        let (storage_handle, _receivers) = aruna_storage::StorageHandle::new();
         let context = DriverContext {
             storage_handle,
             net_handle: None,

--- a/operations/src/lib.rs
+++ b/operations/src/lib.rs
@@ -47,6 +47,7 @@ pub mod native_reference;
 pub mod node_info;
 pub mod notifications;
 pub mod onboarding_secret_state;
+pub mod permission_rules;
 pub mod placement;
 pub mod process_placements;
 mod queue_backoff;

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -90,6 +90,16 @@ pub enum MetadataApiError {
     Internal(String),
 }
 
+/// Order the visible metadata listing is paginated in.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MetadataListOrder {
+    /// Ascending document id, which is creation order for ULID ids.
+    #[default]
+    Created,
+    /// Descending `updated_at_ms`, tie-broken by descending document id.
+    Recent,
+}
+
 #[derive(Debug, Clone)]
 pub struct ListVisibleMetadataDocumentsRequest {
     pub group_id: Option<GroupId>,
@@ -97,6 +107,7 @@ pub struct ListVisibleMetadataDocumentsRequest {
     pub include_summary: bool,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+    pub order: MetadataListOrder,
     pub auth: Option<AuthContext>,
 }
 
@@ -325,9 +336,11 @@ pub async fn list_visible_metadata_documents(
             .map(|group| group.group_id)
             .collect(),
     };
-    // Summary listings must show documents whose projection has not landed yet;
-    // the pending keyspace is scanned once per request, never once per group.
-    let mut pending = if request.include_summary {
+    // Summary listings and recency listings must show documents whose projection
+    // has not landed yet; the pending keyspace is scanned once per request,
+    // never once per group.
+    let recent = request.order == MetadataListOrder::Recent;
+    let mut pending = if request.include_summary || recent {
         load_pending_records(context, request.group_id).await?
     } else {
         HashMap::new()
@@ -341,6 +354,17 @@ pub async fn list_visible_metadata_documents(
             group_records.sort_by_key(|record| record.document_id);
         }
         records.extend(group_records);
+    }
+
+    // Ordering precedes both the estimate scan and the offset window so that
+    // pagination and the early exit page the same sequence.
+    if recent {
+        records.sort_by(|left, right| {
+            right
+                .updated_at_ms
+                .cmp(&left.updated_at_ms)
+                .then_with(|| right.document_id.cmp(&left.document_id))
+        });
     }
 
     // Group-granular estimate: one permission probe per group, reused for every
@@ -2433,6 +2457,7 @@ mod tests {
             include_summary,
             limit: None,
             offset: None,
+            order: MetadataListOrder::default(),
             auth: None,
         }
     }
@@ -2712,6 +2737,93 @@ mod tests {
 
         assert_eq!(result.total_returned, 2);
         assert_eq!(result.total_estimate, Some(2));
+    }
+
+    // Update stamps deliberately disagree with the ascending document ids.
+    async fn seed_timed_records(
+        test: &MetadataTest,
+        group_id: GroupId,
+    ) -> Vec<MetadataRegistryRecord> {
+        let mut records = Vec::new();
+        for updated_at_ms in [10u64, 30, 20] {
+            let mut record = public_record(group_id, Ulid::generate());
+            record.updated_at_ms = updated_at_ms;
+            seed_registry_cache(test, &record).await;
+            records.push(record);
+        }
+        records
+    }
+
+    fn listed_ids(result: &ListVisibleMetadataDocumentsResult) -> Vec<Ulid> {
+        result
+            .documents
+            .iter()
+            .map(|document| document.record.document_id)
+            .collect()
+    }
+
+    // Recency ordering must precede the offset window so pages walk it too.
+    #[tokio::test]
+    async fn orders_recent_first() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        let records = seed_timed_records(&test, group_id).await;
+
+        let page = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                order: MetadataListOrder::Recent,
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(
+            listed_ids(&page),
+            vec![
+                records[1].document_id,
+                records[2].document_id,
+                records[0].document_id
+            ]
+        );
+
+        let second = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                limit: Some(1),
+                offset: Some(1),
+                order: MetadataListOrder::Recent,
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(listed_ids(&second), vec![records[2].document_id]);
+    }
+
+    // The default page stays in ascending document id order.
+    #[tokio::test]
+    async fn default_keeps_created() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        let records = seed_timed_records(&test, group_id).await;
+
+        let page = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            summary_request(group_id, false),
+        )
+        .await
+        .expect("listing succeeds");
+
+        let mut expected = records
+            .iter()
+            .map(|record| record.document_id)
+            .collect::<Vec<_>>();
+        expected.sort();
+        assert_eq!(listed_ids(&page), expected);
     }
 
     #[test]

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -40,6 +40,7 @@ use super::search_cursor::{
     METADATA_SEARCH_MAX_PAGINATION_DEPTH, NodeSearchResult, SearchCursor, SearchCursorError,
     SearchPageCursor, SearchWatermark, paginate, query_fingerprint, resume_fetch_limit,
 };
+use super::summary_cache::summary_cache;
 use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::driver::{DriverContext, drive};
 use crate::get_metadata_document::{
@@ -343,12 +344,16 @@ pub async fn list_visible_metadata_documents(
 
     let mut documents = Vec::with_capacity(selected.len());
     if request.include_summary {
-        let summaries = futures_util::future::join_all(
-            selected
-                .iter()
-                .map(|record| export_rocrate_summary_jsonld(context, &record.graph_iri)),
-        )
-        .await;
+        let exports = selected
+            .iter()
+            .map(|record| {
+                export_rocrate_summary_jsonld(context, &record.graph_iri, record.last_event_id)
+            })
+            .collect::<Vec<_>>();
+        let summaries = stream::iter(exports)
+            .buffered(METADATA_SUMMARY_FANOUT_LIMIT)
+            .collect::<Vec<_>>()
+            .await;
         for (record, summary) in selected.into_iter().zip(summaries) {
             let rocrate_summary_jsonld = match summary {
                 Ok(summary) => Some(summary),
@@ -406,7 +411,12 @@ pub async fn export_metadata_rocrate(
         MetadataRoCrateExportView::Summary => {
             ensure_record_materialized_for_graph_read(context, &record).await?;
             Ok(ExportMetadataRoCrateResult::Summary {
-                jsonld: export_rocrate_summary_jsonld(context, &record.graph_iri).await?,
+                jsonld: export_rocrate_summary_jsonld(
+                    context,
+                    &record.graph_iri,
+                    record.last_event_id,
+                )
+                .await?,
                 record,
             })
         }
@@ -1199,18 +1209,33 @@ async fn export_rocrate_jsonld(
         .map_err(map_metadata_event_error)
 }
 
+/// Summaries are cached per `(graph_iri, cursor)`. The lookup carries no
+/// authorization data because it only runs once `can_read_record` accepted that
+/// record; it MUST NOT be moved above that check.
 async fn export_rocrate_summary_jsonld(
     context: &DriverContext,
     graph_iri: &str,
+    cursor: Ulid,
 ) -> Result<String, MetadataApiError> {
     let handle = context
         .metadata_handle
         .clone()
         .ok_or_else(|| MetadataApiError::Internal("metadata handle unavailable".to_string()))?;
-    handle
+    // The handle rejects deleted graphs before every export, so a hit has to
+    // re-check the authoritative lifecycle record itself.
+    if let Some(summary) = summary_cache().get(graph_iri, cursor, Instant::now()) {
+        if !metadata_graph_is_deleted(context, graph_iri).await? {
+            return Ok(summary.to_string());
+        }
+        summary_cache().remove(graph_iri);
+    }
+
+    let summary = handle
         .export_rocrate_summary_jsonld(graph_iri.to_string())
         .await
-        .map_err(map_metadata_event_error)
+        .map_err(map_metadata_event_error)?;
+    summary_cache().insert(graph_iri, cursor, &summary, Instant::now());
+    Ok(summary)
 }
 
 async fn export_rocrate_page(
@@ -1921,6 +1946,36 @@ async fn run_query_distributed(
     };
     let remote_auth_token = metadata_auth_token_from_bearer(bearer_token.as_deref());
 
+    // Remote partitions authorize on the forwarded credential, so entries are
+    // partitioned by credential digest. The local invalidation signals only
+    // cover the local partition; the TTL bounds remote staleness.
+    let cache_stamp = handle.query_cache().stamp(handle.visibility_generation());
+    let cache_key = super::query_cache::credential_digest(auth.as_ref(), bearer_token.as_deref())
+        .map(|credential| {
+            super::query_cache::remote_key(&super::query_cache::RemoteKeyInput {
+                distributed: mode == MetadataApiQueryMode::Distributed,
+                realm_id,
+                credential: &credential,
+                graph_iris: graph_iris.as_deref(),
+                sparql: &query,
+                allow_partial: scope.allow_partial,
+                target_nodes: scope.target_nodes.as_deref(),
+            })
+        })
+        .filter(|_| !scope.discovery_failed);
+    if let Some(key) = cache_key
+        && let Some(cached) = handle.query_cache().get(&key, cache_stamp, Instant::now())
+    {
+        span.record("cache", "hit");
+        span.record("result", cached.results.kind());
+        record_elapsed_ms(&span, "elapsed_ms", total_started);
+        return Ok((
+            (*cached.results).clone(),
+            super::query_cache::cached_stats(&cached),
+        ));
+    }
+    span.record("cache", "miss");
+
     let local_call: MetadataNodeCall<MetadataQueryResults> = metadata_node_call(
         (
             handle.clone(),
@@ -1971,6 +2026,19 @@ async fn run_query_distributed(
     match &result {
         Ok(results) => {
             span.record("result", results.kind());
+            if let Some(key) = cache_key
+                && super::query_cache::store_complete(
+                    handle.query_cache(),
+                    key,
+                    results,
+                    &fanout_stats,
+                    cache_stamp,
+                    handle.visibility_generation(),
+                    Instant::now(),
+                )
+            {
+                span.record("cache", "stored");
+            }
         }
         Err(_) => {
             span.record("result", "error");

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -51,6 +51,7 @@ use crate::get_realm_nodes::GetRealmNodesOperation;
 use crate::list_groups::ListGroupOperation;
 use crate::list_metadata_documents::ListMetadataDocumentsOperation;
 use crate::metadata::repository::{LIST_METADATA_PAGE_SIZE, StorageReadError};
+use crate::permission_rules::GroupPermissionRules;
 use crate::placement::resolve_shard_holders;
 use crate::s3::search_buckets::{BucketSearchHit, SearchBucketsInput, SearchBucketsOperation};
 
@@ -367,30 +368,32 @@ pub async fn list_visible_metadata_documents(
         });
     }
 
-    // Group-granular estimate: one permission probe per group, reused for every
-    // record in it, so counting never pays a per-document check. A targeted
-    // lookup skips the whole scan and reports the estimate as unknown.
+    // One rule collection (a read per distinct group) replaces the per-record
+    // permission drives; `record_visible` mirrors `can_read_record` for the
+    // same caller and record, so every later check is pure memory.
+    let auth = request
+        .auth
+        .as_ref()
+        .filter(|auth| auth.realm_id == realm_id);
+    let permissions = GroupPermissionRules::collect(
+        context,
+        auth,
+        records
+            .iter()
+            .filter(|record| record.realm_id == realm_id)
+            .map(|record| record.group_id),
+    )
+    .await;
+
     let mut total_estimate = None;
     if limit >= METADATA_ESTIMATE_MIN_LIMIT {
-        let mut group_reads = HashMap::new();
-        let mut matching = 0usize;
-        for record in &records {
-            if !metadata_record_matches_filters(record, request.path_prefix.as_deref()) {
-                continue;
-            }
-            if record.public
-                || group_read_allowed(
-                    context,
-                    realm_id,
-                    request.auth.as_ref(),
-                    record,
-                    &mut group_reads,
-                )
-                .await?
-            {
-                matching += 1;
-            }
-        }
+        let matching = records
+            .iter()
+            .filter(|record| {
+                metadata_record_matches_filters(record, request.path_prefix.as_deref())
+            })
+            .filter(|record| permissions.record_visible(record))
+            .count();
         total_estimate = Some(matching);
     }
 
@@ -401,7 +404,7 @@ pub async fn list_visible_metadata_documents(
         if !metadata_record_matches_filters(&record, request.path_prefix.as_deref()) {
             continue;
         }
-        if !can_read_record(context, realm_id, request.auth.as_ref(), &record).await? {
+        if !permissions.record_visible(&record) {
             continue;
         }
         visible_count += 1;
@@ -1211,23 +1214,6 @@ async fn can_read_record(
         Ok(allowed) => Ok(allowed),
         Err(_) => Ok(false),
     }
-}
-
-/// Probes read access once per group, using the first non-public record met
-/// there as the representative path, and reuses that answer for the group.
-async fn group_read_allowed(
-    context: &DriverContext,
-    realm_id: RealmId,
-    auth: Option<&AuthContext>,
-    record: &MetadataRegistryRecord,
-    probes: &mut HashMap<GroupId, bool>,
-) -> Result<bool, MetadataApiError> {
-    if let Some(&allowed) = probes.get(&record.group_id) {
-        return Ok(allowed);
-    }
-    let allowed = can_read_record(context, realm_id, auth, record).await?;
-    probes.insert(record.group_id, allowed);
-    Ok(allowed)
 }
 
 async fn ensure_permission(
@@ -2380,9 +2366,13 @@ mod tests {
     use std::collections::BTreeMap;
 
     use aruna_core::UserId;
+    use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::metadata::MetadataCreateEventPayload;
     use aruna_core::storage_entries::metadata_create_event_and_pending_projection_write_entries;
-    use aruna_core::structs::PlacementRef;
+    use aruna_core::structs::{
+        Actor, GroupAuthorizationDocument, PlacementRef, RealmAuthorizationDocument, Role,
+    };
+    use aruna_core::types::{Key, RoleId};
     use aruna_storage::storage;
     use tempfile::{TempDir, tempdir};
 
@@ -2688,7 +2678,7 @@ mod tests {
         assert_eq!(browse.total_estimate, Some(3));
     }
 
-    // Anonymous callers resolve no group probe, so only public records count.
+    // Anonymous callers collect no rules, so only public records count.
     #[tokio::test]
     async fn estimate_skips_private() {
         let test = metadata_test();
@@ -2710,6 +2700,231 @@ mod tests {
         assert_eq!(result.documents.len(), 1);
         assert_eq!(result.documents[0].record.document_id, readable.document_id);
         assert_eq!(result.total_estimate, Some(1));
+    }
+
+    fn auth_for(user_id: UserId) -> AuthContext {
+        AuthContext {
+            user_id,
+            realm_id: TEST_REALM_ID,
+            path_restrictions: None,
+        }
+    }
+
+    fn user_role(
+        user_id: UserId,
+        permissions: HashMap<String, Permission>,
+    ) -> HashMap<RoleId, Role> {
+        let role_id = Ulid::generate();
+        HashMap::from([(
+            role_id,
+            Role {
+                role_id,
+                name: "listing".to_string(),
+                permissions,
+                assigned_users: HashSet::from([user_id]),
+            },
+        )])
+    }
+
+    // The rules collection reads both documents; without them a group yields no
+    // rules and every non-public record in it stays hidden.
+    async fn write_auth_docs(test: &MetadataTest, group_id: GroupId, roles: HashMap<RoleId, Role>) {
+        let actor = Actor {
+            node_id: iroh::SecretKey::from_bytes(&[7u8; 32]).public(),
+            user_id: UserId::local(Ulid::generate(), TEST_REALM_ID),
+            realm_id: TEST_REALM_ID,
+        };
+        let realm_doc = RealmAuthorizationDocument::new_default_realm_doc(TEST_REALM_ID);
+        let group_doc = GroupAuthorizationDocument { group_id, roles };
+        let entries = [
+            (
+                Key::from(*TEST_REALM_ID.as_bytes()),
+                realm_doc.to_bytes(&actor).expect("realm doc encodes"),
+            ),
+            (
+                Key::from(group_id.to_bytes()),
+                group_doc.to_bytes(&actor).expect("group doc encodes"),
+            ),
+        ];
+        for (key, value) in entries {
+            match test
+                .context
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: AUTH_KEYSPACE.to_string(),
+                    key,
+                    value: value.into(),
+                    txn_id: None,
+                })
+                .await
+            {
+                Event::Storage(StorageEvent::WriteResult { .. }) => {}
+                other => panic!("unexpected write event: {other:?}"),
+            }
+        }
+    }
+
+    // A caller who holds no role in the group sees the public records only, and
+    // the counts describe the visible set rather than the scanned one.
+    #[tokio::test]
+    async fn stranger_sees_public() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        let stranger = UserId::local(Ulid::generate(), TEST_REALM_ID);
+        write_auth_docs(
+            &test,
+            group_id,
+            user_role(
+                UserId::local(Ulid::generate(), TEST_REALM_ID),
+                HashMap::from([(
+                    format!("/{TEST_REALM_ID}/g/{group_id}/**"),
+                    Permission::WRITE,
+                )]),
+            ),
+        )
+        .await;
+        let visible = public_record(group_id, Ulid::generate());
+        seed_registry_cache(&test, &visible).await;
+        for _ in 0..2 {
+            let mut hidden = public_record(group_id, Ulid::generate());
+            hidden.public = false;
+            seed_registry_cache(&test, &hidden).await;
+        }
+
+        let page = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                auth: Some(auth_for(stranger)),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(listed_ids(&page), vec![visible.document_id]);
+        assert_eq!(page.total_returned, 1);
+        assert_eq!(page.total_estimate, Some(1));
+
+        let beyond = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                offset: Some(1),
+                auth: Some(auth_for(stranger)),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert!(beyond.documents.is_empty());
+        assert_eq!(beyond.total_returned, 0);
+        assert_eq!(beyond.total_estimate, Some(1));
+    }
+
+    // An unauthenticated caller must not inherit a member's grants.
+    #[tokio::test]
+    async fn anonymous_sees_public() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        let member = UserId::local(Ulid::generate(), TEST_REALM_ID);
+        write_auth_docs(
+            &test,
+            group_id,
+            user_role(
+                member,
+                HashMap::from([(
+                    format!("/{TEST_REALM_ID}/g/{group_id}/meta/**"),
+                    Permission::READ,
+                )]),
+            ),
+        )
+        .await;
+        let visible = public_record(group_id, Ulid::generate());
+        seed_registry_cache(&test, &visible).await;
+        let mut hidden = public_record(group_id, Ulid::generate());
+        hidden.public = false;
+        seed_registry_cache(&test, &hidden).await;
+
+        let anonymous = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            summary_request(group_id, false),
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(listed_ids(&anonymous), vec![visible.document_id]);
+        assert_eq!(anonymous.total_estimate, Some(1));
+
+        let signed = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                auth: Some(auth_for(member)),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(signed.total_returned, 2);
+        assert_eq!(signed.total_estimate, Some(2));
+    }
+
+    // A per-document DENY inside a group-wide grant: the estimate must decide
+    // each document, not reuse one representative answer for the whole group.
+    #[tokio::test]
+    async fn estimate_counts_exact() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        let member = UserId::local(Ulid::generate(), TEST_REALM_ID);
+        let mut allowed = public_record(group_id, Ulid::generate());
+        allowed.public = false;
+        let mut denied = public_record(group_id, Ulid::generate());
+        denied.public = false;
+        write_auth_docs(
+            &test,
+            group_id,
+            user_role(
+                member,
+                HashMap::from([
+                    (
+                        format!("/{TEST_REALM_ID}/g/{group_id}/meta/**"),
+                        Permission::READ,
+                    ),
+                    (denied.permission_path.clone(), Permission::DENY),
+                ]),
+            ),
+        )
+        .await;
+        seed_registry_cache(&test, &allowed).await;
+        seed_registry_cache(&test, &denied).await;
+
+        let page = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                auth: Some(auth_for(member)),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(listed_ids(&page), vec![allowed.document_id]);
+        assert_eq!(page.total_estimate, Some(1));
+
+        // A targeted lookup still reports no estimate for the same caller.
+        let lookup = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                limit: Some(METADATA_ESTIMATE_MIN_LIMIT - 1),
+                auth: Some(auth_for(member)),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(lookup.total_returned, 1);
+        assert_eq!(lookup.total_estimate, None);
     }
 
     // path_prefix must scope the estimate to the same set the page came from.

--- a/operations/src/metadata/api.rs
+++ b/operations/src/metadata/api.rs
@@ -56,6 +56,15 @@ use crate::s3::search_buckets::{BucketSearchHit, SearchBucketsInput, SearchBucke
 
 const DEFAULT_LIST_METADATA_LIMIT: usize = 50;
 const MAX_LIST_METADATA_LIMIT: usize = 1_000;
+/// Bounds the response payload and the number of RO-Crate summary exports an
+/// unauthenticated caller can force per request. The realm-wide registry scan
+/// is removed by the cached list path, not by this clamp.
+const ANONYMOUS_LIST_METADATA_LIMIT: usize = 100;
+/// Splits a targeted lookup from a browse page: the portal pages at 48, a
+/// run-crate or preview lookup at 1, and only a browse page pays the estimate.
+const METADATA_ESTIMATE_MIN_LIMIT: usize = 24;
+// Bounded so a single summary page cannot saturate the craqle read permits.
+const METADATA_SUMMARY_FANOUT_LIMIT: usize = 8;
 const METADATA_REFERENCES_DEFAULT_LIMIT: usize = 25;
 const METADATA_REFERENCES_MAX_LIMIT: usize = 100;
 const METADATA_DISTRIBUTED_QUERY_FANOUT_LIMIT: usize = 8;
@@ -103,6 +112,11 @@ pub struct ListVisibleMetadataDocumentsResult {
     pub limit: usize,
     pub offset: usize,
     pub total_returned: usize,
+    /// Approximate number of documents matching the request filters across all
+    /// pages. Group-granular, so it can over- or under-count against the
+    /// glob-granular read rules. `None` when the request was too small to be a
+    /// browse page and the estimate was not computed.
+    pub total_estimate: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -299,28 +313,61 @@ pub async fn list_visible_metadata_documents(
     realm_id: RealmId,
     request: ListVisibleMetadataDocumentsRequest,
 ) -> Result<ListVisibleMetadataDocumentsResult, MetadataApiError> {
-    let limit = request
-        .limit
-        .unwrap_or(DEFAULT_LIST_METADATA_LIMIT)
-        .clamp(1, MAX_LIST_METADATA_LIMIT);
+    let limit = effective_list_limit(request.limit, request.auth.is_none());
     let offset = request.offset.unwrap_or(0);
 
-    let mut records = Vec::new();
-    let include_pending_projection = request.include_summary;
-    if let Some(group_id) = request.group_id {
-        records.extend(
-            load_group_metadata_records(context, group_id, include_pending_projection).await?,
-        );
-    } else {
-        let groups = drive(ListGroupOperation::new(), context)
+    let group_ids = match request.group_id {
+        Some(group_id) => vec![group_id],
+        None => drive(ListGroupOperation::new(), context)
             .await
-            .map_err(|error| MetadataApiError::Internal(error.to_string()))?;
-        for group in groups {
-            records.extend(
-                load_group_metadata_records(context, group.group_id, include_pending_projection)
-                    .await?,
-            );
+            .map_err(|error| MetadataApiError::Internal(error.to_string()))?
+            .into_iter()
+            .map(|group| group.group_id)
+            .collect(),
+    };
+    // Summary listings must show documents whose projection has not landed yet;
+    // the pending keyspace is scanned once per request, never once per group.
+    let mut pending = if request.include_summary {
+        load_pending_records(context, request.group_id).await?
+    } else {
+        HashMap::new()
+    };
+
+    let mut records = Vec::new();
+    for group_id in group_ids {
+        let mut group_records = load_group_records(context, group_id).await?;
+        if let Some(pending_records) = pending.remove(&group_id) {
+            merge_pending_metadata_records(&mut group_records, pending_records);
+            group_records.sort_by_key(|record| record.document_id);
         }
+        records.extend(group_records);
+    }
+
+    // Group-granular estimate: one permission probe per group, reused for every
+    // record in it, so counting never pays a per-document check. A targeted
+    // lookup skips the whole scan and reports the estimate as unknown.
+    let mut total_estimate = None;
+    if limit >= METADATA_ESTIMATE_MIN_LIMIT {
+        let mut group_reads = HashMap::new();
+        let mut matching = 0usize;
+        for record in &records {
+            if !metadata_record_matches_filters(record, request.path_prefix.as_deref()) {
+                continue;
+            }
+            if record.public
+                || group_read_allowed(
+                    context,
+                    realm_id,
+                    request.auth.as_ref(),
+                    record,
+                    &mut group_reads,
+                )
+                .await?
+            {
+                matching += 1;
+            }
+        }
+        total_estimate = Some(matching);
     }
 
     let needed = offset.saturating_add(limit);
@@ -378,6 +425,8 @@ pub async fn list_visible_metadata_documents(
         limit,
         offset,
         total_returned,
+        // Never report fewer than the page already discloses.
+        total_estimate: total_estimate.map(|estimate| estimate.max(total_returned)),
     })
 }
 
@@ -874,14 +923,24 @@ fn authorized_realm_nodes(
         .collect())
 }
 
-async fn load_group_metadata_records(
+fn effective_list_limit(requested: Option<usize>, anonymous: bool) -> usize {
+    let maximum = if anonymous {
+        ANONYMOUS_LIST_METADATA_LIMIT
+    } else {
+        MAX_LIST_METADATA_LIMIT
+    };
+    requested
+        .unwrap_or(DEFAULT_LIST_METADATA_LIMIT)
+        .clamp(1, maximum)
+}
+
+async fn load_group_records(
     context: &DriverContext,
     group_id: GroupId,
-    include_pending_projection: bool,
 ) -> Result<Vec<MetadataRegistryRecord>, MetadataApiError> {
     // Listing remains eventually consistent: the handle-owned visibility cache
     // serves stale snapshots while one refill updates the operation-owned read path.
-    if !include_pending_projection && let Some(metadata_handle) = context.metadata_handle.as_ref() {
+    if let Some(metadata_handle) = context.metadata_handle.as_ref() {
         match metadata_handle
             .list_cached_registry_records_for_group(group_id)
             .await
@@ -896,26 +955,16 @@ async fn load_group_metadata_records(
         }
     }
 
-    let mut records = drive(ListMetadataDocumentsOperation::new(group_id), context)
+    drive(ListMetadataDocumentsOperation::new(group_id), context)
         .await
-        .map_err(|err| MetadataApiError::Internal(err.to_string()))?;
-
-    if include_pending_projection {
-        merge_pending_metadata_records(
-            &mut records,
-            load_pending_group_metadata_records(context, group_id).await?,
-        );
-        records.sort_by_key(|record| record.document_id);
-    }
-
-    Ok(records)
+        .map_err(|err| MetadataApiError::Internal(err.to_string()))
 }
 
-async fn load_pending_group_metadata_records(
+async fn load_pending_records(
     context: &DriverContext,
-    group_id: GroupId,
-) -> Result<Vec<MetadataRegistryRecord>, MetadataApiError> {
-    let mut records = Vec::new();
+    group_filter: Option<GroupId>,
+) -> Result<HashMap<GroupId, Vec<MetadataRegistryRecord>>, MetadataApiError> {
+    let mut records: HashMap<GroupId, Vec<MetadataRegistryRecord>> = HashMap::new();
     let mut start_after = None;
 
     loop {
@@ -950,13 +999,13 @@ async fn load_pending_group_metadata_records(
                 continue;
             };
             let record = event.record;
-            if record.group_id != group_id {
+            if group_filter.is_some_and(|group_id| record.group_id != group_id) {
                 continue;
             }
             if metadata_graph_is_deleted(context, &record.graph_iri).await? {
                 continue;
             }
-            records.push(record);
+            records.entry(record.group_id).or_default().push(record);
         }
 
         if next_start_after.is_none() {
@@ -1138,6 +1187,23 @@ async fn can_read_record(
         Ok(allowed) => Ok(allowed),
         Err(_) => Ok(false),
     }
+}
+
+/// Probes read access once per group, using the first non-public record met
+/// there as the representative path, and reuses that answer for the group.
+async fn group_read_allowed(
+    context: &DriverContext,
+    realm_id: RealmId,
+    auth: Option<&AuthContext>,
+    record: &MetadataRegistryRecord,
+    probes: &mut HashMap<GroupId, bool>,
+) -> Result<bool, MetadataApiError> {
+    if let Some(&allowed) = probes.get(&record.group_id) {
+        return Ok(allowed);
+    }
+    let allowed = can_read_record(context, realm_id, auth, record).await?;
+    probes.insert(record.group_id, allowed);
+    Ok(allowed)
 }
 
 async fn ensure_permission(
@@ -1903,7 +1969,7 @@ fn record_search_node_result(
 #[tracing::instrument(
     name = "metadata.operation.query_distributed",
     level = "debug",
-    skip(context, auth, query, scope),
+    skip(context, auth, bearer_token, query, scope),
     fields(
         mode = ?scope.mode,
         query_len = query.len() as u64,
@@ -1912,6 +1978,7 @@ fn record_search_node_result(
         discovery_ms = field::Empty,
         elapsed_ms = field::Empty,
         result = field::Empty,
+        cache = field::Empty,
     )
 )]
 #[allow(clippy::too_many_arguments)]
@@ -2050,7 +2117,7 @@ async fn run_query_distributed(
 #[tracing::instrument(
     name = "metadata.operation.search_distributed",
     level = "debug",
-    skip(context, auth, query, resume, watermark, scope),
+    skip(context, auth, bearer_token, query, resume, watermark, scope),
     fields(
         mode = ?scope.mode,
         query_len = query.len() as u64,
@@ -2288,8 +2355,364 @@ mod tests {
 
     use std::collections::BTreeMap;
 
+    use aruna_core::UserId;
+    use aruna_core::metadata::MetadataCreateEventPayload;
+    use aruna_core::storage_entries::metadata_create_event_and_pending_projection_write_entries;
+    use aruna_core::structs::PlacementRef;
     use aruna_storage::storage;
-    use tempfile::tempdir;
+    use tempfile::{TempDir, tempdir};
+
+    use crate::metadata::MetadataHandle;
+
+    const TEST_REALM_ID: RealmId = RealmId([7u8; 32]);
+
+    struct MetadataTest {
+        context: DriverContext,
+        _storage_dir: TempDir,
+        _metadata_dir: TempDir,
+    }
+
+    fn metadata_test() -> MetadataTest {
+        let storage_dir = tempdir().expect("storage dir");
+        let metadata_dir = tempdir().expect("metadata dir");
+        let storage_handle =
+            storage::FjallStorage::open(storage_dir.path().to_str().expect("storage path"))
+                .expect("storage opens");
+        let metadata_handle = MetadataHandle::new(
+            metadata_dir.path(),
+            iroh::SecretKey::from_bytes(&[7u8; 32]).public(),
+            storage_handle.clone(),
+            None,
+            None,
+            None,
+        )
+        .expect("metadata handle");
+        MetadataTest {
+            context: DriverContext {
+                storage_handle,
+                net_handle: None,
+                blob_handle: None,
+                metadata_handle: Some(metadata_handle),
+                task_handle: None,
+                compute_handle: None,
+            },
+            _storage_dir: storage_dir,
+            _metadata_dir: metadata_dir,
+        }
+    }
+
+    fn public_record(group_id: GroupId, document_id: Ulid) -> MetadataRegistryRecord {
+        MetadataRegistryRecord {
+            realm_id: TEST_REALM_ID,
+            group_id,
+            document_id,
+            document_path: "datasets/cached".to_string(),
+            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+            public: true,
+            permission_path: MetadataRegistryRecord::permission_path_for(
+                &TEST_REALM_ID,
+                group_id,
+                "datasets/cached",
+                document_id,
+            ),
+            placement: PlacementRef::NIL,
+            holder_node_ids: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            last_event_id: Ulid::generate(),
+        }
+    }
+
+    fn summary_request(
+        group_id: GroupId,
+        include_summary: bool,
+    ) -> ListVisibleMetadataDocumentsRequest {
+        ListVisibleMetadataDocumentsRequest {
+            group_id: Some(group_id),
+            path_prefix: None,
+            include_summary,
+            limit: None,
+            offset: None,
+            auth: None,
+        }
+    }
+
+    // The visibility cache only accepts upserts once it has been filled.
+    async fn seed_registry_cache(test: &MetadataTest, record: &MetadataRegistryRecord) {
+        let handle = test
+            .context
+            .metadata_handle
+            .as_ref()
+            .expect("metadata handle");
+        handle
+            .list_cached_registry_records_for_group(record.group_id)
+            .await
+            .expect("registry cache fills");
+        handle.upsert_cached_registry_record(record.clone());
+    }
+
+    async fn write_pending_marker(test: &MetadataTest, record: &MetadataRegistryRecord) {
+        let event = MetadataCreateEventRecord {
+            event_id: record.last_event_id,
+            record: record.clone(),
+            user_id: UserId::local(Ulid::generate(), TEST_REALM_ID),
+            node_id: iroh::SecretKey::from_bytes(&[7u8; 32]).public(),
+            payload: MetadataCreateEventPayload::Scaffold {
+                name: "Pending".to_string(),
+                description: "Projection in flight".to_string(),
+                date_published: "2026-01-01".to_string(),
+                license: None,
+            },
+            occurred_at_ms: 1,
+        };
+        for (key_space, key, value) in
+            metadata_create_event_and_pending_projection_write_entries(&event)
+                .expect("event encodes")
+        {
+            match test
+                .context
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space,
+                    key,
+                    value,
+                    txn_id: None,
+                })
+                .await
+            {
+                Event::Storage(StorageEvent::WriteResult { .. }) => {}
+                other => panic!("unexpected write event: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn anonymous_limit_clamped() {
+        assert_eq!(
+            effective_list_limit(None, true),
+            DEFAULT_LIST_METADATA_LIMIT
+        );
+        assert_eq!(
+            effective_list_limit(Some(MAX_LIST_METADATA_LIMIT), true),
+            ANONYMOUS_LIST_METADATA_LIMIT
+        );
+        assert_eq!(
+            effective_list_limit(Some(MAX_LIST_METADATA_LIMIT), false),
+            MAX_LIST_METADATA_LIMIT
+        );
+        assert_eq!(
+            effective_list_limit(Some(usize::MAX), false),
+            MAX_LIST_METADATA_LIMIT
+        );
+        assert_eq!(effective_list_limit(Some(0), true), 1);
+    }
+
+    // The record lives only in the registry cache and the graph was never
+    // projected, so a returned summary can only come from the summary cache.
+    #[tokio::test]
+    async fn summary_from_cache() {
+        let test = metadata_test();
+        let record = public_record(Ulid::generate(), Ulid::generate());
+        seed_registry_cache(&test, &record).await;
+        summary_cache().insert(
+            &record.graph_iri,
+            record.last_event_id,
+            "{\"cached\":true}",
+            Instant::now(),
+        );
+
+        let result = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            summary_request(record.group_id, true),
+        )
+        .await
+        .expect("summary listing succeeds");
+
+        assert_eq!(result.documents.len(), 1);
+        assert_eq!(
+            result.documents[0].rocrate_summary_jsonld.as_deref(),
+            Some("{\"cached\":true}")
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_summary_refused() {
+        // A cursor advance must fall through to the handle, not serve the entry.
+        let test = metadata_test();
+        let record = public_record(Ulid::generate(), Ulid::generate());
+        seed_registry_cache(&test, &record).await;
+        summary_cache().insert(
+            &record.graph_iri,
+            Ulid::generate(),
+            "{\"stale\":true}",
+            Instant::now(),
+        );
+
+        let result = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            summary_request(record.group_id, true),
+        )
+        .await
+        .expect("summary listing succeeds");
+
+        assert_eq!(result.documents.len(), 1);
+        assert!(result.documents[0].rocrate_summary_jsonld.is_none());
+    }
+
+    #[tokio::test]
+    async fn pending_summary_listed() {
+        let test = metadata_test();
+        let record = public_record(Ulid::generate(), Ulid::generate());
+        write_pending_marker(&test, &record).await;
+
+        let result = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            summary_request(record.group_id, true),
+        )
+        .await
+        .expect("summary listing succeeds");
+        assert_eq!(result.documents.len(), 1);
+        assert_eq!(result.documents[0].record.document_id, record.document_id);
+        assert!(result.documents[0].rocrate_summary_jsonld.is_none());
+
+        let plain = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            summary_request(record.group_id, false),
+        )
+        .await
+        .expect("plain listing succeeds");
+        assert!(plain.documents.is_empty());
+    }
+
+    // The page window must not truncate the estimate, and paging must not move it.
+    #[tokio::test]
+    async fn estimate_beyond_page() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        let seeded = METADATA_ESTIMATE_MIN_LIMIT + 2;
+        for _ in 0..seeded {
+            seed_registry_cache(&test, &public_record(group_id, Ulid::generate())).await;
+        }
+
+        let page = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                limit: Some(METADATA_ESTIMATE_MIN_LIMIT),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(page.documents.len(), METADATA_ESTIMATE_MIN_LIMIT);
+        assert_eq!(page.total_returned, METADATA_ESTIMATE_MIN_LIMIT);
+        assert_eq!(page.total_estimate, Some(seeded));
+
+        let tail = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                limit: Some(METADATA_ESTIMATE_MIN_LIMIT),
+                offset: Some(seeded - 1),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(tail.documents.len(), 1);
+        assert_eq!(tail.total_estimate, Some(seeded));
+    }
+
+    // A targeted lookup must not pay for the realm-wide estimate scan, and
+    // must report the estimate as absent rather than as a truncated count.
+    #[tokio::test]
+    async fn lookup_omits_estimate() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        for _ in 0..3 {
+            seed_registry_cache(&test, &public_record(group_id, Ulid::generate())).await;
+        }
+
+        let lookup = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                limit: Some(METADATA_ESTIMATE_MIN_LIMIT - 1),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(lookup.total_returned, 3);
+        assert_eq!(lookup.total_estimate, None);
+
+        let browse = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                limit: Some(METADATA_ESTIMATE_MIN_LIMIT),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+        assert_eq!(browse.total_estimate, Some(3));
+    }
+
+    // Anonymous callers resolve no group probe, so only public records count.
+    #[tokio::test]
+    async fn estimate_skips_private() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        let readable = public_record(group_id, Ulid::generate());
+        seed_registry_cache(&test, &readable).await;
+        let mut private = public_record(group_id, Ulid::generate());
+        private.public = false;
+        seed_registry_cache(&test, &private).await;
+
+        let result = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            summary_request(group_id, false),
+        )
+        .await
+        .expect("listing succeeds");
+
+        assert_eq!(result.documents.len(), 1);
+        assert_eq!(result.documents[0].record.document_id, readable.document_id);
+        assert_eq!(result.total_estimate, Some(1));
+    }
+
+    // path_prefix must scope the estimate to the same set the page came from.
+    #[tokio::test]
+    async fn estimate_honours_prefix() {
+        let test = metadata_test();
+        let group_id = Ulid::generate();
+        for _ in 0..2 {
+            seed_registry_cache(&test, &public_record(group_id, Ulid::generate())).await;
+        }
+        let mut other = public_record(group_id, Ulid::generate());
+        other.document_path = "other/excluded".to_string();
+        seed_registry_cache(&test, &other).await;
+
+        let result = list_visible_metadata_documents(
+            &test.context,
+            TEST_REALM_ID,
+            ListVisibleMetadataDocumentsRequest {
+                path_prefix: Some("datasets".to_string()),
+                ..summary_request(group_id, false)
+            },
+        )
+        .await
+        .expect("listing succeeds");
+
+        assert_eq!(result.total_returned, 2);
+        assert_eq!(result.total_estimate, Some(2));
+    }
 
     #[test]
     fn deduplicates_select_rows_from_multiple_nodes() {

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -85,6 +85,10 @@ const SYNC_MIRROR_REQUEST_TIMEOUT: Duration =
 const METADATA_GRAPH_SYNC_ATTEMPTS: usize = 3;
 const METADATA_GRAPH_SYNC_RETRY_AFTER: Duration = Duration::from_millis(250);
 const SLOW_METADATA_BACKEND_THRESHOLD: Duration = Duration::from_millis(100);
+// Craqle rebuilds a describe context per hit and Aruna maps one document per
+// graph, so search enrichment overlaps instead of memoizing; the craqle read
+// semaphore, not this task cap, is the real concurrency limit.
+const METADATA_ENRICH_TASKS: usize = 8;
 pub(crate) const METADATA_QUERY_MAX_BYTES: usize = 64 * 1024;
 pub(crate) const METADATA_QUERY_MAX_ROWS: usize = 10_000;
 pub(crate) const METADATA_QUERY_MAX_RESULT_BYTES: usize = 8 * 1024 * 1024;
@@ -812,17 +816,7 @@ impl MetadataHandle {
             let authorizer = AllowedGraphAuthorizer {
                 graph_iris: HashSet::from([graph_iri.clone()]),
             };
-            inner
-                .node
-                .describe_subject(
-                    &authorizer,
-                    DescribeRequest {
-                        graph: &GraphId::new(&graph_iri),
-                        subject_id: &graph_iri,
-                    },
-                )
-                .map(decode_hit_properties)
-                .unwrap_or_default()
+            describe_hit_properties(&inner.node, &authorizer, &graph_iri, &graph_iri)
         })
         .await
         .unwrap_or_default()
@@ -4931,62 +4925,69 @@ async fn search_realm_scope(
         result = field::Empty,
         hit_count = field::Empty,
     );
-    let blocking_span = search_span.clone();
     let search_started = Instant::now();
-    let _permit = inner.craqle_read_permits.clone().acquire_owned().await.ok();
-    let result = match tokio::task::spawn_blocking(move || {
-        blocking_span.in_scope(|| search_visible_scope(&inner, &scope, &query, limit))
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(error) => Err(MetadataError::TaskJoin(error.to_string())),
-    };
+    let result = search_visible_scope(&inner, Arc::new(scope), query, limit, &search_span).await;
     record_backend_search(span, &search_span, search_started, &result);
     result
 }
 
 // Craqle post-filters the index hits it returns through the request's already
 // resolved scope, so the work scales with the page instead of the realm.
-fn search_visible_scope(
-    inner: &MetadataInner,
-    scope: &GraphVisibilityScope,
-    query: &str,
+async fn search_visible_scope(
+    inner: &Arc<MetadataInner>,
+    scope: Arc<GraphVisibilityScope>,
+    query: String,
     limit: usize,
+    search_span: &Span,
 ) -> Result<Vec<MetadataSearchHit>, MetadataError> {
-    let authorizer = ScopeAuthorizer {
-        scope,
-        visibility_cache: &inner.visibility_cache,
+    let describe = scope_hit_describe(inner, &scope);
+    let mut hits = {
+        let task_inner = inner.clone();
+        let task_scope = scope.clone();
+        let task_query = query.clone();
+        let blocking_span = search_span.clone();
+        let _permit = inner.craqle_read_permits.clone().acquire_owned().await.ok();
+        tokio::task::spawn_blocking(move || {
+            blocking_span.in_scope(|| {
+                let authorizer = ScopeAuthorizer {
+                    scope: &task_scope,
+                    visibility_cache: &task_inner.visibility_cache,
+                };
+                task_inner
+                    .node
+                    .search(
+                        &authorizer,
+                        SearchRequest {
+                            query: &task_query,
+                            limit,
+                        },
+                    )
+                    .map_err(|error| MetadataError::Backend(error.to_string()))
+            })
+        })
+        .await
+        .map_err(|error| MetadataError::TaskJoin(error.to_string()))??
     };
-    let hits = inner
-        .node
-        .search(&authorizer, SearchRequest { query, limit })
-        .map_err(|error| MetadataError::Backend(error.to_string()))?;
-    let mut visible = Vec::with_capacity(hits.len().min(limit));
-    for hit in hits {
-        let Some(record) = scope.record_for_graph(&hit.graph_id) else {
-            continue;
-        };
-        // Enrichment is best-effort: a pending or raced projection must never
-        // fail the search, so fall back to an empty property set.
-        let properties = inner
-            .node
-            .describe_subject(
-                &authorizer,
-                DescribeRequest {
-                    graph: &GraphId::new(&hit.graph_id),
-                    subject_id: &hit.subject_iri,
-                },
-            )
-            .map(decode_hit_properties)
-            .unwrap_or_default();
-        visible.push(metadata_search_hit_from_craqle(
-            hit,
-            record,
-            &properties,
-            query,
-        ));
-    }
+    hits.retain(|hit| scope.record_for_graph(&hit.graph_id).is_some());
+    let targets = hits
+        .iter()
+        .map(|hit| (hit.graph_id.clone(), hit.subject_iri.clone()))
+        .collect::<Vec<_>>();
+    let properties =
+        describe_hits_parallel(&inner.craqle_read_permits, targets, describe, search_span).await;
+    let mut visible = hits
+        .into_iter()
+        .zip(properties)
+        .filter_map(|(hit, properties)| {
+            let record = scope.record_for_graph(&hit.graph_id)?;
+            Some(metadata_search_hit_from_craqle(
+                hit,
+                record,
+                &properties,
+                &query,
+            ))
+        })
+        .collect::<Vec<_>>();
     // The unfiltered entry point returns raw index order; the search cursor's
     // watermark needs the merged score-descending order instead.
     visible.sort_by(compare_hits);
@@ -5048,53 +5049,43 @@ async fn search_candidate_graphs(
             .iter()
             .map(|record| record.graph_iri.clone())
             .collect::<HashSet<_>>();
-        let _permit = inner.craqle_read_permits.clone().acquire_owned().await.ok();
-        let hits = match tokio::task::spawn_blocking(move || {
-            let authorizer = AllowedGraphAuthorizer {
+        let describe = allowed_hit_describe(
+            &inner,
+            Arc::new(AllowedGraphAuthorizer {
                 graph_iris: allowed_graphs,
-            };
-            let mut hits = allowed_records
-                .into_iter()
-                .filter_map(|record| {
-                    let subject_iri = matches.get(&record.document_id)?.first()?.clone();
-                    let properties = inner
-                        .node
-                        .describe_subject(
-                            &authorizer,
-                            DescribeRequest {
-                                graph: &GraphId::new(&record.graph_iri),
-                                subject_id: &subject_iri,
-                            },
-                        )
-                        .map(decode_hit_properties)
-                        .unwrap_or_default();
-                    let title = super::search_enrichment::hit_title(
-                        &properties,
-                        &record.document_path,
-                        &subject_iri,
-                    );
-                    Some(MetadataSearchHit {
-                        document_id: record.document_id.to_string(),
-                        group_id: record.group_id.to_string(),
-                        document_path: record.document_path,
-                        graph_iri: record.graph_iri,
-                        subject_iri,
-                        score: 1.0,
-                        title,
-                        snippet: None,
-                    })
-                })
-                .collect::<Vec<_>>();
-            hits.sort_by(|left, right| left.document_id.cmp(&right.document_id));
-            hits.truncate(limit);
-            hits
-        })
-        .await
-        {
-            Ok(hits) => hits,
-            Err(error) => return Err(MetadataError::TaskJoin(error.to_string())),
-        };
-        return Ok(hits);
+            }),
+        );
+        // The page is ordered by document id alone, so it is cut before the
+        // describes instead of enriching every candidate.
+        let mut candidates = allowed_records
+            .into_iter()
+            .filter_map(|record| {
+                let subject_iri = matches.get(&record.document_id)?.first()?.clone();
+                Some((record, subject_iri))
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by_key(|(record, _)| record.document_id);
+        candidates.truncate(limit);
+        let targets = candidates
+            .iter()
+            .map(|(record, subject_iri)| (record.graph_iri.clone(), subject_iri.clone()))
+            .collect::<Vec<_>>();
+        let properties =
+            describe_hits_parallel(&inner.craqle_read_permits, targets, describe, span).await;
+        return Ok(candidates
+            .into_iter()
+            .zip(properties)
+            .map(|((record, subject_iri), properties)| MetadataSearchHit {
+                document_id: record.document_id.to_string(),
+                group_id: record.group_id.to_string(),
+                title: hit_title(&properties, &record.document_path, &subject_iri),
+                document_path: record.document_path,
+                graph_iri: record.graph_iri,
+                subject_iri,
+                score: 1.0,
+                snippet: None,
+            })
+            .collect());
     }
 
     let by_graph: HashMap<_, _> = allowed_records
@@ -5116,63 +5107,176 @@ async fn search_candidate_graphs(
         result = field::Empty,
         hit_count = field::Empty,
     );
-    let blocking_span = search_span.clone();
     let search_started = Instant::now();
-    let _permit = inner.craqle_read_permits.clone().acquire_owned().await.ok();
-    let result = match tokio::task::spawn_blocking(move || {
-        blocking_span.in_scope(|| {
-            let authorizer = AllowedGraphAuthorizer {
-                graph_iris: allowed_graphs,
-            };
-            let hits = inner
-                .node
-                .search_graphs(
-                    &authorizer,
-                    GraphSearchRequest {
-                        graphs: &graph_ids,
-                        query: &query,
-                        limit,
-                    },
-                )
-                .map_err(|error| MetadataError::Backend(error.to_string()))?;
-            let mut visible = Vec::with_capacity(hits.len().min(limit));
-            for hit in hits {
-                let Some(record) = by_graph.get(&hit.graph_id) else {
-                    continue;
-                };
-                // Enrichment is best-effort: a pending or raced projection must
-                // never fail the search, so fall back to an empty property set.
-                let properties = inner
-                    .node
-                    .describe_subject(
-                        &authorizer,
-                        DescribeRequest {
-                            graph: &GraphId::new(&hit.graph_id),
-                            subject_id: &hit.subject_iri,
-                        },
-                    )
-                    .map(decode_hit_properties)
-                    .unwrap_or_default();
-                visible.push(metadata_search_hit_from_craqle(
-                    hit,
-                    record,
-                    &properties,
-                    &query,
-                ));
-                if visible.len() >= limit {
-                    break;
-                }
-            }
-            Ok(visible)
-        })
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(error) => Err(MetadataError::TaskJoin(error.to_string())),
-    };
+    let authorizer = Arc::new(AllowedGraphAuthorizer {
+        graph_iris: allowed_graphs,
+    });
+    let result = search_allowed_graphs(
+        &inner,
+        authorizer,
+        by_graph,
+        graph_ids,
+        &query,
+        limit,
+        &search_span,
+    )
+    .await;
     record_backend_search(span, &search_span, search_started, &result);
     result
+}
+
+async fn search_allowed_graphs(
+    inner: &Arc<MetadataInner>,
+    authorizer: Arc<AllowedGraphAuthorizer>,
+    by_graph: HashMap<String, MetadataRegistryRecord>,
+    graph_ids: Vec<GraphId>,
+    query: &str,
+    limit: usize,
+    search_span: &Span,
+) -> Result<Vec<MetadataSearchHit>, MetadataError> {
+    let describe = allowed_hit_describe(inner, authorizer.clone());
+    let hits = {
+        let task_inner = inner.clone();
+        let task_query = query.to_string();
+        let blocking_span = search_span.clone();
+        let _permit = inner.craqle_read_permits.clone().acquire_owned().await.ok();
+        tokio::task::spawn_blocking(move || {
+            blocking_span.in_scope(|| {
+                task_inner
+                    .node
+                    .search_graphs(
+                        authorizer.as_ref(),
+                        GraphSearchRequest {
+                            graphs: &graph_ids,
+                            query: &task_query,
+                            limit,
+                        },
+                    )
+                    .map_err(|error| MetadataError::Backend(error.to_string()))
+            })
+        })
+        .await
+        .map_err(|error| MetadataError::TaskJoin(error.to_string()))??
+    };
+    let hits = hits
+        .into_iter()
+        .filter(|hit| by_graph.contains_key(&hit.graph_id))
+        .take(limit)
+        .collect::<Vec<_>>();
+    let targets = hits
+        .iter()
+        .map(|hit| (hit.graph_id.clone(), hit.subject_iri.clone()))
+        .collect::<Vec<_>>();
+    let properties =
+        describe_hits_parallel(&inner.craqle_read_permits, targets, describe, search_span).await;
+    Ok(hits
+        .into_iter()
+        .zip(properties)
+        .filter_map(|(hit, properties)| {
+            let record = by_graph.get(&hit.graph_id)?;
+            Some(metadata_search_hit_from_craqle(
+                hit,
+                record,
+                &properties,
+                query,
+            ))
+        })
+        .collect())
+}
+
+/// Describes one hit's `(graph_iri, subject_iri)` against a fixed authorizer.
+type HitDescribe = Arc<dyn Fn(&str, &str) -> Vec<(String, Term)> + Send + Sync>;
+
+/// Enriches hits in parallel, one blocking task per chunk of `targets`.
+///
+/// The returned properties align with `targets` by index: chunks stay
+/// contiguous and are concatenated in chunk order, so hit order never depends
+/// on which task finished first.
+async fn describe_hits_parallel(
+    read_permits: &Arc<tokio::sync::Semaphore>,
+    targets: Vec<(String, String)>,
+    describe: HitDescribe,
+    span: &Span,
+) -> Vec<Vec<(String, Term)>> {
+    if targets.is_empty() {
+        return Vec::new();
+    }
+    let chunk_size = targets.len().div_ceil(METADATA_ENRICH_TASKS);
+    let tasks = targets
+        .chunks(chunk_size)
+        .map(<[(String, String)]>::to_vec)
+        .map(|chunk| {
+            let permits = read_permits.clone();
+            let describe = describe.clone();
+            let span = span.clone();
+            async move {
+                let chunk_len = chunk.len();
+                let _permit = permits.acquire_owned().await.ok();
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(|| {
+                        chunk
+                            .iter()
+                            .map(|(graph_iri, subject_iri)| describe(graph_iri, subject_iri))
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .await
+                .unwrap_or_else(|error| {
+                    warn!(%error, "metadata search enrichment task failed");
+                    vec![Vec::new(); chunk_len]
+                })
+            }
+        })
+        .collect::<Vec<_>>();
+    futures_util::future::join_all(tasks)
+        .await
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+fn scope_hit_describe(
+    inner: &Arc<MetadataInner>,
+    scope: &Arc<GraphVisibilityScope>,
+) -> HitDescribe {
+    let inner = inner.clone();
+    let scope = scope.clone();
+    Arc::new(move |graph_iri, subject_iri| {
+        let authorizer = ScopeAuthorizer {
+            scope: &scope,
+            visibility_cache: &inner.visibility_cache,
+        };
+        describe_hit_properties(&inner.node, &authorizer, graph_iri, subject_iri)
+    })
+}
+
+fn allowed_hit_describe(
+    inner: &Arc<MetadataInner>,
+    authorizer: Arc<AllowedGraphAuthorizer>,
+) -> HitDescribe {
+    let inner = inner.clone();
+    Arc::new(move |graph_iri, subject_iri| {
+        describe_hit_properties(&inner.node, authorizer.as_ref(), graph_iri, subject_iri)
+    })
+}
+
+// Enrichment is best-effort: a pending or raced projection must never fail the
+// search, so fall back to an empty property set.
+fn describe_hit_properties(
+    node: &CraqleNode,
+    authorizer: &dyn CraqleAuthorizer,
+    graph_iri: &str,
+    subject_iri: &str,
+) -> Vec<(String, Term)> {
+    node.describe_subject(
+        authorizer,
+        DescribeRequest {
+            graph: &GraphId::new(graph_iri),
+            subject_id: subject_iri,
+        },
+    )
+    .map(decode_hit_properties)
+    .unwrap_or_default()
 }
 
 fn clamp_remote_search_graph_limit(limit: usize) -> usize {
@@ -6788,6 +6892,56 @@ mod tests {
             &authorizer,
             &MetadataRegistryRecord::graph_iri_for(Ulid::generate())
         ));
+    }
+
+    #[tokio::test]
+    async fn enrichment_keeps_order() {
+        // The gate forces the describes to complete in exactly reverse order;
+        // the properties must still line up with the targets that asked for them.
+        let count = METADATA_ENRICH_TASKS;
+        let gate = Arc::new((Mutex::new(count - 1), std::sync::Condvar::new()));
+        let describe_gate = gate.clone();
+        let describe: HitDescribe = Arc::new(move |_graph_iri, subject_iri: &str| {
+            let index = subject_iri
+                .rsplit('/')
+                .next()
+                .and_then(|tail| tail.parse::<usize>().ok())
+                .expect("indexed subject");
+            let (turn, ready) = &*describe_gate;
+            let mut turn = turn.lock().expect("gate lock");
+            // Bounded so a lost wakeup fails the assertion instead of hanging.
+            while *turn != index {
+                let (guard, wait) = ready
+                    .wait_timeout(turn, Duration::from_secs(30))
+                    .expect("gate lock");
+                turn = guard;
+                if wait.timed_out() {
+                    break;
+                }
+            }
+            *turn = index.wrapping_sub(1);
+            ready.notify_all();
+            vec![(
+                "urn:test:index".to_string(),
+                Term::Literal(Literal::new_simple_literal(index.to_string())),
+            )]
+        });
+
+        let targets = (0..count)
+            .map(|index| ("urn:graph".to_string(), format!("urn:subject/{index}")))
+            .collect::<Vec<_>>();
+        let permits = Arc::new(tokio::sync::Semaphore::new(count));
+        let properties = describe_hits_parallel(&permits, targets, describe, &Span::none()).await;
+
+        let expected = (0..count)
+            .map(|index| {
+                vec![(
+                    "urn:test:index".to_string(),
+                    Term::Literal(Literal::new_simple_literal(index.to_string())),
+                )]
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(properties, expected);
     }
 
     fn scope_for(

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -54,16 +54,20 @@ use super::protocol::{
     MetadataAuthToken, MetadataTransportMessage, encode_message, read_message,
     write_encoded_message, write_message,
 };
+use super::query_cache::{
+    CachedQuery, LocalScopeKind, MetadataQueryCache, ScopeDigest, graphs_digest, local_key,
+};
 use super::repository::{REGISTRY_FILL_PAGE_SIZE, iter_all_registry_effect, parse_registry_iter};
 use super::search_cursor::METADATA_SEARCH_MAX_PAGINATION_DEPTH;
 use super::search_enrichment::{hit_snippet, hit_title};
+use super::summary_cache::summary_cache;
 use crate::auth::{
     ArunaBearerTokenError, ArunaBearerTokenValidationState, IssuerKeyCache,
     validate_aruna_bearer_token,
 };
 use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::driver::{DriverContext, drive};
-use crate::list_groups::ListGroupOperation;
+use crate::permission_rules::GroupPermissionRules;
 use crate::realm_peer::{RealmPeerError, ensure_realm_peer};
 use crate::s3::create_bucket::{CreateBucketError, CreateBucketOperation};
 use crate::s3::get_bucket_info::{GetBucketInfoError, GetBucketInfoOperation};
@@ -249,6 +253,7 @@ struct MetadataInner {
     document_sync_db: Option<fjall::OptimisticTxDatabase>,
     document_sync_persist_policy: FjallPersistPolicy,
     visibility_cache: MetadataVisibilityCache,
+    query_cache: MetadataQueryCache,
     craqle_permits: Arc<tokio::sync::Semaphore>,
     craqle_read_permits: Arc<tokio::sync::Semaphore>,
     deferred_persist_requested: AtomicBool,
@@ -734,6 +739,7 @@ impl MetadataHandle {
                 document_sync_db,
                 document_sync_persist_policy: metadata_options.document_sync_persist_policy,
                 visibility_cache: MetadataVisibilityCache::new(),
+                query_cache: MetadataQueryCache::new(),
                 craqle_permits: Arc::new(tokio::sync::Semaphore::new(pool_size)),
                 craqle_read_permits: Arc::new(tokio::sync::Semaphore::new(pool_size)),
                 deferred_persist_requested: AtomicBool::new(false),
@@ -824,6 +830,14 @@ impl MetadataHandle {
         })
         .await
         .unwrap_or_default()
+    }
+
+    pub(super) fn query_cache(&self) -> &MetadataQueryCache {
+        &self.inner.query_cache
+    }
+
+    pub(super) fn visibility_generation(&self) -> u64 {
+        self.inner.visibility_cache.current_generation()
     }
 
     /// Test hook: marks all visibility cache entries as expired so the next
@@ -990,7 +1004,8 @@ impl MetadataHandle {
                 let started = Instant::now();
                 // Heavy mutations and cheap reads queue on separate pools so
                 // trivial reads never wait behind long materializations.
-                let permits = if metadata_effect_mutates_graph(&other) {
+                let mutates_graph = metadata_effect_mutates_graph(&other);
+                let permits = if mutates_graph {
                     self.inner.craqle_permits.clone()
                 } else {
                     self.inner.craqle_read_permits.clone()
@@ -1012,6 +1027,12 @@ impl MetadataHandle {
                 };
                 record_elapsed_ms(&span, "elapsed_ms", started);
                 span.record("result", metadata_event_kind(&metadata_event));
+                // WAL-replayed applies skip the lifecycle read and never touch
+                // the visibility generation, so cached results are only
+                // invalidated by this counter.
+                if mutates_graph && !matches!(metadata_event, MetadataEvent::Error { .. }) {
+                    self.inner.query_cache.bump_apply();
+                }
                 Event::Metadata(metadata_event)
             }
         }
@@ -1019,10 +1040,20 @@ impl MetadataHandle {
 
     pub async fn reconcile_document_sync(&self) -> Result<usize, MetadataError> {
         let inner = self.inner.clone();
-        tokio::task::spawn_blocking(move || inner.node.reconcile_irokle())
+        let applied = tokio::task::spawn_blocking(move || inner.node.reconcile_irokle())
             .await
             .map_err(|error| MetadataError::TaskJoin(error.to_string()))?
-            .map_err(|error| MetadataError::Backend(error.to_string()))
+            .map_err(|error| MetadataError::Backend(error.to_string()))?;
+        // Peer document sync writes graphs without emitting an effect, so each
+        // graph the pass touched drops its summary, which may be keyed on a
+        // cursor that already led the content those records just landed.
+        if !applied.is_empty() {
+            self.inner.query_cache.bump_apply();
+            for graph in &applied {
+                summary_cache().remove(graph.as_str());
+            }
+        }
+        Ok(applied.len())
     }
 
     pub async fn prune_graph_if_deleted(&self, graph_iri: String) -> Result<bool, MetadataError> {
@@ -4327,6 +4358,7 @@ async fn warn_unprojected_graphs(inner: Arc<MetadataInner>, records: &[MetadataR
         result = field::Empty,
         row_count = field::Empty,
         triple_count = field::Empty,
+        cache = field::Empty,
     )
 )]
 async fn query_local_graphs(
@@ -4338,6 +4370,11 @@ async fn query_local_graphs(
     let span = Span::current();
     let total_started = Instant::now();
     let query = parse_metadata_query(&sparql)?;
+    // Stamped before any read so a mutation racing this query invalidates the
+    // entry it stores.
+    let cache_stamp = inner
+        .query_cache
+        .stamp(inner.visibility_cache.current_generation());
 
     let records = list_registry_records_for_local_read(inner.clone(), &span).await?;
 
@@ -4366,10 +4403,32 @@ async fn query_local_graphs(
             false
         }
         LocalReadScope::Lazy(scope) => {
-            span.record("readable_groups", scope.readable_groups.len() as u64);
+            span.record("readable_groups", scope.permissions.group_count() as u64);
             true
         }
     };
+
+    let cache_key = match &scope {
+        LocalReadScope::Eager(allowed) => {
+            local_key(LocalScopeKind::Eager, &graphs_digest(allowed), &sparql)
+        }
+        LocalReadScope::Lazy(scope) => local_key(
+            LocalScopeKind::Lazy,
+            &scope.visible_digest(&inner.visibility_cache),
+            &sparql,
+        ),
+    };
+    if let Some(cached) = inner
+        .query_cache
+        .get(&cache_key, cache_stamp, Instant::now())
+    {
+        span.record("cache", "hit");
+        span.record("result", cached.results.kind());
+        record_metadata_query_result_counts(&span, &cached.results);
+        record_elapsed_ms(&span, "elapsed_ms", total_started);
+        return Ok((*cached.results).clone());
+    }
+    span.record("cache", "miss");
 
     let query_span = debug_span!(
         "metadata.backend.craqle.query_graphs",
@@ -4385,6 +4444,7 @@ async fn query_local_graphs(
         query_span.record("graph_count", allowed.len() as u64);
     }
     let blocking_span = query_span.clone();
+    let cache_inner = inner.clone();
     let query_started = Instant::now();
     // Queries are reads: take from the read pool so they never queue behind
     // long-running materializations holding the mutation permits.
@@ -4430,6 +4490,19 @@ async fn query_local_graphs(
             span.record("result", results.kind());
             record_metadata_query_result_counts(&query_span, results);
             record_metadata_query_result_counts(&span, results);
+            let stored = cache_inner.query_cache.insert(
+                cache_key,
+                CachedQuery {
+                    results: Arc::new(results.clone()),
+                    nodes_queried: 0,
+                },
+                cache_stamp,
+                cache_inner.visibility_cache.current_generation(),
+                Instant::now(),
+            );
+            if stored {
+                span.record("cache", "stored");
+            }
         }
         Err(error) => {
             record_error(&query_span, &error.to_string());

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -36,8 +36,8 @@ use craqle::{
     Action as CraqleAction, ActorId, AllowAllAuthorizer, AuthorizationError as CraqleAuthError,
     Authorizer as CraqleAuthorizer, Batch, CraqleError, CraqleFjallPersistMode,
     CraqleIrokleOptions, CraqleNode, CraqleOptions, CraqleRequestDurability, CreateCrateRequest,
-    CreateEntityRequest, GraphId, GraphPolicy, PatchEntityRequest, RoCrateError, SearchStorage,
-    vocab,
+    CreateEntityRequest, DescribeRequest, GraphId, GraphPolicy, GraphSearchRequest,
+    PatchEntityRequest, RoCrateError, SearchStorage, vocab,
 };
 use jsonwebtoken::DecodingKey;
 use oxrdf::{BlankNode, Dataset, GraphName, Literal, NamedNode, NamedOrBlankNode, Quad, Term};
@@ -812,7 +812,13 @@ impl MetadataHandle {
             };
             inner
                 .node
-                .describe_subject(&authorizer, &GraphId::new(&graph_iri), &graph_iri)
+                .describe_subject(
+                    &authorizer,
+                    DescribeRequest {
+                        graph: &GraphId::new(&graph_iri),
+                        subject_id: &graph_iri,
+                    },
+                )
                 .map(decode_hit_properties)
                 .unwrap_or_default()
         })
@@ -4838,8 +4844,10 @@ async fn search_local_graphs(
                         .node
                         .describe_subject(
                             &authorizer,
-                            &GraphId::new(&record.graph_iri),
-                            &subject_iri,
+                            DescribeRequest {
+                                graph: &GraphId::new(&record.graph_iri),
+                                subject_id: &subject_iri,
+                            },
                         )
                         .map(decode_hit_properties)
                         .unwrap_or_default();
@@ -4904,7 +4912,14 @@ async fn search_local_graphs(
             };
             let hits = inner
                 .node
-                .search_graphs(&authorizer, &graph_ids, &query, limit)
+                .search_graphs(
+                    &authorizer,
+                    GraphSearchRequest {
+                        graphs: &graph_ids,
+                        query: &query,
+                        limit,
+                    },
+                )
                 .map_err(|error| MetadataError::Backend(error.to_string()))?;
             let mut visible = Vec::with_capacity(hits.len().min(limit));
             for hit in hits {
@@ -4915,7 +4930,13 @@ async fn search_local_graphs(
                 // never fail the search, so fall back to an empty property set.
                 let properties = inner
                     .node
-                    .describe_subject(&authorizer, &GraphId::new(&hit.graph_id), &hit.subject_iri)
+                    .describe_subject(
+                        &authorizer,
+                        DescribeRequest {
+                            graph: &GraphId::new(&hit.graph_id),
+                            subject_id: &hit.subject_iri,
+                        },
+                    )
                     .map(decode_hit_properties)
                     .unwrap_or_default();
                 visible.push(metadata_search_hit_from_craqle(
@@ -5415,6 +5436,7 @@ mod tests {
     use super::*;
     use aruna_core::UserId;
     use aruna_core::auth::{TOKEN_REVOCATION_LIST_KEY, TRUSTED_REALMS_LIST_KEY, bearer_token_hash};
+    use aruna_core::keys::generate_signing_key;
     use aruna_core::keyspaces::{API_STATE_KEYSPACE, REALM_CONFIG_KEYSPACE};
     use aruna_core::structs::{
         ArunaArn, PathRestriction, PlacementRef, RealmConfigDocument, RealmId, RealmNodeKind,
@@ -5984,8 +6006,7 @@ mod tests {
     }
 
     fn signing_key() -> SigningKey {
-        let mut rng = jsonwebtoken::signature::rand_core::OsRng;
-        SigningKey::generate(&mut rng)
+        generate_signing_key()
     }
 
     fn node_id_from_seed(seed: u8) -> NodeId {

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -2059,9 +2059,7 @@ async fn ensure_remote_metadata_peer_is_configured_for_realm(
                 "remote metadata peer `{peer}` is not configured in realm `{realm_id}`"
             )))
         }
-        Event::Storage(StorageEvent::Error { error }) => Err(MetadataError::Backend(format!(
-            "realm config read failed for `{realm_id}`: {error}"
-        ))),
+        Event::Storage(StorageEvent::Error { error }) => Err(MetadataError::Storage(error)),
         other => Err(MetadataError::Backend(format!(
             "unexpected realm config read result for `{realm_id}`: {other:?}"
         ))),
@@ -2114,9 +2112,7 @@ where
             postcard::from_bytes(&bytes).map_err(|error| MetadataError::Backend(error.to_string()))
         }
         Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(T::default()),
-        Event::Storage(StorageEvent::Error { error }) => {
-            Err(MetadataError::Backend(error.to_string()))
-        }
+        Event::Storage(StorageEvent::Error { error }) => Err(MetadataError::Storage(error)),
         other => Err(MetadataError::Backend(format!(
             "unexpected metadata auth state read result: {other:?}"
         ))),
@@ -2141,9 +2137,7 @@ async fn graph_lifecycle_record(
                     .map_err(|error| MetadataError::Backend(error.to_string()))
             })
             .transpose(),
-        Event::Storage(StorageEvent::Error { error }) => {
-            Err(MetadataError::Backend(error.to_string()))
-        }
+        Event::Storage(StorageEvent::Error { error }) => Err(MetadataError::Storage(error)),
         other => Err(MetadataError::Backend(format!(
             "unexpected metadata graph lifecycle read result: {other:?}"
         ))),
@@ -3617,6 +3611,11 @@ fn metadata_error_from_craqle(error: CraqleError) -> MetadataError {
         CraqleError::Update(craqle::UpdateError::ValidationFailed(violations)) => {
             metadata_violations(violations)
         }
+        // Backend infrastructure, not the document: an apply that fails on disk
+        // or in the search worker must keep retrying instead of being parked.
+        error @ (CraqleError::Io(_) | CraqleError::Store(_) | CraqleError::SearchWorker(_)) => {
+            MetadataError::Persist(error.to_string())
+        }
         other => MetadataError::Backend(other.to_string()),
     }
 }
@@ -4197,9 +4196,7 @@ async fn list_deleted_graph_iris(
                 next_start_after,
             }) => (values, next_start_after),
             Event::Storage(StorageEvent::Error { error }) => {
-                return Err(MetadataError::Backend(format!(
-                    "metadata graph lifecycle iteration failed: {error:?}"
-                )));
+                return Err(MetadataError::Storage(error));
             }
             other => {
                 return Err(MetadataError::Backend(format!(
@@ -5449,6 +5446,15 @@ mod tests {
         assert_eq!(violations[0].code, "missing_root_data_entity");
         assert_eq!(violations[0].pointer, "/@graph");
         assert_eq!(violations[0].entity_id.as_deref(), Some("./"));
+    }
+
+    #[test]
+    fn maps_io_failures() {
+        // Infrastructure must stay distinguishable from a rejected payload: the
+        // materialization queue retries the former forever and parks the latter.
+        let error = metadata_error_from_craqle(CraqleError::Io(std::io::Error::other("disk")));
+
+        assert!(matches!(error, MetadataError::Persist(_)));
     }
 
     #[test]

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -37,7 +37,7 @@ use craqle::{
     Authorizer as CraqleAuthorizer, Batch, CraqleError, CraqleFjallPersistMode,
     CraqleIrokleOptions, CraqleNode, CraqleOptions, CraqleRequestDurability, CreateCrateRequest,
     CreateEntityRequest, DescribeRequest, GraphId, GraphPolicy, GraphSearchRequest,
-    PatchEntityRequest, RoCrateError, SearchStorage, vocab,
+    PatchEntityRequest, RoCrateError, SearchRequest, SearchStorage, vocab,
 };
 use futures_util::FutureExt;
 use jsonwebtoken::DecodingKey;
@@ -59,7 +59,7 @@ use super::query_cache::{
     CachedQuery, LocalScopeKind, MetadataQueryCache, ScopeDigest, graphs_digest, local_key,
 };
 use super::repository::{REGISTRY_FILL_PAGE_SIZE, iter_all_registry_effect, parse_registry_iter};
-use super::search_cursor::METADATA_SEARCH_MAX_PAGINATION_DEPTH;
+use super::search_cursor::{METADATA_SEARCH_MAX_PAGINATION_DEPTH, compare_hits};
 use super::search_enrichment::{hit_snippet, hit_title};
 use super::summary_cache::summary_cache;
 use crate::auth::{
@@ -4828,6 +4828,8 @@ fn snapshot_iri_references(
         graph_filter_count = graph_iris.as_ref().map_or(0, Vec::len) as u64,
         registry_records = field::Empty,
         authorized_graphs = field::Empty,
+        readable_groups = field::Empty,
+        lazy = field::Empty,
         registry_ms = field::Empty,
         authorization_ms = field::Empty,
         craqle_search_ms = field::Empty,
@@ -4850,6 +4852,161 @@ async fn search_local_graphs(
     let total_started = Instant::now();
 
     let records = list_registry_records_for_local_read(inner.clone(), &span).await?;
+    // Without a candidate filter the request spans the realm, so craqle
+    // authorizes the index hits it returns instead of every visible graph.
+    let lazy = iri_filter.is_none() && graph_iris.is_none() && group_id.is_none();
+    span.record("lazy", lazy);
+
+    let result = if lazy {
+        search_realm_scope(inner, auth_context, records, query, limit, &span).await
+    } else {
+        search_candidate_graphs(
+            inner,
+            auth_context,
+            records,
+            graph_iris,
+            query,
+            limit,
+            group_id,
+            iri_filter,
+            &span,
+        )
+        .await
+    };
+
+    match &result {
+        Ok(hits) => {
+            span.record("result", "ok");
+            span.record("hit_count", hits.len() as u64);
+        }
+        Err(error) => record_error(&span, &error.to_string()),
+    }
+    record_elapsed_ms(&span, "elapsed_ms", total_started);
+    result
+}
+
+fn record_backend_search(
+    span: &Span,
+    search_span: &Span,
+    started: Instant,
+    result: &Result<Vec<MetadataSearchHit>, MetadataError>,
+) {
+    let elapsed = started.elapsed();
+    record_duration_ms(search_span, "elapsed_ms", elapsed);
+    record_duration_ms(span, "craqle_search_ms", elapsed);
+    match result {
+        Ok(hits) => {
+            search_span.record("result", "ok");
+            search_span.record("hit_count", hits.len() as u64);
+        }
+        Err(error) => record_error(search_span, &error.to_string()),
+    }
+    warn_if_slow_metadata_backend("search", None, elapsed);
+}
+
+async fn search_realm_scope(
+    inner: Arc<MetadataInner>,
+    auth_context: Option<AuthContext>,
+    records: Arc<Vec<MetadataRegistryRecord>>,
+    query: String,
+    limit: usize,
+    span: &Span,
+) -> Result<Vec<MetadataSearchHit>, MetadataError> {
+    let authorization_started = Instant::now();
+    let scope = resolve_graph_visibility_scope(&inner, auth_context, records)
+        .boxed()
+        .await?;
+    record_elapsed_ms(span, "authorization_ms", authorization_started);
+    span.record("readable_groups", scope.permissions.group_count() as u64);
+    if limit == 0 || scope.records.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let search_span = debug_span!(
+        "metadata.backend.craqle.search",
+        lazy = true,
+        query_len = query.len() as u64,
+        limit = limit as u64,
+        elapsed_ms = field::Empty,
+        result = field::Empty,
+        hit_count = field::Empty,
+    );
+    let blocking_span = search_span.clone();
+    let search_started = Instant::now();
+    let _permit = inner.craqle_read_permits.clone().acquire_owned().await.ok();
+    let result = match tokio::task::spawn_blocking(move || {
+        blocking_span.in_scope(|| search_visible_scope(&inner, &scope, &query, limit))
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(error) => Err(MetadataError::TaskJoin(error.to_string())),
+    };
+    record_backend_search(span, &search_span, search_started, &result);
+    result
+}
+
+// Craqle post-filters the index hits it returns through the request's already
+// resolved scope, so the work scales with the page instead of the realm.
+fn search_visible_scope(
+    inner: &MetadataInner,
+    scope: &GraphVisibilityScope,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<MetadataSearchHit>, MetadataError> {
+    let authorizer = ScopeAuthorizer {
+        scope,
+        visibility_cache: &inner.visibility_cache,
+    };
+    let hits = inner
+        .node
+        .search(&authorizer, SearchRequest { query, limit })
+        .map_err(|error| MetadataError::Backend(error.to_string()))?;
+    let mut visible = Vec::with_capacity(hits.len().min(limit));
+    for hit in hits {
+        let Some(record) = scope.record_for_graph(&hit.graph_id) else {
+            continue;
+        };
+        // Enrichment is best-effort: a pending or raced projection must never
+        // fail the search, so fall back to an empty property set.
+        let properties = inner
+            .node
+            .describe_subject(
+                &authorizer,
+                DescribeRequest {
+                    graph: &GraphId::new(&hit.graph_id),
+                    subject_id: &hit.subject_iri,
+                },
+            )
+            .map(decode_hit_properties)
+            .unwrap_or_default();
+        visible.push(metadata_search_hit_from_craqle(
+            hit,
+            record,
+            &properties,
+            query,
+        ));
+    }
+    // The unfiltered entry point returns raw index order; the search cursor's
+    // watermark needs the merged score-descending order instead.
+    visible.sort_by(compare_hits);
+    Ok(visible)
+}
+
+// Requests narrowed by graph, group, or IRI filter keep a genuine candidate
+// set, so pre-filtering it stays cheaper than post-filtering the whole index.
+#[allow(clippy::too_many_arguments)]
+async fn search_candidate_graphs(
+    inner: Arc<MetadataInner>,
+    auth_context: Option<AuthContext>,
+    records: Arc<Vec<MetadataRegistryRecord>>,
+    graph_iris: Option<Vec<String>>,
+    query: String,
+    limit: usize,
+    group_id: Option<GroupId>,
+    iri_filter: Option<(String, String)>,
+    span: &Span,
+) -> Result<Vec<MetadataSearchHit>, MetadataError> {
     let iri_matches = match iri_filter.as_ref() {
         Some((predicate_iri, object_iri)) => Some(
             super::iri_index::lookup_metadata_iri_references(
@@ -4877,13 +5034,10 @@ async fn search_local_graphs(
     let allowed_records =
         select_authorized_records(inner.clone(), auth_context, records, graph_iris, group_id)
             .await?;
-    record_elapsed_ms(&span, "authorization_ms", authorization_started);
+    record_elapsed_ms(span, "authorization_ms", authorization_started);
     span.record("authorized_graphs", allowed_records.len() as u64);
 
     if limit == 0 || allowed_records.is_empty() {
-        span.record("result", "ok");
-        span.record("hit_count", 0u64);
-        record_elapsed_ms(&span, "elapsed_ms", total_started);
         return Ok(Vec::new());
     }
 
@@ -4940,9 +5094,6 @@ async fn search_local_graphs(
             Ok(hits) => hits,
             Err(error) => return Err(MetadataError::TaskJoin(error.to_string())),
         };
-        span.record("result", "ok");
-        span.record("hit_count", hits.len() as u64);
-        record_elapsed_ms(&span, "elapsed_ms", total_started);
         return Ok(hits);
     }
 
@@ -5020,23 +5171,7 @@ async fn search_local_graphs(
         Ok(result) => result,
         Err(error) => Err(MetadataError::TaskJoin(error.to_string())),
     };
-    let search_elapsed = search_started.elapsed();
-    record_duration_ms(&search_span, "elapsed_ms", search_elapsed);
-    record_duration_ms(&span, "craqle_search_ms", search_elapsed);
-    match &result {
-        Ok(hits) => {
-            search_span.record("result", "ok");
-            span.record("result", "ok");
-            search_span.record("hit_count", hits.len() as u64);
-            span.record("hit_count", hits.len() as u64);
-        }
-        Err(error) => {
-            record_error(&search_span, &error.to_string());
-            record_error(&span, &error.to_string());
-        }
-    }
-    warn_if_slow_metadata_backend("search", None, search_elapsed);
-    record_elapsed_ms(&span, "elapsed_ms", total_started);
+    record_backend_search(span, &search_span, search_started, &result);
     result
 }
 
@@ -5056,6 +5191,38 @@ impl CraqleAuthorizer for AllowedGraphAuthorizer {
         action: CraqleAction,
     ) -> Result<(), CraqleAuthError> {
         if matches!(action, CraqleAction::Read) && self.graph_iris.contains(graph.as_str()) {
+            return Ok(());
+        }
+
+        Err(CraqleAuthError::PermissionDenied {
+            action,
+            graph: graph.as_str().to_string(),
+        })
+    }
+}
+
+/// Lazy counterpart of [`AllowedGraphAuthorizer`], answering craqle per hit.
+///
+/// Craqle's stored policy is ignored on purpose: the registry record, the
+/// lifecycle tombstones and the caller's collected rules are authoritative
+/// here, and a graph without a registry record stays invisible.
+struct ScopeAuthorizer<'a> {
+    scope: &'a GraphVisibilityScope,
+    visibility_cache: &'a MetadataVisibilityCache,
+}
+
+impl CraqleAuthorizer for ScopeAuthorizer<'_> {
+    fn authorize(
+        &self,
+        graph: &GraphId,
+        _policy: &GraphPolicy,
+        action: CraqleAction,
+    ) -> Result<(), CraqleAuthError> {
+        if matches!(action, CraqleAction::Read)
+            && self
+                .scope
+                .graph_visible(self.visibility_cache, graph.as_str())
+        {
             return Ok(());
         }
 
@@ -6497,6 +6664,130 @@ mod tests {
         let cache = MetadataVisibilityCache::new();
         assert!(scope.graph_visible(&cache, &granted.graph_iri));
         assert!(!scope.graph_visible(&cache, &hidden.graph_iri));
+    }
+
+    // Permissive on purpose: craqle's stored policy must not sway the decision.
+    fn open_policy() -> GraphPolicy {
+        GraphPolicy {
+            public: true,
+            permission_paths: Vec::new(),
+        }
+    }
+
+    fn admits(authorizer: &ScopeAuthorizer<'_>, graph_iri: &str) -> bool {
+        authorizer
+            .authorize(&GraphId::new(graph_iri), &open_policy(), CraqleAction::Read)
+            .is_ok()
+    }
+
+    #[test]
+    fn authorizer_admits_public() {
+        let public = registry_record("datasets/public");
+        let scope = scope_for(vec![public.clone()], GroupPermissionRules::default());
+        let cache = MetadataVisibilityCache::new();
+        let authorizer = ScopeAuthorizer {
+            scope: &scope,
+            visibility_cache: &cache,
+        };
+
+        assert!(admits(&authorizer, &public.graph_iri));
+        assert!(
+            authorizer
+                .authorize(
+                    &GraphId::new(&public.graph_iri),
+                    &open_policy(),
+                    CraqleAction::Write,
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn authorizer_refuses_denied() {
+        // A per-document DENY under a group-wide grant hides only that document.
+        let realm = RealmId([7u8; 32]);
+        let group_id = Ulid::generate();
+        let secret = group_record(group_id, "datasets/secret");
+        let open = group_record(group_id, "datasets/open");
+        let rules = HashMap::from([(
+            group_id,
+            read_rules(&[
+                (
+                    format!("/{realm}/g/{group_id}/meta/**").as_str(),
+                    Permission::READ,
+                ),
+                (secret.permission_path.as_str(), Permission::DENY),
+            ]),
+        )]);
+        let scope = scope_for(
+            vec![secret.clone(), open.clone()],
+            GroupPermissionRules::from_groups(Some(realm), rules),
+        );
+        let cache = MetadataVisibilityCache::new();
+        let authorizer = ScopeAuthorizer {
+            scope: &scope,
+            visibility_cache: &cache,
+        };
+
+        assert!(!admits(&authorizer, &secret.graph_iri));
+        assert!(admits(&authorizer, &open.graph_iri));
+    }
+
+    #[test]
+    fn authorizer_admits_narrow() {
+        // A grant on one document shows it without opening the whole group.
+        let realm = RealmId([7u8; 32]);
+        let group_id = Ulid::generate();
+        let granted = group_record(group_id, "datasets/shared");
+        let hidden = group_record(group_id, "datasets/hidden");
+        let rules = HashMap::from([(
+            group_id,
+            read_rules(&[(granted.permission_path.as_str(), Permission::READ)]),
+        )]);
+        let scope = scope_for(
+            vec![granted.clone(), hidden.clone()],
+            GroupPermissionRules::from_groups(Some(realm), rules),
+        );
+        let cache = MetadataVisibilityCache::new();
+        let authorizer = ScopeAuthorizer {
+            scope: &scope,
+            visibility_cache: &cache,
+        };
+
+        assert!(admits(&authorizer, &granted.graph_iri));
+        assert!(!admits(&authorizer, &hidden.graph_iri));
+    }
+
+    #[test]
+    fn authorizer_refuses_deleted() {
+        // Craqle still holds the graph, so only our tombstone can hide it.
+        let deleted = registry_record("datasets/deleted");
+        let scope = scope_for(vec![deleted.clone()], GroupPermissionRules::default());
+        let cache = MetadataVisibilityCache::new();
+        cache.store_lifecycle_deleted(deleted.graph_iri.clone(), true);
+        let authorizer = ScopeAuthorizer {
+            scope: &scope,
+            visibility_cache: &cache,
+        };
+
+        assert!(!admits(&authorizer, &deleted.graph_iri));
+    }
+
+    #[test]
+    fn authorizer_refuses_unlisted() {
+        // Craqle may hold graphs the registry does not list; they stay hidden.
+        let known = registry_record("datasets/known");
+        let scope = scope_for(vec![known], GroupPermissionRules::default());
+        let cache = MetadataVisibilityCache::new();
+        let authorizer = ScopeAuthorizer {
+            scope: &scope,
+            visibility_cache: &cache,
+        };
+
+        assert!(!admits(
+            &authorizer,
+            &MetadataRegistryRecord::graph_iri_for(Ulid::generate())
+        ));
     }
 
     fn scope_for(

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -5176,8 +5176,7 @@ enum LocalReadScope<T> {
 
 struct GraphVisibilityScope {
     records: Arc<Vec<MetadataRegistryRecord>>,
-    auth_realm: Option<RealmId>,
-    readable_groups: HashSet<GroupId>,
+    permissions: GroupPermissionRules,
     lifecycle_visibility: LifecycleVisibility,
 }
 
@@ -5216,9 +5215,21 @@ impl GraphVisibilityScope {
                 }
             }
         }
-        record.public
-            || (self.auth_realm == Some(record.realm_id)
-                && self.readable_groups.contains(&record.group_id))
+        // Rules are collected per group, but every record is decided on its own
+        // permission path, so per-document grants and denials agree with the
+        // decision `can_read_record` makes for the same caller and record.
+        self.permissions.record_visible(record)
+    }
+
+    // Digest of every graph this scope may evaluate, in registry order.
+    fn visible_digest(&self, visibility_cache: &MetadataVisibilityCache) -> [u8; 32] {
+        let mut digest = ScopeDigest::default();
+        for record in self.records.iter() {
+            if self.record_visible(visibility_cache, record) {
+                digest.push(&record.graph_iri);
+            }
+        }
+        digest.finish()
     }
 
     // Graphs without a registry record stay invisible (fail closed).
@@ -5259,42 +5270,26 @@ async fn resolve_graph_visibility_scope(
         LifecycleVisibility::FreshDeletedGraphs(lifecycle_refresh.deleted_graphs)
     };
     let auth_realm = auth_context.as_ref().map(|auth| auth.realm_id);
-    let mut readable_groups = HashSet::new();
-    if let Some(auth_context) = auth_context {
-        let context = DriverContext {
-            storage_handle: inner.storage_handle.clone(),
-            net_handle: None,
-            blob_handle: None,
-            metadata_handle: None,
-            task_handle: None,
-            compute_handle: None,
-        };
-        let groups = drive(ListGroupOperation::new(), &context)
-            .await
-            .map_err(|error| MetadataError::Backend(error.to_string()))?;
-        for group in groups {
-            if group.realm_id != auth_context.realm_id {
-                continue;
-            }
-            let readable = drive(
-                CheckPermissionsOperation::new(CheckPermissionsConfig {
-                    auth_context: auth_context.clone(),
-                    path: format!("/{}/g/{}/meta/**", group.realm_id, group.group_id),
-                    required_permission: Permission::READ,
-                }),
-                &context,
-            )
-            .await
-            .unwrap_or(false);
-            if readable {
-                readable_groups.insert(group.group_id);
-            }
-        }
-    }
+    let context = DriverContext {
+        storage_handle: inner.storage_handle.clone(),
+        net_handle: None,
+        blob_handle: None,
+        metadata_handle: None,
+        task_handle: None,
+        compute_handle: None,
+    };
+    let permissions = GroupPermissionRules::collect(
+        &context,
+        auth_context.as_ref(),
+        records
+            .iter()
+            .filter(|record| Some(record.realm_id) == auth_realm)
+            .map(|record| record.group_id),
+    )
+    .await;
     Ok(GraphVisibilityScope {
         records,
-        auth_realm,
-        readable_groups,
+        permissions,
         lifecycle_visibility,
     })
 }
@@ -6055,6 +6050,39 @@ mod tests {
         }
     }
 
+    fn group_record(group_id: GroupId, document_path: &str) -> MetadataRegistryRecord {
+        let mut record = registry_record(document_path);
+        record.group_id = group_id;
+        record.public = false;
+        record.permission_path = MetadataRegistryRecord::permission_path_for(
+            &record.realm_id,
+            group_id,
+            document_path,
+            record.document_id,
+        );
+        record
+    }
+
+    fn read_rules(patterns: &[(&str, Permission)]) -> crate::permission_rules::PermissionRules {
+        crate::permission_rules::PermissionRules::from_roles(
+            vec![crate::permission_rules::CollectedRole {
+                role: aruna_core::structs::Role {
+                    role_id: Ulid::generate(),
+                    name: "test".to_string(),
+                    permissions: patterns
+                        .iter()
+                        .map(|(pattern, permission)| ((*pattern).to_string(), permission.clone()))
+                        .collect(),
+                    assigned_users: HashSet::new(),
+                },
+                direct: true,
+                public: false,
+            }],
+            None,
+        )
+        .expect("patterns compile")
+    }
+
     fn filled_cache(records: Vec<MetadataRegistryRecord>) -> MetadataVisibilityCache {
         let cache = MetadataVisibilityCache::new();
         cache.store_registry_records(Arc::new(records));
@@ -6327,8 +6355,7 @@ mod tests {
 
         let anonymous = GraphVisibilityScope {
             records: Arc::new(records.clone()),
-            auth_realm: None,
-            readable_groups: HashSet::new(),
+            permissions: GroupPermissionRules::default(),
             lifecycle_visibility: LifecycleVisibility::Cache,
         };
         assert!(anonymous.graph_visible(&cache, &public_record.graph_iri));
@@ -6339,10 +6366,13 @@ mod tests {
             &MetadataRegistryRecord::graph_iri_for(Ulid::generate())
         ));
 
+        let readable = HashMap::from([(
+            private_record.group_id,
+            read_rules(&[(private_record.permission_path.as_str(), Permission::READ)]),
+        )]);
         let member = GraphVisibilityScope {
             records: Arc::new(records.clone()),
-            auth_realm: Some(realm),
-            readable_groups: HashSet::from([private_record.group_id]),
+            permissions: GroupPermissionRules::from_groups(Some(realm), readable.clone()),
             lifecycle_visibility: LifecycleVisibility::Cache,
         };
         assert!(member.graph_visible(&cache, &public_record.graph_iri));
@@ -6351,12 +6381,67 @@ mod tests {
 
         let wrong_realm = GraphVisibilityScope {
             records: Arc::new(records),
-            auth_realm: Some(RealmId([8u8; 32])),
-            readable_groups: HashSet::from([private_record.group_id]),
+            permissions: GroupPermissionRules::from_groups(Some(RealmId([8u8; 32])), readable),
             lifecycle_visibility: LifecycleVisibility::Cache,
         };
         assert!(wrong_realm.graph_visible(&cache, &public_record.graph_iri));
         assert!(!wrong_realm.graph_visible(&cache, &private_record.graph_iri));
+    }
+
+    #[test]
+    fn deny_hides_document() {
+        // A per-document DENY under a group-wide READ hides only that document.
+        let realm = RealmId([7u8; 32]);
+        let group_id = Ulid::generate();
+        let secret = group_record(group_id, "datasets/secret");
+        let open = group_record(group_id, "datasets/open");
+        let mut records = vec![secret.clone(), open.clone()];
+        records.sort_unstable_by_key(|record| record.document_id);
+
+        let rules = HashMap::from([(
+            group_id,
+            read_rules(&[
+                (
+                    format!("/{realm}/g/{group_id}/meta/**").as_str(),
+                    Permission::READ,
+                ),
+                (secret.permission_path.as_str(), Permission::DENY),
+            ]),
+        )]);
+        let scope = GraphVisibilityScope {
+            records: Arc::new(records),
+            permissions: GroupPermissionRules::from_groups(Some(realm), rules),
+            lifecycle_visibility: LifecycleVisibility::Cache,
+        };
+
+        let cache = MetadataVisibilityCache::new();
+        assert!(!scope.graph_visible(&cache, &secret.graph_iri));
+        assert!(scope.graph_visible(&cache, &open.graph_iri));
+    }
+
+    #[test]
+    fn narrow_grant_visible() {
+        // A grant on one document shows it without opening the whole group.
+        let realm = RealmId([7u8; 32]);
+        let group_id = Ulid::generate();
+        let granted = group_record(group_id, "datasets/shared");
+        let hidden = group_record(group_id, "datasets/hidden");
+        let mut records = vec![granted.clone(), hidden.clone()];
+        records.sort_unstable_by_key(|record| record.document_id);
+
+        let rules = HashMap::from([(
+            group_id,
+            read_rules(&[(granted.permission_path.as_str(), Permission::READ)]),
+        )]);
+        let scope = GraphVisibilityScope {
+            records: Arc::new(records),
+            permissions: GroupPermissionRules::from_groups(Some(realm), rules),
+            lifecycle_visibility: LifecycleVisibility::Cache,
+        };
+
+        let cache = MetadataVisibilityCache::new();
+        assert!(scope.graph_visible(&cache, &granted.graph_iri));
+        assert!(!scope.graph_visible(&cache, &hidden.graph_iri));
     }
 
     #[test]
@@ -6366,8 +6451,7 @@ mod tests {
         cache.store_lifecycle_deleted(deleted_record.graph_iri.clone(), false);
         let scope = GraphVisibilityScope {
             records: Arc::new(vec![deleted_record.clone()]),
-            auth_realm: None,
-            readable_groups: HashSet::new(),
+            permissions: GroupPermissionRules::default(),
             lifecycle_visibility: LifecycleVisibility::FreshDeletedGraphs(HashSet::from([
                 deleted_record.graph_iri.clone(),
             ])),

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -39,6 +39,7 @@ use craqle::{
     CreateEntityRequest, DescribeRequest, GraphId, GraphPolicy, GraphSearchRequest,
     PatchEntityRequest, RoCrateError, SearchStorage, vocab,
 };
+use futures_util::FutureExt;
 use jsonwebtoken::DecodingKey;
 use oxrdf::{BlankNode, Dataset, GraphName, Literal, NamedNode, NamedOrBlankNode, Quad, Term};
 use serde::de::DeserializeOwned;
@@ -355,11 +356,6 @@ impl RegistryCacheEntry {
 struct LifecycleDeletedCacheEntry {
     deleted: bool,
     expires_at: Instant,
-}
-
-struct MetadataGraphDeletedRead {
-    deleted: bool,
-    cache_hit: bool,
 }
 
 struct VisibilityFillResult {
@@ -903,7 +899,7 @@ impl MetadataHandle {
                     .instrument(span.clone())
                     .await;
             match result {
-                Ok(read) if read.deleted => {
+                Ok(true) => {
                     span.record("deleted", true);
                     record_elapsed_ms(&span, "elapsed_ms", started);
                     match &effect {
@@ -931,7 +927,7 @@ impl MetadataHandle {
                         _ => {}
                     }
                 }
-                Ok(_) => {
+                Ok(false) => {
                     span.record("deleted", false);
                     record_elapsed_ms(&span, "elapsed_ms", started);
                 }
@@ -2185,22 +2181,16 @@ async fn metadata_graph_deleted(
     inner: Arc<MetadataInner>,
     storage_handle: StorageHandle,
     graph_iri: &str,
-) -> Result<MetadataGraphDeletedRead, MetadataError> {
+) -> Result<bool, MetadataError> {
     if let Some((true, _)) = inner.visibility_cache.lifecycle_deleted_any(graph_iri) {
-        return Ok(MetadataGraphDeletedRead {
-            deleted: true,
-            cache_hit: true,
-        });
+        return Ok(true);
     }
 
     let deleted = graph_lifecycle_deleted(storage_handle, graph_iri).await?;
     inner
         .visibility_cache
         .store_lifecycle_deleted(graph_iri.to_string(), deleted);
-    Ok(MetadataGraphDeletedRead {
-        deleted,
-        cache_hit: false,
-    })
+    Ok(deleted)
 }
 
 async fn graph_lifecycle_deleted(
@@ -5088,10 +5078,7 @@ async fn list_visible_graphs(inner: Arc<MetadataInner>) -> Result<Vec<String>, M
     let mut visible = Vec::with_capacity(graphs.len());
     for graph in graphs {
         let graph_iri = graph.as_str().to_string();
-        if !metadata_graph_deleted(inner.clone(), inner.storage_handle.clone(), &graph_iri)
-            .await?
-            .deleted
-        {
+        if !metadata_graph_deleted(inner.clone(), inner.storage_handle.clone(), &graph_iri).await? {
             visible.push(graph_iri);
         }
     }
@@ -5142,101 +5129,99 @@ async fn select_authorized_records(
     let span = Span::current();
     let started = Instant::now();
     let allowed_graphs = graph_filter.map(|graphs| graphs.into_iter().collect::<HashSet<_>>());
-    let mut visible = Vec::new();
-    let mut deleted_count = 0usize;
-    let mut filtered_count = 0usize;
-    let mut lifecycle_cache_hits = 0usize;
-    let mut lifecycle_cache_misses = 0usize;
-    let mut public_count = 0usize;
-    let mut private_checked_count = 0usize;
-    let mut denied_count = 0usize;
-    for record in records.iter() {
-        if let Some(filter) = allowed_graphs.as_ref()
-            && !filter.contains(&record.graph_iri)
-        {
-            filtered_count += 1;
-            continue;
-        }
-        if let Some(group_id) = group_id
-            && record.group_id != group_id
-        {
-            filtered_count += 1;
-            continue;
-        }
-        let deleted = metadata_graph_deleted(
-            inner.clone(),
-            inner.storage_handle.clone(),
-            &record.graph_iri,
-        )
+    let record_count = records.len();
+    // Filtering first keeps the scope resolution to the groups and lifecycle
+    // entries a filtered request can still see.
+    let candidates = filter_candidate_records(records, allowed_graphs.as_ref(), group_id);
+    let filtered_count = record_count - candidates.len();
+
+    // Boxed so the read paths that already resolve a scope do not nest this
+    // future again: the combined depth exceeds the auto-trait recursion limit.
+    let scope = resolve_graph_visibility_scope(&inner, auth_context, candidates)
+        .boxed()
         .await?;
-        if deleted.cache_hit {
-            lifecycle_cache_hits += 1;
-        } else {
-            lifecycle_cache_misses += 1;
-        }
-        if deleted.deleted {
-            deleted_count += 1;
+    let selection = select_visible_records(&scope, &inner.visibility_cache);
+    let evaluated = scope.records.len() as u64;
+    // Lifecycle is resolved once per request, so the cache counters report how
+    // the whole request was decided instead of per-record point reads.
+    let lifecycle_cached = matches!(scope.lifecycle_visibility, LifecycleVisibility::Cache);
+    span.record("visible_count", selection.visible.len() as u64);
+    span.record("deleted_count", selection.deleted as u64);
+    span.record("filtered_count", filtered_count as u64);
+    span.record(
+        "lifecycle_cache_hits",
+        if lifecycle_cached { evaluated } else { 0 },
+    );
+    span.record(
+        "lifecycle_cache_misses",
+        if lifecycle_cached { 0 } else { evaluated },
+    );
+    span.record("lifecycle_reads", 1u64);
+    span.record("public_count", selection.public as u64);
+    span.record("private_checked_count", selection.private as u64);
+    span.record("denied_count", selection.denied as u64);
+    record_elapsed_ms(&span, "elapsed_ms", started);
+    Ok(selection.visible)
+}
+
+fn filter_candidate_records(
+    records: Arc<Vec<MetadataRegistryRecord>>,
+    allowed_graphs: Option<&HashSet<String>>,
+    group_id: Option<GroupId>,
+) -> Arc<Vec<MetadataRegistryRecord>> {
+    if allowed_graphs.is_none() && group_id.is_none() {
+        return records;
+    }
+    Arc::new(
+        records
+            .iter()
+            .filter(|record| {
+                allowed_graphs.is_none_or(|graphs| graphs.contains(&record.graph_iri))
+                    && group_id.is_none_or(|group_id| record.group_id == group_id)
+            })
+            .cloned()
+            .collect(),
+    )
+}
+
+struct RecordSelection {
+    visible: Vec<MetadataRegistryRecord>,
+    deleted: usize,
+    public: usize,
+    private: usize,
+    denied: usize,
+}
+
+// In-memory counterpart of the lazy scope decision: every record is decided
+// against the already resolved lifecycle snapshot and group rules.
+fn select_visible_records(
+    scope: &GraphVisibilityScope,
+    visibility_cache: &MetadataVisibilityCache,
+) -> RecordSelection {
+    let mut selection = RecordSelection {
+        visible: Vec::new(),
+        deleted: 0,
+        public: 0,
+        private: 0,
+        denied: 0,
+    };
+    for record in scope.records.iter() {
+        if scope.record_deleted(visibility_cache, &record.graph_iri) {
+            selection.deleted += 1;
             continue;
         }
         if record.public {
-            public_count += 1;
+            selection.public += 1;
         } else {
-            private_checked_count += 1;
+            selection.private += 1;
         }
-        if can_read_record_locally(inner.storage_handle.clone(), auth_context.clone(), record)
-            .await?
-        {
-            visible.push(record.clone());
+        if scope.permissions.record_visible(record) {
+            selection.visible.push(record.clone());
         } else {
-            denied_count += 1;
+            selection.denied += 1;
         }
     }
-    span.record("visible_count", visible.len() as u64);
-    span.record("deleted_count", deleted_count as u64);
-    span.record("filtered_count", filtered_count as u64);
-    span.record("lifecycle_cache_hits", lifecycle_cache_hits as u64);
-    span.record("lifecycle_cache_misses", lifecycle_cache_misses as u64);
-    span.record("lifecycle_reads", lifecycle_cache_misses as u64);
-    span.record("public_count", public_count as u64);
-    span.record("private_checked_count", private_checked_count as u64);
-    span.record("denied_count", denied_count as u64);
-    record_elapsed_ms(&span, "elapsed_ms", started);
-    Ok(visible)
-}
-
-async fn can_read_record_locally(
-    storage_handle: StorageHandle,
-    auth_context: Option<AuthContext>,
-    record: &MetadataRegistryRecord,
-) -> Result<bool, MetadataError> {
-    if record.public {
-        return Ok(true);
-    }
-    let Some(auth_context) = auth_context else {
-        return Ok(false);
-    };
-    if auth_context.realm_id != record.realm_id {
-        return Ok(false);
-    }
-
-    let context = DriverContext {
-        storage_handle,
-        net_handle: None,
-        blob_handle: None,
-        metadata_handle: None,
-        task_handle: None,
-        compute_handle: None,
-    };
-    drive(
-        CheckPermissionsOperation::new(CheckPermissionsConfig {
-            auth_context,
-            path: record.permission_path.clone(),
-            required_permission: Permission::READ,
-        }),
-        &context,
-    )
-    .await
-    .map_err(|error| MetadataError::Backend(error.to_string()))
+    selection
 }
 
 // All-metadata reads defer per-graph authorization to evaluation time: the
@@ -5263,35 +5248,32 @@ impl GraphVisibilityScope {
         registry_record_for_graph(&self.records, graph_iri)
     }
 
+    // A tombstone in the request's own snapshot or in the cache hides the graph.
+    fn record_deleted(&self, visibility_cache: &MetadataVisibilityCache, graph_iri: &str) -> bool {
+        if matches!(
+            visibility_cache.lifecycle_deleted_any(graph_iri),
+            Some((true, _))
+        ) {
+            return true;
+        }
+        match &self.lifecycle_visibility {
+            LifecycleVisibility::Cache => false,
+            LifecycleVisibility::FreshDeletedGraphs(deleted_graphs) => {
+                deleted_graphs.contains(graph_iri)
+            }
+        }
+    }
+
     fn record_visible(
         &self,
         visibility_cache: &MetadataVisibilityCache,
         record: &MetadataRegistryRecord,
     ) -> bool {
-        match &self.lifecycle_visibility {
-            LifecycleVisibility::Cache => {
-                if matches!(
-                    visibility_cache.lifecycle_deleted_any(&record.graph_iri),
-                    Some((true, _))
-                ) {
-                    return false;
-                }
-            }
-            LifecycleVisibility::FreshDeletedGraphs(deleted_graphs) => {
-                if deleted_graphs.contains(&record.graph_iri)
-                    || matches!(
-                        visibility_cache.lifecycle_deleted_any(&record.graph_iri),
-                        Some((true, _))
-                    )
-                {
-                    return false;
-                }
-            }
-        }
         // Rules are collected per group, but every record is decided on its own
         // permission path, so per-document grants and denials agree with the
         // decision `can_read_record` makes for the same caller and record.
-        self.permissions.record_visible(record)
+        !self.record_deleted(visibility_cache, &record.graph_iri)
+            && self.permissions.record_visible(record)
     }
 
     // Digest of every graph this scope may evaluate, in registry order.
@@ -6515,6 +6497,150 @@ mod tests {
         let cache = MetadataVisibilityCache::new();
         assert!(scope.graph_visible(&cache, &granted.graph_iri));
         assert!(!scope.graph_visible(&cache, &hidden.graph_iri));
+    }
+
+    fn scope_for(
+        mut records: Vec<MetadataRegistryRecord>,
+        permissions: GroupPermissionRules,
+    ) -> GraphVisibilityScope {
+        records.sort_unstable_by_key(|record| record.document_id);
+        GraphVisibilityScope {
+            records: Arc::new(records),
+            permissions,
+            lifecycle_visibility: LifecycleVisibility::Cache,
+        }
+    }
+
+    #[test]
+    fn selection_excludes_deleted() {
+        let live = registry_record("datasets/live");
+        let deleted = registry_record("datasets/deleted");
+        let cache = MetadataVisibilityCache::new();
+        cache.store_lifecycle_deleted(deleted.graph_iri.clone(), true);
+        let scope = scope_for(
+            vec![live.clone(), deleted.clone()],
+            GroupPermissionRules::default(),
+        );
+
+        let selection = select_visible_records(&scope, &cache);
+
+        assert_eq!(selection.deleted, 1);
+        assert_eq!(
+            selection
+                .visible
+                .iter()
+                .map(|record| record.graph_iri.clone())
+                .collect::<Vec<_>>(),
+            vec![live.graph_iri]
+        );
+    }
+
+    #[test]
+    fn selection_excludes_denied() {
+        // A per-document DENY under a group-wide grant hides only that document.
+        let realm = RealmId([7u8; 32]);
+        let group_id = Ulid::generate();
+        let secret = group_record(group_id, "datasets/secret");
+        let open = group_record(group_id, "datasets/open");
+        let rules = HashMap::from([(
+            group_id,
+            read_rules(&[
+                (
+                    format!("/{realm}/g/{group_id}/meta/**").as_str(),
+                    Permission::READ,
+                ),
+                (secret.permission_path.as_str(), Permission::DENY),
+            ]),
+        )]);
+        let scope = scope_for(
+            vec![secret.clone(), open.clone()],
+            GroupPermissionRules::from_groups(Some(realm), rules),
+        );
+
+        let selection = select_visible_records(&scope, &MetadataVisibilityCache::new());
+
+        assert_eq!(selection.denied, 1);
+        assert_eq!(selection.private, 2);
+        assert_eq!(selection.visible.len(), 1);
+        assert_eq!(selection.visible[0].graph_iri, open.graph_iri);
+    }
+
+    #[test]
+    fn narrow_grant_selected() {
+        let realm = RealmId([7u8; 32]);
+        let group_id = Ulid::generate();
+        let granted = group_record(group_id, "datasets/shared");
+        let hidden = group_record(group_id, "datasets/hidden");
+        let rules = HashMap::from([(
+            group_id,
+            read_rules(&[(granted.permission_path.as_str(), Permission::READ)]),
+        )]);
+        let scope = scope_for(
+            vec![granted.clone(), hidden.clone()],
+            GroupPermissionRules::from_groups(Some(realm), rules),
+        );
+
+        let selection = select_visible_records(&scope, &MetadataVisibilityCache::new());
+
+        assert_eq!(selection.visible.len(), 1);
+        assert_eq!(selection.visible[0].graph_iri, granted.graph_iri);
+        assert_eq!(selection.denied, 1);
+    }
+
+    #[test]
+    fn anonymous_sees_public() {
+        // Anonymous callers hold no rules, so only public records survive.
+        let public = registry_record("datasets/public");
+        let private = group_record(Ulid::generate(), "datasets/private");
+        let scope = scope_for(
+            vec![public.clone(), private.clone()],
+            GroupPermissionRules::default(),
+        );
+
+        let selection = select_visible_records(&scope, &MetadataVisibilityCache::new());
+
+        assert_eq!(selection.public, 1);
+        assert_eq!(selection.denied, 1);
+        assert_eq!(selection.visible.len(), 1);
+        assert_eq!(selection.visible[0].graph_iri, public.graph_iri);
+    }
+
+    #[test]
+    fn filters_restrict_candidates() {
+        let group_id = Ulid::generate();
+        let wanted = group_record(group_id, "datasets/wanted");
+        let same_group = group_record(group_id, "datasets/sibling");
+        let other_group = group_record(Ulid::generate(), "datasets/other");
+        let records = Arc::new(vec![
+            wanted.clone(),
+            same_group.clone(),
+            other_group.clone(),
+        ]);
+
+        let by_graph = filter_candidate_records(
+            records.clone(),
+            Some(&HashSet::from([wanted.graph_iri.clone()])),
+            None,
+        );
+        assert_eq!(by_graph.len(), 1);
+        assert_eq!(by_graph[0].graph_iri, wanted.graph_iri);
+
+        let by_group = filter_candidate_records(records.clone(), None, Some(group_id));
+        assert_eq!(by_group.len(), 2);
+        assert!(by_group.iter().all(|record| record.group_id == group_id));
+
+        let combined = filter_candidate_records(
+            records.clone(),
+            Some(&HashSet::from([
+                wanted.graph_iri.clone(),
+                other_group.graph_iri.clone(),
+            ])),
+            Some(group_id),
+        );
+        assert_eq!(combined.len(), 1);
+        assert_eq!(combined[0].graph_iri, wanted.graph_iri);
+
+        assert_eq!(filter_candidate_records(records, None, None).len(), 3);
     }
 
     #[test]

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use aruna_core::NodeId;
 use aruna_core::alpn::Alpn;
 use aruna_core::auth::{TOKEN_REVOCATION_LIST_KEY, TRUSTED_REALMS_LIST_KEY};
-use aruna_core::effects::{Effect, IterStart, StorageEffect};
+use aruna_core::effects::{Effect, IterStart, StorageEffect, StoragePriority};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{
@@ -151,6 +151,9 @@ async fn create_sync_bucket(
 #[derive(Clone)]
 pub struct MetadataHandle {
     inner: Arc<MetadataInner>,
+    /// Lane for this handle's own storage reads. Background drains use the bulk
+    /// lane so their lifecycle reads stay off the foreground sync path.
+    storage_priority: StoragePriority,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -736,7 +739,23 @@ impl MetadataHandle {
                 deferred_persist_requested: AtomicBool::new(false),
                 deferred_persist_running: AtomicBool::new(false),
             }),
+            storage_priority: StoragePriority::Foreground,
         })
+    }
+
+    /// A handle whose own storage reads dispatch on the bulk lane.
+    pub fn bulk(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            storage_priority: StoragePriority::Bulk,
+        }
+    }
+
+    fn lifecycle_storage(&self) -> StorageHandle {
+        match self.storage_priority {
+            StoragePriority::Foreground => self.inner.storage_handle.clone(),
+            StoragePriority::Bulk => self.inner.storage_handle.bulk(),
+        }
     }
 
     pub fn upsert_cached_registry_record(&self, record: MetadataRegistryRecord) {
@@ -859,9 +878,10 @@ impl MetadataHandle {
                 elapsed_ms = field::Empty,
             );
             let started = Instant::now();
-            let result = metadata_graph_deleted(self.inner.clone(), graph_iri)
-                .instrument(span.clone())
-                .await;
+            let result =
+                metadata_graph_deleted(self.inner.clone(), self.lifecycle_storage(), graph_iri)
+                    .instrument(span.clone())
+                    .await;
             match result {
                 Ok(read) if read.deleted => {
                     span.record("deleted", true);
@@ -1000,7 +1020,7 @@ impl MetadataHandle {
     }
 
     pub async fn prune_graph_if_deleted(&self, graph_iri: String) -> Result<bool, MetadataError> {
-        if !graph_lifecycle_deleted(self.inner.storage_handle.clone(), &graph_iri).await? {
+        if !graph_lifecycle_deleted(self.lifecycle_storage(), &graph_iri).await? {
             return Ok(false);
         }
         self.inner
@@ -2132,6 +2152,7 @@ async fn graph_lifecycle_record(
 
 async fn metadata_graph_deleted(
     inner: Arc<MetadataInner>,
+    storage_handle: StorageHandle,
     graph_iri: &str,
 ) -> Result<MetadataGraphDeletedRead, MetadataError> {
     if let Some((true, _)) = inner.visibility_cache.lifecycle_deleted_any(graph_iri) {
@@ -2141,7 +2162,7 @@ async fn metadata_graph_deleted(
         });
     }
 
-    let deleted = graph_lifecycle_deleted(inner.storage_handle.clone(), graph_iri).await?;
+    let deleted = graph_lifecycle_deleted(storage_handle, graph_iri).await?;
     inner
         .visibility_cache
         .store_lifecycle_deleted(graph_iri.to_string(), deleted);
@@ -4976,7 +4997,7 @@ async fn list_visible_graphs(inner: Arc<MetadataInner>) -> Result<Vec<String>, M
     let mut visible = Vec::with_capacity(graphs.len());
     for graph in graphs {
         let graph_iri = graph.as_str().to_string();
-        if !metadata_graph_deleted(inner.clone(), &graph_iri)
+        if !metadata_graph_deleted(inner.clone(), inner.storage_handle.clone(), &graph_iri)
             .await?
             .deleted
         {
@@ -5051,7 +5072,12 @@ async fn select_authorized_records(
             filtered_count += 1;
             continue;
         }
-        let deleted = metadata_graph_deleted(inner.clone(), &record.graph_iri).await?;
+        let deleted = metadata_graph_deleted(
+            inner.clone(),
+            inner.storage_handle.clone(),
+            &record.graph_iri,
+        )
+        .await?;
         if deleted.cache_hit {
             lifecycle_cache_hits += 1;
         } else {

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -2995,7 +2995,7 @@ fn flush_document_sync_journal(
         }
         Err(error) => {
             record_error(&span, &error.to_string());
-            Err(MetadataError::Backend(format!(
+            Err(MetadataError::Persist(format!(
                 "failed to flush document sync journal: {error}"
             )))
         }
@@ -3010,7 +3010,7 @@ fn flush_metadata_persistence(
     inner
         .node
         .persist_fjall()
-        .map_err(metadata_error_from_craqle)?;
+        .map_err(|error| MetadataError::Persist(error.to_string()))?;
     flush_document_sync_journal(inner, effect_name, graph_iri)
 }
 

--- a/operations/src/metadata/iri_index.rs
+++ b/operations/src/metadata/iri_index.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use aruna_core::effects::{IterStart, StorageEffect};
-use aruna_core::errors::ConversionError;
+use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
     METADATA_IRI_REFERENCE_INDEX_KEYSPACE, METADATA_MATERIALIZATION_STATUS_KEYSPACE,
@@ -17,6 +17,7 @@ use aruna_core::storage_entries::{
 use aruna_core::structs::MetadataRegistryRecord;
 use aruna_storage::StorageHandle;
 use byteview::ByteView;
+use thiserror::Error;
 use ulid::Ulid;
 
 use crate::driver::DriverContext;
@@ -25,6 +26,24 @@ const IRI_INDEX_PAGE_SIZE: usize = 128;
 const IRI_INDEX_WRITE_BATCH_SIZE: usize = 128;
 
 pub(crate) const DCTERMS_CONFORMS_TO_IRI: &str = "http://purl.org/dc/terms/conformsTo";
+
+/// Keeps the storage cause intact so callers can tell an overloaded backend
+/// apart from a genuine index or document problem.
+#[derive(Debug, Error)]
+pub(crate) enum MetadataIriIndexError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+    #[error(transparent)]
+    Conversion(#[from] ConversionError),
+    #[error("unexpected metadata IRI reference index event: {0}")]
+    UnexpectedEvent(String),
+}
+
+impl From<MetadataIriIndexError> for MetadataError {
+    fn from(error: MetadataIriIndexError) -> Self {
+        MetadataError::Backend(error.to_string())
+    }
+}
 
 pub(crate) fn project_metadata_iri_references(
     document_id: Ulid,
@@ -109,7 +128,7 @@ pub(crate) async fn lookup_iri_backlinks(
 async fn scan_iri_reference_records(
     storage: &StorageHandle,
     prefix: Option<ByteView>,
-) -> Result<Vec<MetadataIriReferenceIndexRecord>, MetadataError> {
+) -> Result<Vec<MetadataIriReferenceIndexRecord>, MetadataIriIndexError> {
     let mut start_after = None;
     let mut records = Vec::new();
     loop {
@@ -129,13 +148,8 @@ async fn scan_iri_reference_records(
             }) => {
                 for (_, value) in values {
                     records.push(
-                        postcard::from_bytes::<MetadataIriReferenceIndexRecord>(&value).map_err(
-                            |error| {
-                                MetadataError::Backend(format!(
-                                    "failed to decode metadata IRI reference index: {error}"
-                                ))
-                            },
-                        )?,
+                        postcard::from_bytes::<MetadataIriReferenceIndexRecord>(&value)
+                            .map_err(ConversionError::from)?,
                     );
                 }
                 match next_start_after {
@@ -143,13 +157,9 @@ async fn scan_iri_reference_records(
                     None => break,
                 }
             }
-            Event::Storage(StorageEvent::Error { error }) => {
-                return Err(MetadataError::Backend(error.to_string()));
-            }
+            Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
             other => {
-                return Err(MetadataError::Backend(format!(
-                    "unexpected metadata IRI reference index event: {other:?}"
-                )));
+                return Err(MetadataIriIndexError::UnexpectedEvent(format!("{other:?}")));
             }
         }
     }
@@ -213,7 +223,7 @@ async fn select_iri_reference_keys<F>(
     storage: &StorageHandle,
     txn_id: Option<Ulid>,
     mut select: F,
-) -> Result<Vec<(String, ByteView)>, MetadataError>
+) -> Result<Vec<(String, ByteView)>, MetadataIriIndexError>
 where
     F: FnMut(Ulid, Ulid) -> bool,
 {
@@ -234,13 +244,9 @@ where
                 values,
                 next_start_after,
             }) => (values, next_start_after),
-            Event::Storage(StorageEvent::Error { error }) => {
-                return Err(MetadataError::Backend(error.to_string()));
-            }
+            Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
             other => {
-                return Err(MetadataError::Backend(format!(
-                    "unexpected metadata IRI reference index event: {other:?}"
-                )));
+                return Err(MetadataIriIndexError::UnexpectedEvent(format!("{other:?}")));
             }
         };
         for (key, _) in values {
@@ -265,7 +271,7 @@ pub(crate) async fn superseded_iri_reference_keys(
     storage: &StorageHandle,
     txn_id: Option<Ulid>,
     current_cursors: &HashMap<Ulid, Ulid>,
-) -> Result<Vec<(String, ByteView)>, MetadataError> {
+) -> Result<Vec<(String, ByteView)>, MetadataIriIndexError> {
     select_iri_reference_keys(storage, txn_id, |document_id, cursor| {
         current_cursors
             .get(&document_id)
@@ -282,7 +288,7 @@ async fn stale_rebuild_iri_reference_keys(
     storage: &StorageHandle,
     reprojected: &HashMap<Ulid, Ulid>,
     registered: &HashMap<Ulid, Ulid>,
-) -> Result<Vec<(String, ByteView)>, MetadataError> {
+) -> Result<Vec<(String, ByteView)>, MetadataIriIndexError> {
     select_iri_reference_keys(storage, None, |document_id, cursor| {
         reprojected.get(&document_id) != Some(&cursor)
             && registered.get(&document_id) != Some(&cursor)
@@ -296,10 +302,10 @@ pub(crate) async fn document_iri_reference_keys(
     storage: &StorageHandle,
     document_ids: &BTreeSet<Ulid>,
 ) -> Result<Vec<(String, ByteView)>, MetadataError> {
-    select_iri_reference_keys(storage, None, |document_id, _| {
+    Ok(select_iri_reference_keys(storage, None, |document_id, _| {
         document_ids.contains(&document_id)
     })
-    .await
+    .await?)
 }
 
 pub(crate) async fn delete_iri_reference_keys(
@@ -316,12 +322,10 @@ pub(crate) async fn delete_iri_reference_keys(
         {
             Event::Storage(StorageEvent::BatchDeleteResult { .. }) => {}
             Event::Storage(StorageEvent::Error { error }) => {
-                return Err(MetadataError::Backend(error.to_string()));
+                return Err(MetadataIriIndexError::from(error).into());
             }
             other => {
-                return Err(MetadataError::Backend(format!(
-                    "unexpected metadata IRI reference index delete event: {other:?}"
-                )));
+                return Err(MetadataIriIndexError::UnexpectedEvent(format!("{other:?}")).into());
             }
         }
     }
@@ -393,7 +397,7 @@ fn collect_iri_backlinks(
 async fn read_materialization_status(
     storage: &StorageHandle,
     document_id: Ulid,
-) -> Result<Option<MetadataMaterializationStatusRecord>, MetadataError> {
+) -> Result<Option<MetadataMaterializationStatusRecord>, MetadataIriIndexError> {
     match storage
         .send_storage_effect(StorageEffect::Read {
             key_space: METADATA_MATERIALIZATION_STATUS_KEYSPACE.to_string(),
@@ -403,30 +407,20 @@ async fn read_materialization_status(
         .await
     {
         Event::Storage(StorageEvent::ReadResult { value, .. }) => value
-            .map(|bytes| {
-                postcard::from_bytes(&bytes).map_err(|error| {
-                    MetadataError::Backend(format!(
-                        "failed to decode metadata materialization status: {error}"
-                    ))
-                })
-            })
-            .transpose(),
-        Event::Storage(StorageEvent::Error { error }) => {
-            Err(MetadataError::Backend(error.to_string()))
-        }
-        other => Err(MetadataError::Backend(format!(
-            "unexpected metadata materialization status event: {other:?}"
-        ))),
+            .map(|bytes| postcard::from_bytes(&bytes).map_err(ConversionError::from))
+            .transpose()
+            .map_err(MetadataIriIndexError::from),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
+        other => Err(MetadataIriIndexError::UnexpectedEvent(format!("{other:?}"))),
     }
 }
 
 async fn write_metadata_iri_references(
     storage: &StorageHandle,
     records: &[MetadataIriReferenceIndexRecord],
-) -> Result<(), MetadataError> {
+) -> Result<(), MetadataIriIndexError> {
     for records in records.chunks(IRI_INDEX_WRITE_BATCH_SIZE) {
-        let writes = metadata_iri_reference_write_entries(records)
-            .map_err(|error| MetadataError::Backend(error.to_string()))?;
+        let writes = metadata_iri_reference_write_entries(records)?;
         match storage
             .send_storage_effect(StorageEffect::BatchWrite {
                 writes,
@@ -435,13 +429,9 @@ async fn write_metadata_iri_references(
             .await
         {
             Event::Storage(StorageEvent::BatchWriteResult { .. }) => {}
-            Event::Storage(StorageEvent::Error { error }) => {
-                return Err(MetadataError::Backend(error.to_string()));
-            }
+            Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
             other => {
-                return Err(MetadataError::Backend(format!(
-                    "unexpected metadata IRI reference index write event: {other:?}"
-                )));
+                return Err(MetadataIriIndexError::UnexpectedEvent(format!("{other:?}")));
             }
         }
     }
@@ -640,6 +630,20 @@ mod tests {
             filtered[0].subject_iris,
             vec!["https://example.test/root".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn decode_error_classified() {
+        // A corrupt row must stay a conversion failure: callers charge those to
+        // the document, while storage failures must never spend that budget.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        write_index_row(&storage, Ulid::from_parts(1, 1), Ulid::from_parts(2, 1)).await;
+
+        let error = scan_iri_reference_records(&storage, None)
+            .await
+            .expect_err("malformed row fails to decode");
+        assert!(matches!(error, MetadataIriIndexError::Conversion(_)));
     }
 
     #[tokio::test]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -60,7 +60,7 @@ const DEAD_LETTER_REQUEUE_MAX_MS: u64 = 3_600_000;
 const DEAD_LETTER_REQUEUE_PAGE_SIZE: usize = 256;
 // Jobs per finish transaction. Small enough that a failed commit costs little,
 // large enough that a full batch commits in a handful of transactions.
-const MATERIALIZATION_FINISH_CHUNK: usize = 64;
+const MATERIALIZATION_FINISH_CHUNK: usize = 256;
 
 pub const METADATA_MATERIALIZATION_POLL_AFTER: Duration = Duration::from_secs(5);
 pub const METADATA_MATERIALIZATION_RETRY_AFTER: Duration = Duration::from_secs(1);
@@ -3463,12 +3463,12 @@ mod tests {
     // Rescheduled jobs for `count` distinct documents, rows already persisted.
     async fn reschedule_batch(
         storage: &StorageHandle,
-        count: u8,
+        count: usize,
     ) -> Vec<FinishedMaterializationJob> {
         let mut finished = Vec::new();
         for seed in 0..count {
-            let document_id = Ulid::from_bytes([120 + seed; 16]);
-            let event_id = Ulid::from_parts(1, u128::from(seed));
+            let document_id = Ulid::from_parts(900, seed as u128);
+            let event_id = Ulid::from_parts(1, seed as u128);
             let event = create_event(document_id, event_id, "chunk");
             let job = MetadataMaterializationJobRecord {
                 document_id,
@@ -3502,7 +3502,7 @@ mod tests {
         // so in several transactions so a late failure cannot undo early work.
         let dir = tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let count = u8::try_from(MATERIALIZATION_FINISH_CHUNK + 3).unwrap();
+        let count = MATERIALIZATION_FINISH_CHUNK + 3;
         let finished = reschedule_batch(&storage, count).await;
 
         let before = storage.snapshot_metrics().requests_total;
@@ -3514,7 +3514,7 @@ mod tests {
         // Two chunks, each a handful of requests: far below one transaction per
         // job, and each chunk commits on its own.
         assert!(delta <= 16, "finish issued {delta} storage requests");
-        assert_eq!(index_job_keys(&storage).await.len(), usize::from(count));
+        assert_eq!(index_job_keys(&storage).await.len(), count);
         assert_eq!(storage.snapshot_metrics().conflicts_total, 0);
     }
 

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -54,6 +54,9 @@ const MATERIALIZATION_MAX_ATTEMPTS: u32 = 10;
 
 pub const METADATA_MATERIALIZATION_POLL_AFTER: Duration = Duration::from_secs(5);
 pub const METADATA_MATERIALIZATION_RETRY_AFTER: Duration = Duration::from_secs(1);
+// Small gap between full batches so the timer runtime, other timers, and the
+// storage lanes get scheduled and a healthy drain cannot monopolize the system.
+pub const METADATA_MATERIALIZATION_NEXT_BATCH_AFTER: Duration = Duration::from_millis(25);
 
 #[derive(Debug)]
 pub struct MetadataMaterializationDrainResult {

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -34,7 +34,7 @@ use aruna_tasks::TaskHandle;
 use byteview::ByteView;
 use thiserror::Error;
 use tokio::task::JoinSet;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use ulid::Ulid;
 
 use crate::driver::DriverContext;
@@ -894,8 +894,23 @@ pub async fn requeue_dead_letters(
             if dead_letter.requeue_at_ms > now_ms {
                 continue;
             }
-            if requeue_dead_letter(storage, &dead_letter).await? {
-                requeued = requeued.saturating_add(1);
+            match requeue_dead_letter(storage, &dead_letter).await {
+                Ok(true) => requeued = requeued.saturating_add(1),
+                Ok(false) => {}
+                // A racing finish for the same document aborts this requeue; the
+                // dead letter stays, so one contended document must not stop the
+                // sweep from freeing the rest.
+                Err(MetadataMaterializationQueueError::Storage(
+                    StorageError::TransactionConflict,
+                )) => {
+                    debug!(
+                        event = "materialization.deadletter.contended",
+                        document_id = %dead_letter.job.document_id,
+                        event_id = %dead_letter.job.event_id,
+                        "Deferring contended metadata materialization dead letter"
+                    );
+                }
+                Err(error) => return Err(error),
             }
         }
 
@@ -940,23 +955,6 @@ async fn requeue_dead_letter(
         failures: MATERIALIZATION_MAX_FAILURES.saturating_sub(1),
         parks: dead_letter.parks,
     };
-    if let Some(status) = read_materialization_status(storage, job.document_id, None).await?
-        && dead_letter_superseded(&status, &job)
-    {
-        info!(
-            event = "materialization.deadletter.superseded",
-            document_id = %job.document_id,
-            event_id = %job.event_id,
-            status_event_id = %status.event_id,
-            "Dropping superseded metadata materialization dead letter"
-        );
-        delete_dead_letter(
-            storage,
-            dead_letter_key(job.document_id, job.event_id).to_vec(),
-        )
-        .await?;
-        return Ok(false);
-    }
     let event = match read_create_event(storage, job.document_id, job.event_id).await {
         Ok(event) => event,
         Err(MetadataMaterializationQueueError::MetadataCreateEventMissing { .. }) => {
@@ -974,32 +972,11 @@ async fn requeue_dead_letter(
         ..new_pending_materialization_status(&event, unix_timestamp_millis())
     };
     let txn_id = start_write_transaction(storage).await?;
-    let result = async {
-        transactional_batch_write(
-            storage,
-            txn_id,
-            vec![
-                metadata_materialization_status_write_entry(&status)?,
-                metadata_materialization_job_write_entry(&job)?,
-                metadata_materialization_document_job_write_entry(&job)?,
-            ],
-        )
-        .await?;
-        transactional_batch_delete(
-            storage,
-            txn_id,
-            vec![(
-                METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
-                dead_letter_key(job.document_id, job.event_id),
-            )],
-        )
-        .await
-    }
-    .await;
+    let result = requeue_in_txn(storage, txn_id, &job, &status).await;
     match result {
-        Ok(()) => {
+        Ok(requeued) => {
             commit_storage_transaction(storage, txn_id).await?;
-            Ok(true)
+            Ok(requeued)
         }
         Err(error) => {
             abort_storage_transaction_best_effort(
@@ -1012,6 +989,47 @@ async fn requeue_dead_letter(
             Err(error)
         }
     }
+}
+
+// The status guard is read inside the transaction: a newer event finishing
+// between the read and the commit writes that same key, so the conflict manager
+// aborts this requeue instead of letting it restore an obsolete event.
+async fn requeue_in_txn(
+    storage: &StorageHandle,
+    txn_id: Ulid,
+    job: &MetadataMaterializationJobRecord,
+    status: &MetadataMaterializationStatusRecord,
+) -> Result<bool, MetadataMaterializationQueueError> {
+    let dead_letter_delete = vec![(
+        METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
+        dead_letter_key(job.document_id, job.event_id),
+    )];
+    if let Some(current) =
+        read_materialization_status(storage, job.document_id, Some(txn_id)).await?
+        && dead_letter_superseded(&current, job)
+    {
+        info!(
+            event = "materialization.deadletter.superseded",
+            document_id = %job.document_id,
+            event_id = %job.event_id,
+            status_event_id = %current.event_id,
+            "Dropping superseded metadata materialization dead letter"
+        );
+        transactional_batch_delete(storage, txn_id, dead_letter_delete).await?;
+        return Ok(false);
+    }
+    transactional_batch_write(
+        storage,
+        txn_id,
+        vec![
+            metadata_materialization_status_write_entry(status)?,
+            metadata_materialization_job_write_entry(job)?,
+            metadata_materialization_document_job_write_entry(job)?,
+        ],
+    )
+    .await?;
+    transactional_batch_delete(storage, txn_id, dead_letter_delete).await?;
+    Ok(true)
 }
 
 async fn delete_dead_letter(
@@ -3251,6 +3269,73 @@ mod tests {
             .expect("status survives");
         assert_eq!(status.event_id, newer_event_id);
         assert_eq!(status.state, MetadataMaterializationState::Materialized);
+        assert!(
+            read_document_job(&storage, document_id, old_event_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn requeue_aborts_raced() {
+        // A newer event finishing while the requeue is open must beat it: the
+        // requeue would otherwise reinstate an obsolete event as pending and
+        // delete nothing, leaving the document projected from stale state.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([56u8; 16]);
+        let old_event_id = Ulid::from_parts(1, 1);
+        let newer_event_id = Ulid::from_parts(2, 1);
+        let old_event = create_event(document_id, old_event_id, "old");
+        let newer_event = create_event(document_id, newer_event_id, "newer");
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id: old_event_id,
+            due_at_ms: 1,
+            attempts: MATERIALIZATION_MAX_FAILURES,
+            failures: MATERIALIZATION_MAX_FAILURES,
+            parks: 1,
+        };
+        let status = MetadataMaterializationStatusRecord {
+            failures: job.failures,
+            ..new_pending_materialization_status(&old_event, 1)
+        };
+        write_entries(
+            &storage,
+            vec![metadata_create_event_write_entry(&old_event).unwrap()],
+        )
+        .await;
+
+        let txn_id = start_write_transaction(&storage).await.unwrap();
+        assert!(
+            requeue_in_txn(&storage, txn_id, &job, &status)
+                .await
+                .unwrap()
+        );
+
+        let racing = start_write_transaction(&storage).await.unwrap();
+        transactional_batch_write(
+            &storage,
+            racing,
+            vec![
+                metadata_materialization_status_write_entry(&materialized_status(
+                    document_id,
+                    &newer_event,
+                ))
+                .unwrap(),
+            ],
+        )
+        .await
+        .unwrap();
+        commit_storage_transaction(&storage, racing).await.unwrap();
+
+        assert!(commit_storage_transaction(&storage, txn_id).await.is_err());
+        let current = read_materialization_status(&storage, document_id, None)
+            .await
+            .unwrap()
+            .expect("racing status survives");
+        assert_eq!(current.event_id, newer_event_id);
         assert!(
             read_document_job(&storage, document_id, old_event_id)
                 .await

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -617,6 +617,7 @@ async fn plan_finish_chunk(
                         .saturating_add(queue_retry_after_ms(attempts)),
                     attempts,
                     failures: status.failures,
+                    parks: job.parks,
                 };
                 if should_write_pending_retry_status(current, &status) {
                     plan.writes
@@ -797,13 +798,16 @@ async fn batch_read_values(
 }
 
 // A re-parked job keeps its park count so its requeue backoff keeps growing
-// instead of restarting at the base delay.
+// instead of restarting at the base delay. The count survives a requeue on the
+// job itself, since the requeue deletes the dead letter that carried it.
 fn parked_dead_letter(
     job: &MetadataMaterializationJobRecord,
     status: &MetadataMaterializationStatusRecord,
     previous: Option<&MetadataMaterializationDeadLetterRecord>,
 ) -> MetadataMaterializationDeadLetterRecord {
-    let parks = previous.map_or(1, |previous| previous.parks.saturating_add(1));
+    let parks = previous
+        .map_or(job.parks, |previous| previous.parks.max(job.parks))
+        .saturating_add(1);
     let now_ms = unix_timestamp_millis();
     MetadataMaterializationDeadLetterRecord {
         job: job.clone(),
@@ -934,6 +938,7 @@ async fn requeue_dead_letter(
         due_at_ms: unix_timestamp_millis(),
         attempts: 0,
         failures: MATERIALIZATION_MAX_FAILURES.saturating_sub(1),
+        parks: dead_letter.parks,
     };
     if let Some(status) = read_materialization_status(storage, job.document_id, None).await?
         && dead_letter_superseded(&status, &job)
@@ -1765,6 +1770,7 @@ fn should_write_pending_retry_status(
                     due_at_ms: 0,
                     attempts: next.attempts,
                     failures: next.failures,
+                    parks: 0,
                 },
             )
     })
@@ -2310,6 +2316,7 @@ mod tests {
             due_at_ms: 0,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         older_job_exists(storage, &group, &job, advanced).await
     }
@@ -2412,6 +2419,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let (_, global_key, _) = metadata_materialization_job_write_entry(&old_job).unwrap();
         let document_key = metadata_materialization_document_job_key(document_id, old_event_id);
@@ -2510,6 +2518,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let document_key = metadata_materialization_document_job_key(document_id, old_event_id);
         write_entries(
@@ -2545,6 +2554,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let global_key = metadata_materialization_job_key(&job);
         let document_key = metadata_materialization_document_job_key(document_id, event_id);
@@ -2637,6 +2647,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let mut writes = vec![
             metadata_create_event_write_entry(&event).unwrap(),
@@ -2650,6 +2661,7 @@ mod tests {
                 due_at_ms: now_ms.saturating_add(60_000).saturating_add(index),
                 attempts: 0,
                 failures: 0,
+                parks: 0,
             };
             writes.push(metadata_materialization_job_write_entry(&future_job).unwrap());
         }
@@ -2689,6 +2701,7 @@ mod tests {
                 due_at_ms: 1,
                 attempts: 0,
                 failures: 0,
+                parks: 0,
             };
             writes.push(metadata_create_event_write_entry(&event).unwrap());
             writes.push(metadata_materialization_job_write_entry(&job).unwrap());
@@ -2724,6 +2737,7 @@ mod tests {
                 due_at_ms: 1,
                 attempts: 0,
                 failures: 0,
+                parks: 0,
             };
             writes.push(metadata_create_event_write_entry(&event).unwrap());
             writes.push(metadata_materialization_job_write_entry(&job).unwrap());
@@ -2754,6 +2768,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let mismatched = MetadataMaterializationJobRecord {
             document_id: Ulid::from_bytes([43u8; 16]),
@@ -2761,6 +2776,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let mismatched_sidecar = MetadataMaterializationJobRecord {
             due_at_ms: 999,
@@ -2820,6 +2836,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let mut writes = vec![
             metadata_create_event_write_entry(&first_event).unwrap(),
@@ -2834,6 +2851,7 @@ mod tests {
                 due_at_ms: 1,
                 attempts: 0,
                 failures: 0,
+                parks: 0,
             };
             writes.push(metadata_materialization_document_job_write_entry(&other).unwrap());
         }
@@ -2868,6 +2886,7 @@ mod tests {
             due_at_ms: 1,
             attempts: MATERIALIZATION_MAX_FAILURES - 1,
             failures: MATERIALIZATION_MAX_FAILURES - 1,
+            parks: 0,
         };
         let index_key = metadata_materialization_job_key(&job);
         let sidecar_key = metadata_materialization_document_job_key(document_id, event_id);
@@ -2931,6 +2950,7 @@ mod tests {
             due_at_ms: 1,
             attempts: MATERIALIZATION_MAX_FAILURES - 2,
             failures: MATERIALIZATION_MAX_FAILURES - 2,
+            parks: 0,
         };
         let key = metadata_materialization_job_key(&reschedule);
         match defer_materialization_job(key.as_ref(), &reschedule, &event, &application_failure()) {
@@ -2941,6 +2961,7 @@ mod tests {
         }
         let park = MetadataMaterializationJobRecord {
             failures: MATERIALIZATION_MAX_FAILURES - 1,
+            parks: 0,
             ..reschedule
         };
         assert!(matches!(
@@ -2962,6 +2983,7 @@ mod tests {
             due_at_ms: 1,
             attempts: MATERIALIZATION_MAX_FAILURES + 5,
             failures: MATERIALIZATION_MAX_FAILURES - 1,
+            parks: 0,
         };
         let key = metadata_materialization_job_key(&job);
         let errors = [
@@ -2997,6 +3019,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: MATERIALIZATION_MAX_FAILURES - 1,
+            parks: 0,
         };
         let key = metadata_materialization_job_key(&job);
         let error = MetadataMaterializationQueueError::from(MetadataIriIndexError::Storage(
@@ -3024,6 +3047,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: MATERIALIZATION_MAX_FAILURES - 1,
+            parks: 0,
         };
         let key = metadata_materialization_job_key(&job);
         let errors = [
@@ -3059,6 +3083,7 @@ mod tests {
             due_at_ms: 1,
             attempts: MATERIALIZATION_MAX_FAILURES,
             failures: MATERIALIZATION_MAX_FAILURES,
+            parks: 0,
         };
         let pending = MetadataMaterializationDeadLetterRecord {
             job: job.clone(),
@@ -3119,6 +3144,7 @@ mod tests {
             due_at_ms: 1,
             attempts: MATERIALIZATION_MAX_FAILURES,
             failures: MATERIALIZATION_MAX_FAILURES,
+            parks: 0,
         };
         let due = MetadataMaterializationDeadLetterRecord {
             job: parked,
@@ -3142,10 +3168,20 @@ mod tests {
             .unwrap()
             .expect("job is requeued");
         let key = metadata_materialization_job_key(&requeued);
-        assert!(matches!(
-            defer_materialization_job(key.as_ref(), &requeued, &event, &application_failure()),
-            FinishedMaterializationJob::Parked { .. }
-        ));
+        let FinishedMaterializationJob::Parked { job, status, .. } =
+            defer_materialization_job(key.as_ref(), &requeued, &event, &application_failure())
+        else {
+            panic!("expected park");
+        };
+
+        // The requeue deleted the dead letter that held the park count, so the
+        // job carries it: the second park must wait longer than the first.
+        let reparked = parked_dead_letter(&job, &status, None);
+        assert_eq!(reparked.parks, due.parks + 1);
+        assert!(
+            reparked.requeue_at_ms.saturating_sub(reparked.parked_at_ms)
+                > requeue_after_ms(due.parks)
+        );
     }
 
     // A status that already materialized `event_id`, as a newer event would.
@@ -3159,6 +3195,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         materialization_success_status(&job, event, None)
     }
@@ -3182,6 +3219,7 @@ mod tests {
                 due_at_ms: 1,
                 attempts: MATERIALIZATION_MAX_FAILURES,
                 failures: MATERIALIZATION_MAX_FAILURES,
+                parks: 0,
             },
             last_error: "boom".to_string(),
             parked_at_ms: 1,
@@ -3239,6 +3277,7 @@ mod tests {
             due_at_ms: 1,
             attempts: MATERIALIZATION_MAX_FAILURES - 1,
             failures: MATERIALIZATION_MAX_FAILURES - 1,
+            parks: 0,
         };
         let job_key = metadata_materialization_job_key(&job);
         write_entries(
@@ -3396,6 +3435,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let newer_pending = MetadataMaterializationStatusRecord {
             document_id,
@@ -3514,6 +3554,7 @@ mod tests {
                 due_at_ms: 1,
                 attempts: 0,
                 failures: 0,
+                parks: 0,
             };
             write_entries(
                 storage,
@@ -3613,6 +3654,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let (_, old_job_key, _) = metadata_materialization_job_write_entry(&old_job).unwrap();
         write_entries(
@@ -3645,6 +3687,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         write_entries(
             &storage,
@@ -3698,6 +3741,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let newer_status = MetadataMaterializationStatusRecord {
             document_id,
@@ -3818,6 +3862,7 @@ mod tests {
                 due_at_ms: 1,
                 attempts: 0,
                 failures: 0,
+                parks: 0,
             };
             CompletedMaterializationJob {
                 job_key: metadata_materialization_job_write_entry(&job)
@@ -3981,6 +4026,7 @@ mod tests {
             due_at_ms: 30_000,
             attempts: 1,
             failures: 0,
+            parks: 0,
         };
         let newer_pending = MetadataMaterializationStatusRecord {
             document_id,
@@ -4042,6 +4088,7 @@ mod tests {
                     due_at_ms: 1,
                     attempts: 0,
                     failures: 0,
+                    parks: 0,
                 };
                 let index_key = metadata_materialization_job_key(&job);
                 (job, event, index_key)
@@ -4122,6 +4169,7 @@ mod tests {
             due_at_ms: 1,
             attempts: 0,
             failures: 0,
+            parks: 0,
         };
         let old_index_key = metadata_materialization_job_key(&job);
         write_entries(

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -1654,6 +1654,25 @@ mod tests {
         }
     }
 
+    async fn index_job_keys(storage: &StorageHandle) -> Vec<(u64, Ulid, Ulid)> {
+        match storage
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                prefix: None,
+                start: None,
+                limit: 4096,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult { values, .. }) => values
+                .into_iter()
+                .filter_map(|(key, _)| materialization_job_key_parts(&key))
+                .collect(),
+            other => panic!("unexpected storage event: {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn corrupt_materialization_job_only_is_deleted() {
         let dir = tempdir().unwrap();
@@ -2778,6 +2797,16 @@ mod tests {
                 (job, event, index_key)
             })
             .collect();
+        for (job, _, _) in &jobs {
+            write_entries(
+                &storage,
+                vec![
+                    metadata_materialization_job_write_entry(job).unwrap(),
+                    metadata_materialization_document_job_write_entry(job).unwrap(),
+                ],
+            )
+            .await;
+        }
         let finished: Vec<_> = jobs
             .iter()
             .map(|(job, event, index_key)| {
@@ -2806,6 +2835,85 @@ mod tests {
                 .expect("job requeued");
             assert_eq!(requeued.attempts, 1);
         }
+
+        // Exactly the rescheduled index rows survive: the old due_at=1 keys are
+        // gone and each document keeps one new-due row.
+        let index_keys = index_job_keys(&storage).await;
+        assert_eq!(index_keys.len(), jobs.len());
+        for (job, _, old_key) in &jobs {
+            assert!(
+                !storage_key_exists(
+                    &storage,
+                    METADATA_MATERIALIZATION_JOB_KEYSPACE,
+                    old_key.to_vec()
+                )
+                .await
+            );
+            let row = index_keys
+                .iter()
+                .find(|(_, doc, event)| *doc == job.document_id && *event == job.event_id)
+                .expect("rescheduled index row present");
+            assert_ne!(row.0, job.due_at_ms);
+        }
+    }
+
+    #[tokio::test]
+    async fn failing_apply_reschedules() {
+        // A non-terminal apply failure (missing metadata handle) reschedules the
+        // job with attempts advanced and both rows kept at a new due time.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([90u8; 16]);
+        let event_id = Ulid::from_parts(3, 1);
+        let event = create_event(document_id, event_id, "reschedule");
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: 0,
+        };
+        let old_index_key = metadata_materialization_job_key(&job);
+        write_entries(
+            &storage,
+            vec![
+                metadata_create_event_write_entry(&event).unwrap(),
+                metadata_materialization_job_write_entry(&job).unwrap(),
+                metadata_materialization_document_job_write_entry(&job).unwrap(),
+            ],
+        )
+        .await;
+        let context = DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+            compute_handle: None,
+        };
+
+        let result = process_metadata_materialization_batch(&context)
+            .await
+            .expect("batch drains");
+        assert_eq!(result.processed, 1);
+
+        let requeued = read_document_job(&storage, document_id, event_id)
+            .await
+            .unwrap()
+            .expect("job rescheduled");
+        assert_eq!(requeued.attempts, 1);
+        assert!(
+            !storage_key_exists(
+                &storage,
+                METADATA_MATERIALIZATION_JOB_KEYSPACE,
+                old_index_key.to_vec()
+            )
+            .await
+        );
+        let index_keys = index_job_keys(&storage).await;
+        assert_eq!(index_keys.len(), 1);
+        assert_eq!(index_keys[0].1, document_id);
+        assert_eq!(index_keys[0].2, event_id);
+        assert_ne!(index_keys[0].0, job.due_at_ms);
     }
 
     #[test]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -2135,7 +2135,8 @@ fn materialization_failure_kind(
             MetadataError::ChannelClosed
             | MetadataError::TaskJoin(_)
             | MetadataError::HandleMissing
-            | MetadataError::Persist(_),
+            | MetadataError::Persist(_)
+            | MetadataError::Storage(_),
         )
         | MetadataMaterializationQueueError::MetadataHandleMissing => {
             MaterializationFailureKind::Transient
@@ -3003,6 +3004,40 @@ mod tests {
                 assert_eq!(status.failures, job.failures);
             }
             other => panic!("expected reschedule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn handle_failure_transient() {
+        // The lifecycle read and the craqle apply reach the queue through the
+        // metadata handle; an overloaded lane or a failed disk write there must
+        // not spend the budget reserved for failures the document caused.
+        let document_id = Ulid::from_bytes([53u8; 16]);
+        let event_id = Ulid::from_parts(7, 1);
+        let event = create_event(document_id, event_id, "handle");
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: 0,
+            failures: MATERIALIZATION_MAX_FAILURES - 1,
+        };
+        let key = metadata_materialization_job_key(&job);
+        let errors = [
+            MetadataMaterializationQueueError::Metadata(MetadataError::Storage(
+                StorageError::QueueFull,
+            )),
+            MetadataMaterializationQueueError::Metadata(MetadataError::Storage(
+                StorageError::Timeout,
+            )),
+        ];
+        for error in errors {
+            match defer_materialization_job(key.as_ref(), &job, &event, &error) {
+                FinishedMaterializationJob::Rescheduled { status, .. } => {
+                    assert_eq!(status.failures, job.failures);
+                }
+                other => panic!("expected reschedule, got {other:?}"),
+            }
         }
     }
 

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -467,6 +467,9 @@ async fn schedule_completed_materialization_syncs(
 struct FinishPlan {
     writes: Vec<(String, ByteView, ByteView)>,
     deletes: Vec<(String, ByteView)>,
+    /// Documents whose winning cursor advanced; their prior index rows are
+    /// pruned once per batch rather than once per chunk.
+    superseding: HashMap<Ulid, Ulid>,
 }
 
 // Chunked so a failure costs one chunk instead of the whole batch, and the
@@ -475,27 +478,46 @@ async fn finish_completed_materialization_jobs(
     storage: &StorageHandle,
     finished: Vec<FinishedMaterializationJob>,
 ) -> Result<(), MetadataMaterializationQueueError> {
+    let mut superseding = HashMap::new();
     let mut chunk = Vec::with_capacity(MATERIALIZATION_FINISH_CHUNK);
     for job in finished {
         chunk.push(job);
         if chunk.len() >= MATERIALIZATION_FINISH_CHUNK {
-            finish_chunk(storage, std::mem::take(&mut chunk)).await?;
+            let taken = std::mem::take(&mut chunk);
+            superseding.extend(finish_chunk(storage, taken).await?);
             chunk.reserve(MATERIALIZATION_FINISH_CHUNK);
         }
     }
     if !chunk.is_empty() {
-        finish_chunk(storage, chunk).await?;
+        superseding.extend(finish_chunk(storage, chunk).await?);
     }
-    Ok(())
+    prune_superseded_rows(storage, superseding).await
 }
 
+// The IRI reference index cannot be scanned per document, so this walks the
+// whole keyspace: once per batch, never once per chunk. Cleanup only, so it
+// runs after the chunks commit rather than inside them.
+async fn prune_superseded_rows(
+    storage: &StorageHandle,
+    superseding: HashMap<Ulid, Ulid>,
+) -> Result<(), MetadataMaterializationQueueError> {
+    if superseding.is_empty() {
+        return Ok(());
+    }
+    let stale =
+        super::iri_index::superseded_iri_reference_keys(storage, None, &superseding).await?;
+    delete_materialization_entries(storage, stale).await
+}
+
+/// Returns the documents whose projection this chunk advanced, so the batch can
+/// prune their prior-cursor index rows once.
 async fn finish_chunk(
     storage: &StorageHandle,
     finished: Vec<FinishedMaterializationJob>,
-) -> Result<(), MetadataMaterializationQueueError> {
+) -> Result<HashMap<Ulid, Ulid>, MetadataMaterializationQueueError> {
     let plan = plan_finish_chunk(storage, finished).await?;
     if plan.writes.is_empty() && plan.deletes.is_empty() {
-        return Ok(());
+        return Ok(plan.superseding);
     }
     let txn_id = start_write_transaction(storage).await?;
     let result = async {
@@ -506,7 +528,7 @@ async fn finish_chunk(
     match result {
         Ok(()) => {
             commit_storage_transaction(storage, txn_id).await?;
-            Ok(())
+            Ok(plan.superseding)
         }
         Err(error) => {
             abort_storage_transaction_best_effort(
@@ -653,13 +675,7 @@ async fn plan_finish_chunk(
         }
     }
 
-    // Delete prior-cursor index rows for the re-projected documents so fenced
-    // rows do not accumulate in storage or the predicate-less backlink scan.
-    if !superseding.is_empty() {
-        let stale =
-            super::iri_index::superseded_iri_reference_keys(storage, None, &superseding).await?;
-        plan.deletes.extend(stale);
-    }
+    plan.superseding = superseding;
     Ok(plan)
 }
 

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -57,6 +57,9 @@ const MATERIALIZATION_MAX_FAILURES: u32 = 10;
 const DEAD_LETTER_REQUEUE_BASE_MS: u64 = 60_000;
 const DEAD_LETTER_REQUEUE_MAX_MS: u64 = 3_600_000;
 const DEAD_LETTER_REQUEUE_PAGE_SIZE: usize = 256;
+// Jobs per finish transaction. Small enough that a failed commit costs little,
+// large enough that a full batch commits in a handful of transactions.
+const MATERIALIZATION_FINISH_CHUNK: usize = 64;
 
 pub const METADATA_MATERIALIZATION_POLL_AFTER: Duration = Duration::from_secs(5);
 pub const METADATA_MATERIALIZATION_RETRY_AFTER: Duration = Duration::from_secs(1);
@@ -434,15 +437,47 @@ async fn schedule_completed_materialization_syncs(
     }
 }
 
+/// Row changes for one finish chunk, resolved before the transaction opens.
+#[derive(Debug, Default)]
+struct FinishPlan {
+    writes: Vec<(String, ByteView, ByteView)>,
+    deletes: Vec<(String, ByteView)>,
+}
+
+// Chunked so a failure costs one chunk instead of the whole batch, and the
+// craqle work behind the committed chunks survives.
 async fn finish_completed_materialization_jobs(
     storage: &StorageHandle,
     finished: Vec<FinishedMaterializationJob>,
 ) -> Result<(), MetadataMaterializationQueueError> {
-    if finished.is_empty() {
+    let mut chunk = Vec::with_capacity(MATERIALIZATION_FINISH_CHUNK);
+    for job in finished {
+        chunk.push(job);
+        if chunk.len() >= MATERIALIZATION_FINISH_CHUNK {
+            finish_chunk(storage, std::mem::take(&mut chunk)).await?;
+            chunk.reserve(MATERIALIZATION_FINISH_CHUNK);
+        }
+    }
+    if !chunk.is_empty() {
+        finish_chunk(storage, chunk).await?;
+    }
+    Ok(())
+}
+
+async fn finish_chunk(
+    storage: &StorageHandle,
+    finished: Vec<FinishedMaterializationJob>,
+) -> Result<(), MetadataMaterializationQueueError> {
+    let plan = plan_finish_chunk(storage, finished).await?;
+    if plan.writes.is_empty() && plan.deletes.is_empty() {
         return Ok(());
     }
     let txn_id = start_write_transaction(storage).await?;
-    let result = finish_completed_materialization_jobs_in_txn(storage, txn_id, finished).await;
+    let result = async {
+        transactional_batch_write(storage, txn_id, plan.writes).await?;
+        transactional_batch_delete(storage, txn_id, plan.deletes).await
+    }
+    .await;
     match result {
         Ok(()) => {
             commit_storage_transaction(storage, txn_id).await?;
@@ -461,36 +496,43 @@ async fn finish_completed_materialization_jobs(
     }
 }
 
-async fn finish_completed_materialization_jobs_in_txn(
+// Guards read the pre-transaction snapshot instead of reading inside the
+// transaction: a write-only transaction has an empty read set and can never
+// conflict with a concurrent create, update or inbound sync.
+async fn plan_finish_chunk(
     storage: &StorageHandle,
-    txn_id: Ulid,
     finished: Vec<FinishedMaterializationJob>,
-) -> Result<(), MetadataMaterializationQueueError> {
-    let mut writes = Vec::new();
-    let mut deletes = Vec::with_capacity(finished.len().saturating_mul(2));
+) -> Result<FinishPlan, MetadataMaterializationQueueError> {
+    let snapshot = read_statuses(storage, &finished).await?;
+    let parked = read_dead_letters(storage, &finished).await?;
+    let mut plan = FinishPlan {
+        deletes: Vec::with_capacity(finished.len().saturating_mul(2)),
+        ..FinishPlan::default()
+    };
+    let mut planned: HashMap<Ulid, MetadataMaterializationStatusRecord> = HashMap::new();
     let mut superseding: HashMap<Ulid, Ulid> = HashMap::new();
     for finished in finished {
         match finished {
             FinishedMaterializationJob::Completed(job) => {
                 if let Some(status) = job.status {
-                    let current =
-                        read_materialization_status(storage, status.document_id, Some(txn_id))
-                            .await?;
-                    if should_write_final_materialization_status(current.as_ref(), &status) {
+                    let current = guard_status(&snapshot, &planned, status.document_id);
+                    if should_write_final_materialization_status(current, &status) {
                         superseding.insert(status.document_id, status.event_id);
-                        writes.extend(job.iri_index_writes);
+                        plan.writes.extend(job.iri_index_writes);
                         if let Some(raw_state_write) = job.raw_state_write {
-                            writes.push(raw_state_write);
+                            plan.writes.push(raw_state_write);
                         }
-                        writes.push(metadata_materialization_status_write_entry(&status)?);
+                        plan.writes
+                            .push(metadata_materialization_status_write_entry(&status)?);
+                        planned.insert(status.document_id, status);
                     }
                 }
-                deletes.push((
+                plan.deletes.push((
                     METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
                     ByteView::from(job.job_key),
                 ));
                 if let Some(document_job_key) = job.document_job_key {
-                    deletes.push((
+                    plan.deletes.push((
                         METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
                         ByteView::from(document_job_key),
                     ));
@@ -505,14 +547,12 @@ async fn finish_completed_materialization_jobs_in_txn(
                     METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
                     ByteView::from(job_key),
                 );
-                let current =
-                    read_materialization_status(storage, job.document_id, Some(txn_id)).await?;
+                let current = guard_status(&snapshot, &planned, job.document_id);
                 if current
-                    .as_ref()
                     .is_some_and(|current| materialization_retry_already_advanced(current, &job))
                 {
-                    deletes.push(old_index_delete);
-                    deletes.push((
+                    plan.deletes.push(old_index_delete);
+                    plan.deletes.push((
                         METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
                         metadata_materialization_document_job_key(job.document_id, job.event_id),
                     ));
@@ -527,32 +567,37 @@ async fn finish_completed_materialization_jobs_in_txn(
                     attempts,
                     failures: status.failures,
                 };
-                if should_write_pending_retry_status(current.as_ref(), &status) {
-                    writes.push(metadata_materialization_status_write_entry(&status)?);
+                if should_write_pending_retry_status(current, &status) {
+                    plan.writes
+                        .push(metadata_materialization_status_write_entry(&status)?);
+                    planned.insert(status.document_id, status);
                 }
-                writes.push(metadata_materialization_job_write_entry(&next_job)?);
-                writes.push(metadata_materialization_document_job_write_entry(
-                    &next_job,
-                )?);
-                deletes.push(old_index_delete);
+                plan.writes
+                    .push(metadata_materialization_job_write_entry(&next_job)?);
+                plan.writes
+                    .push(metadata_materialization_document_job_write_entry(
+                        &next_job,
+                    )?);
+                plan.deletes.push(old_index_delete);
             }
             FinishedMaterializationJob::Parked {
                 job_key,
                 job,
                 status,
             } => {
-                let current =
-                    read_materialization_status(storage, job.document_id, Some(txn_id)).await?;
-                if should_write_final_materialization_status(current.as_ref(), &status) {
-                    writes.push(metadata_materialization_status_write_entry(&status)?);
+                let current = guard_status(&snapshot, &planned, job.document_id);
+                if should_write_final_materialization_status(current, &status) {
+                    plan.writes
+                        .push(metadata_materialization_status_write_entry(&status)?);
                 }
-                let dead_letter = parked_dead_letter(storage, &job, &status).await?;
-                writes.push(dead_letter_entry(&dead_letter)?);
-                deletes.push((
+                let previous = parked.get(&(job.document_id, job.event_id));
+                let dead_letter = parked_dead_letter(&job, &status, previous);
+                plan.writes.push(dead_letter_entry(&dead_letter)?);
+                plan.deletes.push((
                     METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
                     ByteView::from(job_key),
                 ));
-                deletes.push((
+                plan.deletes.push((
                     METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
                     metadata_materialization_document_job_key(job.document_id, job.event_id),
                 ));
@@ -566,6 +611,7 @@ async fn finish_completed_materialization_jobs_in_txn(
                     error = status.last_error.as_deref().unwrap_or_default(),
                     "Parked metadata materialization job as dead letter"
                 );
+                planned.insert(status.document_id, status);
             }
         }
     }
@@ -575,30 +621,142 @@ async fn finish_completed_materialization_jobs_in_txn(
     if !superseding.is_empty() {
         let stale =
             super::iri_index::superseded_iri_reference_keys(storage, None, &superseding).await?;
-        deletes.extend(stale);
+        plan.deletes.extend(stale);
     }
+    Ok(plan)
+}
 
-    transactional_batch_write(storage, txn_id, writes).await?;
-    transactional_batch_delete(storage, txn_id, deletes).await
+// A status planned earlier in this chunk is newer than the snapshot, so it is
+// what later jobs of the same document must be judged against.
+fn guard_status<'a>(
+    snapshot: &'a HashMap<Ulid, MetadataMaterializationStatusRecord>,
+    planned: &'a HashMap<Ulid, MetadataMaterializationStatusRecord>,
+    document_id: Ulid,
+) -> Option<&'a MetadataMaterializationStatusRecord> {
+    planned
+        .get(&document_id)
+        .or_else(|| snapshot.get(&document_id))
+}
+
+fn finished_document_id(finished: &FinishedMaterializationJob) -> Ulid {
+    match finished {
+        FinishedMaterializationJob::Completed(job) => job
+            .status
+            .as_ref()
+            .map(|status| status.document_id)
+            .unwrap_or_else(|| {
+                materialization_job_key_target(&job.job_key)
+                    .map(|(document_id, _)| document_id)
+                    .unwrap_or_else(Ulid::nil)
+            }),
+        FinishedMaterializationJob::Rescheduled { job, .. }
+        | FinishedMaterializationJob::Parked { job, .. } => job.document_id,
+    }
+}
+
+async fn read_statuses(
+    storage: &StorageHandle,
+    finished: &[FinishedMaterializationJob],
+) -> Result<HashMap<Ulid, MetadataMaterializationStatusRecord>, MetadataMaterializationQueueError> {
+    let document_ids: BTreeSet<Ulid> = finished.iter().map(finished_document_id).collect();
+    if document_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let reads = document_ids
+        .iter()
+        .map(|document_id| {
+            (
+                METADATA_MATERIALIZATION_STATUS_KEYSPACE.to_string(),
+                metadata_materialization_status_key(*document_id),
+            )
+        })
+        .collect();
+    let values = batch_read_values(storage, reads).await?;
+    let mut statuses = HashMap::new();
+    for (document_id, value) in document_ids.into_iter().zip(values) {
+        if let Some(value) = value {
+            statuses.insert(
+                document_id,
+                postcard::from_bytes(&value).map_err(ConversionError::from)?,
+            );
+        }
+    }
+    Ok(statuses)
+}
+
+async fn read_dead_letters(
+    storage: &StorageHandle,
+    finished: &[FinishedMaterializationJob],
+) -> Result<
+    HashMap<(Ulid, Ulid), MetadataMaterializationDeadLetterRecord>,
+    MetadataMaterializationQueueError,
+> {
+    let targets: BTreeSet<(Ulid, Ulid)> = finished
+        .iter()
+        .filter_map(|finished| match finished {
+            FinishedMaterializationJob::Parked { job, .. } => Some((job.document_id, job.event_id)),
+            _ => None,
+        })
+        .collect();
+    if targets.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let reads = targets
+        .iter()
+        .map(|(document_id, event_id)| {
+            (
+                METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
+                dead_letter_key(*document_id, *event_id),
+            )
+        })
+        .collect();
+    let values = batch_read_values(storage, reads).await?;
+    let mut dead_letters = HashMap::new();
+    for (target, value) in targets.into_iter().zip(values) {
+        if let Some(record) = value.and_then(|value| postcard::from_bytes(&value).ok()) {
+            dead_letters.insert(target, record);
+        }
+    }
+    Ok(dead_letters)
+}
+
+async fn batch_read_values(
+    storage: &StorageHandle,
+    reads: Vec<(String, ByteView)>,
+) -> Result<Vec<Option<ByteView>>, MetadataMaterializationQueueError> {
+    match storage
+        .send_storage_effect(StorageEffect::BatchRead {
+            reads,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchReadResult { values }) => {
+            Ok(values.into_iter().map(|(_, value)| value).collect())
+        }
+        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
+        other => Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
+            "{other:?}"
+        ))),
+    }
 }
 
 // A re-parked job keeps its park count so its requeue backoff keeps growing
 // instead of restarting at the base delay.
-async fn parked_dead_letter(
-    storage: &StorageHandle,
+fn parked_dead_letter(
     job: &MetadataMaterializationJobRecord,
     status: &MetadataMaterializationStatusRecord,
-) -> Result<MetadataMaterializationDeadLetterRecord, MetadataMaterializationQueueError> {
-    let previous = read_dead_letter(storage, job.document_id, job.event_id).await?;
+    previous: Option<&MetadataMaterializationDeadLetterRecord>,
+) -> MetadataMaterializationDeadLetterRecord {
     let parks = previous.map_or(1, |previous| previous.parks.saturating_add(1));
     let now_ms = unix_timestamp_millis();
-    Ok(MetadataMaterializationDeadLetterRecord {
+    MetadataMaterializationDeadLetterRecord {
         job: job.clone(),
         last_error: status.last_error.clone().unwrap_or_default(),
         parked_at_ms: now_ms,
         parks,
         requeue_at_ms: now_ms.saturating_add(requeue_after_ms(parks)),
-    })
+    }
 }
 
 fn requeue_after_ms(parks: u32) -> u64 {
@@ -609,6 +767,7 @@ fn requeue_after_ms(parks: u32) -> u64 {
     )
 }
 
+#[cfg(test)]
 async fn read_dead_letter(
     storage: &StorageHandle,
     document_id: Ulid,
@@ -2796,6 +2955,103 @@ mod tests {
             Some(&retry_status),
             &fresh_final
         ));
+    }
+
+    // Rescheduled jobs for `count` distinct documents, rows already persisted.
+    async fn reschedule_batch(
+        storage: &StorageHandle,
+        count: u8,
+    ) -> Vec<FinishedMaterializationJob> {
+        let mut finished = Vec::new();
+        for seed in 0..count {
+            let document_id = Ulid::from_bytes([120 + seed; 16]);
+            let event_id = Ulid::from_parts(1, u128::from(seed));
+            let event = create_event(document_id, event_id, "chunk");
+            let job = MetadataMaterializationJobRecord {
+                document_id,
+                event_id,
+                due_at_ms: 1,
+                attempts: 0,
+                failures: 0,
+            };
+            write_entries(
+                storage,
+                vec![
+                    metadata_materialization_job_write_entry(&job).unwrap(),
+                    metadata_materialization_document_job_write_entry(&job).unwrap(),
+                ],
+            )
+            .await;
+            let key = metadata_materialization_job_key(&job);
+            finished.push(defer_materialization_job(
+                key.as_ref(),
+                &job,
+                &event,
+                &application_failure(),
+            ));
+        }
+        finished
+    }
+
+    #[tokio::test]
+    async fn finish_commits_chunks() {
+        // More jobs than one chunk holds still resolve completely, and they do
+        // so in several transactions so a late failure cannot undo early work.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let count = u8::try_from(MATERIALIZATION_FINISH_CHUNK + 3).unwrap();
+        let finished = reschedule_batch(&storage, count).await;
+
+        let before = storage.snapshot_metrics().requests_total;
+        finish_completed_materialization_jobs(&storage, finished)
+            .await
+            .unwrap();
+        let delta = storage.snapshot_metrics().requests_total - before;
+
+        // Two chunks, each a handful of requests: far below one transaction per
+        // job, and each chunk commits on its own.
+        assert!(delta <= 16, "finish issued {delta} storage requests");
+        assert_eq!(index_job_keys(&storage).await.len(), usize::from(count));
+        assert_eq!(storage.snapshot_metrics().conflicts_total, 0);
+    }
+
+    #[tokio::test]
+    async fn finish_avoids_conflicts() {
+        // A status write landing between the guard snapshot and the commit must
+        // not conflict: the finish transaction only writes.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let finished = reschedule_batch(&storage, 4).await;
+        let plan = plan_finish_chunk(&storage, finished).await.unwrap();
+
+        let document_id = Ulid::from_bytes([120u8; 16]);
+        let racing = MetadataMaterializationStatusRecord {
+            document_id,
+            event_id: Ulid::from_parts(9, 9),
+            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+            context_digest: None,
+            dataset_digest: None,
+            state: MetadataMaterializationState::Pending,
+            attempts: 0,
+            failures: 0,
+            last_error: None,
+            updated_at_ms: 9,
+        };
+        write_entries(
+            &storage,
+            vec![metadata_materialization_status_write_entry(&racing).unwrap()],
+        )
+        .await;
+
+        let txn_id = start_write_transaction(&storage).await.unwrap();
+        transactional_batch_write(&storage, txn_id, plan.writes)
+            .await
+            .unwrap();
+        transactional_batch_delete(&storage, txn_id, plan.deletes)
+            .await
+            .unwrap();
+        commit_storage_transaction(&storage, txn_id).await.unwrap();
+        assert_eq!(storage.snapshot_metrics().conflicts_total, 0);
     }
 
     #[tokio::test]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -802,7 +802,7 @@ fn defer_materialization_job(
     event: &MetadataCreateEventRecord,
     error: String,
 ) -> FinishedMaterializationJob {
-    if job.attempts.saturating_add(1) > MATERIALIZATION_MAX_ATTEMPTS {
+    if job.attempts.saturating_add(1) >= MATERIALIZATION_MAX_ATTEMPTS {
         FinishedMaterializationJob::Parked {
             job_key: job_key.to_vec(),
             job: job.clone(),
@@ -2109,7 +2109,8 @@ mod tests {
 
     #[tokio::test]
     async fn attempts_cap_parks() {
-        // A job at the attempt cap is parked as Failed with both rows removed.
+        // The apply whose count reaches the cap parks as Failed with both rows
+        // removed; the job at attempts cap-1 is that boundary apply.
         let dir = tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
         let document_id = Ulid::from_bytes([45u8; 16]);
@@ -2119,7 +2120,7 @@ mod tests {
             document_id,
             event_id,
             due_at_ms: 1,
-            attempts: MATERIALIZATION_MAX_ATTEMPTS,
+            attempts: MATERIALIZATION_MAX_ATTEMPTS - 1,
         };
         let index_key = metadata_materialization_job_key(&job);
         let sidecar_key = metadata_materialization_document_job_key(document_id, event_id);
@@ -2160,9 +2161,38 @@ mod tests {
             .unwrap()
             .expect("failed status is written");
         assert_eq!(status.state, MetadataMaterializationState::Failed);
-        assert_eq!(status.attempts, MATERIALIZATION_MAX_ATTEMPTS + 1);
+        assert_eq!(status.attempts, MATERIALIZATION_MAX_ATTEMPTS);
         assert_eq!(status.last_error.as_deref(), Some("boom"));
         assert!(!metadata_materialization_jobs_exist(&storage).await.unwrap());
+    }
+
+    #[test]
+    fn cap_boundary_reschedules() {
+        // Below the cap reschedules with attempts advanced; at the cap parks.
+        let document_id = Ulid::from_bytes([46u8; 16]);
+        let event_id = Ulid::from_parts(2, 1);
+        let event = create_event(document_id, event_id, "boundary");
+        let reschedule = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: MATERIALIZATION_MAX_ATTEMPTS - 2,
+        };
+        let key = metadata_materialization_job_key(&reschedule);
+        match defer_materialization_job(key.as_ref(), &reschedule, &event, "boom".into()) {
+            FinishedMaterializationJob::Rescheduled { status, .. } => {
+                assert_eq!(status.attempts, MATERIALIZATION_MAX_ATTEMPTS - 1);
+            }
+            other => panic!("expected reschedule, got {other:?}"),
+        }
+        let park = MetadataMaterializationJobRecord {
+            attempts: MATERIALIZATION_MAX_ATTEMPTS - 1,
+            ..reschedule
+        };
+        assert!(matches!(
+            defer_materialization_job(key.as_ref(), &park, &event, "boom".into()),
+            FinishedMaterializationJob::Parked { .. }
+        ));
     }
 
     #[test]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -3280,6 +3280,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn finish_keeps_newer() {
+        // A newer job enqueued after the guard snapshot has its status
+        // overwritten by the older completion; it must still be scanned as due
+        // rather than pruned, so the overwrite is self-healing.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([77u8; 16]);
+        let old_event_id = Ulid::from_parts(1, 1);
+        let newer_event_id = Ulid::from_parts(2, 1);
+        let old_event = create_event(document_id, old_event_id, "old");
+        let newer_event = create_event(document_id, newer_event_id, "newer");
+        let old_job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id: old_event_id,
+            due_at_ms: 1,
+            attempts: 0,
+            failures: 0,
+        };
+        let (_, old_job_key, _) = metadata_materialization_job_write_entry(&old_job).unwrap();
+        write_entries(
+            &storage,
+            vec![
+                metadata_create_event_write_entry(&old_event).unwrap(),
+                metadata_materialization_job_write_entry(&old_job).unwrap(),
+                metadata_materialization_document_job_write_entry(&old_job).unwrap(),
+            ],
+        )
+        .await;
+        let finished = vec![FinishedMaterializationJob::Completed(
+            CompletedMaterializationJob {
+                job_key: old_job_key.to_vec(),
+                document_job_key: Some(
+                    metadata_materialization_document_job_key(document_id, old_event_id).to_vec(),
+                ),
+                status: Some(materialization_success_status(&old_job, &old_event, None)),
+                iri_index_writes: Vec::new(),
+                raw_state_write: None,
+                sync: None,
+            },
+        )];
+        let plan = plan_finish_chunk(&storage, finished).await.unwrap();
+
+        // The newer event lands after the snapshot was taken.
+        let newer_job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id: newer_event_id,
+            due_at_ms: 1,
+            attempts: 0,
+            failures: 0,
+        };
+        write_entries(
+            &storage,
+            vec![
+                metadata_create_event_write_entry(&newer_event).unwrap(),
+                metadata_materialization_status_write_entry(&new_pending_materialization_status(
+                    &newer_event,
+                    2,
+                ))
+                .unwrap(),
+                metadata_materialization_job_write_entry(&newer_job).unwrap(),
+                metadata_materialization_document_job_write_entry(&newer_job).unwrap(),
+            ],
+        )
+        .await;
+
+        let txn_id = start_write_transaction(&storage).await.unwrap();
+        transactional_batch_write(&storage, txn_id, plan.writes)
+            .await
+            .unwrap();
+        transactional_batch_delete(&storage, txn_id, plan.deletes)
+            .await
+            .unwrap();
+        commit_storage_transaction(&storage, txn_id).await.unwrap();
+
+        let (jobs, _, _) = scan_due_materialization_jobs(
+            &storage,
+            unix_timestamp_millis(),
+            MATERIALIZATION_BATCH_SIZE,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            jobs.iter().map(|(_, job)| job.event_id).collect::<Vec<_>>(),
+            vec![newer_event_id],
+            "the newer job survives the older completion"
+        );
+    }
+
+    #[tokio::test]
     async fn finish_does_not_regress_newer_status() {
         let dir = tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -268,56 +268,6 @@ fn collect_group_outcome(
     }
 }
 
-fn materialization_job_preferred(
-    candidate: &MetadataMaterializationJobRecord,
-    current: &MetadataMaterializationJobRecord,
-) -> bool {
-    (candidate.attempts, candidate.due_at_ms) > (current.attempts, current.due_at_ms)
-}
-
-fn completed_stale_materialization_job(job_key: Vec<u8>) -> CompletedMaterializationJob {
-    CompletedMaterializationJob {
-        job_key,
-        document_job_key: None,
-        status: None,
-        iri_index_writes: Vec::new(),
-        raw_state_write: None,
-        sync: None,
-    }
-}
-
-fn deduplicate_materialization_jobs(
-    jobs: Vec<(Vec<u8>, MetadataMaterializationJobRecord)>,
-) -> (
-    Vec<(Vec<u8>, MetadataMaterializationJobRecord)>,
-    Vec<CompletedMaterializationJob>,
-) {
-    let mut selected: BTreeMap<Ulid, (Vec<u8>, MetadataMaterializationJobRecord)> = BTreeMap::new();
-    let mut stale = Vec::new();
-    for (job_key, job) in jobs {
-        match selected.get_mut(&job.event_id) {
-            Some((selected_key, selected_job))
-                if materialization_job_preferred(&job, selected_job) =>
-            {
-                let previous_key = std::mem::replace(selected_key, job_key);
-                *selected_job = job;
-                if previous_key.as_slice() != selected_key.as_slice() {
-                    stale.push(completed_stale_materialization_job(previous_key));
-                }
-            }
-            Some((selected_key, _)) => {
-                if selected_key.as_slice() != job_key.as_slice() {
-                    stale.push(completed_stale_materialization_job(job_key));
-                }
-            }
-            None => {
-                selected.insert(job.event_id, (job_key, job));
-            }
-        }
-    }
-    (selected.into_values().collect(), stale)
-}
-
 async fn process_materialization_job_groups(
     context: &DriverContext,
     jobs: Vec<(Vec<u8>, MetadataMaterializationJobRecord)>,
@@ -340,8 +290,7 @@ async fn process_materialization_job_groups(
     };
     let mut first_error = None;
     for (_, jobs) in groups {
-        let (mut jobs, stale_jobs) = deduplicate_materialization_jobs(jobs);
-        completed.extend(stale_jobs);
+        let mut jobs = jobs;
         jobs.sort_by_key(|(_, job)| job.event_id);
         if tasks.len() >= concurrency
             && let Some(result) = tasks.join_next().await
@@ -585,6 +534,41 @@ pub async fn enqueue_metadata_materialization_job(
     Ok(())
 }
 
+async fn read_document_job(
+    storage: &StorageHandle,
+    document_id: Ulid,
+    event_id: Ulid,
+) -> Result<Option<MetadataMaterializationJobRecord>, MetadataMaterializationQueueError> {
+    let key = metadata_materialization_document_job_key(document_id, event_id);
+    match storage
+        .send_storage_effect(StorageEffect::Read {
+            key_space: METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+            key: key.clone(),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(value), ..
+        }) => match postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) {
+            Ok(job) => Ok(Some(job)),
+            Err(error) => {
+                warn!(error = %error, document_id = %document_id, event_id = %event_id, "Deleting malformed metadata materialization document job");
+                delete_materialization_document_job(storage, key.to_vec()).await?;
+                Ok(None)
+            }
+        },
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(None),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
+        other => Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
+            "{other:?}"
+        ))),
+    }
+}
+
+// The due index is due-ordered and its rows are valid only when the sidecar row
+// exists with a matching due time; stale or dead rows are deleted lazily so a
+// scan costs O(due jobs) rather than a full-keyspace pass.
 async fn scan_due_materialization_jobs(
     storage: &StorageHandle,
     now_ms: u64,
@@ -599,7 +583,6 @@ async fn scan_due_materialization_jobs(
 > {
     let mut start_after = None;
     let mut jobs = Vec::new();
-    let mut next_due_at_ms = None;
     loop {
         let event = storage
             .send_storage_effect(StorageEffect::Iter {
@@ -623,139 +606,40 @@ async fn scan_due_materialization_jobs(
             }
         };
 
-        for (key, value) in values {
+        for (key, _value) in values {
             let key = key.to_vec();
-            let job = match postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) {
-                Ok(job) => job,
-                Err(error) => {
-                    warn!(error = %error, key = ?key, "Repairing or deleting malformed metadata materialization job");
-                    if let Some(job) =
-                        repair_or_delete_malformed_materialization_job(storage, key).await?
-                    {
-                        if job.due_at_ms > now_ms {
-                            next_due_at_ms = min_due_at(next_due_at_ms, job.due_at_ms);
-                            continue;
-                        }
-                        jobs.push((metadata_materialization_job_key(&job).to_vec(), job));
-                        if jobs.len() >= limit {
-                            return Ok((jobs, true, next_due_at_ms));
-                        }
-                    }
-                    continue;
-                }
-            };
-            if !materialization_job_key_matches(&key, &job) {
-                warn!(key = ?key, "Repairing metadata materialization job stored under non-canonical key");
-                if let Some(existing_job) = find_decoded_global_materialization_job(
-                    storage,
-                    job.document_id,
-                    job.event_id,
-                    Some(key.as_slice()),
-                )
-                .await?
-                {
-                    delete_materialization_global_job(storage, key).await?;
-                    if existing_job.due_at_ms > now_ms {
-                        next_due_at_ms = min_due_at(next_due_at_ms, existing_job.due_at_ms);
-                        continue;
-                    }
-                    jobs.push((
-                        metadata_materialization_job_key(&existing_job).to_vec(),
-                        existing_job,
-                    ));
-                    if jobs.len() >= limit {
-                        return Ok((jobs, true, next_due_at_ms));
-                    }
-                    continue;
-                }
-                if !materialization_job_is_live(storage, &job).await? {
-                    delete_materialization_global_job(storage, key).await?;
-                    continue;
-                }
-                repair_materialization_job_key(storage, key, &job).await?;
-                if job.due_at_ms > now_ms {
-                    next_due_at_ms = min_due_at(next_due_at_ms, job.due_at_ms);
-                    continue;
-                }
-                jobs.push((metadata_materialization_job_key(&job).to_vec(), job));
-                if jobs.len() >= limit {
-                    return Ok((jobs, true, next_due_at_ms));
-                }
-                continue;
-            }
-            if let Some(existing_job) = find_decoded_global_materialization_job(
-                storage,
-                job.document_id,
-                job.event_id,
-                Some(key.as_slice()),
-            )
-            .await?
-                && materialization_job_preferred(&existing_job, &job)
-            {
-                write_materialization_document_job(storage, &existing_job).await?;
+            let Some((due_at_ms, document_id, event_id)) = materialization_job_key_parts(&key)
+            else {
+                warn!(key = ?key, "Deleting malformed metadata materialization index row");
                 delete_materialization_global_job(storage, key).await?;
-                if existing_job.due_at_ms > now_ms {
-                    next_due_at_ms = min_due_at(next_due_at_ms, existing_job.due_at_ms);
-                    continue;
-                }
-                jobs.push((
-                    metadata_materialization_job_key(&existing_job).to_vec(),
-                    existing_job,
-                ));
-                if jobs.len() >= limit {
-                    return Ok((jobs, true, next_due_at_ms));
-                }
+                continue;
+            };
+            if due_at_ms > now_ms {
+                return Ok((jobs, false, Some(due_at_ms)));
+            }
+            let Some(job) = read_document_job(storage, document_id, event_id).await? else {
+                delete_materialization_global_job(storage, key).await?;
+                continue;
+            };
+            if job.due_at_ms != due_at_ms {
+                delete_materialization_global_job(storage, key).await?;
                 continue;
             }
             if !materialization_job_is_live(storage, &job).await? {
-                match materialization_job_obsolescence(storage, &job).await? {
-                    MaterializationJobObsolescence::Final if job.due_at_ms <= now_ms => {
-                        jobs.push((key, job));
-                        if jobs.len() >= limit {
-                            return Ok((jobs, true, next_due_at_ms));
-                        }
-                    }
-                    MaterializationJobObsolescence::Final => {
-                        delete_materialization_job(storage, key).await?;
-                    }
-                    MaterializationJobObsolescence::RetryAdvanced => {
-                        if let Some(preferred) = find_decoded_global_materialization_job(
-                            storage,
-                            job.document_id,
-                            job.event_id,
-                            Some(key.as_slice()),
-                        )
-                        .await?
-                        {
-                            write_materialization_document_job(storage, &preferred).await?;
-                        }
-                        delete_materialization_global_job(storage, key).await?;
-                    }
-                    MaterializationJobObsolescence::Live => {
-                        delete_materialization_job(storage, key).await?;
-                    }
-                }
+                delete_materialization_job(storage, key).await?;
                 continue;
             }
-            if job.due_at_ms > now_ms {
-                next_due_at_ms = min_due_at(next_due_at_ms, job.due_at_ms);
-                continue;
-            }
-            jobs.push((key, job));
+            jobs.push((metadata_materialization_job_key(&job).to_vec(), job));
             if jobs.len() >= limit {
-                return Ok((jobs, true, next_due_at_ms));
+                return Ok((jobs, true, None));
             }
         }
 
         match next_start_after {
             Some(next) => start_after = Some(next),
-            None => return Ok((jobs, false, next_due_at_ms)),
+            None => return Ok((jobs, false, None)),
         }
     }
-}
-
-fn min_due_at(current: Option<u64>, due_at_ms: u64) -> Option<u64> {
-    Some(current.map_or(due_at_ms, |current| current.min(due_at_ms)))
 }
 
 fn due_after(now_ms: u64, due_at_ms: u64) -> Duration {
@@ -839,16 +723,6 @@ async fn process_materialization_job(
             ));
         }
         MaterializationJobObsolescence::RetryAdvanced => {
-            if let Some(preferred) = find_decoded_global_materialization_job(
-                &context.storage_handle,
-                job.document_id,
-                job.event_id,
-                Some(job_key.as_slice()),
-            )
-            .await?
-            {
-                write_materialization_document_job(&context.storage_handle, &preferred).await?;
-            }
             delete_materialization_global_job(&context.storage_handle, job_key).await?;
             return Ok(ProcessedMaterializationJob::default());
         }
@@ -962,6 +836,9 @@ async fn process_materialization_job(
     }
 }
 
+// The sidecar keyspace is per-document and event-ordered, so the predecessor
+// check costs O(pending jobs for this document): iterate below the target event
+// and stop at the first key that is not an unadvanced, live, older job.
 async fn older_materialization_job_exists(
     storage: &StorageHandle,
     document_id: Ulid,
@@ -998,182 +875,27 @@ async fn older_materialization_job_exists(
         for (key, value) in values {
             let key = key.to_vec();
             if key.as_slice() >= stop_key.as_ref() {
-                return older_global_materialization_job_exists(
-                    storage,
-                    document_id,
-                    event_id,
-                    advanced_event_ids,
-                    status.as_ref(),
-                )
-                .await;
+                return Ok(false);
             }
             let job = match postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) {
                 Ok(job) => job,
                 Err(error) => {
-                    warn!(error = %error, key = ?key, "Repairing or deleting malformed metadata materialization document job while checking predecessors");
-                    if let Some((job_document_id, job_event_id)) =
-                        materialization_document_job_key_target(&key)
-                        && job_document_id == document_id
-                        && job_event_id < event_id
-                        && !advanced_event_ids.contains(&job_event_id)
-                    {
-                        match read_global_materialization_job(
-                            storage,
-                            job_document_id,
-                            job_event_id,
-                        )
-                        .await?
-                        {
-                            Some(job)
-                                if !status.as_ref().is_some_and(|status| {
-                                    materialization_status_obsoletes_job(status, &job)
-                                }) =>
-                            {
-                                write_materialization_document_job(storage, &job).await?;
-                                return Ok(true);
-                            }
-                            _ => {}
-                        }
-                    }
+                    warn!(error = %error, key = ?key, "Deleting malformed metadata materialization document job while checking predecessors");
                     delete_materialization_document_job(storage, key).await?;
                     continue;
                 }
             };
-            if !materialization_document_job_key_matches(&key, &job) {
-                warn!(key = ?key, "Repairing or deleting metadata materialization document job stored under non-canonical key");
-                if let Some((job_document_id, job_event_id)) =
-                    materialization_document_job_key_target(&key)
-                    && job_document_id == document_id
-                    && job_event_id < event_id
-                    && !advanced_event_ids.contains(&job_event_id)
-                {
-                    match read_global_materialization_job(storage, job_document_id, job_event_id)
-                        .await?
-                    {
-                        Some(global_job)
-                            if !status.as_ref().is_some_and(|status| {
-                                materialization_status_obsoletes_job(status, &global_job)
-                            }) =>
-                        {
-                            write_materialization_document_job(storage, &global_job).await?;
-                            return Ok(true);
-                        }
-                        _ => {}
-                    }
-                }
-                delete_materialization_document_job(storage, key).await?;
-                continue;
-            }
-            if job.document_id == document_id
-                && job.event_id < event_id
-                && !advanced_event_ids.contains(&job.event_id)
-                && !status
-                    .as_ref()
-                    .is_some_and(|status| materialization_status_obsoletes_job(status, &job))
-            {
-                match read_global_materialization_job(storage, job.document_id, job.event_id)
-                    .await?
-                {
-                    Some(global_job) => {
-                        if global_job != job {
-                            write_materialization_document_job(storage, &global_job).await?;
-                        }
-                        return Ok(true);
-                    }
-                    None => {
-                        warn!(key = ?key, "Deleting orphan metadata materialization document job");
-                        delete_materialization_document_job(storage, key).await?;
-                    }
-                }
-            }
-        }
-
-        match next_start_after {
-            Some(next) => start_after = Some(next),
-            None => {
-                return older_global_materialization_job_exists(
-                    storage,
-                    document_id,
-                    event_id,
-                    advanced_event_ids,
-                    status.as_ref(),
-                )
-                .await;
-            }
-        }
-    }
-}
-
-async fn older_global_materialization_job_exists(
-    storage: &StorageHandle,
-    document_id: Ulid,
-    event_id: Ulid,
-    advanced_event_ids: &BTreeSet<Ulid>,
-    status: Option<&MetadataMaterializationStatusRecord>,
-) -> Result<bool, MetadataMaterializationQueueError> {
-    let mut start_after = None;
-    loop {
-        let event = storage
-            .send_storage_effect(StorageEffect::Iter {
-                key_space: METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                prefix: None,
-                start: start_after.take().map(IterStart::After),
-                limit: MATERIALIZATION_SCAN_PAGE_SIZE,
-                txn_id: None,
-            })
-            .await;
-        let (values, next_start_after) = match event {
-            Event::Storage(StorageEvent::IterResult {
-                values,
-                next_start_after,
-            }) => (values, next_start_after),
-            Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
-            other => {
-                return Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
-                    "{other:?}"
-                )));
-            }
-        };
-
-        for (key, value) in values {
-            let key = key.to_vec();
-            let mut job = match postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) {
-                Ok(job) => job,
-                Err(error) => {
-                    warn!(error = %error, key = ?key, "Repairing or deleting malformed metadata materialization job while checking global predecessors");
-                    if let Some(job) =
-                        repair_or_delete_malformed_materialization_job(storage, key).await?
-                        && job.document_id == document_id
-                        && job.event_id < event_id
-                        && !advanced_event_ids.contains(&job.event_id)
-                        && !status.is_some_and(|status| {
-                            materialization_status_obsoletes_job(status, &job)
-                        })
-                    {
-                        write_materialization_document_job(storage, &job).await?;
-                        return Ok(true);
-                    }
-                    continue;
-                }
-            };
-            if !materialization_job_key_matches(&key, &job) {
-                warn!(key = ?key, "Repairing metadata materialization job stored under non-canonical key while checking global predecessors");
-                let Some(global_job) =
-                    read_global_materialization_job(storage, job.document_id, job.event_id).await?
-                else {
-                    continue;
-                };
-                job = global_job;
-            }
             if job.document_id != document_id
                 || job.event_id >= event_id
                 || advanced_event_ids.contains(&job.event_id)
-                || status.is_some_and(|status| materialization_status_obsoletes_job(status, &job))
+                || status
+                    .as_ref()
+                    .is_some_and(|status| materialization_status_obsoletes_job(status, &job))
             {
                 continue;
             }
             if !materialization_event_exists(storage, &job).await? {
-                warn!(document_id = %job.document_id, event_id = %job.event_id, "Deleting orphan metadata materialization job while checking global predecessors");
+                warn!(document_id = %job.document_id, event_id = %job.event_id, "Deleting orphan metadata materialization document job while checking predecessors");
                 delete_materialization_job(
                     storage,
                     metadata_materialization_job_key(&job).to_vec(),
@@ -1181,7 +903,6 @@ async fn older_global_materialization_job_exists(
                 .await?;
                 continue;
             }
-            write_materialization_document_job(storage, &job).await?;
             return Ok(true);
         }
 
@@ -1328,7 +1049,7 @@ pub async fn metadata_materialization_jobs_exist(
 ) -> Result<bool, MetadataMaterializationQueueError> {
     let mut start_after = None;
     loop {
-        match storage
+        let (values, next_start_after) = match storage
             .send_storage_effect(StorageEffect::Iter {
                 key_space: METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
                 prefix: None,
@@ -1341,67 +1062,35 @@ pub async fn metadata_materialization_jobs_exist(
             Event::Storage(StorageEvent::IterResult {
                 values,
                 next_start_after,
-            }) => {
-                let Some((key, value)) = values.into_iter().next() else {
-                    return Ok(false);
-                };
-                match postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) {
-                    Ok(job) if materialization_job_key_matches(key.as_ref(), &job) => {
-                        if materialization_job_is_live(storage, &job).await? {
-                            return Ok(true);
-                        }
-                        delete_materialization_global_job(storage, key.to_vec()).await?;
-                    }
-                    Ok(job) => {
-                        let key = key.to_vec();
-                        warn!(key = ?key, "Repairing metadata materialization job stored under non-canonical key while probing queue");
-                        if let Some(existing_job) = find_decoded_global_materialization_job(
-                            storage,
-                            job.document_id,
-                            job.event_id,
-                            Some(key.as_slice()),
-                        )
-                        .await?
-                        {
-                            delete_materialization_global_job(storage, key).await?;
-                            if materialization_job_is_live(storage, &existing_job).await? {
-                                return Ok(true);
-                            }
-                            delete_materialization_global_job(
-                                storage,
-                                metadata_materialization_job_key(&existing_job).to_vec(),
-                            )
-                            .await?;
-                            continue;
-                        }
-                        if materialization_job_is_live(storage, &job).await? {
-                            repair_materialization_job_key(storage, key, &job).await?;
-                            return Ok(true);
-                        }
-                        delete_materialization_global_job(storage, key).await?;
-                    }
-                    Err(error) => {
-                        let key = key.to_vec();
-                        warn!(error = %error, key = ?key, "Repairing or deleting malformed metadata materialization job while probing queue");
-                        if repair_or_delete_malformed_materialization_job(storage, key)
-                            .await?
-                            .is_some()
-                        {
-                            return Ok(true);
-                        }
-                    }
-                }
-                match next_start_after {
-                    Some(next) => start_after = Some(next),
-                    None => return Ok(false),
-                }
-            }
+            }) => (values, next_start_after),
             Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
             other => {
                 return Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
                     "{other:?}"
                 )));
             }
+        };
+        let Some((key, _value)) = values.into_iter().next() else {
+            return Ok(false);
+        };
+        let key = key.to_vec();
+        match materialization_job_key_parts(&key) {
+            Some((due_at_ms, document_id, event_id)) => {
+                match read_document_job(storage, document_id, event_id).await? {
+                    Some(job) if job.due_at_ms == due_at_ms => {
+                        if materialization_job_is_live(storage, &job).await? {
+                            return Ok(true);
+                        }
+                        delete_materialization_job(storage, key).await?;
+                    }
+                    _ => delete_materialization_global_job(storage, key).await?,
+                }
+            }
+            None => delete_materialization_global_job(storage, key).await?,
+        }
+        match next_start_after {
+            Some(next) => start_after = Some(next),
+            None => return Ok(false),
         }
     }
 }
@@ -1435,140 +1124,6 @@ async fn delete_materialization_global_job(
         )],
     )
     .await
-}
-
-async fn repair_or_delete_malformed_materialization_job(
-    storage: &StorageHandle,
-    key: Vec<u8>,
-) -> Result<Option<MetadataMaterializationJobRecord>, MetadataMaterializationQueueError> {
-    let Some((due_at_ms, document_id, event_id)) = materialization_job_key_parts(&key) else {
-        delete_materialization_job(storage, key).await?;
-        return Ok(None);
-    };
-    let probe_job = MetadataMaterializationJobRecord {
-        document_id,
-        event_id,
-        due_at_ms: 0,
-        attempts: 0,
-    };
-    if !materialization_event_exists(storage, &probe_job).await? {
-        delete_materialization_job(storage, key).await?;
-        return Ok(None);
-    }
-    let current = read_materialization_status(storage, document_id, None).await?;
-    if current
-        .as_ref()
-        .is_some_and(|status| materialization_status_obsoletes_job(status, &probe_job))
-    {
-        delete_materialization_job(storage, key).await?;
-        return Ok(None);
-    }
-    if let Some(existing_job) = find_decoded_global_materialization_job(
-        storage,
-        document_id,
-        event_id,
-        Some(key.as_slice()),
-    )
-    .await?
-    {
-        delete_materialization_global_job(storage, key).await?;
-        return Ok(Some(existing_job));
-    }
-    let job = MetadataMaterializationJobRecord {
-        document_id,
-        event_id,
-        due_at_ms,
-        attempts: current
-            .filter(|status| status.event_id == event_id)
-            .map(|status| status.attempts)
-            .unwrap_or(0),
-    };
-    repair_materialization_job_key(storage, key, &job).await?;
-    Ok(Some(job))
-}
-
-async fn find_decoded_global_materialization_job(
-    storage: &StorageHandle,
-    document_id: Ulid,
-    event_id: Ulid,
-    skip_key: Option<&[u8]>,
-) -> Result<Option<MetadataMaterializationJobRecord>, MetadataMaterializationQueueError> {
-    let mut selected: Option<(Vec<u8>, MetadataMaterializationJobRecord)> = None;
-    let mut stale_keys = Vec::new();
-    let mut start_after = None;
-    loop {
-        let event = storage
-            .send_storage_effect(StorageEffect::Iter {
-                key_space: METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                prefix: None,
-                start: start_after.take().map(IterStart::After),
-                limit: MATERIALIZATION_SCAN_PAGE_SIZE,
-                txn_id: None,
-            })
-            .await;
-        let (values, next_start_after) = match event {
-            Event::Storage(StorageEvent::IterResult {
-                values,
-                next_start_after,
-            }) => (values, next_start_after),
-            Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
-            other => {
-                return Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
-                    "{other:?}"
-                )));
-            }
-        };
-
-        for (key, value) in values {
-            if skip_key.is_some_and(|skip_key| key.as_ref() == skip_key) {
-                continue;
-            }
-            let Ok(job) = postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) else {
-                continue;
-            };
-            if job.document_id != document_id || job.event_id != event_id {
-                continue;
-            }
-            let key = key.to_vec();
-            if !materialization_job_is_live(storage, &job).await? {
-                stale_keys.push(key);
-                continue;
-            }
-            match selected.as_mut() {
-                Some((selected_key, selected_job))
-                    if materialization_job_preferred(&job, selected_job) =>
-                {
-                    stale_keys.push(std::mem::replace(selected_key, key));
-                    *selected_job = job;
-                }
-                Some(_) => stale_keys.push(key),
-                None => selected = Some((key, job)),
-            }
-        }
-
-        match next_start_after {
-            Some(next) => start_after = Some(next),
-            None => break,
-        }
-    }
-
-    let Some((key, job)) = selected else {
-        for key in stale_keys {
-            delete_materialization_global_job(storage, key).await?;
-        }
-        return Ok(None);
-    };
-    if !materialization_job_key_matches(&key, &job) {
-        repair_materialization_job_key(storage, key.clone(), &job).await?;
-    }
-    let canonical_key = metadata_materialization_job_key(&job);
-    for stale_key in stale_keys {
-        if stale_key.as_slice() != key.as_slice() && stale_key.as_slice() != canonical_key.as_ref()
-        {
-            delete_materialization_global_job(storage, stale_key).await?;
-        }
-    }
-    Ok(Some(job))
 }
 
 async fn delete_materialization_document_job(
@@ -1607,55 +1162,6 @@ async fn delete_materialization_entries(
     }
 }
 
-async fn repair_materialization_job_key(
-    storage: &StorageHandle,
-    old_key: Vec<u8>,
-    job: &MetadataMaterializationJobRecord,
-) -> Result<(), MetadataMaterializationQueueError> {
-    let canonical_key = metadata_materialization_job_key(job);
-    let txn_id = start_write_transaction(storage).await?;
-    let result = async {
-        transactional_batch_write(
-            storage,
-            txn_id,
-            vec![
-                metadata_materialization_job_write_entry(job)?,
-                metadata_materialization_document_job_write_entry(job)?,
-            ],
-        )
-        .await?;
-        if old_key.as_slice() != canonical_key.as_ref() {
-            transactional_batch_delete(
-                storage,
-                txn_id,
-                vec![(
-                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                    ByteView::from(old_key),
-                )],
-            )
-            .await?;
-        }
-        Ok(())
-    }
-    .await;
-    match result {
-        Ok(()) => {
-            commit_storage_transaction(storage, txn_id).await?;
-            Ok(())
-        }
-        Err(error) => {
-            abort_storage_transaction_best_effort(
-                storage,
-                txn_id,
-                "Failed to abort materialization repair transaction",
-                "Unexpected materialization repair transaction abort result",
-            )
-            .await;
-            Err(error)
-        }
-    }
-}
-
 fn materialization_job_key_target(key: &[u8]) -> Option<(Ulid, Ulid)> {
     materialization_job_key_parts(key).map(|(_, document_id, event_id)| (document_id, event_id))
 }
@@ -1675,28 +1181,6 @@ fn materialization_job_key_parts(key: &[u8]) -> Option<(u64, Ulid, Ulid)> {
         Ulid::from_bytes(document_id),
         Ulid::from_bytes(event_id),
     ))
-}
-
-fn materialization_job_key_matches(key: &[u8], job: &MetadataMaterializationJobRecord) -> bool {
-    metadata_materialization_job_key(job).as_ref() == key
-}
-
-fn materialization_document_job_key_target(key: &[u8]) -> Option<(Ulid, Ulid)> {
-    if key.len() != 32 {
-        return None;
-    }
-    let mut document_id = [0u8; 16];
-    document_id.copy_from_slice(&key[..16]);
-    let mut event_id = [0u8; 16];
-    event_id.copy_from_slice(&key[16..32]);
-    Some((Ulid::from_bytes(document_id), Ulid::from_bytes(event_id)))
-}
-
-fn materialization_document_job_key_matches(
-    key: &[u8],
-    job: &MetadataMaterializationJobRecord,
-) -> bool {
-    metadata_materialization_document_job_key(job.document_id, job.event_id).as_ref() == key
 }
 
 async fn metadata_graph_deleted(
@@ -2013,92 +1497,6 @@ async fn write_materialization_status_and_job(
     }
 }
 
-async fn write_materialization_document_job(
-    storage: &StorageHandle,
-    job: &MetadataMaterializationJobRecord,
-) -> Result<(), MetadataMaterializationQueueError> {
-    let (key_space, key, value) = metadata_materialization_document_job_write_entry(job)?;
-    match storage
-        .send_storage_effect(StorageEffect::Write {
-            key_space,
-            key,
-            value,
-            txn_id: None,
-        })
-        .await
-    {
-        Event::Storage(StorageEvent::WriteResult { .. }) => Ok(()),
-        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
-        other => Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
-            "{other:?}"
-        ))),
-    }
-}
-
-async fn read_global_materialization_job(
-    storage: &StorageHandle,
-    document_id: Ulid,
-    event_id: Ulid,
-) -> Result<Option<MetadataMaterializationJobRecord>, MetadataMaterializationQueueError> {
-    if let Some(job) =
-        find_decoded_global_materialization_job(storage, document_id, event_id, None).await?
-    {
-        return Ok(Some(job));
-    }
-    find_repaired_malformed_global_materialization_job(storage, document_id, event_id).await
-}
-
-async fn find_repaired_malformed_global_materialization_job(
-    storage: &StorageHandle,
-    document_id: Ulid,
-    event_id: Ulid,
-) -> Result<Option<MetadataMaterializationJobRecord>, MetadataMaterializationQueueError> {
-    let mut start_after = None;
-    loop {
-        let event = storage
-            .send_storage_effect(StorageEffect::Iter {
-                key_space: METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                prefix: None,
-                start: start_after.take().map(IterStart::After),
-                limit: MATERIALIZATION_SCAN_PAGE_SIZE,
-                txn_id: None,
-            })
-            .await;
-        let (values, next_start_after) = match event {
-            Event::Storage(StorageEvent::IterResult {
-                values,
-                next_start_after,
-            }) => (values, next_start_after),
-            Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
-            other => {
-                return Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
-                    "{other:?}"
-                )));
-            }
-        };
-
-        for (key, value) in values {
-            let Err(error) = postcard::from_bytes::<MetadataMaterializationJobRecord>(&value)
-            else {
-                continue;
-            };
-            let key = key.to_vec();
-            warn!(error = %error, key = ?key, "Repairing or deleting malformed metadata materialization job while repairing document sidecar");
-            if let Some(job) = repair_or_delete_malformed_materialization_job(storage, key).await?
-                && job.document_id == document_id
-                && job.event_id == event_id
-            {
-                return Ok(Some(job));
-            }
-        }
-
-        match next_start_after {
-            Some(next) => start_after = Some(next),
-            None => return Ok(None),
-        }
-    }
-}
-
 async fn materialization_event_exists(
     storage: &StorageHandle,
     job: &MetadataMaterializationJobRecord,
@@ -2214,43 +1612,6 @@ mod tests {
         }
     }
 
-    async fn read_materialization_document_job(
-        storage: &StorageHandle,
-        key: Vec<u8>,
-    ) -> Option<MetadataMaterializationJobRecord> {
-        match storage
-            .send_storage_effect(StorageEffect::Read {
-                key_space: METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                key: ByteView::from(key),
-                txn_id: None,
-            })
-            .await
-        {
-            Event::Storage(StorageEvent::ReadResult { value, .. }) => value.map(|value| {
-                postcard::from_bytes(&value).expect("materialization document job decodes")
-            }),
-            other => panic!("unexpected storage event: {other:?}"),
-        }
-    }
-
-    async fn read_materialization_global_job_at_key(
-        storage: &StorageHandle,
-        key: Vec<u8>,
-    ) -> Option<MetadataMaterializationJobRecord> {
-        match storage
-            .send_storage_effect(StorageEffect::Read {
-                key_space: METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                key: ByteView::from(key),
-                txn_id: None,
-            })
-            .await
-        {
-            Event::Storage(StorageEvent::ReadResult { value, .. }) => value
-                .map(|value| postcard::from_bytes(&value).expect("materialization job decodes")),
-            other => panic!("unexpected storage event: {other:?}"),
-        }
-    }
-
     #[tokio::test]
     async fn corrupt_materialization_job_only_is_deleted() {
         let dir = tempdir().unwrap();
@@ -2306,6 +1667,7 @@ mod tests {
                 ),
                 metadata_create_event_write_entry(&event).unwrap(),
                 metadata_materialization_job_write_entry(&valid_job).expect("job entry"),
+                metadata_materialization_document_job_write_entry(&valid_job).expect("sidecar"),
             ],
         )
         .await;
@@ -2382,51 +1744,6 @@ mod tests {
             )
             .await
             .unwrap()
-        );
-    }
-
-    #[tokio::test]
-    async fn malformed_document_sidecar_repairs_from_valid_global_job_and_blocks_newer() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let document_id = Ulid::from_bytes([15u8; 16]);
-        let old_event_id = Ulid::from_parts(15, 1);
-        let newer_event_id = Ulid::from_parts(15, 2);
-        let old_job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id: old_event_id,
-            due_at_ms: unix_timestamp_millis().saturating_add(60_000),
-            attempts: 0,
-        };
-        let old_event = create_event(document_id, old_event_id, "malformed-sidecar");
-        let document_key = metadata_materialization_document_job_key(document_id, old_event_id);
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&old_event).unwrap(),
-                metadata_materialization_job_write_entry(&old_job).unwrap(),
-                (
-                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                    document_key.clone(),
-                    ByteView::from(vec![1, 2, 3]),
-                ),
-            ],
-        )
-        .await;
-
-        assert!(
-            older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
-        );
-        assert_eq!(
-            read_materialization_document_job(&storage, document_key.to_vec()).await,
-            Some(old_job)
         );
     }
 
@@ -2509,293 +1826,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn noncanonical_future_materialization_job_does_not_hide_due_job() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let now_ms = unix_timestamp_millis();
-        let future_job = MetadataMaterializationJobRecord {
-            document_id: Ulid::from_bytes([18u8; 16]),
-            event_id: Ulid::from_parts(18, 1),
-            due_at_ms: now_ms.saturating_add(60_000),
-            attempts: 0,
-        };
-        let due_job = MetadataMaterializationJobRecord {
-            document_id: Ulid::from_bytes([19u8; 16]),
-            event_id: Ulid::from_parts(19, 1),
-            due_at_ms: 1,
-            attempts: 0,
-        };
-        let future_event = create_event(future_job.document_id, future_job.event_id, "future");
-        let due_event = create_event(due_job.document_id, due_job.event_id, "due");
-        let misplaced_key = vec![0];
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&future_event).unwrap(),
-                metadata_create_event_write_entry(&due_event).unwrap(),
-                (
-                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                    ByteView::from(misplaced_key.clone()),
-                    ByteView::from(postcard::to_allocvec(&future_job).unwrap()),
-                ),
-                metadata_materialization_job_write_entry(&due_job).unwrap(),
-            ],
-        )
-        .await;
-
-        let (jobs, has_more_due, _next_due_at_ms) =
-            scan_due_materialization_jobs(&storage, now_ms, 8)
-                .await
-                .unwrap();
-
-        assert_eq!(
-            jobs,
-            vec![(metadata_materialization_job_key(&due_job).to_vec(), due_job)]
-        );
-        assert!(!has_more_due);
-        assert!(
-            !storage_key_exists(
-                &storage,
-                METADATA_MATERIALIZATION_JOB_KEYSPACE,
-                misplaced_key
-            )
-            .await
-        );
-        assert!(
-            storage_key_exists(
-                &storage,
-                METADATA_MATERIALIZATION_JOB_KEYSPACE,
-                metadata_materialization_job_key(&future_job).to_vec()
-            )
-            .await
-        );
-    }
-
-    #[tokio::test]
-    async fn due_noncanonical_materialization_job_after_future_job_is_repaired() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let now_ms = unix_timestamp_millis();
-        let future_job = MetadataMaterializationJobRecord {
-            document_id: Ulid::from_bytes([20u8; 16]),
-            event_id: Ulid::from_parts(20, 1),
-            due_at_ms: now_ms.saturating_add(60_000),
-            attempts: 0,
-        };
-        let due_job = MetadataMaterializationJobRecord {
-            document_id: Ulid::from_bytes([21u8; 16]),
-            event_id: Ulid::from_parts(21, 1),
-            due_at_ms: 1,
-            attempts: 0,
-        };
-        let future_event = create_event(future_job.document_id, future_job.event_id, "future");
-        let due_event = create_event(due_job.document_id, due_job.event_id, "due");
-        let misplaced_key = vec![255];
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&future_event).unwrap(),
-                metadata_create_event_write_entry(&due_event).unwrap(),
-                metadata_materialization_job_write_entry(&future_job).unwrap(),
-                (
-                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                    ByteView::from(misplaced_key.clone()),
-                    ByteView::from(postcard::to_allocvec(&due_job).unwrap()),
-                ),
-            ],
-        )
-        .await;
-
-        let (jobs, has_more_due, _next_due_at_ms) =
-            scan_due_materialization_jobs(&storage, now_ms, 8)
-                .await
-                .unwrap();
-
-        assert_eq!(
-            jobs,
-            vec![(metadata_materialization_job_key(&due_job).to_vec(), due_job)]
-        );
-        assert!(!has_more_due);
-        assert!(
-            !storage_key_exists(
-                &storage,
-                METADATA_MATERIALIZATION_JOB_KEYSPACE,
-                misplaced_key
-            )
-            .await
-        );
-    }
-
-    #[tokio::test]
-    async fn malformed_future_materialization_retry_preserves_encoded_due_at() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let now_ms = unix_timestamp_millis();
-        let document_id = Ulid::from_bytes([26u8; 16]);
-        let event_id = Ulid::from_parts(26, 1);
-        let event = create_event(document_id, event_id, "malformed-future-retry");
-        let future_job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id,
-            due_at_ms: now_ms.saturating_add(60_000),
-            attempts: 1,
-        };
-        let future_key = metadata_materialization_job_key(&future_job);
-        let pending_retry = MetadataMaterializationStatusRecord {
-            document_id,
-            event_id,
-            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
-            context_digest: None,
-            dataset_digest: None,
-            state: MetadataMaterializationState::Pending,
-            attempts: 1,
-            last_error: Some("transient".to_string()),
-            updated_at_ms: now_ms,
-        };
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&event).unwrap(),
-                metadata_materialization_status_write_entry(&pending_retry).unwrap(),
-                (
-                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                    future_key.clone(),
-                    ByteView::from(vec![1, 2, 3]),
-                ),
-            ],
-        )
-        .await;
-
-        let (jobs, has_more_due, next_due_at_ms) =
-            scan_due_materialization_jobs(&storage, now_ms, 8)
-                .await
-                .unwrap();
-
-        assert!(jobs.is_empty());
-        assert!(!has_more_due);
-        assert_eq!(next_due_at_ms, Some(future_job.due_at_ms));
-        assert_eq!(
-            read_materialization_global_job_at_key(&storage, future_key.to_vec()).await,
-            Some(future_job)
-        );
-    }
-
-    #[tokio::test]
-    async fn noncanonical_materialization_duplicate_preserves_future_retry() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let now_ms = unix_timestamp_millis();
-        let document_id = Ulid::from_bytes([27u8; 16]);
-        let event_id = Ulid::from_parts(27, 1);
-        let event = create_event(document_id, event_id, "noncanonical-future-retry");
-        let future_job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id,
-            due_at_ms: now_ms.saturating_add(60_000),
-            attempts: 1,
-        };
-        let stale_job = MetadataMaterializationJobRecord {
-            due_at_ms: 1,
-            attempts: 0,
-            ..future_job.clone()
-        };
-        let misplaced_key = vec![0];
-        let future_key = metadata_materialization_job_key(&future_job);
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&event).unwrap(),
-                metadata_materialization_job_write_entry(&future_job).unwrap(),
-                (
-                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                    ByteView::from(misplaced_key.clone()),
-                    ByteView::from(postcard::to_allocvec(&stale_job).unwrap()),
-                ),
-            ],
-        )
-        .await;
-
-        let (jobs, has_more_due, next_due_at_ms) =
-            scan_due_materialization_jobs(&storage, now_ms, 8)
-                .await
-                .unwrap();
-
-        assert!(jobs.is_empty());
-        assert!(!has_more_due);
-        assert_eq!(next_due_at_ms, Some(future_job.due_at_ms));
-        assert!(
-            !storage_key_exists(
-                &storage,
-                METADATA_MATERIALIZATION_JOB_KEYSPACE,
-                misplaced_key
-            )
-            .await
-        );
-        assert_eq!(
-            read_materialization_global_job_at_key(&storage, future_key.to_vec()).await,
-            Some(future_job)
-        );
-    }
-
-    #[tokio::test]
-    async fn canonical_materialization_duplicate_preserves_future_retry() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let now_ms = unix_timestamp_millis();
-        let document_id = Ulid::from_bytes([28u8; 16]);
-        let event_id = Ulid::from_parts(28, 1);
-        let event = create_event(document_id, event_id, "canonical-future-retry");
-        let future_job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id,
-            due_at_ms: now_ms.saturating_add(60_000),
-            attempts: 1,
-        };
-        let stale_job = MetadataMaterializationJobRecord {
-            due_at_ms: 1,
-            attempts: 0,
-            ..future_job.clone()
-        };
-        let stale_key = metadata_materialization_job_key(&stale_job);
-        let future_key = metadata_materialization_job_key(&future_job);
-        let document_key = metadata_materialization_document_job_key(document_id, event_id);
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&event).unwrap(),
-                metadata_materialization_job_write_entry(&stale_job).unwrap(),
-                metadata_materialization_job_write_entry(&future_job).unwrap(),
-            ],
-        )
-        .await;
-
-        let (jobs, has_more_due, next_due_at_ms) =
-            scan_due_materialization_jobs(&storage, now_ms, 8)
-                .await
-                .unwrap();
-
-        assert!(jobs.is_empty());
-        assert!(!has_more_due);
-        assert_eq!(next_due_at_ms, Some(future_job.due_at_ms));
-        assert!(
-            !storage_key_exists(
-                &storage,
-                METADATA_MATERIALIZATION_JOB_KEYSPACE,
-                stale_key.to_vec()
-            )
-            .await
-        );
-        assert_eq!(
-            read_materialization_global_job_at_key(&storage, future_key.to_vec()).await,
-            Some(future_job.clone())
-        );
-        assert_eq!(
-            read_materialization_document_job(&storage, document_key.to_vec()).await,
-            Some(future_job)
-        );
-    }
-
-    #[tokio::test]
     async fn orphan_global_materialization_job_is_deleted() {
         let dir = tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
@@ -2850,135 +1880,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn noncanonical_decodable_document_sidecar_repairs_from_global_job() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let document_id = Ulid::from_bytes([23u8; 16]);
-        let old_event_id = Ulid::from_parts(23, 1);
-        let newer_event_id = Ulid::from_parts(23, 2);
-        let old_job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id: old_event_id,
-            due_at_ms: unix_timestamp_millis().saturating_add(60_000),
-            attempts: 0,
-        };
-        let wrong_job = MetadataMaterializationJobRecord {
-            event_id: Ulid::from_parts(23, 99),
-            ..old_job.clone()
-        };
-        let old_event = create_event(document_id, old_event_id, "noncanonical-sidecar");
-        let document_key = metadata_materialization_document_job_key(document_id, old_event_id);
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&old_event).unwrap(),
-                metadata_materialization_job_write_entry(&old_job).unwrap(),
-                (
-                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                    document_key.clone(),
-                    ByteView::from(postcard::to_allocvec(&wrong_job).unwrap()),
-                ),
-            ],
-        )
-        .await;
-
-        assert!(
-            older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
-        );
-        assert_eq!(
-            read_materialization_document_job(&storage, document_key.to_vec()).await,
-            Some(old_job)
-        );
-    }
-
-    #[tokio::test]
-    async fn missing_document_sidecar_repairs_from_global_job_and_blocks_newer() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let document_id = Ulid::from_bytes([24u8; 16]);
-        let old_event_id = Ulid::from_parts(24, 1);
-        let newer_event_id = Ulid::from_parts(24, 2);
-        let event = create_event(document_id, old_event_id, "missing-sidecar");
-        let old_job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id: old_event_id,
-            due_at_ms: unix_timestamp_millis().saturating_add(60_000),
-            attempts: 0,
-        };
-        let document_key = metadata_materialization_document_job_key(document_id, old_event_id);
-        write_entries(
-            &storage,
-            vec![
-                metadata_create_event_write_entry(&event).unwrap(),
-                metadata_materialization_job_write_entry(&old_job).unwrap(),
-            ],
-        )
-        .await;
-
-        assert!(
-            older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
-        );
-        assert_eq!(
-            read_materialization_document_job(&storage, document_key.to_vec()).await,
-            Some(old_job)
-        );
-    }
-
-    #[tokio::test]
-    async fn future_orphan_global_materialization_job_is_deleted_during_predecessor_check() {
-        let dir = tempdir().unwrap();
-        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
-        let document_id = Ulid::from_bytes([25u8; 16]);
-        let old_event_id = Ulid::from_parts(25, 1);
-        let newer_event_id = Ulid::from_parts(25, 2);
-        let old_job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id: old_event_id,
-            due_at_ms: unix_timestamp_millis().saturating_add(60_000),
-            attempts: 0,
-        };
-        let global_key = metadata_materialization_job_key(&old_job);
-        write_entries(
-            &storage,
-            vec![metadata_materialization_job_write_entry(&old_job).unwrap()],
-        )
-        .await;
-
-        assert!(
-            !older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
-        );
-        assert!(
-            !storage_key_exists(
-                &storage,
-                METADATA_MATERIALIZATION_JOB_KEYSPACE,
-                global_key.to_vec()
-            )
-            .await
-        );
-    }
-
-    #[tokio::test]
     async fn corrupt_materialization_document_job_is_deleted_while_checking_predecessors() {
         let dir = tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
@@ -3009,6 +1910,158 @@ mod tests {
             )
             .await
         );
+    }
+
+    #[tokio::test]
+    async fn scan_stops_early() {
+        // Due jobs sort before future jobs, so the scan returns at the first
+        // future key without paging the whole keyspace.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let now_ms = unix_timestamp_millis();
+        let document_id = Ulid::from_bytes([40u8; 16]);
+        let due_event = Ulid::from_parts(1, 1);
+        let event = create_event(document_id, due_event, "due");
+        let due_job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id: due_event,
+            due_at_ms: 1,
+            attempts: 0,
+        };
+        let mut writes = vec![
+            metadata_create_event_write_entry(&event).unwrap(),
+            metadata_materialization_job_write_entry(&due_job).unwrap(),
+            metadata_materialization_document_job_write_entry(&due_job).unwrap(),
+        ];
+        for index in 0..600u64 {
+            let future_job = MetadataMaterializationJobRecord {
+                document_id: Ulid::from_bytes([41u8; 16]),
+                event_id: Ulid::from_parts(2, u128::from(index)),
+                due_at_ms: now_ms.saturating_add(60_000).saturating_add(index),
+                attempts: 0,
+            };
+            writes.push(metadata_materialization_job_write_entry(&future_job).unwrap());
+        }
+        write_entries(&storage, writes).await;
+
+        let before = storage.snapshot_metrics().requests_total;
+        let (jobs, has_more_due, next_due_at_ms) =
+            scan_due_materialization_jobs(&storage, now_ms, MATERIALIZATION_BATCH_SIZE)
+                .await
+                .unwrap();
+        let delta = storage.snapshot_metrics().requests_total - before;
+
+        assert_eq!(
+            jobs,
+            vec![(metadata_materialization_job_key(&due_job).to_vec(), due_job)]
+        );
+        assert!(!has_more_due);
+        assert!(next_due_at_ms.is_some());
+        assert!(delta <= 10, "scan issued {delta} storage requests");
+    }
+
+    #[tokio::test]
+    async fn stale_index_pruned() {
+        // An index row with no sidecar, and one whose sidecar due time differs,
+        // are both deleted and yield no job.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let now_ms = unix_timestamp_millis();
+        let orphan = MetadataMaterializationJobRecord {
+            document_id: Ulid::from_bytes([42u8; 16]),
+            event_id: Ulid::from_parts(1, 1),
+            due_at_ms: 1,
+            attempts: 0,
+        };
+        let mismatched = MetadataMaterializationJobRecord {
+            document_id: Ulid::from_bytes([43u8; 16]),
+            event_id: Ulid::from_parts(1, 2),
+            due_at_ms: 1,
+            attempts: 0,
+        };
+        let mismatched_sidecar = MetadataMaterializationJobRecord {
+            due_at_ms: 999,
+            ..mismatched.clone()
+        };
+        let orphan_key = metadata_materialization_job_key(&orphan);
+        let mismatched_key = metadata_materialization_job_key(&mismatched);
+        write_entries(
+            &storage,
+            vec![
+                metadata_materialization_job_write_entry(&orphan).unwrap(),
+                metadata_materialization_job_write_entry(&mismatched).unwrap(),
+                metadata_materialization_document_job_write_entry(&mismatched_sidecar).unwrap(),
+            ],
+        )
+        .await;
+
+        let (jobs, has_more_due, _next) =
+            scan_due_materialization_jobs(&storage, now_ms, MATERIALIZATION_BATCH_SIZE)
+                .await
+                .unwrap();
+
+        assert!(jobs.is_empty());
+        assert!(!has_more_due);
+        assert!(
+            !storage_key_exists(
+                &storage,
+                METADATA_MATERIALIZATION_JOB_KEYSPACE,
+                orphan_key.to_vec()
+            )
+            .await
+        );
+        assert!(
+            !storage_key_exists(
+                &storage,
+                METADATA_MATERIALIZATION_JOB_KEYSPACE,
+                mismatched_key.to_vec()
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn older_check_bounded() {
+        // The predecessor check for one document must not scan the sidecar rows
+        // of unrelated documents.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([44u8; 16]);
+        let first = Ulid::from_parts(1, 1);
+        let middle = Ulid::from_parts(2, 1);
+        let last = Ulid::from_parts(3, 1);
+        let first_event = create_event(document_id, first, "first");
+        let job_for = |event_id: Ulid| MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: 0,
+        };
+        let mut writes = vec![
+            metadata_create_event_write_entry(&first_event).unwrap(),
+            metadata_materialization_document_job_write_entry(&job_for(first)).unwrap(),
+            metadata_materialization_document_job_write_entry(&job_for(middle)).unwrap(),
+            metadata_materialization_document_job_write_entry(&job_for(last)).unwrap(),
+        ];
+        for index in 0..500u64 {
+            let other = MetadataMaterializationJobRecord {
+                document_id: Ulid::from_parts(9, u128::from(index)),
+                event_id: Ulid::from_parts(9, u128::from(index)),
+                due_at_ms: 1,
+                attempts: 0,
+            };
+            writes.push(metadata_materialization_document_job_write_entry(&other).unwrap());
+        }
+        write_entries(&storage, writes).await;
+
+        let before = storage.snapshot_metrics().requests_total;
+        let older = older_materialization_job_exists(&storage, document_id, middle, &BTreeSet::new())
+            .await
+            .unwrap();
+        let delta = storage.snapshot_metrics().requests_total - before;
+
+        assert!(older);
+        assert!(delta <= 10, "older check issued {delta} storage requests");
     }
 
     #[test]
@@ -3438,7 +2491,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unrelated_jobs_do_not_force_global_predecessor_scan() {
+    async fn older_check_local() {
+        // Predecessor lookups read the status then one document-local sidecar
+        // scan; they never fall back to a full global keyspace scan.
         let (storage, receiver) = StorageHandle::new();
         let document_id = Ulid::from_bytes([11u8; 16]);
         let event_id = Ulid::from_parts(11, 2);
@@ -3487,27 +2542,10 @@ mod tests {
                 next_start_after: None,
             });
 
-            let (effect, response_tx, _span, _enqueued_at, _in_flight) =
-                receiver.recv().expect("global predecessor scan");
-            match effect {
-                StorageEffect::Iter {
-                    key_space,
-                    prefix,
-                    start,
-                    limit,
-                    txn_id: None,
-                } => {
-                    assert_eq!(key_space, METADATA_MATERIALIZATION_JOB_KEYSPACE);
-                    assert_eq!(prefix, None);
-                    assert_eq!(start, None);
-                    assert_eq!(limit, MATERIALIZATION_SCAN_PAGE_SIZE);
-                }
-                other => panic!("unexpected storage effect: {other:?}"),
-            }
-            response_tx.send(StorageEvent::IterResult {
-                values: Vec::new(),
-                next_start_after: None,
-            });
+            assert!(
+                receiver.recv().is_err(),
+                "no global predecessor scan is issued"
+            );
         });
 
         assert!(
@@ -3515,6 +2553,7 @@ mod tests {
                 .await
                 .unwrap()
         );
+        drop(storage);
         scripted.join().expect("scripted storage actor finished");
     }
 

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -8,18 +8,19 @@ use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{
     METADATA_EVENT_LOG_KEYSPACE, METADATA_GRAPH_LIFECYCLE_KEYSPACE,
-    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE, METADATA_MATERIALIZATION_JOB_KEYSPACE,
-    METADATA_MATERIALIZATION_STATUS_KEYSPACE,
+    METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE, METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE,
+    METADATA_MATERIALIZATION_JOB_KEYSPACE, METADATA_MATERIALIZATION_STATUS_KEYSPACE,
 };
 use aruna_core::metadata::{
     MetadataApplyRoCrateRequest, MetadataCreateCrateRequest, MetadataCreateEventPayload,
     MetadataCreateEventRecord, MetadataEffect, MetadataError, MetadataEvent,
-    MetadataGraphLifecycleRecord, MetadataGraphPolicy, MetadataMaterializationJobRecord,
-    MetadataMaterializationState, MetadataMaterializationStatusRecord, MetadataRawRevision,
-    MetadataRequestDurability, deterministic_materialization_actor,
+    MetadataGraphLifecycleRecord, MetadataGraphPolicy, MetadataMaterializationDeadLetterRecord,
+    MetadataMaterializationJobRecord, MetadataMaterializationState,
+    MetadataMaterializationStatusRecord, MetadataRawRevision, MetadataRequestDurability,
+    deterministic_materialization_actor,
 };
 use aruna_core::storage_entries::{
-    metadata_event_log_key, metadata_graph_lifecycle_key,
+    dead_letter_entry, dead_letter_key, metadata_event_log_key, metadata_graph_lifecycle_key,
     metadata_materialization_document_job_key, metadata_materialization_document_job_prefix,
     metadata_materialization_document_job_write_entry, metadata_materialization_job_key,
     metadata_materialization_job_write_entry, metadata_materialization_status_key,
@@ -47,10 +48,15 @@ use super::queue_storage::{
 use super::raw::{MetadataRawReadError, RawStateCache};
 
 const MATERIALIZATION_SCAN_PAGE_SIZE: usize = 512;
-const MATERIALIZATION_BATCH_SIZE: usize = 128;
-// Backoff reaches its 30s cap by attempt 7, so ten attempts is about two
-// minutes of retries before a job is parked as Failed and both rows deleted.
-const MATERIALIZATION_MAX_ATTEMPTS: u32 = 10;
+const MATERIALIZATION_BATCH_SIZE: usize = 512;
+// Only application failures count here: infrastructure errors retry forever with
+// backoff, so an overloaded node never parks work it could still finish.
+const MATERIALIZATION_MAX_FAILURES: u32 = 10;
+// Parked jobs return to the queue on this backoff, doubling per park up to the
+// cap, so a node recovers on its own once the cause clears.
+const DEAD_LETTER_REQUEUE_BASE_MS: u64 = 60_000;
+const DEAD_LETTER_REQUEUE_MAX_MS: u64 = 3_600_000;
+const DEAD_LETTER_REQUEUE_PAGE_SIZE: usize = 256;
 
 pub const METADATA_MATERIALIZATION_POLL_AFTER: Duration = Duration::from_secs(5);
 pub const METADATA_MATERIALIZATION_RETRY_AFTER: Duration = Duration::from_secs(1);
@@ -519,6 +525,7 @@ async fn finish_completed_materialization_jobs_in_txn(
                     due_at_ms: unix_timestamp_millis()
                         .saturating_add(queue_retry_after_ms(attempts)),
                     attempts,
+                    failures: status.failures,
                 };
                 if should_write_pending_retry_status(current.as_ref(), &status) {
                     writes.push(metadata_materialization_status_write_entry(&status)?);
@@ -539,6 +546,8 @@ async fn finish_completed_materialization_jobs_in_txn(
                 if should_write_final_materialization_status(current.as_ref(), &status) {
                     writes.push(metadata_materialization_status_write_entry(&status)?);
                 }
+                let dead_letter = parked_dead_letter(storage, &job, &status).await?;
+                writes.push(dead_letter_entry(&dead_letter)?);
                 deletes.push((
                     METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
                     ByteView::from(job_key),
@@ -552,8 +561,10 @@ async fn finish_completed_materialization_jobs_in_txn(
                     document_id = %job.document_id,
                     event_id = %job.event_id,
                     attempts = status.attempts,
+                    failures = status.failures,
+                    requeue_at_ms = dead_letter.requeue_at_ms,
                     error = status.last_error.as_deref().unwrap_or_default(),
-                    "Parked metadata materialization job after exceeding attempt cap"
+                    "Parked metadata materialization job as dead letter"
                 );
             }
         }
@@ -569,6 +580,199 @@ async fn finish_completed_materialization_jobs_in_txn(
 
     transactional_batch_write(storage, txn_id, writes).await?;
     transactional_batch_delete(storage, txn_id, deletes).await
+}
+
+// A re-parked job keeps its park count so its requeue backoff keeps growing
+// instead of restarting at the base delay.
+async fn parked_dead_letter(
+    storage: &StorageHandle,
+    job: &MetadataMaterializationJobRecord,
+    status: &MetadataMaterializationStatusRecord,
+) -> Result<MetadataMaterializationDeadLetterRecord, MetadataMaterializationQueueError> {
+    let previous = read_dead_letter(storage, job.document_id, job.event_id).await?;
+    let parks = previous.map_or(1, |previous| previous.parks.saturating_add(1));
+    let now_ms = unix_timestamp_millis();
+    Ok(MetadataMaterializationDeadLetterRecord {
+        job: job.clone(),
+        last_error: status.last_error.clone().unwrap_or_default(),
+        parked_at_ms: now_ms,
+        parks,
+        requeue_at_ms: now_ms.saturating_add(requeue_after_ms(parks)),
+    })
+}
+
+fn requeue_after_ms(parks: u32) -> u64 {
+    crate::queue_backoff::retry_after_ms(
+        parks.saturating_sub(1),
+        DEAD_LETTER_REQUEUE_BASE_MS,
+        DEAD_LETTER_REQUEUE_MAX_MS,
+    )
+}
+
+async fn read_dead_letter(
+    storage: &StorageHandle,
+    document_id: Ulid,
+    event_id: Ulid,
+) -> Result<Option<MetadataMaterializationDeadLetterRecord>, MetadataMaterializationQueueError> {
+    match storage
+        .send_storage_effect(StorageEffect::Read {
+            key_space: METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
+            key: dead_letter_key(document_id, event_id),
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::ReadResult {
+            value: Some(value), ..
+        }) => Ok(postcard::from_bytes(&value).ok()),
+        Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(None),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
+        other => Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
+            "{other:?}"
+        ))),
+    }
+}
+
+/// Returns due dead letters to the queue with a fresh failure budget and clears
+/// their terminal status, so a node converges once the cause clears. Returns the
+/// number of jobs requeued.
+pub async fn requeue_dead_letters(
+    storage: &StorageHandle,
+) -> Result<usize, MetadataMaterializationQueueError> {
+    let now_ms = unix_timestamp_millis();
+    let mut start_after = None;
+    let mut requeued = 0usize;
+    loop {
+        let (values, next_start_after) = match storage
+            .send_storage_effect(StorageEffect::Iter {
+                key_space: METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
+                prefix: None,
+                start: start_after.take().map(IterStart::After),
+                limit: DEAD_LETTER_REQUEUE_PAGE_SIZE,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::IterResult {
+                values,
+                next_start_after,
+            }) => (values, next_start_after),
+            Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
+            other => {
+                return Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
+                    "{other:?}"
+                )));
+            }
+        };
+
+        for (key, value) in values {
+            let Ok(dead_letter) =
+                postcard::from_bytes::<MetadataMaterializationDeadLetterRecord>(&value)
+            else {
+                warn!(key = ?key.to_vec(), "Deleting malformed metadata materialization dead letter");
+                delete_dead_letter(storage, key.to_vec()).await?;
+                continue;
+            };
+            if dead_letter.requeue_at_ms > now_ms {
+                continue;
+            }
+            requeue_dead_letter(storage, &dead_letter).await?;
+            requeued = requeued.saturating_add(1);
+        }
+
+        match next_start_after {
+            Some(next) => start_after = Some(next),
+            None => break,
+        }
+    }
+    if requeued > 0 {
+        info!(
+            event = "materialization.deadletter.requeued",
+            jobs = requeued,
+            "Requeued parked metadata materialization jobs"
+        );
+    }
+    Ok(requeued)
+}
+
+// The parked status is terminal for this event, so it must be cleared with the
+// job rows or the requeued job is pruned as obsolete on the next scan.
+async fn requeue_dead_letter(
+    storage: &StorageHandle,
+    dead_letter: &MetadataMaterializationDeadLetterRecord,
+) -> Result<(), MetadataMaterializationQueueError> {
+    let job = MetadataMaterializationJobRecord {
+        document_id: dead_letter.job.document_id,
+        event_id: dead_letter.job.event_id,
+        due_at_ms: unix_timestamp_millis(),
+        attempts: 0,
+        failures: 0,
+    };
+    let event = match read_create_event(storage, job.document_id, job.event_id).await {
+        Ok(event) => event,
+        Err(MetadataMaterializationQueueError::MetadataCreateEventMissing { .. }) => {
+            return delete_dead_letter(
+                storage,
+                dead_letter_key(job.document_id, job.event_id).to_vec(),
+            )
+            .await;
+        }
+        Err(error) => return Err(error),
+    };
+    let status = new_pending_materialization_status(&event, unix_timestamp_millis());
+    let txn_id = start_write_transaction(storage).await?;
+    let result = async {
+        transactional_batch_write(
+            storage,
+            txn_id,
+            vec![
+                metadata_materialization_status_write_entry(&status)?,
+                metadata_materialization_job_write_entry(&job)?,
+                metadata_materialization_document_job_write_entry(&job)?,
+            ],
+        )
+        .await?;
+        transactional_batch_delete(
+            storage,
+            txn_id,
+            vec![(
+                METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
+                dead_letter_key(job.document_id, job.event_id),
+            )],
+        )
+        .await
+    }
+    .await;
+    match result {
+        Ok(()) => {
+            commit_storage_transaction(storage, txn_id).await?;
+            Ok(())
+        }
+        Err(error) => {
+            abort_storage_transaction_best_effort(
+                storage,
+                txn_id,
+                "Failed to abort materialization dead letter requeue",
+                "Unexpected materialization dead letter requeue abort result",
+            )
+            .await;
+            Err(error)
+        }
+    }
+}
+
+async fn delete_dead_letter(
+    storage: &StorageHandle,
+    key: Vec<u8>,
+) -> Result<(), MetadataMaterializationQueueError> {
+    delete_materialization_entries(
+        storage,
+        vec![(
+            METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE.to_string(),
+            ByteView::from(key),
+        )],
+    )
+    .await
 }
 
 async fn transactional_batch_write(
@@ -795,25 +999,32 @@ impl ProcessedMaterializationJob {
     }
 }
 
-// Attempt-capped jobs park as Failed; others reschedule with backoff. The
-// resulting row writes and deletes are folded into the per-batch finish txn.
+// Jobs that exhaust the failure budget park as a dead letter; others reschedule
+// with backoff. The resulting row writes and deletes are folded into the
+// per-batch finish txn.
 fn defer_materialization_job(
     job_key: &[u8],
     job: &MetadataMaterializationJobRecord,
     event: &MetadataCreateEventRecord,
-    error: String,
+    error: &MetadataMaterializationQueueError,
 ) -> FinishedMaterializationJob {
-    if job.attempts.saturating_add(1) >= MATERIALIZATION_MAX_ATTEMPTS {
+    let application_failure = matches!(
+        materialization_failure_kind(error),
+        MaterializationFailureKind::Application
+    );
+    let failures = job.failures.saturating_add(u32::from(application_failure));
+    let message = error.to_string();
+    if failures >= MATERIALIZATION_MAX_FAILURES {
         FinishedMaterializationJob::Parked {
             job_key: job_key.to_vec(),
             job: job.clone(),
-            status: materialization_failure_status(job, event, error, true),
+            status: materialization_failure_status(job, event, message, failures, true),
         }
     } else {
         FinishedMaterializationJob::Rescheduled {
             job_key: job_key.to_vec(),
             job: job.clone(),
-            status: materialization_failure_status(job, event, error, false),
+            status: materialization_failure_status(job, event, message, failures, false),
         }
     }
 }
@@ -889,6 +1100,7 @@ async fn process_materialization_job(
                     &job,
                     &event,
                     "metadata graph was deleted before materialization".to_string(),
+                    job.failures,
                     true,
                 )),
                 iri_index_writes: Vec::new(),
@@ -910,7 +1122,7 @@ async fn process_materialization_job(
                 Ok(writes) => writes,
                 Err(error) => {
                     return Ok(ProcessedMaterializationJob::deferred(
-                        defer_materialization_job(&job_key, &job, &event, error.to_string()),
+                        defer_materialization_job(&job_key, &job, &event, &error),
                         craqle_elapsed,
                     ));
                 }
@@ -943,6 +1155,7 @@ async fn process_materialization_job(
                         &job,
                         &event,
                         error.to_string(),
+                        job.failures,
                         true,
                     )),
                     iri_index_writes: Vec::new(),
@@ -953,7 +1166,7 @@ async fn process_materialization_job(
             ))
         }
         Err(error) => Ok(ProcessedMaterializationJob::deferred(
-            defer_materialization_job(&job_key, &job, &event, error.to_string()),
+            defer_materialization_job(&job_key, &job, &event, &error),
             craqle_elapsed,
         )),
     }
@@ -1162,6 +1375,7 @@ fn should_write_pending_retry_status(
                     event_id: next.event_id,
                     due_at_ms: 0,
                     attempts: next.attempts,
+                    failures: next.failures,
                 },
             )
     })
@@ -1480,6 +1694,7 @@ fn materialization_success_status(
         dataset_digest: raw_revision.and_then(|revision| revision.dataset_digest),
         state: MetadataMaterializationState::Materialized,
         attempts: job.attempts.saturating_add(1),
+        failures: job.failures,
         last_error: None,
         updated_at_ms: unix_timestamp_millis(),
     }
@@ -1489,6 +1704,7 @@ fn materialization_failure_status(
     job: &MetadataMaterializationJobRecord,
     event: &MetadataCreateEventRecord,
     error: String,
+    failures: u32,
     terminal: bool,
 ) -> MetadataMaterializationStatusRecord {
     MetadataMaterializationStatusRecord {
@@ -1503,15 +1719,50 @@ fn materialization_failure_status(
             MetadataMaterializationState::Pending
         },
         attempts: job.attempts.saturating_add(1),
+        failures,
         last_error: Some(error),
         updated_at_ms: unix_timestamp_millis(),
     }
 }
 
+/// How a failed materialization attempt is charged. Only [`Application`]
+/// failures spend the budget that eventually parks a job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MaterializationFailureKind {
+    Terminal,
+    Transient,
+    Application,
+}
+
+fn materialization_failure_kind(
+    error: &MetadataMaterializationQueueError,
+) -> MaterializationFailureKind {
+    match error {
+        MetadataMaterializationQueueError::Metadata(
+            MetadataError::InvalidInput(_) | MetadataError::Validation(_),
+        ) => MaterializationFailureKind::Terminal,
+        MetadataMaterializationQueueError::Storage(
+            StorageError::Timeout
+            | StorageError::QueueFull
+            | StorageError::ChannelClosed
+            | StorageError::PersistError(_),
+        )
+        | MetadataMaterializationQueueError::Metadata(
+            MetadataError::ChannelClosed
+            | MetadataError::TaskJoin(_)
+            | MetadataError::HandleMissing,
+        )
+        | MetadataMaterializationQueueError::MetadataHandleMissing => {
+            MaterializationFailureKind::Transient
+        }
+        _ => MaterializationFailureKind::Application,
+    }
+}
+
 fn is_terminal_materialization_error(error: &MetadataMaterializationQueueError) -> bool {
     matches!(
-        error,
-        MetadataMaterializationQueueError::Metadata(MetadataError::InvalidInput(_))
+        materialization_failure_kind(error),
+        MaterializationFailureKind::Terminal
     )
 }
 
@@ -1752,6 +2003,7 @@ mod tests {
             event_id: old_event_id,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let (_, global_key, _) = metadata_materialization_job_write_entry(&old_job).unwrap();
         let document_key = metadata_materialization_document_job_key(document_id, old_event_id);
@@ -1859,6 +2111,7 @@ mod tests {
             event_id: old_event_id,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let document_key = metadata_materialization_document_job_key(document_id, old_event_id);
         write_entries(
@@ -1898,6 +2151,7 @@ mod tests {
             event_id,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let global_key = metadata_materialization_job_key(&job);
         let document_key = metadata_materialization_document_job_key(document_id, event_id);
@@ -1989,6 +2243,7 @@ mod tests {
             event_id: due_event,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let mut writes = vec![
             metadata_create_event_write_entry(&event).unwrap(),
@@ -2001,6 +2256,7 @@ mod tests {
                 event_id: Ulid::from_parts(2, u128::from(index)),
                 due_at_ms: now_ms.saturating_add(60_000).saturating_add(index),
                 attempts: 0,
+                failures: 0,
             };
             writes.push(metadata_materialization_job_write_entry(&future_job).unwrap());
         }
@@ -2034,12 +2290,14 @@ mod tests {
             event_id: Ulid::from_parts(1, 1),
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let mismatched = MetadataMaterializationJobRecord {
             document_id: Ulid::from_bytes([43u8; 16]),
             event_id: Ulid::from_parts(1, 2),
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let mismatched_sidecar = MetadataMaterializationJobRecord {
             due_at_ms: 999,
@@ -2098,6 +2356,7 @@ mod tests {
             event_id,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let mut writes = vec![
             metadata_create_event_write_entry(&first_event).unwrap(),
@@ -2111,6 +2370,7 @@ mod tests {
                 event_id: Ulid::from_parts(9, u128::from(index)),
                 due_at_ms: 1,
                 attempts: 0,
+                failures: 0,
             };
             writes.push(metadata_materialization_document_job_write_entry(&other).unwrap());
         }
@@ -2127,10 +2387,14 @@ mod tests {
         assert!(delta <= 10, "older check issued {delta} storage requests");
     }
 
+    fn application_failure() -> MetadataMaterializationQueueError {
+        MetadataMaterializationQueueError::Metadata(MetadataError::Backend("boom".to_string()))
+    }
+
     #[tokio::test]
-    async fn attempts_cap_parks() {
-        // The apply whose count reaches the cap parks as Failed with both rows
-        // removed; the job at attempts cap-1 is that boundary apply.
+    async fn failure_cap_parks() {
+        // The apply that spends the last of the failure budget parks as a dead
+        // letter: both job rows go, the record that can requeue them stays.
         let dir = tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
         let document_id = Ulid::from_bytes([45u8; 16]);
@@ -2140,7 +2404,8 @@ mod tests {
             document_id,
             event_id,
             due_at_ms: 1,
-            attempts: MATERIALIZATION_MAX_ATTEMPTS - 1,
+            attempts: MATERIALIZATION_MAX_FAILURES - 1,
+            failures: MATERIALIZATION_MAX_FAILURES - 1,
         };
         let index_key = metadata_materialization_job_key(&job);
         let sidecar_key = metadata_materialization_document_job_key(document_id, event_id);
@@ -2154,7 +2419,8 @@ mod tests {
         )
         .await;
 
-        let parked = defer_materialization_job(index_key.as_ref(), &job, &event, "boom".into());
+        let parked =
+            defer_materialization_job(index_key.as_ref(), &job, &event, &application_failure());
         assert!(matches!(parked, FinishedMaterializationJob::Parked { .. }));
         finish_completed_materialization_jobs(&storage, vec![parked])
             .await
@@ -2181,14 +2447,19 @@ mod tests {
             .unwrap()
             .expect("failed status is written");
         assert_eq!(status.state, MetadataMaterializationState::Failed);
-        assert_eq!(status.attempts, MATERIALIZATION_MAX_ATTEMPTS);
-        assert_eq!(status.last_error.as_deref(), Some("boom"));
+        assert_eq!(status.failures, MATERIALIZATION_MAX_FAILURES);
         assert!(!metadata_materialization_jobs_exist(&storage).await.unwrap());
+        let dead_letter = read_dead_letter(&storage, document_id, event_id)
+            .await
+            .unwrap()
+            .expect("dead letter is written");
+        assert_eq!(dead_letter.parks, 1);
+        assert!(dead_letter.requeue_at_ms > unix_timestamp_millis());
     }
 
     #[test]
     fn cap_boundary_reschedules() {
-        // Below the cap reschedules with attempts advanced; at the cap parks.
+        // Below the cap reschedules with failures advanced; at the cap parks.
         let document_id = Ulid::from_bytes([46u8; 16]);
         let event_id = Ulid::from_parts(2, 1);
         let event = create_event(document_id, event_id, "boundary");
@@ -2196,23 +2467,109 @@ mod tests {
             document_id,
             event_id,
             due_at_ms: 1,
-            attempts: MATERIALIZATION_MAX_ATTEMPTS - 2,
+            attempts: MATERIALIZATION_MAX_FAILURES - 2,
+            failures: MATERIALIZATION_MAX_FAILURES - 2,
         };
         let key = metadata_materialization_job_key(&reschedule);
-        match defer_materialization_job(key.as_ref(), &reschedule, &event, "boom".into()) {
+        match defer_materialization_job(key.as_ref(), &reschedule, &event, &application_failure()) {
             FinishedMaterializationJob::Rescheduled { status, .. } => {
-                assert_eq!(status.attempts, MATERIALIZATION_MAX_ATTEMPTS - 1);
+                assert_eq!(status.failures, MATERIALIZATION_MAX_FAILURES - 1);
             }
             other => panic!("expected reschedule, got {other:?}"),
         }
         let park = MetadataMaterializationJobRecord {
-            attempts: MATERIALIZATION_MAX_ATTEMPTS - 1,
+            failures: MATERIALIZATION_MAX_FAILURES - 1,
             ..reschedule
         };
         assert!(matches!(
-            defer_materialization_job(key.as_ref(), &park, &event, "boom".into()),
+            defer_materialization_job(key.as_ref(), &park, &event, &application_failure()),
             FinishedMaterializationJob::Parked { .. }
         ));
+    }
+
+    #[test]
+    fn transient_skips_cap() {
+        // A storage timeout is infrastructure: it advances the retry backoff but
+        // must never spend the failure budget that parks a job.
+        let document_id = Ulid::from_bytes([47u8; 16]);
+        let event_id = Ulid::from_parts(3, 1);
+        let event = create_event(document_id, event_id, "transient");
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: MATERIALIZATION_MAX_FAILURES + 5,
+            failures: MATERIALIZATION_MAX_FAILURES - 1,
+        };
+        let key = metadata_materialization_job_key(&job);
+        let timeout = MetadataMaterializationQueueError::Storage(StorageError::Timeout);
+        match defer_materialization_job(key.as_ref(), &job, &event, &timeout) {
+            FinishedMaterializationJob::Rescheduled { status, .. } => {
+                assert_eq!(status.failures, job.failures);
+                assert_eq!(status.attempts, job.attempts + 1);
+            }
+            other => panic!("expected reschedule, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn deadletters_requeue_due() {
+        // A due dead letter returns to the queue with a fresh budget and a
+        // pending status; one that is not due yet stays parked.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([48u8; 16]);
+        let event_id = Ulid::from_parts(4, 1);
+        let event = create_event(document_id, event_id, "requeue");
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: MATERIALIZATION_MAX_FAILURES,
+            failures: MATERIALIZATION_MAX_FAILURES,
+        };
+        let pending = MetadataMaterializationDeadLetterRecord {
+            job: job.clone(),
+            last_error: "boom".to_string(),
+            parked_at_ms: 1,
+            parks: 1,
+            requeue_at_ms: unix_timestamp_millis().saturating_add(600_000),
+        };
+        write_entries(
+            &storage,
+            vec![
+                metadata_create_event_write_entry(&event).unwrap(),
+                dead_letter_entry(&pending).unwrap(),
+            ],
+        )
+        .await;
+        assert_eq!(requeue_dead_letters(&storage).await.unwrap(), 0);
+
+        let due = MetadataMaterializationDeadLetterRecord {
+            requeue_at_ms: 1,
+            ..pending
+        };
+        write_entries(&storage, vec![dead_letter_entry(&due).unwrap()]).await;
+        assert_eq!(requeue_dead_letters(&storage).await.unwrap(), 1);
+
+        assert!(
+            read_dead_letter(&storage, document_id, event_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let requeued = read_document_job(&storage, document_id, event_id)
+            .await
+            .unwrap()
+            .expect("job is requeued");
+        assert_eq!(requeued.failures, 0);
+        assert_eq!(requeued.attempts, 0);
+        let status = read_materialization_status(&storage, document_id, None)
+            .await
+            .unwrap()
+            .expect("status is reset");
+        assert_eq!(status.state, MetadataMaterializationState::Pending);
+        assert!(metadata_materialization_jobs_exist(&storage).await.unwrap());
     }
 
     #[test]
@@ -2338,6 +2695,7 @@ mod tests {
             event_id: older_event_id,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let newer_pending = MetadataMaterializationStatusRecord {
             document_id,
@@ -2347,6 +2705,7 @@ mod tests {
             dataset_digest: None,
             state: MetadataMaterializationState::Pending,
             attempts: 0,
+            failures: 0,
             last_error: None,
             updated_at_ms: 1,
         };
@@ -2378,6 +2737,7 @@ mod tests {
             dataset_digest: None,
             state: MetadataMaterializationState::Pending,
             attempts: 1,
+            failures: 0,
             last_error: Some("transient".to_string()),
             updated_at_ms: 1,
         };
@@ -2389,6 +2749,7 @@ mod tests {
             dataset_digest: None,
             state: MetadataMaterializationState::Pending,
             attempts: 0,
+            failures: 0,
             last_error: None,
             updated_at_ms: 2,
         };
@@ -2412,6 +2773,7 @@ mod tests {
             dataset_digest: None,
             state: MetadataMaterializationState::Pending,
             attempts: 1,
+            failures: 0,
             last_error: Some("transient".to_string()),
             updated_at_ms: 1,
         };
@@ -2449,6 +2811,7 @@ mod tests {
             event_id: old_event_id,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let newer_status = MetadataMaterializationStatusRecord {
             document_id,
@@ -2458,6 +2821,7 @@ mod tests {
             dataset_digest: None,
             state: MetadataMaterializationState::Pending,
             attempts: 7,
+            failures: 0,
             last_error: Some("newer pending".to_string()),
             updated_at_ms: 7,
         };
@@ -2567,6 +2931,7 @@ mod tests {
                 event_id,
                 due_at_ms: 1,
                 attempts: 0,
+                failures: 0,
             };
             CompletedMaterializationJob {
                 job_key: metadata_materialization_job_write_entry(&job)
@@ -2729,6 +3094,7 @@ mod tests {
             event_id: older_event_id,
             due_at_ms: 30_000,
             attempts: 1,
+            failures: 0,
         };
         let newer_pending = MetadataMaterializationStatusRecord {
             document_id,
@@ -2738,6 +3104,7 @@ mod tests {
             dataset_digest: None,
             state: MetadataMaterializationState::Pending,
             attempts: 0,
+            failures: 0,
             last_error: None,
             updated_at_ms: 1,
         };
@@ -2793,6 +3160,7 @@ mod tests {
                     event_id,
                     due_at_ms: 1,
                     attempts: 0,
+                    failures: 0,
                 };
                 let index_key = metadata_materialization_job_key(&job);
                 (job, event, index_key)
@@ -2811,7 +3179,7 @@ mod tests {
         let finished: Vec<_> = jobs
             .iter()
             .map(|(job, event, index_key)| {
-                defer_materialization_job(index_key.as_ref(), job, event, "transient".into())
+                defer_materialization_job(index_key.as_ref(), job, event, &application_failure())
             })
             .collect();
         assert!(
@@ -2872,6 +3240,7 @@ mod tests {
             event_id,
             due_at_ms: 1,
             attempts: 0,
+            failures: 0,
         };
         let old_index_key = metadata_materialization_job_key(&job);
         write_entries(

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -41,6 +41,7 @@ use crate::driver::DriverContext;
 
 use crate::queue_backoff::queue_retry_after_ms;
 
+use super::iri_index::MetadataIriIndexError;
 use super::queue_storage::{
     MetadataQueueStorageError, abort_storage_transaction_best_effort, commit_storage_transaction,
     start_write_transaction,
@@ -145,6 +146,8 @@ pub enum MetadataMaterializationQueueError {
     MetadataCreateEventMissing { document_id: Ulid, event_id: Ulid },
     #[error("unexpected event while processing metadata materialization queue: {0}")]
     UnexpectedEvent(String),
+    #[error("inconsistent metadata raw event log: {0}")]
+    InconsistentLog(String),
 }
 
 impl From<MetadataQueueStorageError> for MetadataMaterializationQueueError {
@@ -163,6 +166,17 @@ impl From<MetadataRawReadError> for MetadataMaterializationQueueError {
             MetadataRawReadError::Conversion(error) => Self::Conversion(error),
             MetadataRawReadError::Metadata(error) => Self::Metadata(error),
             MetadataRawReadError::UnexpectedEvent(event) => Self::UnexpectedEvent(event),
+            MetadataRawReadError::InconsistentLog(message) => Self::InconsistentLog(message),
+        }
+    }
+}
+
+impl From<MetadataIriIndexError> for MetadataMaterializationQueueError {
+    fn from(error: MetadataIriIndexError) -> Self {
+        match error {
+            MetadataIriIndexError::Storage(error) => Self::Storage(error),
+            MetadataIriIndexError::Conversion(error) => Self::Conversion(error),
+            MetadataIriIndexError::UnexpectedEvent(event) => Self::UnexpectedEvent(event),
         }
     }
 }
@@ -598,6 +612,24 @@ async fn plan_finish_chunk(
                 status,
             } => {
                 let current = guard_status(&snapshot, &planned, job.document_id);
+                let job_deletes = [
+                    (
+                        METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                        ByteView::from(job_key),
+                    ),
+                    (
+                        METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                        metadata_materialization_document_job_key(job.document_id, job.event_id),
+                    ),
+                ];
+                // An already-superseded job must not leave a dead letter behind:
+                // requeueing it later would resurrect an obsolete event.
+                if current
+                    .is_some_and(|current| materialization_retry_already_advanced(current, &job))
+                {
+                    plan.deletes.extend(job_deletes);
+                    continue;
+                }
                 if should_write_final_materialization_status(current, &status) {
                     plan.writes
                         .push(metadata_materialization_status_write_entry(&status)?);
@@ -605,14 +637,7 @@ async fn plan_finish_chunk(
                 let previous = parked.get(&(job.document_id, job.event_id));
                 let dead_letter = parked_dead_letter(&job, &status, previous);
                 plan.writes.push(dead_letter_entry(&dead_letter)?);
-                plan.deletes.push((
-                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                    ByteView::from(job_key),
-                ));
-                plan.deletes.push((
-                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                    metadata_materialization_document_job_key(job.document_id, job.event_id),
-                ));
+                plan.deletes.extend(job_deletes);
                 warn!(
                     event = "materialization.job.parked",
                     document_id = %job.document_id,
@@ -803,9 +828,9 @@ async fn read_dead_letter(
     }
 }
 
-/// Returns due dead letters to the queue with a fresh failure budget and clears
-/// their terminal status, so a node converges once the cause clears. Returns the
-/// number of jobs requeued.
+/// Returns due dead letters to the queue and clears their terminal status, so a
+/// node converges once the cause clears. Dead letters the document has moved
+/// past are dropped instead. Returns the number of jobs requeued.
 pub async fn requeue_dead_letters(
     storage: &StorageHandle,
 ) -> Result<usize, MetadataMaterializationQueueError> {
@@ -846,8 +871,9 @@ pub async fn requeue_dead_letters(
             if dead_letter.requeue_at_ms > now_ms {
                 continue;
             }
-            requeue_dead_letter(storage, &dead_letter).await?;
-            requeued = requeued.saturating_add(1);
+            if requeue_dead_letter(storage, &dead_letter).await? {
+                requeued = requeued.saturating_add(1);
+            }
         }
 
         match next_start_after {
@@ -865,31 +891,64 @@ pub async fn requeue_dead_letters(
     Ok(requeued)
 }
 
+// The parked job's own status is Failed at its own event, so only a final status
+// beyond that means the document moved on and requeueing would regress it.
+fn dead_letter_superseded(
+    status: &MetadataMaterializationStatusRecord,
+    job: &MetadataMaterializationJobRecord,
+) -> bool {
+    materialization_status_obsoletes_job(status, job)
+        && (status.event_id > job.event_id
+            || status.state == MetadataMaterializationState::Materialized)
+}
+
 // The parked status is terminal for this event, so it must be cleared with the
-// job rows or the requeued job is pruned as obsolete on the next scan.
+// job rows or the requeued job is pruned as obsolete on the next scan. The
+// requeued job keeps one failure of budget so a poison document re-parks fast.
 async fn requeue_dead_letter(
     storage: &StorageHandle,
     dead_letter: &MetadataMaterializationDeadLetterRecord,
-) -> Result<(), MetadataMaterializationQueueError> {
+) -> Result<bool, MetadataMaterializationQueueError> {
     let job = MetadataMaterializationJobRecord {
         document_id: dead_letter.job.document_id,
         event_id: dead_letter.job.event_id,
         due_at_ms: unix_timestamp_millis(),
         attempts: 0,
-        failures: 0,
+        failures: MATERIALIZATION_MAX_FAILURES.saturating_sub(1),
     };
+    if let Some(status) = read_materialization_status(storage, job.document_id, None).await?
+        && dead_letter_superseded(&status, &job)
+    {
+        info!(
+            event = "materialization.deadletter.superseded",
+            document_id = %job.document_id,
+            event_id = %job.event_id,
+            status_event_id = %status.event_id,
+            "Dropping superseded metadata materialization dead letter"
+        );
+        delete_dead_letter(
+            storage,
+            dead_letter_key(job.document_id, job.event_id).to_vec(),
+        )
+        .await?;
+        return Ok(false);
+    }
     let event = match read_create_event(storage, job.document_id, job.event_id).await {
         Ok(event) => event,
         Err(MetadataMaterializationQueueError::MetadataCreateEventMissing { .. }) => {
-            return delete_dead_letter(
+            delete_dead_letter(
                 storage,
                 dead_letter_key(job.document_id, job.event_id).to_vec(),
             )
-            .await;
+            .await?;
+            return Ok(false);
         }
         Err(error) => return Err(error),
     };
-    let status = new_pending_materialization_status(&event, unix_timestamp_millis());
+    let status = MetadataMaterializationStatusRecord {
+        failures: job.failures,
+        ..new_pending_materialization_status(&event, unix_timestamp_millis())
+    };
     let txn_id = start_write_transaction(storage).await?;
     let result = async {
         transactional_batch_write(
@@ -916,7 +975,7 @@ async fn requeue_dead_letter(
     match result {
         Ok(()) => {
             commit_storage_transaction(storage, txn_id).await?;
-            Ok(())
+            Ok(true)
         }
         Err(error) => {
             abort_storage_transaction_best_effort(
@@ -2052,16 +2111,15 @@ fn materialization_failure_kind(
         MetadataMaterializationQueueError::Metadata(
             MetadataError::InvalidInput(_) | MetadataError::Validation(_),
         ) => MaterializationFailureKind::Terminal,
-        MetadataMaterializationQueueError::Storage(
-            StorageError::Timeout
-            | StorageError::QueueFull
-            | StorageError::ChannelClosed
-            | StorageError::PersistError(_),
-        )
+        // A storage failure or an off-contract adapter event is never the
+        // document's fault, so it must not spend the budget that parks a job.
+        MetadataMaterializationQueueError::Storage(_)
+        | MetadataMaterializationQueueError::UnexpectedEvent(_)
         | MetadataMaterializationQueueError::Metadata(
             MetadataError::ChannelClosed
             | MetadataError::TaskJoin(_)
-            | MetadataError::HandleMissing,
+            | MetadataError::HandleMissing
+            | MetadataError::Persist(_),
         )
         | MetadataMaterializationQueueError::MetadataHandleMissing => {
             MaterializationFailureKind::Transient
@@ -2886,11 +2944,47 @@ mod tests {
             failures: MATERIALIZATION_MAX_FAILURES - 1,
         };
         let key = metadata_materialization_job_key(&job);
-        let timeout = MetadataMaterializationQueueError::Storage(StorageError::Timeout);
-        match defer_materialization_job(key.as_ref(), &job, &event, &timeout) {
+        let errors = [
+            MetadataMaterializationQueueError::Storage(StorageError::Timeout),
+            MetadataMaterializationQueueError::Storage(StorageError::TransactionConflict),
+            // A failed durability flush runs after every apply; charging it would
+            // park documents whenever the disk is the bottleneck.
+            MetadataMaterializationQueueError::Metadata(MetadataError::Persist(
+                "journal".to_string(),
+            )),
+        ];
+        for error in errors {
+            match defer_materialization_job(key.as_ref(), &job, &event, &error) {
+                FinishedMaterializationJob::Rescheduled { status, .. } => {
+                    assert_eq!(status.failures, job.failures);
+                    assert_eq!(status.attempts, job.attempts + 1);
+                }
+                other => panic!("expected reschedule, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn iri_failure_transient() {
+        // A bulk-lane QueueFull surfaced through the IRI index keeps its storage
+        // cause, so it defers without spending the failure budget.
+        let document_id = Ulid::from_bytes([51u8; 16]);
+        let event_id = Ulid::from_parts(5, 1);
+        let event = create_event(document_id, event_id, "indexed");
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: 0,
+            failures: MATERIALIZATION_MAX_FAILURES - 1,
+        };
+        let key = metadata_materialization_job_key(&job);
+        let error = MetadataMaterializationQueueError::from(MetadataIriIndexError::Storage(
+            StorageError::QueueFull,
+        ));
+        match defer_materialization_job(key.as_ref(), &job, &event, &error) {
             FinishedMaterializationJob::Rescheduled { status, .. } => {
                 assert_eq!(status.failures, job.failures);
-                assert_eq!(status.attempts, job.attempts + 1);
             }
             other => panic!("expected reschedule, got {other:?}"),
         }
@@ -2898,8 +2992,8 @@ mod tests {
 
     #[tokio::test]
     async fn deadletters_requeue_due() {
-        // A due dead letter returns to the queue with a fresh budget and a
-        // pending status; one that is not due yet stays parked.
+        // A due dead letter returns to the queue with one failure of budget left
+        // and a pending status; one that is not due yet stays parked.
         let dir = tempdir().unwrap();
         let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
         let document_id = Ulid::from_bytes([48u8; 16]);
@@ -2946,7 +3040,7 @@ mod tests {
             .await
             .unwrap()
             .expect("job is requeued");
-        assert_eq!(requeued.failures, 0);
+        assert_eq!(requeued.failures, MATERIALIZATION_MAX_FAILURES - 1);
         assert_eq!(requeued.attempts, 0);
         let status = read_materialization_status(&storage, document_id, None)
             .await
@@ -2954,6 +3048,174 @@ mod tests {
             .expect("status is reset");
         assert_eq!(status.state, MetadataMaterializationState::Pending);
         assert!(metadata_materialization_jobs_exist(&storage).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn requeued_parks_fast() {
+        // A requeued dead letter carries one failure of budget, so a document
+        // that is still poisonous re-parks after a single apply.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([53u8; 16]);
+        let event_id = Ulid::from_parts(6, 1);
+        let event = create_event(document_id, event_id, "poison");
+        let parked = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: MATERIALIZATION_MAX_FAILURES,
+            failures: MATERIALIZATION_MAX_FAILURES,
+        };
+        let due = MetadataMaterializationDeadLetterRecord {
+            job: parked,
+            last_error: "boom".to_string(),
+            parked_at_ms: 1,
+            parks: 1,
+            requeue_at_ms: 1,
+        };
+        write_entries(
+            &storage,
+            vec![
+                metadata_create_event_write_entry(&event).unwrap(),
+                dead_letter_entry(&due).unwrap(),
+            ],
+        )
+        .await;
+        assert_eq!(requeue_dead_letters(&storage).await.unwrap(), 1);
+
+        let requeued = read_document_job(&storage, document_id, event_id)
+            .await
+            .unwrap()
+            .expect("job is requeued");
+        let key = metadata_materialization_job_key(&requeued);
+        assert!(matches!(
+            defer_materialization_job(key.as_ref(), &requeued, &event, &application_failure()),
+            FinishedMaterializationJob::Parked { .. }
+        ));
+    }
+
+    // A status that already materialized `event_id`, as a newer event would.
+    fn materialized_status(
+        document_id: Ulid,
+        event: &MetadataCreateEventRecord,
+    ) -> MetadataMaterializationStatusRecord {
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id: event.event_id,
+            due_at_ms: 1,
+            attempts: 0,
+            failures: 0,
+        };
+        materialization_success_status(&job, event, None)
+    }
+
+    #[tokio::test]
+    async fn deadletter_drops_superseded() {
+        // Requeueing a dead letter whose document has since materialized a newer
+        // event would regress the projection, so the dead letter is dropped.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([54u8; 16]);
+        let old_event_id = Ulid::from_parts(1, 1);
+        let newer_event_id = Ulid::from_parts(2, 1);
+        let old_event = create_event(document_id, old_event_id, "old");
+        let newer_event = create_event(document_id, newer_event_id, "newer");
+        let newer_status = materialized_status(document_id, &newer_event);
+        let due = MetadataMaterializationDeadLetterRecord {
+            job: MetadataMaterializationJobRecord {
+                document_id,
+                event_id: old_event_id,
+                due_at_ms: 1,
+                attempts: MATERIALIZATION_MAX_FAILURES,
+                failures: MATERIALIZATION_MAX_FAILURES,
+            },
+            last_error: "boom".to_string(),
+            parked_at_ms: 1,
+            parks: 1,
+            requeue_at_ms: 1,
+        };
+        write_entries(
+            &storage,
+            vec![
+                metadata_create_event_write_entry(&old_event).unwrap(),
+                metadata_create_event_write_entry(&newer_event).unwrap(),
+                metadata_materialization_status_write_entry(&newer_status).unwrap(),
+                dead_letter_entry(&due).unwrap(),
+            ],
+        )
+        .await;
+
+        assert_eq!(requeue_dead_letters(&storage).await.unwrap(), 0);
+
+        assert!(
+            read_dead_letter(&storage, document_id, old_event_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let status = read_materialization_status(&storage, document_id, None)
+            .await
+            .unwrap()
+            .expect("status survives");
+        assert_eq!(status.event_id, newer_event_id);
+        assert_eq!(status.state, MetadataMaterializationState::Materialized);
+        assert!(
+            read_document_job(&storage, document_id, old_event_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn park_skips_superseded() {
+        // Parking a job the document has already moved past must not leave a
+        // dead letter that a later sweep could resurrect.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([55u8; 16]);
+        let old_event_id = Ulid::from_parts(1, 1);
+        let newer_event_id = Ulid::from_parts(2, 1);
+        let old_event = create_event(document_id, old_event_id, "old");
+        let newer_event = create_event(document_id, newer_event_id, "newer");
+        let newer_status = materialized_status(document_id, &newer_event);
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id: old_event_id,
+            due_at_ms: 1,
+            attempts: MATERIALIZATION_MAX_FAILURES - 1,
+            failures: MATERIALIZATION_MAX_FAILURES - 1,
+        };
+        let job_key = metadata_materialization_job_key(&job);
+        write_entries(
+            &storage,
+            vec![
+                metadata_materialization_status_write_entry(&newer_status).unwrap(),
+                metadata_materialization_job_write_entry(&job).unwrap(),
+                metadata_materialization_document_job_write_entry(&job).unwrap(),
+            ],
+        )
+        .await;
+
+        let parked =
+            defer_materialization_job(job_key.as_ref(), &job, &old_event, &application_failure());
+        assert!(matches!(parked, FinishedMaterializationJob::Parked { .. }));
+        let plan = plan_finish_chunk(&storage, vec![parked]).await.unwrap();
+
+        assert!(
+            !plan
+                .writes
+                .iter()
+                .any(|(key_space, _, _)| key_space == METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE)
+        );
+        assert!(plan.deletes.contains(&(
+            METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+            job_key.clone()
+        )));
+        assert!(plan.deletes.contains(&(
+            METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+            metadata_materialization_document_job_key(document_id, old_event_id)
+        )));
     }
 
     #[test]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -54,8 +54,9 @@ const MATERIALIZATION_MAX_ATTEMPTS: u32 = 10;
 
 pub const METADATA_MATERIALIZATION_POLL_AFTER: Duration = Duration::from_secs(5);
 pub const METADATA_MATERIALIZATION_RETRY_AFTER: Duration = Duration::from_secs(1);
-// Small gap between full batches so the timer runtime, other timers, and the
-// storage lanes get scheduled and a healthy drain cannot monopolize the system.
+// Best-effort gap between full batches; enqueue ResetTimer(ZERO) and refire on
+// completion can bypass it under continuous refill, so real fairness is enforced
+// by the bulk storage lane, not this constant.
 pub const METADATA_MATERIALIZATION_NEXT_BATCH_AFTER: Duration = Duration::from_millis(25);
 
 #[derive(Debug)]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -335,12 +335,23 @@ async fn process_materialization_job_groups(
             let mut outcome = MaterializationGroupOutcome::default();
             let mut advanced_event_ids = BTreeSet::new();
             let mut raw_state_cache = RawStateCache::default();
+            let Some(document_id) = jobs.first().map(|(_, job)| job.document_id) else {
+                return outcome;
+            };
+            let group = match load_group_jobs(&context.storage_handle, document_id).await {
+                Ok(group) => group,
+                Err(error) => {
+                    outcome.error = Some(error);
+                    return outcome;
+                }
+            };
             for (job_key, job) in jobs {
                 let event_id = job.event_id;
                 match process_materialization_job(
                     &context,
                     job_key,
                     job,
+                    &group,
                     &advanced_event_ids,
                     &mut raw_state_cache,
                 )
@@ -503,7 +514,8 @@ async fn plan_finish_chunk(
     storage: &StorageHandle,
     finished: Vec<FinishedMaterializationJob>,
 ) -> Result<FinishPlan, MetadataMaterializationQueueError> {
-    let snapshot = read_statuses(storage, &finished).await?;
+    let snapshot =
+        read_status_map(storage, finished.iter().map(finished_document_id).collect()).await?;
     let parked = read_dead_letters(storage, &finished).await?;
     let mut plan = FinishPlan {
         deletes: Vec::with_capacity(finished.len().saturating_mul(2)),
@@ -654,11 +666,10 @@ fn finished_document_id(finished: &FinishedMaterializationJob) -> Ulid {
     }
 }
 
-async fn read_statuses(
+async fn read_status_map(
     storage: &StorageHandle,
-    finished: &[FinishedMaterializationJob],
+    document_ids: BTreeSet<Ulid>,
 ) -> Result<HashMap<Ulid, MetadataMaterializationStatusRecord>, MetadataMaterializationQueueError> {
-    let document_ids: BTreeSet<Ulid> = finished.iter().map(finished_document_id).collect();
     if document_ids.is_empty() {
         return Ok(HashMap::new());
     }
@@ -1040,8 +1051,9 @@ async fn read_document_job(
 }
 
 // The due index is due-ordered and its rows are valid only when the sidecar row
-// exists with a matching due time; stale or dead rows are deleted lazily so a
-// scan costs O(due jobs) rather than a full-keyspace pass.
+// exists with a matching due time. A page resolves its sidecars, events and
+// statuses in three batch reads and prunes dead rows in one delete, so the scan
+// costs O(pages) requests rather than O(due jobs).
 async fn scan_due_materialization_jobs(
     storage: &StorageHandle,
     now_ms: u64,
@@ -1079,33 +1091,79 @@ async fn scan_due_materialization_jobs(
             }
         };
 
+        let mut stale = Vec::new();
+        let mut candidates = Vec::new();
+        let mut next_due_at_ms = None;
         for (key, _value) in values {
             let key = key.to_vec();
             let Some((due_at_ms, document_id, event_id)) = materialization_job_key_parts(&key)
             else {
                 warn!(key = ?key, "Deleting malformed metadata materialization index row");
-                delete_materialization_global_job(storage, key).await?;
+                stale.push((
+                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                    ByteView::from(key),
+                ));
                 continue;
             };
             if due_at_ms > now_ms {
-                return Ok((jobs, false, Some(due_at_ms)));
+                next_due_at_ms = Some(due_at_ms);
+                break;
             }
-            let Some(job) = read_document_job(storage, document_id, event_id).await? else {
-                delete_materialization_global_job(storage, key).await?;
-                continue;
-            };
-            if job.due_at_ms != due_at_ms {
-                delete_materialization_global_job(storage, key).await?;
-                continue;
+            candidates.push((key, due_at_ms, document_id, event_id));
+        }
+
+        let sidecars = read_document_jobs(
+            storage,
+            &candidates
+                .iter()
+                .map(|(_, _, document_id, event_id)| (*document_id, *event_id))
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+        let mut due = Vec::new();
+        for ((key, due_at_ms, document_id, event_id), sidecar) in
+            candidates.into_iter().zip(sidecars)
+        {
+            match sidecar {
+                Some(job) if job.due_at_ms == due_at_ms => due.push((key, job)),
+                Some(_) | None => {
+                    // The sidecar is authoritative: an index row it does not
+                    // match is stale. A malformed sidecar is dropped with it.
+                    stale.push((
+                        METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                        ByteView::from(key),
+                    ));
+                    if sidecar.is_none() {
+                        stale.push((
+                            METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                            metadata_materialization_document_job_key(document_id, event_id),
+                        ));
+                    }
+                }
             }
-            if !materialization_job_is_live(storage, &job).await? {
-                delete_materialization_job(storage, key).await?;
-                continue;
-            }
+        }
+
+        let (live, dead) = filter_live_jobs(storage, due).await?;
+        for (key, job) in dead {
+            stale.push((
+                METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                ByteView::from(key),
+            ));
+            stale.push((
+                METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                metadata_materialization_document_job_key(job.document_id, job.event_id),
+            ));
+        }
+        delete_materialization_entries(storage, stale).await?;
+
+        for (_, job) in live {
             jobs.push((metadata_materialization_job_key(&job).to_vec(), job));
             if jobs.len() >= limit {
                 return Ok((jobs, true, None));
             }
+        }
+        if let Some(due_at_ms) = next_due_at_ms {
+            return Ok((jobs, false, Some(due_at_ms)));
         }
 
         match next_start_after {
@@ -1113,6 +1171,70 @@ async fn scan_due_materialization_jobs(
             None => return Ok((jobs, false, None)),
         }
     }
+}
+
+async fn read_document_jobs(
+    storage: &StorageHandle,
+    targets: &[(Ulid, Ulid)],
+) -> Result<Vec<Option<MetadataMaterializationJobRecord>>, MetadataMaterializationQueueError> {
+    if targets.is_empty() {
+        return Ok(Vec::new());
+    }
+    let reads = targets
+        .iter()
+        .map(|(document_id, event_id)| {
+            (
+                METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                metadata_materialization_document_job_key(*document_id, *event_id),
+            )
+        })
+        .collect();
+    Ok(batch_read_values(storage, reads)
+        .await?
+        .into_iter()
+        .map(|value| value.and_then(|value| postcard::from_bytes(&value).ok()))
+        .collect())
+}
+
+// Live means the create event still exists and no status has advanced past the
+// job. Dead jobs are returned so the caller can prune both of their rows.
+type ScannedJobs = Vec<(Vec<u8>, MetadataMaterializationJobRecord)>;
+
+async fn filter_live_jobs(
+    storage: &StorageHandle,
+    jobs: ScannedJobs,
+) -> Result<(ScannedJobs, ScannedJobs), MetadataMaterializationQueueError> {
+    if jobs.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let statuses = read_status_map(
+        storage,
+        jobs.iter().map(|(_, job)| job.document_id).collect(),
+    )
+    .await?;
+    let event_reads = jobs
+        .iter()
+        .map(|(_, job)| {
+            (
+                METADATA_EVENT_LOG_KEYSPACE.to_string(),
+                metadata_event_log_key(job.document_id, job.event_id),
+            )
+        })
+        .collect();
+    let events = batch_read_values(storage, event_reads).await?;
+    let mut live = Vec::with_capacity(jobs.len());
+    let mut dead = Vec::new();
+    for ((key, job), event) in jobs.into_iter().zip(events) {
+        let advanced = statuses
+            .get(&job.document_id)
+            .is_some_and(|status| materialization_retry_already_advanced(status, &job));
+        if event.is_none() || advanced {
+            dead.push((key, job));
+        } else {
+            live.push((key, job));
+        }
+    }
+    Ok((live, dead))
 }
 
 fn due_after(now_ms: u64, due_at_ms: u64) -> Duration {
@@ -1192,27 +1314,19 @@ async fn process_materialization_job(
     context: &DriverContext,
     job_key: Vec<u8>,
     job: MetadataMaterializationJobRecord,
+    group: &GroupJobs,
     advanced_event_ids: &BTreeSet<Ulid>,
     raw_state_cache: &mut RawStateCache,
 ) -> Result<ProcessedMaterializationJob, MetadataMaterializationQueueError> {
-    if older_materialization_job_exists(
-        &context.storage_handle,
-        job.document_id,
-        job.event_id,
-        advanced_event_ids,
-    )
-    .await?
-    {
+    if older_job_exists(&context.storage_handle, group, &job, advanced_event_ids).await? {
         return Ok(ProcessedMaterializationJob::blocked());
     }
     let document_job_key =
         metadata_materialization_document_job_key(job.document_id, job.event_id).to_vec();
 
-    let (obsolescence, event) = tokio::join!(
-        materialization_job_obsolescence(&context.storage_handle, &job),
-        read_create_event(&context.storage_handle, job.document_id, job.event_id),
-    );
-    match obsolescence? {
+    let obsolescence = job_obsolescence(group.status.as_ref(), &job);
+    let event = read_create_event(&context.storage_handle, job.document_id, job.event_id).await;
+    match obsolescence {
         MaterializationJobObsolescence::Live => {}
         MaterializationJobObsolescence::Final => {
             return Ok(ProcessedMaterializationJob::completed(
@@ -1331,18 +1445,24 @@ async fn process_materialization_job(
     }
 }
 
-// The sidecar keyspace is per-document and event-ordered, so the predecessor
-// check costs O(pending jobs for this document): iterate below the target event
-// and stop at the first key that is not an unadvanced, live, older job.
-async fn older_materialization_job_exists(
+/// Everything a document's group needs to order its own events: its queued jobs
+/// and its status, loaded once instead of once per event.
+#[derive(Debug, Default)]
+struct GroupJobs {
+    pending: Vec<MetadataMaterializationJobRecord>,
+    status: Option<MetadataMaterializationStatusRecord>,
+}
+
+// The sidecar keyspace is per-document and event-ordered, so this costs one
+// prefix scan plus one status read for the whole group.
+async fn load_group_jobs(
     storage: &StorageHandle,
     document_id: Ulid,
-    event_id: Ulid,
-    advanced_event_ids: &BTreeSet<Ulid>,
-) -> Result<bool, MetadataMaterializationQueueError> {
+) -> Result<GroupJobs, MetadataMaterializationQueueError> {
     let status = read_materialization_status(storage, document_id, None).await?;
     let prefix = metadata_materialization_document_job_prefix(document_id);
-    let stop_key = metadata_materialization_document_job_key(document_id, event_id);
+    let mut pending = Vec::new();
+    let mut malformed = Vec::new();
     let mut start_after = None;
     loop {
         let event = storage
@@ -1368,44 +1488,56 @@ async fn older_materialization_job_exists(
         };
 
         for (key, value) in values {
-            let key = key.to_vec();
-            if key.as_slice() >= stop_key.as_ref() {
-                return Ok(false);
-            }
-            let job = match postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) {
-                Ok(job) => job,
+            match postcard::from_bytes::<MetadataMaterializationJobRecord>(&value) {
+                Ok(job) if job.document_id == document_id => pending.push(job),
+                Ok(_) => {}
                 Err(error) => {
-                    warn!(error = %error, key = ?key, "Deleting malformed metadata materialization document job while checking predecessors");
-                    delete_materialization_document_job(storage, key).await?;
-                    continue;
+                    warn!(error = %error, key = ?key.to_vec(), "Deleting malformed metadata materialization document job");
+                    malformed.push((
+                        METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                        key,
+                    ));
                 }
-            };
-            if job.document_id != document_id
-                || job.event_id >= event_id
-                || advanced_event_ids.contains(&job.event_id)
-                || status
-                    .as_ref()
-                    .is_some_and(|status| materialization_status_obsoletes_job(status, &job))
-            {
-                continue;
             }
-            if !materialization_event_exists(storage, &job).await? {
-                warn!(document_id = %job.document_id, event_id = %job.event_id, "Deleting orphan metadata materialization document job while checking predecessors");
-                delete_materialization_job(
-                    storage,
-                    metadata_materialization_job_key(&job).to_vec(),
-                )
-                .await?;
-                continue;
-            }
-            return Ok(true);
         }
 
         match next_start_after {
             Some(next) => start_after = Some(next),
-            None => return Ok(false),
+            None => break,
         }
     }
+    delete_materialization_entries(storage, malformed).await?;
+    pending.sort_by_key(|job| job.event_id);
+    Ok(GroupJobs { pending, status })
+}
+
+// An unadvanced, live job for an earlier event of the same document must run
+// first, so this one waits for the next batch.
+async fn older_job_exists(
+    storage: &StorageHandle,
+    group: &GroupJobs,
+    job: &MetadataMaterializationJobRecord,
+    advanced_event_ids: &BTreeSet<Ulid>,
+) -> Result<bool, MetadataMaterializationQueueError> {
+    for pending in &group.pending {
+        if pending.event_id >= job.event_id
+            || advanced_event_ids.contains(&pending.event_id)
+            || group
+                .status
+                .as_ref()
+                .is_some_and(|status| materialization_status_obsoletes_job(status, pending))
+        {
+            continue;
+        }
+        if !materialization_event_exists(storage, pending).await? {
+            warn!(document_id = %pending.document_id, event_id = %pending.event_id, "Deleting orphan metadata materialization job");
+            delete_materialization_job(storage, metadata_materialization_job_key(pending).to_vec())
+                .await?;
+            continue;
+        }
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 async fn read_create_event(
@@ -1446,20 +1578,20 @@ async fn read_create_event(
     }
 }
 
-async fn materialization_job_obsolescence(
-    storage: &StorageHandle,
+fn job_obsolescence(
+    status: Option<&MetadataMaterializationStatusRecord>,
     job: &MetadataMaterializationJobRecord,
-) -> Result<MaterializationJobObsolescence, MetadataMaterializationQueueError> {
-    let Some(status) = read_materialization_status(storage, job.document_id, None).await? else {
-        return Ok(MaterializationJobObsolescence::Live);
+) -> MaterializationJobObsolescence {
+    let Some(status) = status else {
+        return MaterializationJobObsolescence::Live;
     };
-    if materialization_status_obsoletes_job(&status, job) {
-        return Ok(MaterializationJobObsolescence::Final);
+    if materialization_status_obsoletes_job(status, job) {
+        return MaterializationJobObsolescence::Final;
     }
     if status.event_id == job.event_id && status.attempts > job.attempts {
-        return Ok(MaterializationJobObsolescence::RetryAdvanced);
+        return MaterializationJobObsolescence::RetryAdvanced;
     }
-    Ok(MaterializationJobObsolescence::Live)
+    MaterializationJobObsolescence::Live
 }
 
 async fn read_materialization_status(
@@ -2065,6 +2197,25 @@ mod tests {
         }
     }
 
+    // Loads the document's group first, exactly as the drain does before it
+    // checks a job's predecessors.
+    async fn older_exists(
+        storage: &StorageHandle,
+        document_id: Ulid,
+        event_id: Ulid,
+        advanced: &BTreeSet<Ulid>,
+    ) -> Result<bool, MetadataMaterializationQueueError> {
+        let group = load_group_jobs(storage, document_id).await?;
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 0,
+            attempts: 0,
+            failures: 0,
+        };
+        older_job_exists(storage, &group, &job, advanced).await
+    }
+
     async fn index_job_keys(storage: &StorageHandle) -> Vec<(u64, Ulid, Ulid)> {
         match storage
             .send_storage_effect(StorageEffect::Iter {
@@ -2209,14 +2360,9 @@ mod tests {
             .await
         );
         assert!(
-            !older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
+            !older_exists(&storage, document_id, newer_event_id, &BTreeSet::new())
+                .await
+                .unwrap()
         );
     }
 
@@ -2239,14 +2385,9 @@ mod tests {
         .await;
 
         assert!(
-            !older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
+            !older_exists(&storage, document_id, newer_event_id, &BTreeSet::new())
+                .await
+                .unwrap()
         );
         assert!(
             !storage_key_exists(
@@ -2280,14 +2421,9 @@ mod tests {
         .await;
 
         assert!(
-            !older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
+            !older_exists(&storage, document_id, newer_event_id, &BTreeSet::new())
+                .await
+                .unwrap()
         );
         assert!(
             !storage_key_exists(
@@ -2373,7 +2509,7 @@ mod tests {
         .await;
 
         assert!(
-            !older_materialization_job_exists(&storage, document_id, event_id, &BTreeSet::new())
+            !older_exists(&storage, document_id, event_id, &BTreeSet::new())
                 .await
                 .unwrap()
         );
@@ -2435,6 +2571,42 @@ mod tests {
         assert!(!has_more_due);
         assert!(next_due_at_ms.is_some());
         assert!(delta <= 10, "scan issued {delta} storage requests");
+    }
+
+    #[tokio::test]
+    async fn scan_batches_reads() {
+        // A page of due jobs resolves in a handful of batch reads instead of a
+        // sidecar, event and status read per row.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let now_ms = unix_timestamp_millis();
+        let mut writes = Vec::new();
+        for index in 0..64u8 {
+            let document_id = Ulid::from_bytes([index; 16]);
+            let event_id = Ulid::from_parts(1, u128::from(index));
+            let event = create_event(document_id, event_id, "batched");
+            let job = MetadataMaterializationJobRecord {
+                document_id,
+                event_id,
+                due_at_ms: 1,
+                attempts: 0,
+                failures: 0,
+            };
+            writes.push(metadata_create_event_write_entry(&event).unwrap());
+            writes.push(metadata_materialization_job_write_entry(&job).unwrap());
+            writes.push(metadata_materialization_document_job_write_entry(&job).unwrap());
+        }
+        write_entries(&storage, writes).await;
+
+        let before = storage.snapshot_metrics().requests_total;
+        let (jobs, _, _) =
+            scan_due_materialization_jobs(&storage, now_ms, MATERIALIZATION_BATCH_SIZE)
+                .await
+                .unwrap();
+        let delta = storage.snapshot_metrics().requests_total - before;
+
+        assert_eq!(jobs.len(), 64);
+        assert!(delta <= 8, "scan issued {delta} storage requests");
     }
 
     #[tokio::test]
@@ -2536,10 +2708,9 @@ mod tests {
         write_entries(&storage, writes).await;
 
         let before = storage.snapshot_metrics().requests_total;
-        let older =
-            older_materialization_job_exists(&storage, document_id, middle, &BTreeSet::new())
-                .await
-                .unwrap();
+        let older = older_exists(&storage, document_id, middle, &BTreeSet::new())
+            .await
+            .unwrap();
         let delta = storage.snapshot_metrics().requests_total - before;
 
         assert!(older);
@@ -3330,7 +3501,7 @@ mod tests {
         });
 
         assert!(
-            !older_materialization_job_exists(&storage, document_id, event_id, &BTreeSet::new())
+            !older_exists(&storage, document_id, event_id, &BTreeSet::new())
                 .await
                 .unwrap()
         );
@@ -3381,20 +3552,15 @@ mod tests {
         .await;
 
         assert!(
-            older_materialization_job_exists(
-                &storage,
-                document_id,
-                newer_event_id,
-                &BTreeSet::new()
-            )
-            .await
-            .unwrap()
+            older_exists(&storage, document_id, newer_event_id, &BTreeSet::new())
+                .await
+                .unwrap()
         );
 
         let mut advanced = BTreeSet::new();
         advanced.insert(older_event_id);
         assert!(
-            !older_materialization_job_exists(&storage, document_id, newer_event_id, &advanced)
+            !older_exists(&storage, document_id, newer_event_id, &advanced)
                 .await
                 .unwrap()
         );

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -2585,7 +2585,8 @@ mod tests {
     async fn older_check_local() {
         // Predecessor lookups read the status then one document-local sidecar
         // scan; they never fall back to a full global keyspace scan.
-        let (storage, receiver) = StorageHandle::new();
+        let (storage, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         let document_id = Ulid::from_bytes([11u8; 16]);
         let event_id = Ulid::from_parts(11, 2);
         let scripted = thread::spawn(move || {
@@ -2710,7 +2711,8 @@ mod tests {
 
     #[tokio::test]
     async fn retry_reschedule_is_atomic() {
-        let (storage, receiver) = StorageHandle::new();
+        let (storage, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         let txn_id = Ulid::from_parts(5, 1);
         let document_id = Ulid::from_bytes([4u8; 16]);
         let event_id = Ulid::from_parts(5, 2);

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -9,7 +9,8 @@ use aruna_core::handle::Handle;
 use aruna_core::keyspaces::{
     METADATA_EVENT_LOG_KEYSPACE, METADATA_GRAPH_LIFECYCLE_KEYSPACE,
     METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE, METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE,
-    METADATA_MATERIALIZATION_JOB_KEYSPACE, METADATA_MATERIALIZATION_STATUS_KEYSPACE,
+    METADATA_MATERIALIZATION_JOB_KEYSPACE, METADATA_MATERIALIZATION_PRUNE_KEYSPACE,
+    METADATA_MATERIALIZATION_STATUS_KEYSPACE,
 };
 use aruna_core::metadata::{
     MetadataApplyRoCrateRequest, MetadataCreateCrateRequest, MetadataCreateEventPayload,
@@ -20,7 +21,8 @@ use aruna_core::metadata::{
     deterministic_materialization_actor,
 };
 use aruna_core::storage_entries::{
-    dead_letter_entry, dead_letter_key, metadata_event_log_key, metadata_graph_lifecycle_key,
+    dead_letter_entry, dead_letter_key, materialization_prune_entry, materialization_prune_key,
+    metadata_event_log_key, metadata_graph_lifecycle_key,
     metadata_materialization_document_job_key, metadata_materialization_document_job_prefix,
     metadata_materialization_document_job_write_entry, metadata_materialization_job_key,
     metadata_materialization_job_write_entry, metadata_materialization_status_key,
@@ -476,12 +478,23 @@ struct FinishPlan {
 }
 
 // Chunked so a failure costs one chunk instead of the whole batch, and the
-// craqle work behind the committed chunks survives.
+// craqle work behind the committed chunks survives. The chunks that did commit
+// are still pruned, since their job rows are gone and nothing else would.
 async fn finish_completed_materialization_jobs(
     storage: &StorageHandle,
     finished: Vec<FinishedMaterializationJob>,
 ) -> Result<(), MetadataMaterializationQueueError> {
     let mut superseding = HashMap::new();
+    let finish = finish_chunks(storage, finished, &mut superseding).await;
+    let prune = prune_superseded_rows(storage, superseding).await;
+    finish.and(prune)
+}
+
+async fn finish_chunks(
+    storage: &StorageHandle,
+    finished: Vec<FinishedMaterializationJob>,
+    superseding: &mut HashMap<Ulid, Ulid>,
+) -> Result<(), MetadataMaterializationQueueError> {
     let mut chunk = Vec::with_capacity(MATERIALIZATION_FINISH_CHUNK);
     for job in finished {
         chunk.push(job);
@@ -494,22 +507,127 @@ async fn finish_completed_materialization_jobs(
     if !chunk.is_empty() {
         superseding.extend(finish_chunk(storage, chunk).await?);
     }
-    prune_superseded_rows(storage, superseding).await
+    Ok(())
 }
 
 // The IRI reference index cannot be scanned per document, so this walks the
 // whole keyspace: once per batch, never once per chunk. Cleanup only, so it
-// runs after the chunks commit rather than inside them.
+// runs after the chunks commit rather than inside them, and a failure is parked
+// durably: the finished jobs are gone, so nothing else would retry it.
 async fn prune_superseded_rows(
     storage: &StorageHandle,
-    superseding: HashMap<Ulid, Ulid>,
+    mut superseding: HashMap<Ulid, Ulid>,
 ) -> Result<(), MetadataMaterializationQueueError> {
+    let pending = read_pending_prunes(storage).await?;
+    for (document_id, cursor) in pending.iter() {
+        superseding.entry(*document_id).or_insert(*cursor);
+    }
     if superseding.is_empty() {
         return Ok(());
     }
-    let stale =
-        super::iri_index::superseded_iri_reference_keys(storage, None, &superseding).await?;
+    match prune_index_rows(storage, &superseding).await {
+        Ok(()) if pending.is_empty() => Ok(()),
+        Ok(()) => delete_pending_prunes(storage, pending.keys().copied().collect()).await,
+        Err(error) => {
+            warn!(
+                error = %error,
+                documents = superseding.len(),
+                "Deferring metadata materialization index pruning"
+            );
+            persist_pending_prunes(storage, &superseding).await
+        }
+    }
+}
+
+async fn prune_index_rows(
+    storage: &StorageHandle,
+    superseding: &HashMap<Ulid, Ulid>,
+) -> Result<(), MetadataMaterializationQueueError> {
+    let stale = super::iri_index::superseded_iri_reference_keys(storage, None, superseding).await?;
     delete_materialization_entries(storage, stale).await
+}
+
+// One page per batch: leftovers stay parked for the next drain, so a long
+// backlog cannot make a single batch scan unboundedly.
+async fn read_pending_prunes(
+    storage: &StorageHandle,
+) -> Result<HashMap<Ulid, Ulid>, MetadataMaterializationQueueError> {
+    match storage
+        .send_storage_effect(StorageEffect::Iter {
+            key_space: METADATA_MATERIALIZATION_PRUNE_KEYSPACE.to_string(),
+            prefix: None,
+            start: None,
+            limit: MATERIALIZATION_SCAN_PAGE_SIZE,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::IterResult { values, .. }) => {
+            let mut pending = HashMap::new();
+            for (key, value) in values {
+                let (Ok(document_id), Ok(cursor)) = (
+                    <[u8; 16]>::try_from(key.as_ref()),
+                    postcard::from_bytes::<Ulid>(&value),
+                ) else {
+                    warn!(key = ?key.to_vec(), "Deleting malformed metadata materialization prune entry");
+                    delete_materialization_entries(
+                        storage,
+                        vec![(
+                            METADATA_MATERIALIZATION_PRUNE_KEYSPACE.to_string(),
+                            key.clone(),
+                        )],
+                    )
+                    .await?;
+                    continue;
+                };
+                pending.insert(Ulid::from_bytes(document_id), cursor);
+            }
+            Ok(pending)
+        }
+        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
+        other => Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
+            "{other:?}"
+        ))),
+    }
+}
+
+async fn persist_pending_prunes(
+    storage: &StorageHandle,
+    superseding: &HashMap<Ulid, Ulid>,
+) -> Result<(), MetadataMaterializationQueueError> {
+    let mut writes = Vec::with_capacity(superseding.len());
+    for (document_id, cursor) in superseding {
+        writes.push(materialization_prune_entry(*document_id, *cursor)?);
+    }
+    match storage
+        .send_storage_effect(StorageEffect::BatchWrite {
+            writes,
+            txn_id: None,
+        })
+        .await
+    {
+        Event::Storage(StorageEvent::BatchWriteResult { .. }) => Ok(()),
+        Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
+        other => Err(MetadataMaterializationQueueError::UnexpectedEvent(format!(
+            "{other:?}"
+        ))),
+    }
+}
+
+async fn delete_pending_prunes(
+    storage: &StorageHandle,
+    document_ids: Vec<Ulid>,
+) -> Result<(), MetadataMaterializationQueueError> {
+    let deletes = document_ids
+        .into_iter()
+        .map(|document_id| {
+            (
+                METADATA_MATERIALIZATION_PRUNE_KEYSPACE.to_string(),
+                materialization_prune_key(document_id),
+            )
+        })
+        .collect();
+    delete_materialization_entries(storage, deletes).await
 }
 
 /// Returns the documents whose projection this chunk advanced, so the batch can
@@ -4028,6 +4146,53 @@ mod tests {
             }) => assert_eq!(value.as_ref(), second.to_bytes()),
             other => panic!("unexpected storage event: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn prune_resumes_parked() {
+        // A prune that failed after its jobs were deleted leaves nothing to retry
+        // from, so the batch parks the cursor: a later batch must finish the work
+        // and clear the parked entry.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([57u8; 16]);
+        let stale = Ulid::from_parts(1, 1);
+        let current = Ulid::from_parts(2, 1);
+        let stale_key =
+            aruna_core::storage_entries::metadata_iri_reference_key("p", "o", document_id, stale);
+        write_entries(
+            &storage,
+            vec![
+                (
+                    METADATA_IRI_REFERENCE_INDEX_KEYSPACE.to_string(),
+                    stale_key.clone(),
+                    ByteView::from(vec![1u8]),
+                ),
+                materialization_prune_entry(document_id, current).unwrap(),
+            ],
+        )
+        .await;
+
+        prune_superseded_rows(&storage, HashMap::new())
+            .await
+            .unwrap();
+
+        assert!(
+            !storage_key_exists(
+                &storage,
+                METADATA_IRI_REFERENCE_INDEX_KEYSPACE,
+                stale_key.to_vec()
+            )
+            .await
+        );
+        assert!(
+            !storage_key_exists(
+                &storage,
+                METADATA_MATERIALIZATION_PRUNE_KEYSPACE,
+                materialization_prune_key(document_id).to_vec()
+            )
+            .await
+        );
     }
 
     #[tokio::test]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -81,9 +81,26 @@ struct CompletedMaterializationSync {
     peers: Vec<NodeId>,
 }
 
+/// The outcome of one job attempt, resolved together in the per-batch finish
+/// transaction so a batch of failures costs one transaction, not one each.
+#[derive(Debug)]
+enum FinishedMaterializationJob {
+    Completed(CompletedMaterializationJob),
+    Rescheduled {
+        job_key: Vec<u8>,
+        job: MetadataMaterializationJobRecord,
+        status: MetadataMaterializationStatusRecord,
+    },
+    Parked {
+        job_key: Vec<u8>,
+        job: MetadataMaterializationJobRecord,
+        status: MetadataMaterializationStatusRecord,
+    },
+}
+
 #[derive(Debug, Default)]
 struct MaterializationGroupOutcome {
-    completed: Vec<CompletedMaterializationJob>,
+    finished: Vec<FinishedMaterializationJob>,
     processed: usize,
     craqle_elapsed: Duration,
     error: Option<MetadataMaterializationQueueError>,
@@ -249,7 +266,7 @@ fn materialization_group_concurrency() -> usize {
 
 fn collect_group_outcome(
     result: Result<MaterializationGroupOutcome, tokio::task::JoinError>,
-    completed: &mut Vec<CompletedMaterializationJob>,
+    finished: &mut Vec<FinishedMaterializationJob>,
     timings: &mut MaterializationBatchTimings,
     first_error: &mut Option<MetadataMaterializationQueueError>,
 ) {
@@ -259,7 +276,7 @@ fn collect_group_outcome(
             timings.craqle_elapsed = timings
                 .craqle_elapsed
                 .saturating_add(outcome.craqle_elapsed);
-            completed.extend(outcome.completed);
+            finished.extend(outcome.finished);
             if first_error.is_none() {
                 *first_error = outcome.error;
             }
@@ -289,7 +306,7 @@ async fn process_materialization_job_groups(
 
     let concurrency = materialization_group_concurrency();
     let mut tasks = JoinSet::new();
-    let mut completed = Vec::new();
+    let mut finished = Vec::new();
     let mut timings = MaterializationBatchTimings {
         groups: groups.len(),
         ..MaterializationBatchTimings::default()
@@ -301,7 +318,7 @@ async fn process_materialization_job_groups(
         if tasks.len() >= concurrency
             && let Some(result) = tasks.join_next().await
         {
-            collect_group_outcome(result, &mut completed, &mut timings, &mut first_error);
+            collect_group_outcome(result, &mut finished, &mut timings, &mut first_error);
         }
         let context = context.clone();
         tasks.spawn(async move {
@@ -326,9 +343,11 @@ async fn process_materialization_job_groups(
                         if processed_job.attempted {
                             outcome.processed = outcome.processed.saturating_add(1);
                         }
-                        if let Some(completed) = processed_job.completed {
-                            advanced_event_ids.insert(event_id);
-                            outcome.completed.push(completed);
+                        if let Some(finished) = processed_job.finished {
+                            if matches!(finished, FinishedMaterializationJob::Completed(_)) {
+                                advanced_event_ids.insert(event_id);
+                            }
+                            outcome.finished.push(finished);
                         }
                         if processed_job.stop_group {
                             break;
@@ -345,15 +364,11 @@ async fn process_materialization_job_groups(
     }
 
     while let Some(result) = tasks.join_next().await {
-        collect_group_outcome(result, &mut completed, &mut timings, &mut first_error);
+        collect_group_outcome(result, &mut finished, &mut timings, &mut first_error);
     }
     let finish_started = Instant::now();
-    let syncs = completed
-        .iter()
-        .filter_map(|job| job.sync.clone())
-        .collect::<Vec<_>>();
-    if let Err(error) =
-        finish_completed_materialization_jobs(&context.storage_handle, completed).await
+    let syncs = dedupe_graph_syncs(&finished);
+    if let Err(error) = finish_completed_materialization_jobs(&context.storage_handle, finished).await
         && first_error.is_none()
     {
         first_error = Some(error);
@@ -364,6 +379,20 @@ async fn process_materialization_job_groups(
     }
     schedule_completed_materialization_syncs(context, syncs).await;
     Ok(timings)
+}
+
+// One SyncGraphBestEffort per graph, keeping the last peers seen, so a batch
+// carrying many events for one document schedules a single sync.
+fn dedupe_graph_syncs(finished: &[FinishedMaterializationJob]) -> Vec<CompletedMaterializationSync> {
+    let mut by_graph: BTreeMap<String, CompletedMaterializationSync> = BTreeMap::new();
+    for job in finished {
+        if let FinishedMaterializationJob::Completed(job) = job
+            && let Some(sync) = &job.sync
+        {
+            by_graph.insert(sync.graph_iri.clone(), sync.clone());
+        }
+    }
+    by_graph.into_values().collect()
 }
 
 async fn schedule_completed_materialization_syncs(
@@ -397,13 +426,13 @@ async fn schedule_completed_materialization_syncs(
 
 async fn finish_completed_materialization_jobs(
     storage: &StorageHandle,
-    completed: Vec<CompletedMaterializationJob>,
+    finished: Vec<FinishedMaterializationJob>,
 ) -> Result<(), MetadataMaterializationQueueError> {
-    if completed.is_empty() {
+    if finished.is_empty() {
         return Ok(());
     }
     let txn_id = start_write_transaction(storage).await?;
-    let result = finish_completed_materialization_jobs_in_txn(storage, txn_id, completed).await;
+    let result = finish_completed_materialization_jobs_in_txn(storage, txn_id, finished).await;
     match result {
         Ok(()) => {
             commit_storage_transaction(storage, txn_id).await?;
@@ -425,33 +454,102 @@ async fn finish_completed_materialization_jobs(
 async fn finish_completed_materialization_jobs_in_txn(
     storage: &StorageHandle,
     txn_id: Ulid,
-    completed: Vec<CompletedMaterializationJob>,
+    finished: Vec<FinishedMaterializationJob>,
 ) -> Result<(), MetadataMaterializationQueueError> {
     let mut writes = Vec::new();
-    let mut deletes = Vec::with_capacity(completed.len().saturating_mul(2));
+    let mut deletes = Vec::with_capacity(finished.len().saturating_mul(2));
     let mut superseding: HashMap<Ulid, Ulid> = HashMap::new();
-    for job in completed {
-        if let Some(status) = job.status {
-            let current =
-                read_materialization_status(storage, status.document_id, Some(txn_id)).await?;
-            if should_write_final_materialization_status(current.as_ref(), &status) {
-                superseding.insert(status.document_id, status.event_id);
-                writes.extend(job.iri_index_writes);
-                if let Some(raw_state_write) = job.raw_state_write {
-                    writes.push(raw_state_write);
+    for finished in finished {
+        match finished {
+            FinishedMaterializationJob::Completed(job) => {
+                if let Some(status) = job.status {
+                    let current =
+                        read_materialization_status(storage, status.document_id, Some(txn_id))
+                            .await?;
+                    if should_write_final_materialization_status(current.as_ref(), &status) {
+                        superseding.insert(status.document_id, status.event_id);
+                        writes.extend(job.iri_index_writes);
+                        if let Some(raw_state_write) = job.raw_state_write {
+                            writes.push(raw_state_write);
+                        }
+                        writes.push(metadata_materialization_status_write_entry(&status)?);
+                    }
                 }
-                writes.push(metadata_materialization_status_write_entry(&status)?);
+                deletes.push((
+                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                    ByteView::from(job.job_key),
+                ));
+                if let Some(document_job_key) = job.document_job_key {
+                    deletes.push((
+                        METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                        ByteView::from(document_job_key),
+                    ));
+                }
             }
-        }
-        deletes.push((
-            METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-            ByteView::from(job.job_key),
-        ));
-        if let Some(document_job_key) = job.document_job_key {
-            deletes.push((
-                METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                ByteView::from(document_job_key),
-            ));
+            FinishedMaterializationJob::Rescheduled {
+                job_key,
+                job,
+                status,
+            } => {
+                let old_index_delete = (
+                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                    ByteView::from(job_key),
+                );
+                let current =
+                    read_materialization_status(storage, job.document_id, Some(txn_id)).await?;
+                if current
+                    .as_ref()
+                    .is_some_and(|current| materialization_retry_already_advanced(current, &job))
+                {
+                    deletes.push(old_index_delete);
+                    deletes.push((
+                        METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                        metadata_materialization_document_job_key(job.document_id, job.event_id),
+                    ));
+                    continue;
+                }
+                let attempts = job.attempts.saturating_add(1);
+                let next_job = MetadataMaterializationJobRecord {
+                    document_id: job.document_id,
+                    event_id: job.event_id,
+                    due_at_ms: unix_timestamp_millis()
+                        .saturating_add(queue_retry_after_ms(attempts)),
+                    attempts,
+                };
+                if should_write_pending_retry_status(current.as_ref(), &status) {
+                    writes.push(metadata_materialization_status_write_entry(&status)?);
+                }
+                writes.push(metadata_materialization_job_write_entry(&next_job)?);
+                writes.push(metadata_materialization_document_job_write_entry(&next_job)?);
+                deletes.push(old_index_delete);
+            }
+            FinishedMaterializationJob::Parked {
+                job_key,
+                job,
+                status,
+            } => {
+                let current =
+                    read_materialization_status(storage, job.document_id, Some(txn_id)).await?;
+                if should_write_final_materialization_status(current.as_ref(), &status) {
+                    writes.push(metadata_materialization_status_write_entry(&status)?);
+                }
+                deletes.push((
+                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                    ByteView::from(job_key),
+                ));
+                deletes.push((
+                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                    metadata_materialization_document_job_key(job.document_id, job.event_id),
+                ));
+                warn!(
+                    event = "materialization.job.parked",
+                    document_id = %job.document_id,
+                    event_id = %job.event_id,
+                    attempts = status.attempts,
+                    error = status.last_error.as_deref().unwrap_or_default(),
+                    "Parked metadata materialization job after exceeding attempt cap"
+                );
+            }
         }
     }
 
@@ -654,7 +752,7 @@ fn due_after(now_ms: u64, due_at_ms: u64) -> Duration {
 
 #[derive(Debug, Default)]
 struct ProcessedMaterializationJob {
-    completed: Option<CompletedMaterializationJob>,
+    finished: Option<FinishedMaterializationJob>,
     craqle_elapsed: Duration,
     attempted: bool,
     stop_group: bool,
@@ -663,16 +761,18 @@ struct ProcessedMaterializationJob {
 impl ProcessedMaterializationJob {
     fn completed(job: CompletedMaterializationJob, craqle_elapsed: Duration) -> Self {
         Self {
-            completed: Some(job),
+            finished: Some(FinishedMaterializationJob::Completed(job)),
             craqle_elapsed,
             attempted: true,
             stop_group: false,
         }
     }
 
-    fn rescheduled(craqle_elapsed: Duration) -> Self {
+    // Rescheduled and parked jobs both stop the group so later events for the
+    // same document do not apply out of order this batch.
+    fn deferred(finished: FinishedMaterializationJob, craqle_elapsed: Duration) -> Self {
         Self {
-            completed: None,
+            finished: Some(finished),
             craqle_elapsed,
             attempted: true,
             stop_group: true,
@@ -681,10 +781,33 @@ impl ProcessedMaterializationJob {
 
     fn blocked() -> Self {
         Self {
-            completed: None,
+            finished: None,
             craqle_elapsed: Duration::ZERO,
             attempted: false,
             stop_group: true,
+        }
+    }
+}
+
+// Attempt-capped jobs park as Failed; others reschedule with backoff. The
+// resulting row writes and deletes are folded into the per-batch finish txn.
+fn defer_materialization_job(
+    job_key: &[u8],
+    job: &MetadataMaterializationJobRecord,
+    event: &MetadataCreateEventRecord,
+    error: String,
+) -> FinishedMaterializationJob {
+    if job.attempts.saturating_add(1) > MATERIALIZATION_MAX_ATTEMPTS {
+        FinishedMaterializationJob::Parked {
+            job_key: job_key.to_vec(),
+            job: job.clone(),
+            status: materialization_failure_status(job, event, error, true),
+        }
+    } else {
+        FinishedMaterializationJob::Rescheduled {
+            job_key: job_key.to_vec(),
+            job: job.clone(),
+            status: materialization_failure_status(job, event, error, false),
         }
     }
 }
@@ -780,15 +903,10 @@ async fn process_materialization_job(
             {
                 Ok(writes) => writes,
                 Err(error) => {
-                    reschedule_materialization_job(
-                        &context.storage_handle,
-                        &job_key,
-                        &job,
-                        &event,
-                        error.to_string(),
-                    )
-                    .await?;
-                    return Ok(ProcessedMaterializationJob::rescheduled(craqle_elapsed));
+                    return Ok(ProcessedMaterializationJob::deferred(
+                        defer_materialization_job(&job_key, &job, &event, error.to_string()),
+                        craqle_elapsed,
+                    ));
                 }
             };
             Ok(ProcessedMaterializationJob::completed(
@@ -828,17 +946,10 @@ async fn process_materialization_job(
                 craqle_elapsed,
             ))
         }
-        Err(error) => {
-            reschedule_materialization_job(
-                &context.storage_handle,
-                &job_key,
-                &job,
-                &event,
-                error.to_string(),
-            )
-            .await?;
-            Ok(ProcessedMaterializationJob::rescheduled(craqle_elapsed))
-        }
+        Err(error) => Ok(ProcessedMaterializationJob::deferred(
+            defer_materialization_job(&job_key, &job, &event, error.to_string()),
+            craqle_elapsed,
+        )),
     }
 }
 
@@ -1389,115 +1500,6 @@ fn materialization_failure_status(
         last_error: Some(error),
         updated_at_ms: unix_timestamp_millis(),
     }
-}
-
-async fn reschedule_materialization_job(
-    storage: &StorageHandle,
-    job_key: &[u8],
-    job: &MetadataMaterializationJobRecord,
-    event: &MetadataCreateEventRecord,
-    error: String,
-) -> Result<(), MetadataMaterializationQueueError> {
-    let txn_id = start_write_transaction(storage).await?;
-    let result =
-        reschedule_materialization_job_in_txn(storage, txn_id, job_key, job, event, error).await;
-    match result {
-        Ok(()) => {
-            commit_storage_transaction(storage, txn_id).await?;
-            Ok(())
-        }
-        Err(error) => {
-            abort_storage_transaction_best_effort(
-                storage,
-                txn_id,
-                "Failed to abort materialization storage transaction",
-                "Unexpected materialization storage transaction abort result",
-            )
-            .await;
-            Err(error)
-        }
-    }
-}
-
-async fn reschedule_materialization_job_in_txn(
-    storage: &StorageHandle,
-    txn_id: Ulid,
-    job_key: &[u8],
-    job: &MetadataMaterializationJobRecord,
-    event: &MetadataCreateEventRecord,
-    error: String,
-) -> Result<(), MetadataMaterializationQueueError> {
-    let old_global_job_delete = (
-        METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-        ByteView::from(job_key.to_vec()),
-    );
-    let current = read_materialization_status(storage, job.document_id, Some(txn_id)).await?;
-    if current
-        .as_ref()
-        .is_some_and(|status| materialization_retry_already_advanced(status, job))
-    {
-        return transactional_batch_delete(
-            storage,
-            txn_id,
-            vec![
-                old_global_job_delete,
-                (
-                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                    metadata_materialization_document_job_key(job.document_id, job.event_id),
-                ),
-            ],
-        )
-        .await;
-    }
-
-    let attempts = job.attempts.saturating_add(1);
-    if attempts > MATERIALIZATION_MAX_ATTEMPTS {
-        let status = materialization_failure_status(job, event, error.clone(), true);
-        let mut writes = Vec::new();
-        if should_write_final_materialization_status(current.as_ref(), &status) {
-            writes.push(metadata_materialization_status_write_entry(&status)?);
-        }
-        transactional_batch_write(storage, txn_id, writes).await?;
-        transactional_batch_delete(
-            storage,
-            txn_id,
-            vec![
-                old_global_job_delete,
-                (
-                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                    metadata_materialization_document_job_key(job.document_id, job.event_id),
-                ),
-            ],
-        )
-        .await?;
-        warn!(
-            event = "materialization.job.parked",
-            document_id = %job.document_id,
-            event_id = %job.event_id,
-            attempts,
-            error = %error,
-            "Parked metadata materialization job after exceeding attempt cap"
-        );
-        return Ok(());
-    }
-    let status = materialization_failure_status(job, event, error, false);
-    let retry_delay_ms = queue_retry_after_ms(attempts);
-    let next_job = MetadataMaterializationJobRecord {
-        document_id: job.document_id,
-        event_id: job.event_id,
-        due_at_ms: unix_timestamp_millis().saturating_add(retry_delay_ms),
-        attempts,
-    };
-    let mut writes = Vec::with_capacity(3);
-    if should_write_pending_retry_status(current.as_ref(), &status) {
-        writes.push(metadata_materialization_status_write_entry(&status)?);
-    }
-    writes.push(metadata_materialization_job_write_entry(&next_job)?);
-    writes.push(metadata_materialization_document_job_write_entry(
-        &next_job,
-    )?);
-    transactional_batch_write(storage, txn_id, writes).await?;
-    transactional_batch_delete(storage, txn_id, vec![old_global_job_delete]).await
 }
 
 fn is_terminal_materialization_error(error: &MetadataMaterializationQueueError) -> bool {
@@ -2125,7 +2127,9 @@ mod tests {
         )
         .await;
 
-        reschedule_materialization_job(&storage, index_key.as_ref(), &job, &event, "boom".into())
+        let parked = defer_materialization_job(index_key.as_ref(), &job, &event, "boom".into());
+        assert!(matches!(parked, FinishedMaterializationJob::Parked { .. }));
+        finish_completed_materialization_jobs(&storage, vec![parked])
             .await
             .unwrap();
 
@@ -2416,28 +2420,30 @@ mod tests {
 
         finish_completed_materialization_jobs(
             &storage,
-            vec![CompletedMaterializationJob {
-                job_key: old_job_key.to_vec(),
-                document_job_key: Some(
-                    metadata_materialization_document_job_key(
-                        old_job.document_id,
-                        old_job.event_id,
-                    )
-                    .to_vec(),
-                ),
-                status: Some(materialization_success_status(&old_job, &old_event, None)),
-                iri_index_writes: vec![(
-                    METADATA_IRI_REFERENCE_INDEX_KEYSPACE.to_string(),
-                    ByteView::from(stale_index_key.clone()),
-                    ByteView::from(vec![1]),
-                )],
-                raw_state_write: Some((
-                    METADATA_RAW_REVISION_KEYSPACE.to_string(),
-                    raw_state_key.clone(),
-                    ByteView::from(vec![1]),
-                )),
-                sync: None,
-            }],
+            vec![FinishedMaterializationJob::Completed(
+                CompletedMaterializationJob {
+                    job_key: old_job_key.to_vec(),
+                    document_job_key: Some(
+                        metadata_materialization_document_job_key(
+                            old_job.document_id,
+                            old_job.event_id,
+                        )
+                        .to_vec(),
+                    ),
+                    status: Some(materialization_success_status(&old_job, &old_event, None)),
+                    iri_index_writes: vec![(
+                        METADATA_IRI_REFERENCE_INDEX_KEYSPACE.to_string(),
+                        ByteView::from(stale_index_key.clone()),
+                        ByteView::from(vec![1]),
+                    )],
+                    raw_state_write: Some((
+                        METADATA_RAW_REVISION_KEYSPACE.to_string(),
+                        raw_state_key.clone(),
+                        ByteView::from(vec![1]),
+                    )),
+                    sync: None,
+                },
+            )],
         )
         .await
         .unwrap();
@@ -2536,12 +2542,18 @@ mod tests {
 
         let first = Ulid::from_parts(1, 1);
         let second = Ulid::from_parts(2, 1);
-        finish_completed_materialization_jobs(&storage, vec![build(first)])
-            .await
-            .unwrap();
-        finish_completed_materialization_jobs(&storage, vec![build(second)])
-            .await
-            .unwrap();
+        finish_completed_materialization_jobs(
+            &storage,
+            vec![FinishedMaterializationJob::Completed(build(first))],
+        )
+        .await
+        .unwrap();
+        finish_completed_materialization_jobs(
+            &storage,
+            vec![FinishedMaterializationJob::Completed(build(second))],
+        )
+        .await
+        .unwrap();
 
         let key_of = |cursor: Ulid| {
             aruna_core::storage_entries::metadata_iri_reference_key("p", "o", document_id, cursor)
@@ -2710,104 +2722,77 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retry_reschedule_is_atomic() {
-        let (storage, receivers) = StorageHandle::new();
-        let receiver = receivers.foreground;
-        let txn_id = Ulid::from_parts(5, 1);
-        let document_id = Ulid::from_bytes([4u8; 16]);
-        let event_id = Ulid::from_parts(5, 2);
-        let event = create_event(document_id, event_id, "retry");
-        let job = MetadataMaterializationJobRecord {
-            document_id,
-            event_id,
-            due_at_ms: 1,
-            attempts: 0,
-        };
-        let old_job_key = b"old-job".to_vec();
-        let scripted = thread::spawn({
-            let old_job_key = old_job_key.clone();
-            move || {
-                let (effect, response_tx, _span, _enqueued_at, _in_flight) =
-                    receiver.recv().expect("start transaction request");
-                assert_eq!(effect, StorageEffect::StartTransaction { read: false });
-                response_tx.send(StorageEvent::TransactionStarted { txn_id });
-
-                let (effect, response_tx, _span, _enqueued_at, _in_flight) =
-                    receiver.recv().expect("status read request");
-                let status_key = match effect {
-                    StorageEffect::Read {
-                        key_space,
-                        key,
-                        txn_id: Some(read_txn_id),
-                    } => {
-                        assert_eq!(read_txn_id, txn_id);
-                        assert_eq!(key_space, METADATA_MATERIALIZATION_STATUS_KEYSPACE);
-                        key
-                    }
-                    other => panic!("unexpected storage effect: {other:?}"),
+    async fn reschedules_batched() {
+        // Three failing jobs across distinct documents resolve in one finish
+        // transaction: the request delta stays at single-transaction scale.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let jobs: Vec<_> = (0..3u8)
+            .map(|seed| {
+                let document_id = Ulid::from_bytes([70 + seed; 16]);
+                let event_id = Ulid::from_parts(1, u128::from(seed));
+                let event = create_event(document_id, event_id, "retry");
+                let job = MetadataMaterializationJobRecord {
+                    document_id,
+                    event_id,
+                    due_at_ms: 1,
+                    attempts: 0,
                 };
-                response_tx.send(StorageEvent::ReadResult {
-                    key: status_key,
-                    value: None,
-                });
+                let index_key = metadata_materialization_job_key(&job);
+                (job, event, index_key)
+            })
+            .collect();
+        let finished: Vec<_> = jobs
+            .iter()
+            .map(|(job, event, index_key)| {
+                defer_materialization_job(index_key.as_ref(), job, event, "transient".into())
+            })
+            .collect();
+        assert!(finished.iter().all(|finished| matches!(
+            finished,
+            FinishedMaterializationJob::Rescheduled { .. }
+        )));
 
-                let (effect, response_tx, _span, _enqueued_at, _in_flight) =
-                    receiver.recv().expect("retry writes request");
-                let write_entries = match effect {
-                    StorageEffect::BatchWrite {
-                        writes,
-                        txn_id: Some(write_txn_id),
-                    } => {
-                        assert_eq!(write_txn_id, txn_id);
-                        assert_eq!(writes.len(), 3);
-                        writes
-                    }
-                    other => panic!("unexpected storage effect: {other:?}"),
-                };
-                assert_eq!(write_entries[0].0, METADATA_MATERIALIZATION_STATUS_KEYSPACE);
-                assert_eq!(write_entries[1].0, METADATA_MATERIALIZATION_JOB_KEYSPACE);
-                assert_eq!(
-                    write_entries[2].0,
-                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE
-                );
-                response_tx.send(StorageEvent::BatchWriteResult {
-                    entries: write_entries
-                        .iter()
-                        .map(|(key_space, key, _)| (key_space.clone(), key.clone()))
-                        .collect(),
-                });
-
-                let (effect, response_tx, _span, _enqueued_at, _in_flight) =
-                    receiver.recv().expect("old job delete request");
-                let deletes = match effect {
-                    StorageEffect::BatchDelete {
-                        deletes,
-                        txn_id: Some(delete_txn_id),
-                    } => {
-                        assert_eq!(delete_txn_id, txn_id);
-                        deletes
-                    }
-                    other => panic!("unexpected storage effect: {other:?}"),
-                };
-                assert_eq!(
-                    deletes,
-                    vec![(
-                        METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                        ByteView::from(old_job_key)
-                    )]
-                );
-                response_tx.send(StorageEvent::BatchDeleteResult { entries: deletes });
-
-                let (effect, response_tx, _span, _enqueued_at, _in_flight) =
-                    receiver.recv().expect("commit request");
-                assert_eq!(effect, StorageEffect::CommitTransaction { txn_id });
-                response_tx.send(StorageEvent::TransactionCommitted { txn_id });
-            }
-        });
-
-        reschedule_materialization_job(&storage, &old_job_key, &job, &event, "transient".into())
+        let before = storage.snapshot_metrics().requests_total;
+        finish_completed_materialization_jobs(&storage, finished)
             .await
             .unwrap();
-        scripted.join().expect("scripted storage actor finished");
+        let delta = storage.snapshot_metrics().requests_total - before;
+
+        // A single finish transaction issues far fewer requests than one
+        // transaction per job would.
+        assert!(delta <= 10, "finish issued {delta} storage requests");
+        for (job, _, _) in &jobs {
+            let requeued = read_document_job(&storage, job.document_id, job.event_id)
+                .await
+                .unwrap()
+                .expect("job requeued");
+            assert_eq!(requeued.attempts, 1);
+        }
+    }
+
+    #[test]
+    fn sync_dedupes_graphs() {
+        let graph_iri = MetadataRegistryRecord::graph_iri_for(Ulid::from_bytes([50u8; 16]));
+        let completed = |peers: Vec<NodeId>| {
+            FinishedMaterializationJob::Completed(CompletedMaterializationJob {
+                job_key: vec![1],
+                document_job_key: None,
+                status: None,
+                iri_index_writes: Vec::new(),
+                raw_state_write: None,
+                sync: Some(CompletedMaterializationSync {
+                    graph_iri: graph_iri.clone(),
+                    peers,
+                }),
+            })
+        };
+        let finished = vec![completed(vec![node(1)]), completed(vec![node(2)])];
+
+        let syncs = dedupe_graph_syncs(&finished);
+
+        assert_eq!(syncs.len(), 1);
+        assert_eq!(syncs[0].graph_iri, graph_iri);
+        assert_eq!(syncs[0].peers, vec![node(2)]);
     }
 }

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -48,6 +48,9 @@ use super::raw::{MetadataRawReadError, RawStateCache};
 
 const MATERIALIZATION_SCAN_PAGE_SIZE: usize = 512;
 const MATERIALIZATION_BATCH_SIZE: usize = 128;
+// Backoff reaches its 30s cap by attempt 7, so ten attempts is about two
+// minutes of retries before a job is parked as Failed and both rows deleted.
+const MATERIALIZATION_MAX_ATTEMPTS: u32 = 10;
 
 pub const METADATA_MATERIALIZATION_POLL_AFTER: Duration = Duration::from_secs(5);
 pub const METADATA_MATERIALIZATION_RETRY_AFTER: Duration = Duration::from_secs(1);
@@ -1445,6 +1448,35 @@ async fn reschedule_materialization_job_in_txn(
     }
 
     let attempts = job.attempts.saturating_add(1);
+    if attempts > MATERIALIZATION_MAX_ATTEMPTS {
+        let status = materialization_failure_status(job, event, error.clone(), true);
+        let mut writes = Vec::new();
+        if should_write_final_materialization_status(current.as_ref(), &status) {
+            writes.push(metadata_materialization_status_write_entry(&status)?);
+        }
+        transactional_batch_write(storage, txn_id, writes).await?;
+        transactional_batch_delete(
+            storage,
+            txn_id,
+            vec![
+                old_global_job_delete,
+                (
+                    METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                    metadata_materialization_document_job_key(job.document_id, job.event_id),
+                ),
+            ],
+        )
+        .await?;
+        warn!(
+            event = "materialization.job.parked",
+            document_id = %job.document_id,
+            event_id = %job.event_id,
+            attempts,
+            error = %error,
+            "Parked metadata materialization job after exceeding attempt cap"
+        );
+        return Ok(());
+    }
     let status = materialization_failure_status(job, event, error, false);
     let retry_delay_ms = queue_retry_after_ms(attempts);
     let next_job = MetadataMaterializationJobRecord {
@@ -2062,6 +2094,62 @@ mod tests {
 
         assert!(older);
         assert!(delta <= 10, "older check issued {delta} storage requests");
+    }
+
+    #[tokio::test]
+    async fn attempts_cap_parks() {
+        // A job at the attempt cap is parked as Failed with both rows removed.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let document_id = Ulid::from_bytes([45u8; 16]);
+        let event_id = Ulid::from_parts(1, 1);
+        let event = create_event(document_id, event_id, "capped");
+        let job = MetadataMaterializationJobRecord {
+            document_id,
+            event_id,
+            due_at_ms: 1,
+            attempts: MATERIALIZATION_MAX_ATTEMPTS,
+        };
+        let index_key = metadata_materialization_job_key(&job);
+        let sidecar_key = metadata_materialization_document_job_key(document_id, event_id);
+        write_entries(
+            &storage,
+            vec![
+                metadata_create_event_write_entry(&event).unwrap(),
+                metadata_materialization_job_write_entry(&job).unwrap(),
+                metadata_materialization_document_job_write_entry(&job).unwrap(),
+            ],
+        )
+        .await;
+
+        reschedule_materialization_job(&storage, index_key.as_ref(), &job, &event, "boom".into())
+            .await
+            .unwrap();
+
+        assert!(
+            !storage_key_exists(
+                &storage,
+                METADATA_MATERIALIZATION_JOB_KEYSPACE,
+                index_key.to_vec()
+            )
+            .await
+        );
+        assert!(
+            !storage_key_exists(
+                &storage,
+                METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE,
+                sidecar_key.to_vec()
+            )
+            .await
+        );
+        let status = read_materialization_status(&storage, document_id, None)
+            .await
+            .unwrap()
+            .expect("failed status is written");
+        assert_eq!(status.state, MetadataMaterializationState::Failed);
+        assert_eq!(status.attempts, MATERIALIZATION_MAX_ATTEMPTS + 1);
+        assert_eq!(status.last_error.as_deref(), Some("boom"));
+        assert!(!metadata_materialization_jobs_exist(&storage).await.unwrap());
     }
 
     #[test]

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -368,7 +368,8 @@ async fn process_materialization_job_groups(
     }
     let finish_started = Instant::now();
     let syncs = dedupe_graph_syncs(&finished);
-    if let Err(error) = finish_completed_materialization_jobs(&context.storage_handle, finished).await
+    if let Err(error) =
+        finish_completed_materialization_jobs(&context.storage_handle, finished).await
         && first_error.is_none()
     {
         first_error = Some(error);
@@ -383,7 +384,9 @@ async fn process_materialization_job_groups(
 
 // One SyncGraphBestEffort per graph, keeping the last peers seen, so a batch
 // carrying many events for one document schedules a single sync.
-fn dedupe_graph_syncs(finished: &[FinishedMaterializationJob]) -> Vec<CompletedMaterializationSync> {
+fn dedupe_graph_syncs(
+    finished: &[FinishedMaterializationJob],
+) -> Vec<CompletedMaterializationSync> {
     let mut by_graph: BTreeMap<String, CompletedMaterializationSync> = BTreeMap::new();
     for job in finished {
         if let FinishedMaterializationJob::Completed(job) = job
@@ -520,7 +523,9 @@ async fn finish_completed_materialization_jobs_in_txn(
                     writes.push(metadata_materialization_status_write_entry(&status)?);
                 }
                 writes.push(metadata_materialization_job_write_entry(&next_job)?);
-                writes.push(metadata_materialization_document_job_write_entry(&next_job)?);
+                writes.push(metadata_materialization_document_job_write_entry(
+                    &next_job,
+                )?);
                 deletes.push(old_index_delete);
             }
             FinishedMaterializationJob::Parked {
@@ -2092,9 +2097,10 @@ mod tests {
         write_entries(&storage, writes).await;
 
         let before = storage.snapshot_metrics().requests_total;
-        let older = older_materialization_job_exists(&storage, document_id, middle, &BTreeSet::new())
-            .await
-            .unwrap();
+        let older =
+            older_materialization_job_exists(&storage, document_id, middle, &BTreeSet::new())
+                .await
+                .unwrap();
         let delta = storage.snapshot_metrics().requests_total - before;
 
         assert!(older);
@@ -2748,10 +2754,11 @@ mod tests {
                 defer_materialization_job(index_key.as_ref(), job, event, "transient".into())
             })
             .collect();
-        assert!(finished.iter().all(|finished| matches!(
-            finished,
-            FinishedMaterializationJob::Rescheduled { .. }
-        )));
+        assert!(
+            finished
+                .iter()
+                .all(|finished| matches!(finished, FinishedMaterializationJob::Rescheduled { .. }))
+        );
 
         let before = storage.snapshot_metrics().requests_total;
         finish_completed_materialization_jobs(&storage, finished)

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -410,10 +410,13 @@ async fn process_materialization_job_groups(
         first_error = Some(error);
     }
     timings.finish_elapsed = finish_started.elapsed();
+    // The applies behind these syncs are already durable, so they are scheduled
+    // even when a later finish chunk failed: the committed chunks deleted their
+    // job rows, so nothing would retry their only explicit push.
+    schedule_completed_materialization_syncs(context, syncs).await;
     if let Some(error) = first_error {
         return Err(error);
     }
-    schedule_completed_materialization_syncs(context, syncs).await;
     Ok(timings)
 }
 

--- a/operations/src/metadata/materialization_queue.rs
+++ b/operations/src/metadata/materialization_queue.rs
@@ -1051,9 +1051,9 @@ async fn read_document_job(
 }
 
 // The due index is due-ordered and its rows are valid only when the sidecar row
-// exists with a matching due time. A page resolves its sidecars, events and
-// statuses in three batch reads and prunes dead rows in one delete, so the scan
-// costs O(pages) requests rather than O(due jobs).
+// exists with a matching due time. Rows resolve in slices of the outstanding
+// limit, each slice costing three batch reads, and a page prunes its dead rows
+// in one delete: a full batch costs O(slices) requests, not O(due jobs).
 async fn scan_due_materialization_jobs(
     storage: &StorageHandle,
     now_ms: u64,
@@ -1112,56 +1112,25 @@ async fn scan_due_materialization_jobs(
             candidates.push((key, due_at_ms, document_id, event_id));
         }
 
-        let sidecars = read_document_jobs(
-            storage,
-            &candidates
-                .iter()
-                .map(|(_, _, document_id, event_id)| (*document_id, *event_id))
-                .collect::<Vec<_>>(),
-        )
-        .await?;
-        let mut due = Vec::new();
-        for ((key, due_at_ms, document_id, event_id), sidecar) in
-            candidates.into_iter().zip(sidecars)
-        {
-            match sidecar {
-                Some(job) if job.due_at_ms == due_at_ms => due.push((key, job)),
-                Some(_) | None => {
-                    // The sidecar is authoritative: an index row it does not
-                    // match is stale. A malformed sidecar is dropped with it.
-                    stale.push((
-                        METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                        ByteView::from(key),
-                    ));
-                    if sidecar.is_none() {
-                        stale.push((
-                            METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                            metadata_materialization_document_job_key(document_id, event_id),
-                        ));
-                    }
+        // Resolved in slices of the outstanding limit so a probe for a single
+        // due job does not read a whole page of sidecars, events and statuses.
+        let mut cursor = 0usize;
+        while cursor < candidates.len() {
+            let remaining = limit.saturating_sub(jobs.len()).max(1);
+            let end = candidates.len().min(cursor.saturating_add(remaining));
+            let (live, dead) = resolve_due_jobs(storage, &candidates[cursor..end]).await?;
+            cursor = end;
+            stale.extend(dead);
+            for (_, job) in live {
+                jobs.push((metadata_materialization_job_key(&job).to_vec(), job));
+                if jobs.len() >= limit {
+                    delete_materialization_entries(storage, stale).await?;
+                    return Ok((jobs, true, None));
                 }
             }
         }
-
-        let (live, dead) = filter_live_jobs(storage, due).await?;
-        for (key, job) in dead {
-            stale.push((
-                METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
-                ByteView::from(key),
-            ));
-            stale.push((
-                METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
-                metadata_materialization_document_job_key(job.document_id, job.event_id),
-            ));
-        }
         delete_materialization_entries(storage, stale).await?;
 
-        for (_, job) in live {
-            jobs.push((metadata_materialization_job_key(&job).to_vec(), job));
-            if jobs.len() >= limit {
-                return Ok((jobs, true, None));
-            }
-        }
         if let Some(due_at_ms) = next_due_at_ms {
             return Ok((jobs, false, Some(due_at_ms)));
         }
@@ -1171,6 +1140,57 @@ async fn scan_due_materialization_jobs(
             None => return Ok((jobs, false, None)),
         }
     }
+}
+
+/// One index row seen by the scan: its key, the due time encoded in it and the
+/// sidecar it points at.
+type DueCandidate = (Vec<u8>, u64, Ulid, Ulid);
+
+// Resolves a slice of index rows against their sidecars and liveness, returning
+// the live jobs and the rows the caller should prune.
+async fn resolve_due_jobs(
+    storage: &StorageHandle,
+    candidates: &[DueCandidate],
+) -> Result<(ScannedJobs, Vec<(String, ByteView)>), MetadataMaterializationQueueError> {
+    let targets: Vec<(Ulid, Ulid)> = candidates
+        .iter()
+        .map(|(_, _, document_id, event_id)| (*document_id, *event_id))
+        .collect();
+    let sidecars = read_document_jobs(storage, &targets).await?;
+    let mut due = Vec::with_capacity(candidates.len());
+    let mut stale = Vec::new();
+    for ((key, due_at_ms, document_id, event_id), sidecar) in candidates.iter().zip(sidecars) {
+        match sidecar {
+            Some(job) if job.due_at_ms == *due_at_ms => due.push((key.clone(), job)),
+            // The sidecar is authoritative: an index row it does not match is
+            // stale. A missing or malformed sidecar is dropped with it.
+            sidecar => {
+                stale.push((
+                    METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+                    ByteView::from(key.clone()),
+                ));
+                if sidecar.is_none() {
+                    stale.push((
+                        METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+                        metadata_materialization_document_job_key(*document_id, *event_id),
+                    ));
+                }
+            }
+        }
+    }
+
+    let (live, dead) = filter_live_jobs(storage, due).await?;
+    for (key, job) in dead {
+        stale.push((
+            METADATA_MATERIALIZATION_JOB_KEYSPACE.to_string(),
+            ByteView::from(key),
+        ));
+        stale.push((
+            METADATA_MATERIALIZATION_DOCUMENT_JOB_KEYSPACE.to_string(),
+            metadata_materialization_document_job_key(job.document_id, job.event_id),
+        ));
+    }
+    Ok((live, stale))
 }
 
 async fn read_document_jobs(
@@ -2607,6 +2627,40 @@ mod tests {
 
         assert_eq!(jobs.len(), 64);
         assert!(delta <= 8, "scan issued {delta} storage requests");
+    }
+
+    #[tokio::test]
+    async fn probe_reads_one() {
+        // The timer probe asks for a single due job, so it must not resolve the
+        // whole page of index rows behind it.
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let mut writes = Vec::new();
+        for index in 0..64u8 {
+            let document_id = Ulid::from_bytes([100 + index; 16]);
+            let event_id = Ulid::from_parts(1, u128::from(index));
+            let event = create_event(document_id, event_id, "probe");
+            let job = MetadataMaterializationJobRecord {
+                document_id,
+                event_id,
+                due_at_ms: 1,
+                attempts: 0,
+                failures: 0,
+            };
+            writes.push(metadata_create_event_write_entry(&event).unwrap());
+            writes.push(metadata_materialization_job_write_entry(&job).unwrap());
+            writes.push(metadata_materialization_document_job_write_entry(&job).unwrap());
+        }
+        write_entries(&storage, writes).await;
+
+        let before = storage.snapshot_metrics().requests_total;
+        let after = next_metadata_materialization_timer_after(&storage)
+            .await
+            .unwrap();
+        let delta = storage.snapshot_metrics().requests_total - before;
+
+        assert_eq!(after, Some(Duration::ZERO));
+        assert!(delta <= 6, "probe issued {delta} storage requests");
     }
 
     #[tokio::test]

--- a/operations/src/metadata/mod.rs
+++ b/operations/src/metadata/mod.rs
@@ -12,6 +12,7 @@ pub mod raw;
 pub mod repository;
 mod search_cursor;
 mod search_enrichment;
+pub mod stats;
 mod summary_cache;
 
 use std::sync::Arc;

--- a/operations/src/metadata/mod.rs
+++ b/operations/src/metadata/mod.rs
@@ -6,11 +6,13 @@ pub mod materialization_queue;
 pub mod projector;
 mod protocol;
 pub mod prune_queue;
+mod query_cache;
 mod queue_storage;
 pub mod raw;
 pub mod repository;
 mod search_cursor;
 mod search_enrichment;
+mod summary_cache;
 
 use std::sync::Arc;
 

--- a/operations/src/metadata/query_cache.rs
+++ b/operations/src/metadata/query_cache.rs
@@ -1,0 +1,564 @@
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use aruna_core::NodeId;
+use aruna_core::metadata::MetadataQueryResults;
+use aruna_core::structs::{AuthContext, RealmId};
+use lru::LruCache;
+
+use super::api::MetadataFanoutStats;
+
+/// Backstop staleness of a cached result. Matches the visibility cache TTL so
+/// a query never promises fresher data than the listing path does.
+pub(super) const METADATA_QUERY_CACHE_TTL: Duration = Duration::from_secs(30);
+pub(super) const METADATA_QUERY_CACHE_MAX_ENTRIES: usize = 512;
+pub(super) const METADATA_QUERY_CACHE_MAX_BYTES: usize = 32 * 1024 * 1024;
+
+const TAG_EAGER: u8 = 1;
+const TAG_LAZY: u8 = 2;
+const TAG_FANOUT: u8 = 3;
+const NO_CREDENTIAL: &[u8] = b"aruna.metadata.query.anonymous";
+const ENTRY_OVERHEAD: usize = 64;
+
+// Length prefixes keep concatenated components unambiguous, so no two
+// different component lists can hash to the same key.
+fn push_bytes(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+/// Incremental digest over the graph IRIs a query is allowed to evaluate.
+#[derive(Default)]
+pub(super) struct ScopeDigest(blake3::Hasher);
+
+impl ScopeDigest {
+    pub(super) fn push(&mut self, graph_iri: &str) {
+        push_bytes(&mut self.0, graph_iri.as_bytes());
+    }
+
+    pub(super) fn finish(self) -> [u8; 32] {
+        *self.0.finalize().as_bytes()
+    }
+}
+
+/// Digest of an unordered graph set.
+pub(super) fn graphs_digest(graph_iris: &[String]) -> [u8; 32] {
+    let mut graphs = graph_iris.iter().map(String::as_str).collect::<Vec<_>>();
+    graphs.sort_unstable();
+    graphs.dedup();
+    let mut digest = ScopeDigest::default();
+    for graph in graphs {
+        digest.push(graph);
+    }
+    digest.finish()
+}
+
+/// Fingerprint of the caller's credential. The bearer token is only ever
+/// hashed here; neither the token nor this digest is logged or stored.
+pub(super) fn credential_digest(
+    auth: Option<&AuthContext>,
+    bearer_token: Option<&str>,
+) -> Option<[u8; 32]> {
+    let mut hasher = blake3::Hasher::new();
+    match auth {
+        Some(auth) => push_bytes(&mut hasher, &serde_json::to_vec(auth).ok()?),
+        None => push_bytes(&mut hasher, NO_CREDENTIAL),
+    }
+    match bearer_token {
+        Some(token) => push_bytes(&mut hasher, token.as_bytes()),
+        None => push_bytes(&mut hasher, NO_CREDENTIAL),
+    }
+    Some(*hasher.finalize().as_bytes())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(super) struct QueryCacheKey([u8; 32]);
+
+#[derive(Clone, Copy)]
+pub(super) enum LocalScopeKind {
+    /// Caller-supplied graph filter: exactly the named graphs are evaluated.
+    Eager,
+    /// No graph filter: the digest covers the resolved visible graph set.
+    Lazy,
+}
+
+impl LocalScopeKind {
+    fn tag(self) -> u8 {
+        match self {
+            Self::Eager => TAG_EAGER,
+            Self::Lazy => TAG_LAZY,
+        }
+    }
+}
+
+/// Key for a locally evaluated query: an entry is shared only between callers
+/// whose authorization resolved to the identical graph set, so a hit can never
+/// expose a graph the caller could not have evaluated itself.
+pub(super) fn local_key(kind: LocalScopeKind, scope: &[u8; 32], sparql: &str) -> QueryCacheKey {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[kind.tag()]);
+    push_bytes(&mut hasher, scope);
+    push_bytes(&mut hasher, sparql.as_bytes());
+    QueryCacheKey(*hasher.finalize().as_bytes())
+}
+
+pub(super) struct RemoteKeyInput<'a> {
+    pub(super) distributed: bool,
+    /// Realm the request resolved against; the credential digest alone cannot
+    /// separate realms, so it must not depend on one process serving one realm.
+    pub(super) realm_id: RealmId,
+    pub(super) credential: &'a [u8; 32],
+    pub(super) graph_iris: Option<&'a [String]>,
+    pub(super) sparql: &'a str,
+    pub(super) allow_partial: bool,
+    pub(super) target_nodes: Option<&'a [NodeId]>,
+}
+
+/// Key for a merged fan-out result. Remote partitions authorize on the
+/// forwarded credential, so entries are partitioned by realm and credential
+/// digest and never shared across callers.
+pub(super) fn remote_key(input: &RemoteKeyInput<'_>) -> QueryCacheKey {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[
+        TAG_FANOUT,
+        u8::from(input.distributed),
+        u8::from(input.allow_partial),
+    ]);
+    push_bytes(&mut hasher, input.realm_id.as_bytes());
+    push_bytes(&mut hasher, input.credential);
+    match input.graph_iris {
+        Some(graph_iris) => {
+            hasher.update(&[1u8]);
+            push_bytes(&mut hasher, &graphs_digest(graph_iris));
+        }
+        None => {
+            hasher.update(&[0u8]);
+        }
+    }
+    push_bytes(&mut hasher, input.sparql.as_bytes());
+    match input.target_nodes {
+        Some(nodes) => {
+            hasher.update(&[1u8]);
+            let mut nodes = nodes.iter().map(NodeId::as_bytes).collect::<Vec<_>>();
+            nodes.sort_unstable();
+            nodes.dedup();
+            hasher.update(&(nodes.len() as u64).to_le_bytes());
+            for node in nodes {
+                push_bytes(&mut hasher, node);
+            }
+        }
+        None => {
+            hasher.update(&[0u8]);
+        }
+    }
+    QueryCacheKey(*hasher.finalize().as_bytes())
+}
+
+/// Invalidation stamp: the visibility generation covers registry and
+/// lifecycle changes, the apply counter covers graph content written by
+/// replayed or already-durable effects that skip the lifecycle read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct CacheStamp {
+    generation: u64,
+    applies: u64,
+}
+
+#[derive(Clone)]
+pub(super) struct CachedQuery {
+    pub(super) results: Arc<MetadataQueryResults>,
+    /// Partitions merged into this result; zero for a local evaluation.
+    pub(super) nodes_queried: usize,
+}
+
+struct CacheEntry {
+    value: CachedQuery,
+    stamp: CacheStamp,
+    expires_at: Instant,
+    bytes: usize,
+}
+
+struct CacheState {
+    entries: LruCache<QueryCacheKey, CacheEntry>,
+    bytes: usize,
+}
+
+/// Bounded LRU of SPARQL results shared by every caller whose authorization
+/// resolves to the same scope.
+pub(super) struct MetadataQueryCache {
+    state: Mutex<CacheState>,
+    applies: AtomicU64,
+    ttl: Duration,
+    max_bytes: usize,
+}
+
+impl Default for MetadataQueryCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetadataQueryCache {
+    pub(super) fn new() -> Self {
+        Self::with_limits(
+            METADATA_QUERY_CACHE_MAX_ENTRIES,
+            METADATA_QUERY_CACHE_MAX_BYTES,
+            METADATA_QUERY_CACHE_TTL,
+        )
+    }
+
+    pub(super) fn with_limits(max_entries: usize, max_bytes: usize, ttl: Duration) -> Self {
+        let capacity = NonZeroUsize::new(max_entries).unwrap_or(NonZeroUsize::MIN);
+        Self {
+            state: Mutex::new(CacheState {
+                entries: LruCache::new(capacity),
+                bytes: 0,
+            }),
+            applies: AtomicU64::new(0),
+            ttl,
+            max_bytes,
+        }
+    }
+
+    /// Marks every cached result stale after a graph-mutating effect applied.
+    pub(super) fn bump_apply(&self) {
+        self.applies.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(super) fn stamp(&self, generation: u64) -> CacheStamp {
+        CacheStamp {
+            generation,
+            applies: self.applies.load(Ordering::Acquire),
+        }
+    }
+
+    pub(super) fn get(
+        &self,
+        key: &QueryCacheKey,
+        stamp: CacheStamp,
+        now: Instant,
+    ) -> Option<CachedQuery> {
+        let mut state = self.state.lock().unwrap_or_else(|lock| lock.into_inner());
+        let entry = state.entries.get(key)?;
+        if entry.stamp != stamp || entry.expires_at <= now {
+            let bytes = entry.bytes;
+            state.entries.pop(key);
+            state.bytes = state.bytes.saturating_sub(bytes);
+            return None;
+        }
+        Some(entry.value.clone())
+    }
+
+    pub(super) fn insert(
+        &self,
+        key: QueryCacheKey,
+        value: CachedQuery,
+        stamp: CacheStamp,
+        generation: u64,
+        now: Instant,
+    ) -> bool {
+        // A mutation that landed while the query ran already invalidated this
+        // result; storing it would only evict a fresher entry. The generation
+        // is checked too, because entries are shared across callers.
+        if stamp != self.stamp(generation) {
+            return false;
+        }
+        let bytes = ENTRY_OVERHEAD.saturating_add(results_bytes(&value.results));
+        if bytes > self.max_bytes {
+            return false;
+        }
+        let entry = CacheEntry {
+            value,
+            stamp,
+            expires_at: now + self.ttl,
+            bytes,
+        };
+        let mut state = self.state.lock().unwrap_or_else(|lock| lock.into_inner());
+        if let Some(replaced) = state.entries.put(key, entry) {
+            state.bytes = state.bytes.saturating_sub(replaced.bytes);
+        }
+        state.bytes = state.bytes.saturating_add(bytes);
+        while state.bytes > self.max_bytes {
+            let Some((_, evicted)) = state.entries.pop_lru() else {
+                break;
+            };
+            state.bytes = state.bytes.saturating_sub(evicted.bytes);
+        }
+        true
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .entries
+            .len()
+    }
+}
+
+/// Caches a fan-out result only when every partition answered. A partial
+/// answer would pin the missing partitions for the whole TTL and could not be
+/// replayed with an honest envelope.
+pub(super) fn store_complete(
+    cache: &MetadataQueryCache,
+    key: QueryCacheKey,
+    results: &MetadataQueryResults,
+    stats: &MetadataFanoutStats,
+    stamp: CacheStamp,
+    generation: u64,
+    now: Instant,
+) -> bool {
+    if stats.nodes_failed > 0 || stats.discovery_failed || !stats.failed_partitions.is_empty() {
+        return false;
+    }
+    cache.insert(
+        key,
+        CachedQuery {
+            results: Arc::new(results.clone()),
+            nodes_queried: stats.nodes_queried,
+        },
+        stamp,
+        generation,
+        now,
+    )
+}
+
+/// Fan-out envelope replayed from a cached entry: only complete results are
+/// cached, so no partition can be reported as failed.
+pub(super) fn cached_stats(cached: &CachedQuery) -> MetadataFanoutStats {
+    MetadataFanoutStats {
+        nodes_queried: cached.nodes_queried,
+        nodes_failed: 0,
+        failed_partitions: Vec::new(),
+        discovery_failed: false,
+    }
+}
+
+fn results_bytes(results: &MetadataQueryResults) -> usize {
+    const CELL_OVERHEAD: usize = 48;
+    match results {
+        MetadataQueryResults::Boolean(_) => 0,
+        MetadataQueryResults::Solutions(rows) => rows
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|(name, value)| name.len() + value.len() + CELL_OVERHEAD)
+                    .sum::<usize>()
+                    + CELL_OVERHEAD
+            })
+            .sum(),
+        MetadataQueryResults::Graph(triples) => triples
+            .iter()
+            .map(|(subject, predicate, object)| {
+                subject.len() + predicate.len() + object.len() + CELL_OVERHEAD
+            })
+            .sum(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    const TTL: Duration = Duration::from_secs(30);
+
+    fn cache() -> MetadataQueryCache {
+        MetadataQueryCache::with_limits(8, 1 << 20, TTL)
+    }
+
+    fn key(sparql: &str) -> QueryCacheKey {
+        local_key(LocalScopeKind::Lazy, &graphs_digest(&[]), sparql)
+    }
+
+    fn rows(count: usize) -> MetadataQueryResults {
+        MetadataQueryResults::Solutions(
+            (0..count)
+                .map(|index| BTreeMap::from([("name".to_string(), format!("value-{index:06}"))]))
+                .collect(),
+        )
+    }
+
+    fn cached(results: MetadataQueryResults) -> CachedQuery {
+        CachedQuery {
+            results: Arc::new(results),
+            nodes_queried: 1,
+        }
+    }
+
+    fn complete_stats() -> MetadataFanoutStats {
+        MetadataFanoutStats {
+            nodes_queried: 2,
+            nodes_failed: 0,
+            failed_partitions: Vec::new(),
+            discovery_failed: false,
+        }
+    }
+
+    fn remote(realm: RealmId) -> QueryCacheKey {
+        remote_key(&RemoteKeyInput {
+            distributed: true,
+            realm_id: realm,
+            credential: &[9u8; 32],
+            graph_iris: None,
+            sparql: "ASK { ?s ?p ?o }",
+            allow_partial: false,
+            target_nodes: None,
+        })
+    }
+
+    #[test]
+    fn returns_stored_entry() {
+        let cache = cache();
+        let stamp = cache.stamp(7);
+        let now = Instant::now();
+        assert!(cache.insert(key("ASK { ?s ?p ?o }"), cached(rows(3)), stamp, 7, now));
+        let hit = cache
+            .get(&key("ASK { ?s ?p ?o }"), stamp, now)
+            .expect("entry must be cached");
+        assert_eq!(*hit.results, rows(3));
+        assert!(cache.get(&key("ASK { ?x ?y ?z }"), stamp, now).is_none());
+    }
+
+    #[test]
+    fn stale_generation_misses() {
+        let cache = cache();
+        let now = Instant::now();
+        cache.insert(key("q"), cached(rows(1)), cache.stamp(1), 1, now);
+        assert!(cache.get(&key("q"), cache.stamp(2), now).is_none());
+        // The miss must also drop the entry instead of resurrecting it later.
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn apply_bump_invalidates() {
+        let cache = cache();
+        let now = Instant::now();
+        let stamp = cache.stamp(1);
+        cache.insert(key("q"), cached(rows(1)), stamp, 1, now);
+        cache.bump_apply();
+        assert!(cache.get(&key("q"), cache.stamp(1), now).is_none());
+    }
+
+    #[test]
+    fn insert_checks_generation() {
+        // A visibility-only change during evaluation must not be stored: keys
+        // are shared by digest, so the entry would leak across callers.
+        let cache = cache();
+        let now = Instant::now();
+        let stamp = cache.stamp(1);
+        assert!(!cache.insert(key("q"), cached(rows(1)), stamp, 2, now));
+        assert_eq!(cache.len(), 0);
+        assert!(cache.insert(key("q"), cached(rows(1)), stamp, 1, now));
+    }
+
+    #[test]
+    fn realm_splits_key() {
+        // One process serving one realm must not be the only thing keeping
+        // fan-out entries apart.
+        assert_ne!(remote(RealmId([1u8; 32])), remote(RealmId([2u8; 32])));
+        assert_eq!(remote(RealmId([1u8; 32])), remote(RealmId([1u8; 32])));
+    }
+
+    #[test]
+    fn scope_changes_key() {
+        let visible = ["urn:a".to_string(), "urn:b".to_string()];
+        let narrowed = ["urn:a".to_string()];
+        let sparql = "SELECT ?s WHERE { ?s ?p ?o }";
+        let wide = local_key(LocalScopeKind::Lazy, &graphs_digest(&visible), sparql);
+        let narrow = local_key(LocalScopeKind::Lazy, &graphs_digest(&narrowed), sparql);
+        assert_ne!(wide, narrow);
+        // Order and duplicates must not split the entry for one scope.
+        let reordered = [
+            "urn:b".to_string(),
+            "urn:a".to_string(),
+            "urn:a".to_string(),
+        ];
+        assert_eq!(
+            wide,
+            local_key(LocalScopeKind::Lazy, &graphs_digest(&reordered), sparql)
+        );
+        assert_ne!(
+            wide,
+            local_key(LocalScopeKind::Eager, &graphs_digest(&visible), sparql)
+        );
+    }
+
+    #[test]
+    fn byte_budget_evicts() {
+        let cache = MetadataQueryCache::with_limits(64, 4096, TTL);
+        let stamp = cache.stamp(1);
+        let now = Instant::now();
+        for index in 0..16 {
+            assert!(cache.insert(key(&format!("q{index}")), cached(rows(4)), stamp, 1, now));
+        }
+        assert!(cache.len() < 16, "byte budget never evicted");
+        assert!(cache.get(&key("q15"), stamp, now).is_some());
+        assert!(cache.get(&key("q0"), stamp, now).is_none());
+        // A result larger than the whole budget is never admitted.
+        assert!(!cache.insert(key("huge"), cached(rows(4096)), stamp, 1, now));
+    }
+
+    #[test]
+    fn ttl_expires_entry() {
+        let cache = cache();
+        let stamp = cache.stamp(1);
+        let now = Instant::now();
+        cache.insert(key("q"), cached(rows(1)), stamp, 1, now);
+        assert!(
+            cache
+                .get(&key("q"), stamp, now + TTL - Duration::from_secs(1))
+                .is_some()
+        );
+        assert!(cache.get(&key("q"), stamp, now + TTL).is_none());
+    }
+
+    #[test]
+    fn partial_result_uncached() {
+        let cache = cache();
+        let stamp = cache.stamp(1);
+        let now = Instant::now();
+        let results = rows(2);
+        for stats in [
+            MetadataFanoutStats {
+                nodes_failed: 1,
+                ..complete_stats()
+            },
+            MetadataFanoutStats {
+                discovery_failed: true,
+                ..complete_stats()
+            },
+            MetadataFanoutStats {
+                failed_partitions: vec![NodeId::from_bytes(&[1u8; 32]).expect("node id")],
+                ..complete_stats()
+            },
+        ] {
+            assert!(!store_complete(
+                &cache,
+                key("q"),
+                &results,
+                &stats,
+                stamp,
+                1,
+                now
+            ));
+            assert!(cache.get(&key("q"), stamp, now).is_none());
+        }
+        assert!(store_complete(
+            &cache,
+            key("q"),
+            &results,
+            &complete_stats(),
+            stamp,
+            1,
+            now
+        ));
+        let hit = cache.get(&key("q"), stamp, now).expect("complete result");
+        assert_eq!(cached_stats(&hit).nodes_queried, 2);
+        assert_eq!(cached_stats(&hit).nodes_failed, 0);
+    }
+}

--- a/operations/src/metadata/raw.rs
+++ b/operations/src/metadata/raw.rs
@@ -73,6 +73,10 @@ pub enum MetadataRawReadError {
     Metadata(#[from] MetadataError),
     #[error("unexpected metadata raw-read event: {0}")]
     UnexpectedEvent(String),
+    /// The event log itself is inconsistent, so retrying the same read cannot
+    /// help. Kept apart from [`Self::UnexpectedEvent`], which is adapter noise.
+    #[error("inconsistent metadata raw event log: {0}")]
+    InconsistentLog(String),
 }
 
 pub async fn load_raw_view(
@@ -146,7 +150,7 @@ pub(crate) async fn prepare_raw_event(
                 .iter()
                 .any(|candidate| candidate.event_id == event.event_id)
             {
-                return Err(MetadataRawReadError::UnexpectedEvent(format!(
+                return Err(MetadataRawReadError::InconsistentLog(format!(
                     "raw event log is missing {}",
                     event.event_id
                 )));
@@ -198,7 +202,7 @@ async fn initial_raw_state(
         }
     };
     let state = resolve_raw_state(&events)?.ok_or_else(|| {
-        MetadataRawReadError::UnexpectedEvent(format!(
+        MetadataRawReadError::InconsistentLog(format!(
             "raw event log is missing {}",
             event.event_id
         ))
@@ -235,7 +239,7 @@ async fn rebuild_raw_state(
         .await?,
     );
     resolve_raw_state(&events)?.ok_or_else(|| {
-        MetadataRawReadError::UnexpectedEvent(format!(
+        MetadataRawReadError::InconsistentLog(format!(
             "raw base event is missing for {}",
             event.record.document_id
         ))
@@ -374,14 +378,14 @@ async fn read_raw_event(
                 postcard::from_bytes(&value).map_err(ConversionError::from)?;
             validate_raw_event(document_id, &event)?;
             if event.event_id != event_id {
-                return Err(MetadataRawReadError::UnexpectedEvent(format!(
+                return Err(MetadataRawReadError::InconsistentLog(format!(
                     "raw event key mismatch for {document_id}/{event_id}"
                 )));
             }
             Ok(event)
         }
         Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Err(
-            MetadataRawReadError::UnexpectedEvent(format!("raw event {event_id} is missing")),
+            MetadataRawReadError::InconsistentLog(format!("raw event {event_id} is missing")),
         ),
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
         other => Err(MetadataRawReadError::UnexpectedEvent(format!("{other:?}"))),
@@ -446,7 +450,7 @@ fn validate_raw_event(
     event: &MetadataCreateEventRecord,
 ) -> Result<(), MetadataRawReadError> {
     if event.record.document_id != document_id {
-        return Err(MetadataRawReadError::UnexpectedEvent(format!(
+        return Err(MetadataRawReadError::InconsistentLog(format!(
             "raw event belongs to document {}",
             event.record.document_id
         )));

--- a/operations/src/metadata/search_cursor.rs
+++ b/operations/src/metadata/search_cursor.rs
@@ -281,7 +281,7 @@ fn score_key(score: f32) -> i64 {
     (score as f64 * 1_000_000.0) as i64
 }
 
-fn compare_hits(left: &MetadataSearchHit, right: &MetadataSearchHit) -> Ordering {
+pub(super) fn compare_hits(left: &MetadataSearchHit, right: &MetadataSearchHit) -> Ordering {
     score_key(right.score)
         .cmp(&score_key(left.score))
         .then_with(|| left.graph_iri.cmp(&right.graph_iri))

--- a/operations/src/metadata/stats.rs
+++ b/operations/src/metadata/stats.rs
@@ -1,0 +1,241 @@
+use aruna_core::structs::RealmId;
+
+use super::api::MetadataApiError;
+use crate::driver::DriverContext;
+
+/// Realm-wide number of live metadata documents, not filtered by what any
+/// caller may read.
+///
+/// The count comes from the cached registry snapshot, so it costs one cached
+/// read and excludes lifecycle-deleted graphs. Returns `None` when the node
+/// runs without a metadata subsystem, so an absent count stays distinguishable
+/// from zero documents.
+///
+/// An exact per-caller count would need per-document glob evaluation, because
+/// read visibility is glob-granular: a `DENY` can subtract a single document
+/// from a group-wide grant. The realm total discloses only document volume,
+/// which callers already reach realm auth to see.
+pub async fn count_realm_documents(
+    context: &DriverContext,
+    realm_id: RealmId,
+) -> Result<Option<u64>, MetadataApiError> {
+    let Some(metadata_handle) = context.metadata_handle.as_ref() else {
+        return Ok(None);
+    };
+    let records = metadata_handle
+        .list_cached_registry_records()
+        .await
+        .map_err(|error| MetadataApiError::Internal(error.to_string()))?;
+    Ok(Some(
+        records
+            .iter()
+            .filter(|record| record.realm_id == realm_id)
+            .count() as u64,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use aruna_core::effects::StorageEffect;
+    use aruna_core::events::{Event, StorageEvent};
+    use aruna_core::metadata::MetadataGraphLifecycleRecord;
+    use aruna_core::storage_entries::{
+        metadata_graph_lifecycle_write_entry, metadata_registry_write_entries,
+    };
+    use aruna_core::structs::{MetadataRegistryRecord, PlacementRef};
+    use aruna_core::types::GroupId;
+    use aruna_storage::{FjallStorage, StorageHandle};
+    use byteview::ByteView;
+    use tempfile::{TempDir, tempdir};
+    use ulid::Ulid;
+
+    use super::*;
+    use crate::metadata::MetadataHandle;
+
+    const REALM_SEED: [u8; 32] = [7u8; 32];
+
+    struct Fixture {
+        _storage_dir: TempDir,
+        _metadata_dir: TempDir,
+        storage: StorageHandle,
+        context: Arc<DriverContext>,
+        realm_id: RealmId,
+    }
+
+    fn setup_fixture() -> Fixture {
+        let storage_dir = tempdir().expect("temp dir");
+        let metadata_dir = tempdir().expect("metadata dir");
+        let storage = FjallStorage::open(storage_dir.path().to_str().expect("utf-8 path"))
+            .expect("storage opens");
+        let node_id = iroh::SecretKey::from_bytes(&[8u8; 32]).public();
+        let metadata_handle = MetadataHandle::new(
+            metadata_dir.path(),
+            node_id,
+            storage.clone(),
+            None,
+            None,
+            None,
+        )
+        .expect("metadata handle opens");
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: Some(metadata_handle),
+            task_handle: None,
+            compute_handle: None,
+        });
+        Fixture {
+            _storage_dir: storage_dir,
+            _metadata_dir: metadata_dir,
+            storage,
+            context,
+            realm_id: RealmId::from_bytes(REALM_SEED),
+        }
+    }
+
+    fn registry_record(
+        realm_id: RealmId,
+        group_id: GroupId,
+        public: bool,
+    ) -> MetadataRegistryRecord {
+        let document_id = Ulid::generate();
+        let path = format!("datasets/{document_id}");
+        MetadataRegistryRecord {
+            realm_id,
+            group_id,
+            document_id,
+            document_path: path.clone(),
+            graph_iri: MetadataRegistryRecord::graph_iri_for(document_id),
+            public,
+            permission_path: MetadataRegistryRecord::permission_path_for(
+                &realm_id,
+                group_id,
+                &path,
+                document_id,
+            ),
+            placement: PlacementRef::NIL,
+            holder_node_ids: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            last_event_id: Ulid::nil(),
+        }
+    }
+
+    async fn write_entries(storage: &StorageHandle, writes: Vec<(String, ByteView, ByteView)>) {
+        match storage
+            .send_storage_effect(StorageEffect::BatchWrite {
+                writes,
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::BatchWriteResult { .. }) => {}
+            other => panic!("unexpected storage event: {other:?}"),
+        }
+    }
+
+    async fn write_record(fixture: &Fixture, record: &MetadataRegistryRecord) {
+        write_entries(
+            &fixture.storage,
+            metadata_registry_write_entries(record).expect("registry entries"),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn counts_realm_total() {
+        // Private documents and groups the caller holds no role in still count.
+        let fixture = setup_fixture();
+        let first_group = Ulid::generate();
+        let second_group = Ulid::generate();
+        for record in [
+            registry_record(fixture.realm_id, first_group, false),
+            registry_record(fixture.realm_id, first_group, true),
+            registry_record(fixture.realm_id, second_group, false),
+        ] {
+            write_record(&fixture, &record).await;
+        }
+
+        assert_eq!(
+            count_realm_documents(&fixture.context, fixture.realm_id)
+                .await
+                .expect("count succeeds"),
+            Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn skips_foreign_realm() {
+        let fixture = setup_fixture();
+        let group_id = Ulid::generate();
+        write_record(&fixture, &registry_record(fixture.realm_id, group_id, true)).await;
+        write_record(
+            &fixture,
+            &registry_record(RealmId::from_bytes([9u8; 32]), group_id, true),
+        )
+        .await;
+
+        assert_eq!(
+            count_realm_documents(&fixture.context, fixture.realm_id)
+                .await
+                .expect("count succeeds"),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn deleted_not_counted() {
+        // A graph lifecycle tombstone hides its document from the count even
+        // while the registry row is still present.
+        let fixture = setup_fixture();
+        let group_id = Ulid::generate();
+        let kept = registry_record(fixture.realm_id, group_id, true);
+        let deleted = registry_record(fixture.realm_id, group_id, true);
+        write_record(&fixture, &kept).await;
+        write_record(&fixture, &deleted).await;
+        let tombstone = MetadataGraphLifecycleRecord::deleted(
+            deleted.graph_iri.clone(),
+            fixture.realm_id,
+            group_id,
+            deleted.document_id,
+            2,
+        );
+        write_entries(
+            &fixture.storage,
+            vec![metadata_graph_lifecycle_write_entry(&tombstone).expect("lifecycle entry")],
+        )
+        .await;
+
+        assert_eq!(
+            count_realm_documents(&fixture.context, fixture.realm_id)
+                .await
+                .expect("count succeeds"),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn unconfigured_reports_none() {
+        // An absent count must stay distinguishable from zero documents.
+        let storage_dir = tempdir().expect("temp dir");
+        let context = DriverContext {
+            storage_handle: FjallStorage::open(storage_dir.path().to_str().expect("utf-8 path"))
+                .expect("storage opens"),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: None,
+            compute_handle: None,
+        };
+
+        assert_eq!(
+            count_realm_documents(&context, RealmId::from_bytes(REALM_SEED))
+                .await
+                .expect("count succeeds"),
+            None
+        );
+    }
+}

--- a/operations/src/metadata/summary_cache.rs
+++ b/operations/src/metadata/summary_cache.rs
@@ -1,0 +1,248 @@
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use lru::LruCache;
+use ulid::Ulid;
+
+// Two maximum-size list pages worth of documents, capped by bytes so a few
+// unusually large summaries cannot grow the cache without bound. The pair
+// encodes a 16 KiB average summary and roughly 32 MiB of resident memory.
+const SUMMARY_CACHE_ENTRIES: usize = 2_048;
+const SUMMARY_CACHE_BYTES: usize = 32 * 1024 * 1024;
+/// Backstop staleness bound, matching the visibility and query cache TTLs, so
+/// any coherence hole between the registry cursor and the local graph content
+/// expires instead of surviving until the next event or eviction.
+const SUMMARY_CACHE_TTL: Duration = Duration::from_secs(30);
+
+static SUMMARY_CACHE: OnceLock<MetadataSummaryCache> = OnceLock::new();
+
+pub(crate) fn summary_cache() -> &'static MetadataSummaryCache {
+    SUMMARY_CACHE.get_or_init(|| {
+        MetadataSummaryCache::new(
+            SUMMARY_CACHE_ENTRIES,
+            SUMMARY_CACHE_BYTES,
+            SUMMARY_CACHE_TTL,
+        )
+    })
+}
+
+/// RO-Crate summary cache keyed by `(graph_iri, cursor)`, where the cursor is
+/// the document's `last_event_id`. A replicated cursor can lead the local graph
+/// content, so document sync invalidates and the TTL bounds what it misses.
+pub(crate) struct MetadataSummaryCache {
+    state: Mutex<SummaryCacheState>,
+    ttl: Duration,
+    max_bytes: usize,
+}
+
+struct SummaryCacheState {
+    entries: LruCache<String, SummaryEntry>,
+    bytes: usize,
+}
+
+struct SummaryEntry {
+    cursor: Ulid,
+    summary: Arc<str>,
+    expires_at: Instant,
+}
+
+impl MetadataSummaryCache {
+    pub(crate) fn new(max_entries: usize, max_bytes: usize, ttl: Duration) -> Self {
+        let capacity = NonZeroUsize::new(max_entries).unwrap_or(NonZeroUsize::MIN);
+        Self {
+            state: Mutex::new(SummaryCacheState {
+                entries: LruCache::new(capacity),
+                bytes: 0,
+            }),
+            ttl,
+            max_bytes,
+        }
+    }
+
+    /// Only one summary per graph is retained, so a cursor advance both misses
+    /// and frees the superseded entry.
+    pub(crate) fn get(&self, graph_iri: &str, cursor: Ulid, now: Instant) -> Option<Arc<str>> {
+        let mut state = self.state.lock().unwrap_or_else(|lock| lock.into_inner());
+        let entry = state.entries.get(graph_iri)?;
+        if entry.expires_at <= now {
+            let size = entry_size(graph_iri, &entry.summary);
+            state.entries.pop(graph_iri);
+            state.bytes = state.bytes.saturating_sub(size);
+            return None;
+        }
+        (entry.cursor == cursor).then(|| entry.summary.clone())
+    }
+
+    pub(crate) fn insert(&self, graph_iri: &str, cursor: Ulid, summary: &str, now: Instant) {
+        let size = entry_size(graph_iri, summary);
+        if size > self.max_bytes {
+            return;
+        }
+        let mut state = self.state.lock().unwrap_or_else(|lock| lock.into_inner());
+        let entry = SummaryEntry {
+            cursor,
+            summary: Arc::from(summary),
+            expires_at: now + self.ttl,
+        };
+        if let Some((key, replaced)) = state.entries.push(graph_iri.to_string(), entry) {
+            state.bytes = state
+                .bytes
+                .saturating_sub(entry_size(&key, &replaced.summary));
+        }
+        state.bytes = state.bytes.saturating_add(size);
+        while state.bytes > self.max_bytes {
+            let Some((key, evicted)) = state.entries.pop_lru() else {
+                break;
+            };
+            state.bytes = state
+                .bytes
+                .saturating_sub(entry_size(&key, &evicted.summary));
+        }
+    }
+
+    pub(crate) fn remove(&self, graph_iri: &str) {
+        let mut state = self.state.lock().unwrap_or_else(|lock| lock.into_inner());
+        if let Some(removed) = state.entries.pop(graph_iri) {
+            state.bytes = state
+                .bytes
+                .saturating_sub(entry_size(graph_iri, &removed.summary));
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .entries
+            .len()
+    }
+}
+
+fn entry_size(graph_iri: &str, summary: &str) -> usize {
+    graph_iri.len() + summary.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TTL: Duration = Duration::from_secs(30);
+
+    fn cache(max_entries: usize, max_bytes: usize) -> MetadataSummaryCache {
+        MetadataSummaryCache::new(max_entries, max_bytes, TTL)
+    }
+
+    #[test]
+    fn hit_returns_entry() {
+        let cache = cache(4, 1024);
+        let cursor = Ulid::generate();
+        let now = Instant::now();
+        cache.insert("urn:graph:a", cursor, "{\"@graph\":[]}", now);
+
+        assert_eq!(
+            cache.get("urn:graph:a", cursor, now).as_deref(),
+            Some("{\"@graph\":[]}")
+        );
+        assert!(cache.get("urn:graph:b", cursor, now).is_none());
+    }
+
+    #[test]
+    fn cursor_advance_misses() {
+        // A stale summary must never survive an update of the same document.
+        let cache = cache(4, 1024);
+        let first = Ulid::generate();
+        let second = Ulid::generate();
+        let now = Instant::now();
+        cache.insert("urn:graph:a", first, "stale", now);
+
+        assert!(cache.get("urn:graph:a", second, now).is_none());
+        cache.insert("urn:graph:a", second, "fresh", now);
+        assert_eq!(
+            cache.get("urn:graph:a", second, now).as_deref(),
+            Some("fresh")
+        );
+        assert!(cache.get("urn:graph:a", first, now).is_none());
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn budget_evicts_lru() {
+        let cache = cache(8, 32);
+        let cursor = Ulid::generate();
+        let now = Instant::now();
+        cache.insert("a", cursor, &"x".repeat(15), now);
+        cache.insert("b", cursor, &"y".repeat(15), now);
+        assert_eq!(cache.len(), 2);
+
+        cache.insert("c", cursor, &"z".repeat(15), now);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get("a", cursor, now).is_none());
+        assert!(cache.get("b", cursor, now).is_some());
+        assert!(cache.get("c", cursor, now).is_some());
+    }
+
+    #[test]
+    fn oversized_entry_skipped() {
+        let cache = cache(4, 16);
+        let cursor = Ulid::generate();
+        let now = Instant::now();
+        cache.insert("a", cursor, &"x".repeat(64), now);
+
+        assert!(cache.get("a", cursor, now).is_none());
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn remove_frees_budget() {
+        let cache = cache(4, 32);
+        let cursor = Ulid::generate();
+        let now = Instant::now();
+        cache.insert("a", cursor, &"x".repeat(20), now);
+        cache.remove("a");
+        cache.insert("b", cursor, &"y".repeat(20), now);
+
+        assert!(cache.get("b", cursor, now).is_some());
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn sync_drops_summaries() {
+        // Document sync can land content under a cursor a listing already
+        // cached, so only the synced graph loses its entry and its bytes.
+        let cache = cache(4, 32);
+        let cursor = Ulid::generate();
+        let now = Instant::now();
+        let kept = "y".repeat(10);
+        cache.insert("a", cursor, &"x".repeat(10), now);
+        cache.insert("b", cursor, &kept, now);
+        cache.remove("a");
+
+        assert!(cache.get("a", cursor, now).is_none());
+        assert_eq!(
+            cache.get("b", cursor, now).as_deref(),
+            Some(kept.as_str()),
+            "a graph the sync never touched must keep its summary"
+        );
+        assert_eq!(cache.len(), 1);
+        // Only fits if removing "a" released its bytes as well as its slot.
+        cache.insert("c", cursor, &"z".repeat(20), now);
+        assert!(cache.get("c", cursor, now).is_some());
+        assert!(cache.get("b", cursor, now).is_some());
+    }
+
+    #[test]
+    fn expired_entry_misses() {
+        // The TTL bounds any coherence hole the cursor key cannot see.
+        let cache = cache(4, 1024);
+        let cursor = Ulid::generate();
+        let now = Instant::now();
+        cache.insert("a", cursor, "summary", now);
+        let fresh = now + TTL - Duration::from_secs(1);
+
+        assert!(cache.get("a", cursor, fresh).is_some());
+        assert!(cache.get("a", cursor, now + TTL).is_none());
+        assert_eq!(cache.len(), 0);
+    }
+}

--- a/operations/src/permission_rules.rs
+++ b/operations/src/permission_rules.rs
@@ -1,0 +1,789 @@
+use std::collections::{BTreeSet, HashMap};
+
+use aruna_core::effects::{Effect, StorageEffect};
+use aruna_core::errors::AuthorizationError;
+use aruna_core::events::{Event, StorageEvent};
+use aruna_core::keyspaces::AUTH_KEYSPACE;
+use aruna_core::operation::Operation;
+use aruna_core::structs::{
+    AuthContext, GroupAuthorizationDocument, MetadataRegistryRecord, PathRestriction, Permission,
+    RealmAuthorizationDocument, RealmId, Role,
+};
+use aruna_core::types::{Effects, GroupId, TxnId};
+use globset::{Glob, GlobMatcher};
+use smallvec::smallvec;
+use ulid::Ulid;
+
+use crate::driver::{DriverContext, drive};
+
+/// A role that applies to the caller: `direct` when the caller is assigned to
+/// it, `public` when the realm's Everyone principal is.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollectedRole {
+    pub role: Role,
+    pub direct: bool,
+    pub public: bool,
+}
+
+#[derive(Clone, Debug)]
+struct CompiledRule {
+    matcher: GlobMatcher,
+    permission: Permission,
+    direct: bool,
+    public: bool,
+}
+
+impl PartialEq for CompiledRule {
+    fn eq(&self, other: &Self) -> bool {
+        self.matcher.glob() == other.matcher.glob()
+            && self.permission == other.permission
+            && self.direct == other.direct
+            && self.public == other.public
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CompiledRestriction {
+    matcher: GlobMatcher,
+    permission: Permission,
+}
+
+impl PartialEq for CompiledRestriction {
+    fn eq(&self, other: &Self) -> bool {
+        self.matcher.glob() == other.matcher.glob() && self.permission == other.permission
+    }
+}
+
+/// The caller's effective permission rules for one realm or group scope.
+/// `allows` is the single authorization decision used by every read path, so a
+/// caller holding many paths can decide in memory after one collection.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PermissionRules {
+    rules: Vec<CompiledRule>,
+    restrictions: Option<Vec<CompiledRestriction>>,
+}
+
+impl PermissionRules {
+    /// Compiles the role patterns once. An unusable pattern fails the whole
+    /// collection so callers deny instead of silently dropping a rule.
+    pub fn from_roles(
+        roles: Vec<CollectedRole>,
+        restrictions: Option<&[PathRestriction]>,
+    ) -> Result<Self, AuthorizationError> {
+        let mut rules = Vec::new();
+        for CollectedRole {
+            role,
+            direct,
+            public,
+        } in roles
+        {
+            for (pattern, permission) in role.permissions {
+                rules.push(CompiledRule {
+                    matcher: Glob::new(&pattern)?.compile_matcher(),
+                    permission,
+                    direct,
+                    public,
+                });
+            }
+        }
+
+        let restrictions = restrictions
+            .map(|restrictions| {
+                restrictions
+                    .iter()
+                    .map(|restriction| {
+                        Ok(CompiledRestriction {
+                            matcher: Glob::new(&restriction.pattern)?.compile_matcher(),
+                            permission: restriction.permission.clone(),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, AuthorizationError>>()
+            })
+            .transpose()?;
+
+        Ok(Self {
+            rules,
+            restrictions,
+        })
+    }
+
+    /// A matching direct DENY denies outright, a public role only ever grants
+    /// READ, and token path restrictions act as a whitelist on top.
+    pub fn allows(&self, path: &str, required: &Permission) -> bool {
+        let mut allowed = false;
+        for rule in &self.rules {
+            if !rule.matcher.is_match(path) {
+                continue;
+            }
+            if rule.public && rule.permission == Permission::READ && *required == Permission::READ {
+                allowed = true;
+            }
+            if rule.direct {
+                match rule.permission {
+                    Permission::DENY => return false,
+                    Permission::READ => {
+                        if *required == Permission::READ {
+                            allowed = true;
+                        }
+                    }
+                    Permission::WRITE => allowed = true,
+                }
+            }
+        }
+
+        allowed && self.restrictions_allow(path, required)
+    }
+
+    fn restrictions_allow(&self, path: &str, required: &Permission) -> bool {
+        let Some(restrictions) = self.restrictions.as_ref() else {
+            return true;
+        };
+
+        let mut allowed = false;
+        for restriction in restrictions {
+            if !restriction.matcher.is_match(path) {
+                continue;
+            }
+            match restriction.permission {
+                Permission::DENY => return false,
+                Permission::READ => {
+                    if *required == Permission::READ {
+                        allowed = true;
+                    }
+                }
+                Permission::WRITE => allowed = true,
+            }
+        }
+        allowed
+    }
+}
+
+/// The caller's rules for a set of groups, collected once per request: every
+/// candidate path is then decided in memory instead of driving one permission
+/// check per path.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GroupPermissionRules {
+    realm_id: Option<RealmId>,
+    groups: HashMap<GroupId, PermissionRules>,
+}
+
+impl GroupPermissionRules {
+    /// One rules drive per distinct group. Anonymous callers hold no rules, and
+    /// a group whose collection fails keeps none, so its records stay hidden.
+    pub async fn collect(
+        context: &DriverContext,
+        auth_context: Option<&AuthContext>,
+        group_ids: impl IntoIterator<Item = GroupId>,
+    ) -> Self {
+        let Some(auth_context) = auth_context else {
+            return Self::default();
+        };
+
+        let mut groups = HashMap::new();
+        for group_id in group_ids.into_iter().collect::<BTreeSet<_>>() {
+            let Ok(rules) = drive(
+                PermissionRulesOperation::new(PermissionRulesConfig {
+                    auth_context: auth_context.clone(),
+                    path: format!("/{}/g/{group_id}", auth_context.realm_id),
+                }),
+                context,
+            )
+            .await
+            else {
+                continue;
+            };
+            groups.insert(group_id, rules);
+        }
+
+        Self {
+            realm_id: Some(auth_context.realm_id),
+            groups,
+        }
+    }
+
+    pub fn from_groups(
+        realm_id: Option<RealmId>,
+        groups: HashMap<GroupId, PermissionRules>,
+    ) -> Self {
+        Self { realm_id, groups }
+    }
+
+    /// Mirrors `can_read_record`: public records need no authorization, every
+    /// other record is decided on its own permission path. Records outside the
+    /// caller's realm stay hidden, which is stricter than a cross-realm check.
+    pub fn record_visible(&self, record: &MetadataRegistryRecord) -> bool {
+        record.public
+            || (self.realm_id == Some(record.realm_id)
+                && self.allows(record.group_id, &record.permission_path, &Permission::READ))
+    }
+
+    pub fn allows(&self, group_id: GroupId, path: &str, required: &Permission) -> bool {
+        self.groups
+            .get(&group_id)
+            .is_some_and(|rules| rules.allows(path, required))
+    }
+
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PermissionRulesConfig {
+    pub auth_context: AuthContext,
+    /// Selects the authorization documents to read: only the realm and the
+    /// optional group segment matter, the remaining path is ignored.
+    pub path: String,
+}
+
+/// Reads the realm and group authorization documents once and returns the
+/// caller's rules, so bulk read paths pay O(scopes) storage reads instead of
+/// one permission check per candidate path.
+#[derive(Debug, PartialEq)]
+pub struct PermissionRulesOperation {
+    config: PermissionRulesConfig,
+    txn_id: Option<TxnId>,
+    group_id: Option<GroupId>,
+    realm_auth_doc: Option<RealmAuthorizationDocument>,
+    group_auth_doc: Option<GroupAuthorizationDocument>,
+    output: Option<Result<PermissionRules, AuthorizationError>>,
+    state: PermissionRulesState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum PermissionRulesState {
+    Init,
+    StartTransaction,
+    GetRealmAuthDoc,
+    GetGroupAuthDoc,
+    CollectRules,
+    Finish,
+    Error,
+}
+
+impl std::fmt::Display for PermissionRulesState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                PermissionRulesState::Init => "PermissionRulesState::Init",
+                PermissionRulesState::StartTransaction => "PermissionRulesState::StartTransaction",
+                PermissionRulesState::GetRealmAuthDoc => "PermissionRulesState::GetRealmAuthDoc",
+                PermissionRulesState::GetGroupAuthDoc => "PermissionRulesState::GetGroupAuthDoc",
+                PermissionRulesState::CollectRules => "PermissionRulesState::CollectRules",
+                PermissionRulesState::Finish => "PermissionRulesState::Finish",
+                PermissionRulesState::Error => "PermissionRulesState::Error",
+            }
+        )
+    }
+}
+
+impl PermissionRulesOperation {
+    pub fn new(config: PermissionRulesConfig) -> Self {
+        PermissionRulesOperation {
+            config,
+            txn_id: None,
+            group_id: None,
+            realm_auth_doc: None,
+            group_auth_doc: None,
+            output: None,
+            state: PermissionRulesState::Init,
+        }
+    }
+
+    fn handle_transaction(&mut self, event: Event) -> Effects {
+        let got = format!("{event:?}");
+        if let (
+            PermissionRulesState::StartTransaction,
+            Event::Storage(StorageEvent::TransactionStarted { txn_id }),
+        ) = (self.state, event)
+        {
+            self.txn_id = Some(txn_id);
+            match self.read_realm_doc() {
+                Ok(effects) => effects,
+                Err(err) => self.fail(err),
+            }
+        } else {
+            self.unexpected_event(
+                self.state,
+                "Event::Storage(StorageEvent::TransactionStart)",
+                got,
+            )
+        }
+    }
+
+    fn handle_realm_auth(&mut self, event: Event) -> Effects {
+        let got = format!("{event:?}");
+        if let (
+            PermissionRulesState::GetRealmAuthDoc,
+            Event::Storage(StorageEvent::ReadResult { value, .. }),
+        ) = (self.state, event)
+        {
+            match self.store_realm_doc(value) {
+                Ok(effects) => effects,
+                Err(err) => self.fail(err),
+            }
+        } else {
+            self.unexpected_event(self.state, "Event::Storage(StorageEvent::ReadResult)", got)
+        }
+    }
+
+    fn handle_group_auth(&mut self, event: Event) -> Effects {
+        let got = format!("{event:?}");
+        if let (
+            PermissionRulesState::GetGroupAuthDoc,
+            Event::Storage(StorageEvent::ReadResult { value, .. }),
+        ) = (self.state, event)
+        {
+            match self.store_group_doc(value) {
+                Ok(effects) => effects,
+                Err(err) => self.fail(err),
+            }
+        } else {
+            self.unexpected_event(self.state, "Event::Storage(StorageEvent::ReadResult)", got)
+        }
+    }
+
+    fn handle_commit(&mut self, event: Event) -> Effects {
+        let got = format!("{event:?}");
+        if let (
+            PermissionRulesState::CollectRules,
+            Event::Storage(StorageEvent::TransactionCommitted { .. }),
+        ) = (self.state, event)
+        {
+            match self.emit_rules() {
+                Ok(effects) => effects,
+                Err(err) => self.fail(err),
+            }
+        } else {
+            self.unexpected_event(
+                self.state,
+                "Event::Storage(StorageEvent::TransactionCommitted)",
+                got,
+            )
+        }
+    }
+
+    fn parse_path(path: &str) -> Result<(RealmId, Option<GroupId>), AuthorizationError> {
+        let mut levels = path.split("/");
+        levels.next();
+        let realm = levels
+            .next()
+            .and_then(|rid| RealmId::from_base64(rid).ok())
+            .ok_or_else(|| AuthorizationError::InvalidRealmId)?;
+
+        let separator = levels.next();
+
+        let group = if separator == Some("g") {
+            levels.next().and_then(|g| Ulid::from_string(g).ok())
+        } else {
+            None
+        };
+
+        Ok((realm, group))
+    }
+
+    fn read_realm_doc(&mut self) -> Result<Effects, AuthorizationError> {
+        self.state = PermissionRulesState::GetRealmAuthDoc;
+        let (realm, group) = PermissionRulesOperation::parse_path(&self.config.path)?;
+        self.group_id = group;
+        Ok(smallvec![Effect::Storage(StorageEffect::Read {
+            key_space: AUTH_KEYSPACE.to_string(),
+            key: (*realm.as_bytes()).into(),
+            txn_id: self.txn_id
+        })])
+    }
+
+    fn store_realm_doc(
+        &mut self,
+        value: Option<byteview::ByteView>,
+    ) -> Result<Effects, AuthorizationError> {
+        self.realm_auth_doc = Some(RealmAuthorizationDocument::from_bytes(
+            &value.ok_or_else(|| AuthorizationError::AuthDocNotFound)?,
+        )?);
+
+        match self.group_id {
+            Some(group) => {
+                self.state = PermissionRulesState::GetGroupAuthDoc;
+                Ok(smallvec![Effect::Storage(StorageEffect::Read {
+                    txn_id: self.txn_id,
+                    key_space: AUTH_KEYSPACE.to_string(),
+                    key: group.to_bytes().into(),
+                })])
+            }
+            None => {
+                self.state = PermissionRulesState::CollectRules;
+                Ok(smallvec![Effect::Storage(
+                    StorageEffect::CommitTransaction {
+                        txn_id: self
+                            .txn_id
+                            .ok_or_else(|| AuthorizationError::NoTransactionFound)?
+                    }
+                )])
+            }
+        }
+    }
+
+    fn store_group_doc(
+        &mut self,
+        value: Option<byteview::ByteView>,
+    ) -> Result<Effects, AuthorizationError> {
+        self.state = PermissionRulesState::CollectRules;
+        self.group_auth_doc = Some(GroupAuthorizationDocument::from_bytes(
+            &value.ok_or_else(|| AuthorizationError::AuthDocNotFound)?,
+        )?);
+
+        Ok(smallvec![Effect::Storage(
+            StorageEffect::CommitTransaction {
+                txn_id: self
+                    .txn_id
+                    .ok_or_else(|| AuthorizationError::NoTransactionFound)?
+            }
+        )])
+    }
+
+    fn emit_rules(&mut self) -> Result<Effects, AuthorizationError> {
+        self.state = PermissionRulesState::Finish;
+        let roles = self.collect_roles()?;
+        self.output = Some(Ok(PermissionRules::from_roles(
+            roles,
+            self.config.auth_context.path_restrictions.as_deref(),
+        )?));
+        Ok(smallvec![])
+    }
+
+    fn collect_roles(&mut self) -> Result<Vec<CollectedRole>, AuthorizationError> {
+        let realm_auth_doc = self
+            .realm_auth_doc
+            .as_ref()
+            .ok_or_else(|| AuthorizationError::AuthDocNotFound)?;
+        let realm_id = realm_auth_doc.realm_id;
+        let auth_user = self.config.auth_context.user_id;
+        let mut roles = realm_auth_doc.roles.clone();
+        if let Some(group) = &self.group_auth_doc {
+            roles.extend(group.roles.clone());
+        }
+        Ok(roles
+            .into_values()
+            .filter_map(|role| {
+                // Public roles apply by assigning this realm's exact Everyone
+                // principal. Other nil user ids are not public for this realm.
+                let public = role.is_public(realm_id);
+                let direct = !auth_user.is_nil() && role.assigned_users.contains(&auth_user);
+                (public || direct).then_some(CollectedRole {
+                    role,
+                    direct,
+                    public,
+                })
+            })
+            .collect())
+    }
+
+    fn fail(&mut self, err: AuthorizationError) -> Effects {
+        self.state = PermissionRulesState::Error;
+        self.output = Some(Err(err));
+        self.abort()
+    }
+
+    fn fail_with_cleanup(&mut self, err: AuthorizationError, cleanup_effects: Effects) -> Effects {
+        self.state = PermissionRulesState::Error;
+        self.output = Some(Err(err));
+        cleanup_effects
+    }
+
+    fn unexpected_event(
+        &mut self,
+        state: PermissionRulesState,
+        expected: &'static str,
+        got: String,
+    ) -> Effects {
+        let cleanup_effects = self.abort();
+        self.fail_with_cleanup(
+            AuthorizationError::UnexpectedEvent {
+                state: state.to_string(),
+                expected,
+                got,
+            },
+            cleanup_effects,
+        )
+    }
+
+    fn fail_on_storage(&mut self, event: Event) -> Result<Event, Effects> {
+        if let Event::Storage(StorageEvent::Error { error }) = event {
+            return Err(self.fail(error.into()));
+        }
+
+        Ok(event)
+    }
+}
+
+impl Operation for PermissionRulesOperation {
+    type Output = PermissionRules;
+
+    type Error = AuthorizationError;
+
+    fn start(&mut self) -> Effects {
+        self.state = PermissionRulesState::StartTransaction;
+
+        smallvec![Effect::Storage(StorageEffect::StartTransaction {
+            read: true
+        })]
+    }
+
+    fn step(&mut self, event: Event) -> Effects {
+        let event = match self.fail_on_storage(event) {
+            Ok(event) => event,
+            Err(effects) => return effects,
+        };
+
+        match self.state {
+            PermissionRulesState::StartTransaction => self.handle_transaction(event),
+            PermissionRulesState::GetRealmAuthDoc => self.handle_realm_auth(event),
+            PermissionRulesState::GetGroupAuthDoc => self.handle_group_auth(event),
+            PermissionRulesState::CollectRules => self.handle_commit(event),
+            PermissionRulesState::Finish
+            | PermissionRulesState::Init
+            | PermissionRulesState::Error => smallvec![],
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(
+            self.state,
+            PermissionRulesState::Finish | PermissionRulesState::Error
+        )
+    }
+
+    fn finalize(self) -> Result<Self::Output, Self::Error> {
+        self.output.ok_or_else(|| AuthorizationError::NotFinished)?
+    }
+
+    fn abort(&mut self) -> Effects {
+        match self.txn_id {
+            Some(txn_id) => smallvec![Effect::Storage(StorageEffect::AbortTransaction { txn_id })],
+            None => smallvec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::{HashMap, HashSet};
+
+    use aruna_core::UserId;
+    use aruna_core::structs::{
+        AuthContext, MetadataRegistryRecord, PathRestriction, Permission,
+        RealmAuthorizationDocument, RealmId, Role,
+    };
+    use ulid::Ulid;
+
+    use super::{CollectedRole, PermissionRules, PermissionRulesConfig, PermissionRulesOperation};
+
+    fn role(permissions: HashMap<String, Permission>, assigned: HashSet<UserId>) -> Role {
+        Role {
+            role_id: Ulid::generate(),
+            name: "test".to_string(),
+            permissions,
+            assigned_users: assigned,
+        }
+    }
+
+    fn direct_rules(permissions: HashMap<String, Permission>) -> PermissionRules {
+        PermissionRules::from_roles(
+            vec![CollectedRole {
+                role: role(permissions, HashSet::new()),
+                direct: true,
+                public: false,
+            }],
+            None,
+        )
+        .expect("patterns compile")
+    }
+
+    #[test]
+    fn parses_scope_path() {
+        let realm_id = RealmId([4u8; 32]);
+        let group_id = Ulid::generate();
+        let (parsed_realm, parsed_group) =
+            PermissionRulesOperation::parse_path(&format!("/{realm_id}/g/{group_id}"))
+                .expect("group path parses");
+        assert_eq!(parsed_realm, realm_id);
+        assert_eq!(parsed_group, Some(group_id));
+
+        let (parsed_realm, parsed_group) =
+            PermissionRulesOperation::parse_path(&format!("/{realm_id}/admin"))
+                .expect("realm path parses");
+        assert_eq!(parsed_realm, realm_id);
+        assert!(parsed_group.is_none());
+
+        assert!(PermissionRulesOperation::parse_path("/abcd/g/nope").is_err());
+    }
+
+    #[test]
+    fn deny_wins() {
+        // A per-document DENY must beat the group-wide READ it overlaps.
+        let realm_id = RealmId([5u8; 32]);
+        let group_id = Ulid::generate();
+        let secret = MetadataRegistryRecord::permission_path_for(
+            &realm_id,
+            group_id,
+            "datasets/secret",
+            Ulid::generate(),
+        );
+        let sibling = MetadataRegistryRecord::permission_path_for(
+            &realm_id,
+            group_id,
+            "datasets/open",
+            Ulid::generate(),
+        );
+        let rules = direct_rules(HashMap::from([
+            (
+                format!("/{realm_id}/g/{group_id}/meta/**"),
+                Permission::READ,
+            ),
+            (secret.clone(), Permission::DENY),
+        ]));
+
+        assert!(!rules.allows(&secret, &Permission::READ));
+        assert!(rules.allows(&sibling, &Permission::READ));
+    }
+
+    #[test]
+    fn narrow_grant_matches() {
+        // A grant on one document must not open the rest of the group.
+        let realm_id = RealmId([6u8; 32]);
+        let group_id = Ulid::generate();
+        let granted = MetadataRegistryRecord::permission_path_for(
+            &realm_id,
+            group_id,
+            "datasets/shared",
+            Ulid::generate(),
+        );
+        let other = MetadataRegistryRecord::permission_path_for(
+            &realm_id,
+            group_id,
+            "datasets/private",
+            Ulid::generate(),
+        );
+        let rules = direct_rules(HashMap::from([(granted.clone(), Permission::READ)]));
+
+        assert!(rules.allows(&granted, &Permission::READ));
+        assert!(!rules.allows(&other, &Permission::READ));
+        assert!(!rules.allows(&granted, &Permission::WRITE));
+    }
+
+    #[test]
+    fn restrictions_gate_access() {
+        let realm_id = RealmId([7u8; 32]);
+        let group_id = Ulid::generate();
+        let pattern = format!("/{realm_id}/g/{group_id}/meta/**");
+        let path = format!("/{realm_id}/g/{group_id}/meta/document");
+        let granted = HashMap::from([(format!("/{realm_id}/g/{group_id}/**"), Permission::WRITE)]);
+        let restricted = |permission: Permission| {
+            PermissionRules::from_roles(
+                vec![CollectedRole {
+                    role: role(granted.clone(), HashSet::new()),
+                    direct: true,
+                    public: false,
+                }],
+                Some(&[PathRestriction {
+                    pattern: pattern.clone(),
+                    permission,
+                }]),
+            )
+            .expect("patterns compile")
+        };
+
+        let read_only = restricted(Permission::READ);
+        assert!(read_only.allows(&path, &Permission::READ));
+        assert!(!read_only.allows(&path, &Permission::WRITE));
+        assert!(!read_only.allows(
+            &format!("/{realm_id}/g/{group_id}/data/x"),
+            &Permission::READ
+        ));
+        assert!(!restricted(Permission::DENY).allows(&path, &Permission::READ));
+    }
+
+    #[test]
+    fn public_grants_read() {
+        // Public roles grant READ to everyone but never WRITE, and a direct
+        // DENY still wins over a public grant.
+        let realm_id = RealmId([8u8; 32]);
+        let group_id = Ulid::generate();
+        let path = format!("/{realm_id}/g/{group_id}/data/object");
+        let public = |permission: Permission| {
+            PermissionRules::from_roles(
+                vec![CollectedRole {
+                    role: role(
+                        HashMap::from([(path.clone(), permission)]),
+                        HashSet::from([UserId::nil(realm_id)]),
+                    ),
+                    direct: false,
+                    public: true,
+                }],
+                None,
+            )
+            .expect("patterns compile")
+        };
+
+        assert!(public(Permission::READ).allows(&path, &Permission::READ));
+        assert!(!public(Permission::WRITE).allows(&path, &Permission::WRITE));
+        assert!(!public(Permission::READ).allows(&path, &Permission::WRITE));
+
+        let denied = PermissionRules::from_roles(
+            vec![
+                CollectedRole {
+                    role: role(
+                        HashMap::from([(path.clone(), Permission::READ)]),
+                        HashSet::from([UserId::nil(realm_id)]),
+                    ),
+                    direct: false,
+                    public: true,
+                },
+                CollectedRole {
+                    role: role(
+                        HashMap::from([(path.clone(), Permission::DENY)]),
+                        HashSet::new(),
+                    ),
+                    direct: true,
+                    public: false,
+                },
+            ],
+            None,
+        )
+        .expect("patterns compile");
+        assert!(!denied.allows(&path, &Permission::READ));
+    }
+
+    #[test]
+    fn skips_foreign_nil() {
+        // Only this realm's Everyone principal makes a role public.
+        let realm_id = RealmId([9u8; 32]);
+        let other_realm = RealmId([10u8; 32]);
+        let group_id = Ulid::generate();
+        let mut operation = PermissionRulesOperation::new(PermissionRulesConfig {
+            auth_context: AuthContext::anonymous(realm_id),
+            path: format!("/{realm_id}/g/{group_id}"),
+        });
+        let foreign = role(
+            HashMap::from([(
+                format!("/{realm_id}/g/{group_id}/data/**"),
+                Permission::READ,
+            )]),
+            HashSet::from([UserId::nil(other_realm)]),
+        );
+        operation.realm_auth_doc = Some(RealmAuthorizationDocument {
+            realm_id,
+            roles: HashMap::from([(foreign.role_id, foreign)]),
+            operation_restrictions: HashMap::new(),
+        });
+
+        assert!(
+            operation
+                .collect_roles()
+                .expect("roles collected")
+                .is_empty()
+        );
+    }
+}

--- a/operations/src/queue_lag.rs
+++ b/operations/src/queue_lag.rs
@@ -10,7 +10,8 @@ use aruna_core::effects::{IterStart, StorageEffect};
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
     BLOB_REPLICATION_JOB_KEYSPACE, DOCUMENT_SYNC_OUTBOX_KEYSPACE,
-    METADATA_MATERIALIZATION_JOB_KEYSPACE, REFERENCE_METADATA_REFRESH_JOB_KEYSPACE,
+    METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE, METADATA_MATERIALIZATION_JOB_KEYSPACE,
+    REFERENCE_METADATA_REFRESH_JOB_KEYSPACE,
 };
 use aruna_core::util::unix_timestamp_millis;
 use aruna_storage::StorageHandle;
@@ -39,6 +40,9 @@ pub struct QueueLagSnapshot {
 pub struct DurableQueueLagSample {
     pub document_sync_outbox: Result<QueueLagSnapshot, String>,
     pub metadata_materialization: Result<QueueLagSnapshot, String>,
+    /// Parked materialization jobs awaiting requeue; a depth that only grows
+    /// means documents are failing to materialize.
+    pub materialization_dead_letters: Result<QueueLagSnapshot, String>,
     pub blob_replication: Result<QueueLagSnapshot, String>,
     pub reference_metadata_refresh: Result<QueueLagSnapshot, String>,
 }
@@ -77,9 +81,16 @@ impl QueueLagReporter {
             false,
         ))
         .await;
+        let materialization_dead_letters = probe_with_timeout(probe_queue_depth(
+            storage,
+            METADATA_MATERIALIZATION_DEAD_LETTER_KEYSPACE,
+            false,
+        ))
+        .await;
         let sample = DurableQueueLagSample {
             document_sync_outbox,
             metadata_materialization,
+            materialization_dead_letters,
             blob_replication,
             reference_metadata_refresh,
         };

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -42,7 +42,8 @@ use crate::jobs::{JOB_DRAIN_RETRY_AFTER, JOB_PRUNE_POLL_AFTER, JOB_PRUNE_RETRY_A
 use crate::metadata::materialization_queue::{
     METADATA_MATERIALIZATION_NEXT_BATCH_AFTER, METADATA_MATERIALIZATION_POLL_AFTER,
     METADATA_MATERIALIZATION_RETRY_AFTER, metadata_materialization_jobs_exist,
-    process_metadata_materialization_batch, restore_metadata_materialization_timer,
+    process_metadata_materialization_batch, requeue_dead_letters,
+    restore_metadata_materialization_timer,
 };
 use crate::metadata::projector::{
     METADATA_PROJECTION_RETRY_AFTER, drain_pending_metadata_projection_queue,
@@ -1792,12 +1793,21 @@ async fn durable_queue_rearm_loop(context: Weak<DriverContext>, task_handle: Tas
         )
         .await;
         restore_pending_metadata_projection_timer(&context.storage_handle, &task_handle).await;
+        sweep_dead_letters(&context.storage_handle).await;
         restore_metadata_materialization_timer(&context.storage_handle.bulk(), &task_handle).await;
         restore_metadata_graph_prune_timer(&context.storage_handle, &task_handle).await;
         restore_notification_prune_timer(&context.storage_handle, &task_handle).await;
         restore_job_queue_timer(&context.storage_handle, &task_handle).await;
         restore_job_prune_timer(&context.storage_handle, &task_handle).await;
         restore_mirror_timer(&context.storage_handle, &task_handle).await;
+    }
+}
+
+// Parked materialization jobs come back on their own backoff, so a node that hit
+// the failure cap during a storm converges again without an operator or restart.
+async fn sweep_dead_letters(storage: &aruna_storage::StorageHandle) {
+    if let Err(error) = requeue_dead_letters(&storage.bulk()).await {
+        warn!(error = ?error, "Failed to requeue metadata materialization dead letters");
     }
 }
 
@@ -1866,6 +1876,7 @@ async fn initialize_task_handler(
     crate::node_info::restore_node_info_publish_timer(&context.storage_handle, &task_handle).await;
     restore_notification_outbox_timer(&context.storage_handle, &task_handle, Duration::ZERO).await;
     restore_pending_metadata_projection_timer(&context.storage_handle, &task_handle).await;
+    sweep_dead_letters(&context.storage_handle).await;
     restore_metadata_materialization_timer(&context.storage_handle.bulk(), &task_handle).await;
     restore_metadata_graph_prune_timer(&context.storage_handle, &task_handle).await;
     restore_notification_prune_timer(&context.storage_handle, &task_handle).await;

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -103,6 +103,8 @@ pub static UNDELIVERABLE_RECORD_COUNT: std::sync::atomic::AtomicU64 =
 
 const DRAIN_SUBBATCH_RECORDS: usize = 512;
 const DURABLE_QUEUE_REARM_AFTER: Duration = Duration::from_secs(5);
+/// Rearm ticks between dead-letter sweeps, i.e. one sweep a minute.
+const DEAD_LETTER_SWEEP_TICKS: usize = 12;
 /// How long a record may wait for its shard topic's genesis before the drain
 /// stops treating the wait as normal and says so at error level.
 const OUTBOX_STUCK_AFTER: Duration = Duration::from_secs(300);
@@ -1778,11 +1780,13 @@ fn spawn_durable_queue_rearm(context: &Arc<DriverContext>, task_handle: &TaskHan
 }
 
 async fn durable_queue_rearm_loop(context: Weak<DriverContext>, task_handle: TaskHandle) {
+    let mut ticks = 0usize;
     loop {
         tokio::time::sleep(DURABLE_QUEUE_REARM_AFTER).await;
         let Some(context) = context.upgrade() else {
             return;
         };
+        ticks = ticks.saturating_add(1);
         restore_blob_replication_timer(&context.storage_handle, &task_handle).await;
         restore_reference_metadata_refresh_timer(&context.storage_handle, &task_handle).await;
         restore_document_sync_outbox_timers(&context.storage_handle, &task_handle).await;
@@ -1797,7 +1801,11 @@ async fn durable_queue_rearm_loop(context: Weak<DriverContext>, task_handle: Tas
         )
         .await;
         restore_pending_metadata_projection_timer(&context.storage_handle, &task_handle).await;
-        sweep_dead_letters(&context.storage_handle).await;
+        // Dead letters retry on a minute-scale backoff, so sweeping every rearm
+        // tick would scan the keyspace far more often than it can yield work.
+        if ticks.is_multiple_of(DEAD_LETTER_SWEEP_TICKS) {
+            sweep_dead_letters(&context.storage_handle).await;
+        }
         restore_metadata_materialization_timer(&context.storage_handle.bulk(), &task_handle).await;
         restore_metadata_graph_prune_timer(&context.storage_handle, &task_handle).await;
         restore_notification_prune_timer(&context.storage_handle, &task_handle).await;

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1198,26 +1198,24 @@ impl OperationsTaskHandler {
                 )
                 .await;
             }
-            Ok(_) => {
-                match metadata_materialization_jobs_exist(&bulk.storage_handle).await {
-                    Ok(false) => {}
-                    Ok(true) => {
-                        self.reschedule_timer(
-                            TaskKey::DrainMetadataMaterializationQueue,
-                            METADATA_MATERIALIZATION_POLL_AFTER,
-                        )
-                        .await;
-                    }
-                    Err(error) => {
-                        warn!(task_id = ?TaskKey::DrainMetadataMaterializationQueue, error = ?error, "Failed to probe metadata materialization jobs");
-                        self.reschedule_timer(
-                            TaskKey::DrainMetadataMaterializationQueue,
-                            METADATA_MATERIALIZATION_RETRY_AFTER,
-                        )
-                        .await;
-                    }
+            Ok(_) => match metadata_materialization_jobs_exist(&bulk.storage_handle).await {
+                Ok(false) => {}
+                Ok(true) => {
+                    self.reschedule_timer(
+                        TaskKey::DrainMetadataMaterializationQueue,
+                        METADATA_MATERIALIZATION_POLL_AFTER,
+                    )
+                    .await;
                 }
-            }
+                Err(error) => {
+                    warn!(task_id = ?TaskKey::DrainMetadataMaterializationQueue, error = ?error, "Failed to probe metadata materialization jobs");
+                    self.reschedule_timer(
+                        TaskKey::DrainMetadataMaterializationQueue,
+                        METADATA_MATERIALIZATION_RETRY_AFTER,
+                    )
+                    .await;
+                }
+            },
             Err(error) => {
                 warn!(task_id = ?TaskKey::DrainMetadataMaterializationQueue, error = ?error, "Failed to drain metadata materialization queue");
                 self.reschedule_timer(

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -41,9 +41,9 @@ use crate::jobs::store::release_job;
 use crate::jobs::{JOB_DRAIN_RETRY_AFTER, JOB_PRUNE_POLL_AFTER, JOB_PRUNE_RETRY_AFTER};
 use crate::metadata::materialization_queue::{
     METADATA_MATERIALIZATION_NEXT_BATCH_AFTER, METADATA_MATERIALIZATION_POLL_AFTER,
-    METADATA_MATERIALIZATION_RETRY_AFTER, metadata_materialization_jobs_exist,
-    process_metadata_materialization_batch, requeue_dead_letters,
-    restore_metadata_materialization_timer,
+    METADATA_MATERIALIZATION_RETRY_AFTER, MetadataMaterializationDrainResult,
+    metadata_materialization_jobs_exist, process_metadata_materialization_batch,
+    requeue_dead_letters, restore_metadata_materialization_timer,
 };
 use crate::metadata::projector::{
     METADATA_PROJECTION_RETRY_AFTER, drain_pending_metadata_projection_queue,
@@ -1177,6 +1177,10 @@ impl OperationsTaskHandler {
     fn bulk_context(&self) -> DriverContext {
         let mut context = self.context.as_ref().clone();
         context.storage_handle = context.storage_handle.bulk();
+        context.metadata_handle = context
+            .metadata_handle
+            .as_ref()
+            .map(|metadata_handle| metadata_handle.bulk());
         context
     }
 
@@ -1186,7 +1190,7 @@ impl OperationsTaskHandler {
             Ok(result) if result.has_more_due => {
                 self.reschedule_timer(
                     TaskKey::DrainMetadataMaterializationQueue,
-                    METADATA_MATERIALIZATION_NEXT_BATCH_AFTER,
+                    drain_delay(&result),
                 )
                 .await;
             }
@@ -1803,6 +1807,16 @@ async fn durable_queue_rearm_loop(context: Weak<DriverContext>, task_handle: Tas
     }
 }
 
+// A batch that processed nothing is blocked behind jobs that are not due yet, so
+// it backs off instead of rescanning the same head at batch pace.
+fn drain_delay(result: &MetadataMaterializationDrainResult) -> Duration {
+    if result.processed == 0 {
+        METADATA_MATERIALIZATION_RETRY_AFTER
+    } else {
+        METADATA_MATERIALIZATION_NEXT_BATCH_AFTER
+    }
+}
+
 // Parked materialization jobs come back on their own backoff, so a node that hit
 // the failure cap during a storm converges again without an operator or restart.
 async fn sweep_dead_letters(storage: &aruna_storage::StorageHandle) {
@@ -2027,6 +2041,26 @@ mod tests {
     use ulid::Ulid;
 
     use crate::notifications::outbox::new_notification_outbox_record;
+
+    #[test]
+    fn blocked_batch_waits() {
+        // Nothing processed means the due head is blocked, so the next scan
+        // waits instead of respinning at the 25ms batch pace.
+        let blocked = MetadataMaterializationDrainResult {
+            processed: 0,
+            has_more_due: true,
+            next_due_after: None,
+        };
+        let progressing = MetadataMaterializationDrainResult {
+            processed: 4,
+            ..blocked
+        };
+        assert_eq!(drain_delay(&blocked), METADATA_MATERIALIZATION_RETRY_AFTER);
+        assert_eq!(
+            drain_delay(&progressing),
+            METADATA_MATERIALIZATION_NEXT_BATCH_AFTER
+        );
+    }
 
     struct RecordingTaskHandler {
         seen: mpsc::Sender<TaskKey>,

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -40,9 +40,9 @@ use crate::jobs::runtime::JobsRuntime;
 use crate::jobs::store::release_job;
 use crate::jobs::{JOB_DRAIN_RETRY_AFTER, JOB_PRUNE_POLL_AFTER, JOB_PRUNE_RETRY_AFTER};
 use crate::metadata::materialization_queue::{
-    METADATA_MATERIALIZATION_POLL_AFTER, METADATA_MATERIALIZATION_RETRY_AFTER,
-    metadata_materialization_jobs_exist, process_metadata_materialization_batch,
-    restore_metadata_materialization_timer,
+    METADATA_MATERIALIZATION_NEXT_BATCH_AFTER, METADATA_MATERIALIZATION_POLL_AFTER,
+    METADATA_MATERIALIZATION_RETRY_AFTER, metadata_materialization_jobs_exist,
+    process_metadata_materialization_batch, restore_metadata_materialization_timer,
 };
 use crate::metadata::projector::{
     METADATA_PROJECTION_RETRY_AFTER, drain_pending_metadata_projection_queue,
@@ -1176,7 +1176,7 @@ impl OperationsTaskHandler {
             Ok(result) if result.has_more_due => {
                 self.reschedule_timer(
                     TaskKey::DrainMetadataMaterializationQueue,
-                    std::time::Duration::ZERO,
+                    METADATA_MATERIALIZATION_NEXT_BATCH_AFTER,
                 )
                 .await;
             }

--- a/operations/src/task_incoming.rs
+++ b/operations/src/task_incoming.rs
@@ -1171,8 +1171,17 @@ impl OperationsTaskHandler {
         }
     }
 
+    /// A context whose storage effects dispatch on the bulk lane, so background
+    /// queue draining never starves foreground sync traffic.
+    fn bulk_context(&self) -> DriverContext {
+        let mut context = self.context.as_ref().clone();
+        context.storage_handle = context.storage_handle.bulk();
+        context
+    }
+
     async fn drain_metadata_materialization_queue(&self) {
-        match process_metadata_materialization_batch(&self.context).await {
+        let bulk = self.bulk_context();
+        match process_metadata_materialization_batch(&bulk).await {
             Ok(result) if result.has_more_due => {
                 self.reschedule_timer(
                     TaskKey::DrainMetadataMaterializationQueue,
@@ -1190,7 +1199,7 @@ impl OperationsTaskHandler {
                 .await;
             }
             Ok(_) => {
-                match metadata_materialization_jobs_exist(&self.context.storage_handle).await {
+                match metadata_materialization_jobs_exist(&bulk.storage_handle).await {
                     Ok(false) => {}
                     Ok(true) => {
                         self.reschedule_timer(
@@ -1221,7 +1230,8 @@ impl OperationsTaskHandler {
     }
 
     async fn drain_metadata_graph_prune_queue(&self) {
-        match process_metadata_graph_prune_batch(&self.context).await {
+        let bulk = self.bulk_context();
+        match process_metadata_graph_prune_batch(&bulk).await {
             Ok(result) if result.has_more_due => {
                 self.reschedule_timer(
                     TaskKey::DrainMetadataGraphPruneQueue,
@@ -1238,7 +1248,7 @@ impl OperationsTaskHandler {
                 )
                 .await;
             }
-            Ok(_) => match metadata_graph_prune_jobs_exist(&self.context.storage_handle).await {
+            Ok(_) => match metadata_graph_prune_jobs_exist(&bulk.storage_handle).await {
                 Ok(false) => {}
                 Ok(true) => {
                     self.reschedule_timer(
@@ -1784,7 +1794,7 @@ async fn durable_queue_rearm_loop(context: Weak<DriverContext>, task_handle: Tas
         )
         .await;
         restore_pending_metadata_projection_timer(&context.storage_handle, &task_handle).await;
-        restore_metadata_materialization_timer(&context.storage_handle, &task_handle).await;
+        restore_metadata_materialization_timer(&context.storage_handle.bulk(), &task_handle).await;
         restore_metadata_graph_prune_timer(&context.storage_handle, &task_handle).await;
         restore_notification_prune_timer(&context.storage_handle, &task_handle).await;
         restore_job_queue_timer(&context.storage_handle, &task_handle).await;
@@ -1858,7 +1868,7 @@ async fn initialize_task_handler(
     crate::node_info::restore_node_info_publish_timer(&context.storage_handle, &task_handle).await;
     restore_notification_outbox_timer(&context.storage_handle, &task_handle, Duration::ZERO).await;
     restore_pending_metadata_projection_timer(&context.storage_handle, &task_handle).await;
-    restore_metadata_materialization_timer(&context.storage_handle, &task_handle).await;
+    restore_metadata_materialization_timer(&context.storage_handle.bulk(), &task_handle).await;
     restore_metadata_graph_prune_timer(&context.storage_handle, &task_handle).await;
     restore_notification_prune_timer(&context.storage_handle, &task_handle).await;
     restore_blob_replication_timer(&context.storage_handle, &task_handle).await;

--- a/operations/tests/auth_validation.rs
+++ b/operations/tests/auth_validation.rs
@@ -1,5 +1,6 @@
 use aruna_core::UserId;
 use aruna_core::auth::bearer_token_hash;
+use aruna_core::keys::generate_signing_key;
 use aruna_core::structs::{RealmId, TokenClaims};
 use aruna_operations::auth::{
     ArunaBearerTokenError, ArunaBearerTokenValidationState, validate_aruna_bearer_token,
@@ -187,8 +188,7 @@ fn realm_fixture() -> (SigningKey, RealmId, UserId) {
 }
 
 fn signing_key() -> SigningKey {
-    let mut rng = jsonwebtoken::signature::rand_core::OsRng;
-    SigningKey::generate(&mut rng)
+    generate_signing_key()
 }
 
 fn trusted_state(realm_id: RealmId) -> TestAuthState {

--- a/operations/tests/metadata_create_concurrency.rs
+++ b/operations/tests/metadata_create_concurrency.rs
@@ -1,0 +1,91 @@
+//! Regression coverage for parallel metadata creates in one realm.
+
+use std::sync::Arc;
+
+use aruna_core::UserId;
+use aruna_core::structs::{Actor, RealmId};
+use aruna_operations::create_metadata_document::{
+    CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
+    create_metadata_document,
+};
+use aruna_operations::driver::DriverContext;
+use aruna_operations::metadata::MetadataHandle;
+use aruna_storage::FjallStorage;
+use ulid::Ulid;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+const CONCURRENT_CREATES: usize = 8;
+
+fn scaffold(index: usize) -> CreateMetadataDocumentPayload {
+    CreateMetadataDocumentPayload::Scaffold {
+        name: format!("Concurrent Dataset {index}"),
+        description: "Concurrent create regression".to_string(),
+        date_published: "2026-07-24".to_string(),
+        license: Some("https://creativecommons.org/licenses/by/4.0/".to_string()),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_creates_succeed() -> Result<(), BoxError> {
+    // Parallel creates in one realm must not raise transaction conflicts now
+    // that the unchanged realm-config write-back is gone.
+    let temp_dir = tempfile::tempdir()?;
+    let storage = FjallStorage::open(
+        temp_dir
+            .path()
+            .join("fjall")
+            .to_str()
+            .ok_or("invalid storage path")?,
+    )?;
+    let node_id = iroh::SecretKey::generate().public();
+    let metadata_handle = MetadataHandle::new(
+        temp_dir.path().join("metadata"),
+        node_id,
+        storage.clone(),
+        None,
+        None,
+        None,
+    )?;
+    let context = Arc::new(DriverContext {
+        storage_handle: storage.clone(),
+        net_handle: None,
+        blob_handle: None,
+        metadata_handle: Some(metadata_handle),
+        task_handle: None,
+        compute_handle: None,
+    });
+
+    let realm_id = RealmId([61u8; 32]);
+    let group_id = Ulid::generate();
+    let mut handles = Vec::with_capacity(CONCURRENT_CREATES);
+    for index in 0..CONCURRENT_CREATES {
+        let context = context.clone();
+        handles.push(tokio::spawn(async move {
+            let document_id = Ulid::generate();
+            let operation = CreateMetadataDocumentOperation::new_for_generated_document_id(
+                CreateMetadataDocumentConfig {
+                    actor: Actor {
+                        node_id,
+                        user_id: UserId::local(Ulid::generate(), realm_id),
+                        realm_id,
+                    },
+                    group_id,
+                    document_id,
+                    document_path: format!("datasets/concurrent-{index}"),
+                    public: true,
+                    payload: scaffold(index),
+                },
+            );
+            create_metadata_document(operation, context).await
+        }));
+    }
+
+    for handle in handles {
+        handle
+            .await?
+            .map_err(|error| format!("concurrent create failed: {error:?}"))?;
+    }
+    assert_eq!(storage.snapshot_metrics().conflicts_total, 0);
+    Ok(())
+}

--- a/operations/tests/metadata_create_concurrency.rs
+++ b/operations/tests/metadata_create_concurrency.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use aruna_core::UserId;
-use aruna_core::structs::{Actor, RealmId};
+use aruna_core::effects::StorageEffect;
+use aruna_core::keyspaces::REALM_CONFIG_KEYSPACE;
+use aruna_core::structs::{Actor, RealmConfigDocument, RealmId};
 use aruna_operations::create_metadata_document::{
     CreateMetadataDocumentConfig, CreateMetadataDocumentOperation, CreateMetadataDocumentPayload,
     create_metadata_document,
@@ -58,6 +60,23 @@ async fn concurrent_creates_succeed() -> Result<(), BoxError> {
 
     let realm_id = RealmId([61u8; 32]);
     let group_id = Ulid::generate();
+    // The realm config must exist: the conflict this guards against came from
+    // creates writing it back, which only happened when the row was present.
+    let seed_actor = Actor {
+        node_id,
+        user_id: UserId::local(Ulid::generate(), realm_id),
+        realm_id,
+    };
+    let realm_config = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+    storage
+        .send_storage_effect(StorageEffect::Write {
+            key_space: REALM_CONFIG_KEYSPACE.to_string(),
+            key: (*realm_id.as_bytes()).into(),
+            value: realm_config.to_bytes(&seed_actor)?.into(),
+            txn_id: None,
+        })
+        .await;
+
     let mut handles = Vec::with_capacity(CONCURRENT_CREATES);
     for index in 0..CONCURRENT_CREATES {
         let context = context.clone();

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -347,10 +347,10 @@ async fn generated_metadata_create_foreground_storage_effect_count_is_reduced()
         .requests_total;
 
     assert_eq!(created.record.document_id, document_id);
-    // Realm config read (outside the transaction so it cannot conflict), start,
-    // fence read, atomic event/fence write, and commit; a generated id still
-    // skips the existing-document read a client-supplied id needs.
-    assert_eq!(after - before, 5);
+    // Transaction start, the fence read of acceptance, path and realm config,
+    // the atomic event/fence write, and commit; a generated id still skips the
+    // existing-document read a client-supplied id needs.
+    assert_eq!(after - before, 4);
     Ok(())
 }
 

--- a/operations/tests/metadata_crud.rs
+++ b/operations/tests/metadata_crud.rs
@@ -347,9 +347,10 @@ async fn generated_metadata_create_foreground_storage_effect_count_is_reduced()
         .requests_total;
 
     assert_eq!(created.record.document_id, document_id);
-    // Transaction start, realm config read, atomic event/fence write, and commit;
-    // a generated id still skips the existing-document read a client-supplied id needs.
-    assert_eq!(after - before, 4);
+    // Realm config read (outside the transaction so it cannot conflict), start,
+    // fence read, atomic event/fence write, and commit; a generated id still
+    // skips the existing-document read a client-supplied id needs.
+    assert_eq!(after - before, 5);
     Ok(())
 }
 

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -1,3 +1,4 @@
+use aruna_core::keys::generate_signing_key;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -478,7 +479,7 @@ struct Realm {
 
 impl Realm {
     fn new() -> Self {
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
         Self {
             realm_id,

--- a/operations/tests/metadata_materialization_recovery.rs
+++ b/operations/tests/metadata_materialization_recovery.rs
@@ -155,7 +155,13 @@ async fn raw_projection_diverges() -> Result<(), Box<dyn std::error::Error>> {
         node_b.graph_fingerprint(&graph)?
     );
     let mut projected_names = node_a
-        .describe_subject(&GrantAuthorizer::default(), &graph, "#lab")?
+        .describe_subject(
+            &GrantAuthorizer::default(),
+            craqle::DescribeRequest {
+                graph: &graph,
+                subject_id: "#lab",
+            },
+        )?
         .iter()
         .filter_map(|(predicate, object)| {
             (predicate == &craqle::EncodedTerm::from_named_node(&craqle::vocab::schema_name()))

--- a/operations/tests/metadata_materialization_recovery.rs
+++ b/operations/tests/metadata_materialization_recovery.rs
@@ -292,6 +292,7 @@ async fn final_status_with_leftover_job_is_cleaned_without_reapply()
         dataset_digest: None,
         state: MetadataMaterializationState::Materialized,
         attempts: 1,
+        failures: 0,
         last_error: None,
         updated_at_ms: 2,
     };

--- a/operations/tests/metadata_materialization_recovery.rs
+++ b/operations/tests/metadata_materialization_recovery.rs
@@ -13,8 +13,9 @@ use aruna_core::metadata::{
     resolve_raw_revision,
 };
 use aruna_core::storage_entries::{
-    metadata_create_event_write_entry, metadata_materialization_job_write_entry,
-    metadata_materialization_status_key, metadata_materialization_status_write_entry,
+    metadata_create_event_write_entry, metadata_materialization_document_job_write_entry,
+    metadata_materialization_job_write_entry, metadata_materialization_status_key,
+    metadata_materialization_status_write_entry,
 };
 use aruna_core::structs::{Actor, MetadataRegistryRecord, PlacementRef, RealmId};
 use aruna_operations::driver::DriverContext;
@@ -244,6 +245,7 @@ async fn crash_after_craqle_apply_before_finish_retries_idempotently()
             metadata_create_event_write_entry(&event)?,
             metadata_materialization_status_write_entry(&status)?,
             metadata_materialization_job_write_entry(&job)?,
+            metadata_materialization_document_job_write_entry(&job)?,
         ],
     )
     .await?;
@@ -298,13 +300,16 @@ async fn final_status_with_leftover_job_is_cleaned_without_reapply()
         vec![
             metadata_materialization_status_write_entry(&final_status)?,
             metadata_materialization_job_write_entry(&job)?,
+            metadata_materialization_document_job_write_entry(&job)?,
         ],
     )
     .await?;
 
     let drained = process_metadata_materialization_batch(test.context.as_ref()).await?;
 
-    assert_eq!(drained.processed, 1);
+    // The final status obsoletes the leftover job, so the scan prunes it as
+    // not-live rather than reapplying: nothing is processed, both rows go.
+    assert_eq!(drained.processed, 0);
     assert_eq!(job_count(&test.context.storage_handle).await?, 0);
     assert_eq!(
         read_status(&test.context.storage_handle, document_id).await?,

--- a/operations/tests/metadata_query_concurrency.rs
+++ b/operations/tests/metadata_query_concurrency.rs
@@ -483,6 +483,66 @@ async fn search_honors_explicit_graph_filter_before_visible_limit() -> Result<()
     Ok(())
 }
 
+async fn replay_crate(harness: &TestHarness, graph_iri: &str, name: &str) -> Result<(), BoxError> {
+    let event = harness
+        .handle
+        .send_metadata_effect(MetadataEffect::CreateCrate {
+            request: MetadataCreateCrateRequest {
+                graph_iri: graph_iri.to_string(),
+                name: name.to_string(),
+                description: format!("Crate graph {name}"),
+                date_published: "2026-01-01".to_string(),
+                license: None,
+                policy: MetadataGraphPolicy {
+                    public: true,
+                    permission_paths: Vec::new(),
+                },
+                durability: MetadataRequestDurability::WalAlreadyDurable,
+                deterministic_actor: None,
+            },
+        })
+        .await;
+    match event {
+        Event::Metadata(MetadataEvent::CreateCrateResult { .. }) => Ok(()),
+        other => Err(format!("replay crate failed: {other:?}").into()),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn query_cache_invalidates() -> Result<(), BoxError> {
+    // The second crate replays an already-durable write: it skips the
+    // lifecycle read and never advances the visibility generation, so only the
+    // apply counter can invalidate the cached result.
+    let harness = build_harness(None).await?;
+    let graphs = [0usize, 1]
+        .map(|index| format!("https://w3id.org/aruna/bench-{index:04}"))
+        .to_vec();
+    let records = graphs
+        .iter()
+        .enumerate()
+        .map(|(index, graph_iri)| registry_record(harness.group_id, index, Some(graph_iri.clone())))
+        .collect::<Vec<_>>();
+    write_registry_records(&harness, &records).await?;
+    create_crate(&harness, &graphs[0], &crate_name(0)).await?;
+
+    let first = query_names(&harness).await?;
+    assert!(
+        names_contain(&first, 0),
+        "cold query missed the first crate"
+    );
+    assert!(!names_contain(&first, 1), "second crate exists too early");
+    assert_eq!(query_names(&harness).await?, first, "repeat query diverged");
+
+    replay_crate(&harness, &graphs[1], &crate_name(1)).await?;
+    let second = query_names(&harness).await?;
+    assert!(
+        names_contain(&second, 1),
+        "cached result survived a graph mutation"
+    );
+    assert!(names_contain(&second, 0), "first crate vanished");
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn lazy_visibility_matches_eager_query_and_search_semantics() -> Result<(), BoxError> {
     let harness = build_harness(None).await?;

--- a/operations/tests/rocrate_drivers.rs
+++ b/operations/tests/rocrate_drivers.rs
@@ -57,6 +57,10 @@ use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use ulid::Ulid;
 
+const ELABFTW: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/fixtures/eln/elabftw.eln"
+));
 const BUCKET: &str = "rocrate-target";
 const TARGET_KEY: &str = "imported/data.txt";
 const SOURCE_KEY: &str = "sources/crate.zip";
@@ -166,6 +170,114 @@ async fn drivers_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
     archive.by_name("data.txt")?.read_to_end(&mut payload)?;
     assert_eq!(payload, PAYLOAD);
     assert!(archive.by_name("ro-crate-metadata.json").is_ok());
+
+    fixture.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn imports_eln_export() -> Result<(), Box<dyn std::error::Error>> {
+    // The eLabFTW export identifies its folders and files with literal spaces.
+    let fixture = build_fixture(false).await?;
+    let document_id = Ulid::generate();
+    let upload_id = upload_media(&fixture, ELABFTW.to_vec(), RoCrateMediaType::Eln).await?;
+    let spec = import_spec(&fixture, upload_id, document_id);
+    let job_id = JobId::new();
+    let context = claim_context(&fixture, job_id, JobPayload::ImportRoCrate(spec.clone())).await?;
+    let result = match run_rocrate_import(&context, &spec).await {
+        JobRunOutcome::Succeeded(JobResultPayload::ImportRoCrate(result)) => result,
+        JobRunOutcome::Failed(error) => {
+            return Err(format!("eln import failed: {}", error.message).into());
+        }
+        _ => return Err("eln import did not finish".into()),
+    };
+    assert_eq!(result.entries_total, 3);
+    assert_eq!(result.imported, 2);
+    assert_eq!(result.unlisted, 1);
+    assert_eq!(result.document_id, Some(document_id));
+    assert_eq!(
+        object_versions(
+            &fixture,
+            "imported/Demo - Gold-master-experiment - 4af4da4e/example.jpg"
+        )
+        .await?
+        .len(),
+        1
+    );
+    assert_eq!(
+        replay_metadata_event_log(fixture.context.as_ref()).await?,
+        1
+    );
+    assert_eq!(
+        process_metadata_materialization_batch(fixture.context.as_ref())
+            .await?
+            .processed,
+        1
+    );
+
+    fixture.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn imports_nested_folders() -> Result<(), Box<dyn std::error::Error>> {
+    // Mirrors an ELN export: wrapper directory, doubled separator, spaced ids.
+    let fixture = build_fixture(false).await?;
+    let document_id = Ulid::generate();
+    let upload_id = upload_media(&fixture, nested_eln().await?, RoCrateMediaType::Eln).await?;
+    let spec = import_spec(&fixture, upload_id, document_id);
+    let job_id = JobId::new();
+    let context = claim_context(&fixture, job_id, JobPayload::ImportRoCrate(spec.clone())).await?;
+    let result = match run_rocrate_import(&context, &spec).await {
+        JobRunOutcome::Succeeded(JobResultPayload::ImportRoCrate(result)) => result,
+        JobRunOutcome::Failed(error) => {
+            return Err(format!("nested import failed: {}", error.message).into());
+        }
+        _ => return Err("nested import did not finish".into()),
+    };
+    assert_eq!(result.imported, 1);
+    assert_eq!(result.unlisted, 1);
+    assert_eq!(
+        object_versions(&fixture, "imported/Demo - Experiment - abc123/example.txt")
+            .await?
+            .len(),
+        1
+    );
+    assert_eq!(
+        replay_metadata_event_log(fixture.context.as_ref()).await?,
+        1
+    );
+    assert_eq!(
+        process_metadata_materialization_batch(fixture.context.as_ref())
+            .await?
+            .processed,
+        1
+    );
+
+    fixture.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn imports_mixed_encoding() -> Result<(), Box<dyn std::error::Error>> {
+    // One entity is encoded and referenced literally; the other is the reverse.
+    let fixture = build_fixture(false).await?;
+    let document_id = Ulid::generate();
+    let upload_id = create_upload(&fixture, mixed_archive().await?).await?;
+    let spec = import_spec(&fixture, upload_id, document_id);
+    let job_id = JobId::new();
+    let context = claim_context(&fixture, job_id, JobPayload::ImportRoCrate(spec.clone())).await?;
+    let result = match run_rocrate_import(&context, &spec).await {
+        JobRunOutcome::Succeeded(JobResultPayload::ImportRoCrate(result)) => result,
+        JobRunOutcome::Failed(error) => {
+            return Err(format!("mixed-encoding import failed: {}", error.message).into());
+        }
+        _ => return Err("mixed-encoding import did not finish".into()),
+    };
+    assert_eq!(result.imported, 2);
+    for key in ["imported/data/a b.txt", "imported/data/c d.txt"] {
+        assert_eq!(object_versions(&fixture, key).await?.len(), 1, "{key}");
+    }
 
     fixture.stop().await;
     Ok(())
@@ -1133,6 +1245,14 @@ async fn create_upload(
     fixture: &Fixture,
     archive: Vec<u8>,
 ) -> Result<Ulid, Box<dyn std::error::Error>> {
+    upload_media(fixture, archive, RoCrateMediaType::Zip).await
+}
+
+async fn upload_media(
+    fixture: &Fixture,
+    archive: Vec<u8>,
+    media_type: RoCrateMediaType,
+) -> Result<Ulid, Box<dyn std::error::Error>> {
     let upload_id = Ulid::generate();
     let size = archive.len() as u64;
     let blob = BackendStream::<Result<Bytes, StreamError>>::new(stream::once(async move {
@@ -1165,7 +1285,7 @@ async fn create_upload(
         location,
         blake3,
         size: stored_size,
-        media_type: RoCrateMediaType::Zip,
+        media_type,
         expires_at_ms: unix_timestamp_millis().saturating_add(60_000),
         claimed_by: None,
     };
@@ -1470,6 +1590,105 @@ fn pair_json() -> String {
         ]
     })
     .to_string()
+}
+
+fn nested_json() -> String {
+    let folder = "./Demo - Experiment - abc123/";
+    serde_json::json!({
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+                "about": {"@id": "./"}
+            },
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "name": "Nested fixture",
+                "description": "Folder datasets carrying spaces",
+                "datePublished": "2026-07-27",
+                "hasPart": [{"@id": folder}, {"@id": "./ -  - bb8b469d/"}]
+            },
+            {
+                "@id": folder,
+                "@type": "Dataset",
+                "name": "Experiment",
+                "hasPart": [{"@id": format!("{folder}example.txt")}]
+            },
+            {"@id": "./ -  - bb8b469d/", "@type": "Dataset", "name": "Untitled"},
+            {"@id": format!("{folder}example.txt"), "@type": "File", "name": "Example"}
+        ]
+    })
+    .to_string()
+}
+
+async fn nested_eln() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let wrapper = "2026-07-27-export";
+    let mut archive = async_zip::base::write::ZipFileWriter::new(Vec::new());
+    for (name, bytes) in [
+        (
+            format!("{wrapper}/ro-crate-metadata.json"),
+            nested_json().into_bytes(),
+        ),
+        (
+            // Exports in the wild double the separator after the folder name.
+            format!("{wrapper}/Demo - Experiment - abc123//example.txt"),
+            PAYLOAD.to_vec(),
+        ),
+        (
+            format!("{wrapper}/ro-crate-preview.html"),
+            b"<html></html>".to_vec(),
+        ),
+    ] {
+        archive
+            .write_entry_whole(
+                ZipEntryBuilder::new(name.into(), Compression::Deflate),
+                &bytes,
+            )
+            .await?;
+    }
+    Ok(archive.close().await?)
+}
+
+async fn mixed_archive() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let json = serde_json::json!({
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+                "about": {"@id": "./"}
+            },
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "name": "Mixed fixture",
+                "description": "Identifiers and references disagree on encoding",
+                "datePublished": "2026-07-27",
+                "hasPart": [{"@id": "./data/a%20b.txt"}, {"@id": "./data/c d.txt"}]
+            },
+            {"@id": "./data/a b.txt", "@type": "File", "name": "Literal"},
+            {"@id": "./data/c%20d.txt", "@type": "File", "name": "Encoded"}
+        ]
+    })
+    .to_string();
+    let mut archive = async_zip::base::write::ZipFileWriter::new(Vec::new());
+    for (name, bytes) in [
+        ("ro-crate-metadata.json", json.into_bytes()),
+        ("data/a b.txt", PAYLOAD.to_vec()),
+        ("data/c d.txt", PAYLOAD.to_vec()),
+    ] {
+        archive
+            .write_entry_whole(
+                ZipEntryBuilder::new(name.to_string().into(), Compression::Deflate),
+                &bytes,
+            )
+            .await?;
+    }
+    Ok(archive.close().await?)
 }
 
 async fn pair_archive() -> Result<Vec<u8>, Box<dyn std::error::Error>> {

--- a/operations/tests/rocrate_drivers.rs
+++ b/operations/tests/rocrate_drivers.rs
@@ -896,7 +896,8 @@ fn storage_proxy(
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    let (storage, receiver) = StorageHandle::new();
+    let (storage, receivers) = StorageHandle::new();
+    let receiver = receivers.foreground;
     let (hit_sender, hit) = oneshot::channel();
     let (release, release_receiver) = mpsc::channel();
     let stop = Arc::new(AtomicBool::new(false));

--- a/operations/tests/rocrate_drivers.rs
+++ b/operations/tests/rocrate_drivers.rs
@@ -7,9 +7,11 @@ use std::time::{Duration, SystemTime};
 
 use aruna_blob::blob::BlobHandler;
 use aruna_core::effects::{BlobEffect, StorageEffect};
+use aruna_core::errors::StorageError;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::{
     AUTH_KEYSPACE, BLOB_VERSIONS_KEYSPACE, REALM_CONFIG_KEYSPACE, ROCRATE_UPLOAD_KEYSPACE,
+    S3_BUCKET_KEYSPACE,
 };
 use aruna_core::stream::{BackendStream, StreamError};
 use aruna_core::structs::{
@@ -80,6 +82,7 @@ struct StorageGate {
     hit: Option<oneshot::Receiver<()>>,
     release: mpsc::Sender<()>,
     stop: Arc<AtomicBool>,
+    faulty: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
 }
 
@@ -99,6 +102,12 @@ impl StorageGate {
 
     fn release(&self) {
         self.release.send(()).expect("version gate releases");
+    }
+
+    /// Make every bucket lookup fail, which is what an interrupted cleanup
+    /// looks like from inside the import.
+    fn fail_buckets(&self, faulty: bool) {
+        self.faulty.store(faulty, Ordering::Release);
     }
 
     async fn stop(&mut self) {
@@ -355,6 +364,97 @@ async fn rollback_removes_writes() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("first entry report row is missing")?;
     assert_eq!(first.code, ReasonCode::Failed);
     assert_eq!(first.detail.arn, None);
+    assert_eq!(first.detail.version_id, None);
+
+    fixture.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn resumes_pending_rollback() -> Result<(), Box<dyn std::error::Error>> {
+    // A run that dies inside cleanup leaves written versions behind, so the
+    // resumed run must load the plan and roll them back.
+    let mut fixture = build_fixture(true).await?;
+    let document_id = Ulid::generate();
+    let upload_id = create_upload(&fixture, pair_archive().await?).await?;
+    let spec = import_spec(&fixture, upload_id, document_id);
+    let job_id = JobId::new();
+    let mut first_context =
+        claim_context(&fixture, job_id, JobPayload::ImportRoCrate(spec.clone())).await?;
+    first_context.final_attempt = true;
+    let first_token = first_context.claim_token;
+    let mut first_run = tokio::spawn({
+        let spec = spec.clone();
+        async move { run_rocrate_import(&first_context, &spec).await }
+    });
+    let mut hit = fixture.gate.as_mut().expect("gated fixture").take_hit();
+
+    let gate_result = tokio::time::timeout(Duration::from_secs(30), async {
+        tokio::select! {
+            result = &mut first_run => Err(format!(
+                "import ended before the committed version gate: {}",
+                run_name(result)
+            )),
+            result = &mut hit => {
+                result.map_err(|error| error.to_string())?;
+                Ok(())
+            }
+        }
+    })
+    .await
+    .map_err(|_| "import did not reach the committed version gate")?;
+    gate_result?;
+
+    // Break every bucket lookup once the first payload is committed: the next
+    // write fails, and the rollback that follows cannot finish either.
+    let gate = fixture.gate.as_ref().expect("gated fixture");
+    gate.fail_buckets(true);
+    gate.release();
+    let JobRunOutcome::Failed(interrupted) = first_run.await? else {
+        return Err("import with an unreadable bucket did not fail".into());
+    };
+    assert!(
+        interrupted.message.contains("rollback cannot read bucket"),
+        "{}",
+        interrupted.message
+    );
+    assert_eq!(
+        object_versions(&fixture, "imported/data1.txt").await?.len(),
+        1,
+        "the interrupted cleanup must leave its write in place"
+    );
+    gate.fail_buckets(false);
+
+    release_job(
+        &fixture.context.storage_handle,
+        job_id,
+        first_token,
+        unix_timestamp_millis(),
+    )
+    .await?;
+    let second_context =
+        claim_context(&fixture, job_id, JobPayload::ImportRoCrate(spec.clone())).await?;
+
+    let JobRunOutcome::Failed(error) = run_rocrate_import(&second_context, &spec).await else {
+        return Err("resumed cleanup did not fail the import".into());
+    };
+
+    assert!(
+        error.message.contains("1 written object was removed"),
+        "{}",
+        error.message
+    );
+    assert!(
+        object_versions(&fixture, "imported/data1.txt")
+            .await?
+            .is_empty()
+    );
+    let rows = read_rows(&fixture, job_id).await?;
+    let first = rows
+        .iter()
+        .find(|row| row.entry_key == "data1.txt")
+        .ok_or("first entry report row is missing")?;
+    assert_eq!(first.code, ReasonCode::Failed);
     assert_eq!(first.detail.version_id, None);
 
     fixture.stop().await;
@@ -1092,12 +1192,20 @@ fn storage_proxy(
     let (release, release_receiver) = mpsc::channel();
     let stop = Arc::new(AtomicBool::new(false));
     let thread_stop = stop.clone();
+    let faulty = Arc::new(AtomicBool::new(false));
+    let thread_faulty = faulty.clone();
     let thread = std::thread::Builder::new()
         .name("rocrate-storage-gate".to_string())
         .spawn(move || {
             let mut version_transaction = None;
             let mut hit_sender = Some(hit_sender);
             while let Ok((effect, response, _span, _queued, _in_flight)) = receiver.recv() {
+                if thread_faulty.load(Ordering::Acquire) && bucket_read(&effect) {
+                    response.send(StorageEvent::Error {
+                        error: StorageError::ReadError,
+                    });
+                    continue;
+                }
                 if let Some(transaction) = version_txn(&effect) {
                     version_transaction = Some(transaction);
                 }
@@ -1137,9 +1245,17 @@ fn storage_proxy(
             hit: Some(hit),
             release,
             stop,
+            faulty,
             thread: Some(thread),
         },
     ))
+}
+
+fn bucket_read(effect: &StorageEffect) -> bool {
+    matches!(
+        effect,
+        StorageEffect::Read { key_space, .. } if key_space == S3_BUCKET_KEYSPACE
+    )
 }
 
 fn version_txn(effect: &StorageEffect) -> Option<Ulid> {

--- a/operations/tests/rocrate_drivers.rs
+++ b/operations/tests/rocrate_drivers.rs
@@ -284,6 +284,84 @@ async fn imports_mixed_encoding() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
+async fn rejects_before_writes() -> Result<(), Box<dyn std::error::Error>> {
+    // An unreachable file entity must fail the job without touching the bucket.
+    let fixture = build_fixture(false).await?;
+    let document_id = Ulid::generate();
+    let upload_id = create_upload(&fixture, orphan_archive().await?).await?;
+    let spec = import_spec(&fixture, upload_id, document_id);
+    let job_id = JobId::new();
+    let context = claim_context(&fixture, job_id, JobPayload::ImportRoCrate(spec.clone())).await?;
+    let JobRunOutcome::Failed(error) = run_rocrate_import(&context, &spec).await else {
+        return Err("orphaned crate was imported".into());
+    };
+    assert!(
+        error.message.contains("no objects were written"),
+        "{}",
+        error.message
+    );
+    assert!(object_versions(&fixture, TARGET_KEY).await?.is_empty());
+    let rows = read_rows(&fixture, job_id).await?;
+    assert!(rows.iter().all(|row| row.detail.arn.is_none()));
+    assert!(rows.iter().any(|row| {
+        row.detail
+            .validation
+            .as_ref()
+            .is_some_and(|violation| violation.code == "orphaned_data_entity")
+    }));
+
+    fixture.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn rollback_removes_writes() -> Result<(), Box<dyn std::error::Error>> {
+    // The second payload fails its checksum after the first one has landed.
+    let fixture = build_fixture(false).await?;
+    let existing = put_object(&fixture, "imported/data1.txt", b"kept".to_vec()).await?;
+    let mut archive = pair_archive().await?;
+    let local = zip_offsets(&archive, b"PK\x03\x04")[2];
+    let central = zip_offsets(&archive, b"PK\x01\x02")[2];
+    write_u32(&mut archive, local + 14, 0);
+    write_u32(&mut archive, central + 16, 0);
+    let document_id = Ulid::generate();
+    let upload_id = create_upload(&fixture, archive).await?;
+    let spec = import_spec(&fixture, upload_id, document_id);
+    let job_id = JobId::new();
+    let context = claim_context(&fixture, job_id, JobPayload::ImportRoCrate(spec.clone())).await?;
+
+    let JobRunOutcome::Failed(error) = run_rocrate_import(&context, &spec).await else {
+        return Err("checksum mismatch did not fail the import".into());
+    };
+
+    assert!(
+        error.message.contains("1 written object was removed"),
+        "{}",
+        error.message
+    );
+    assert_eq!(
+        object_versions(&fixture, "imported/data1.txt").await?,
+        vec![existing.version_id]
+    );
+    assert!(
+        object_versions(&fixture, "imported/data2.txt")
+            .await?
+            .is_empty()
+    );
+    let rows = read_rows(&fixture, job_id).await?;
+    let first = rows
+        .iter()
+        .find(|row| row.entry_key == "data1.txt")
+        .ok_or("first entry report row is missing")?;
+    assert_eq!(first.code, ReasonCode::Failed);
+    assert_eq!(first.detail.arn, None);
+    assert_eq!(first.detail.version_id, None);
+
+    fixture.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn report_rows_coexist() -> Result<(), Box<dyn std::error::Error>> {
     let fixture = build_fixture(false).await?;
     let payload_path = "signature/ro-crate-metadata.json.minisig";
@@ -425,7 +503,7 @@ async fn rejects_directory_limit() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(
         message,
-        format!("ZIP central directory exceeds limit {directory_limit}")
+        format!("ZIP central directory exceeds limit {directory_limit}; no objects were written")
     );
     fixture.stop().await;
     Ok(())
@@ -1689,6 +1767,35 @@ async fn mixed_archive() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
             .await?;
     }
     Ok(archive.close().await?)
+}
+
+async fn orphan_archive() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let json = serde_json::json!({
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+                "about": {"@id": "./"}
+            },
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "name": "Orphan fixture",
+                "description": "The root never mentions its file",
+                "datePublished": "2026-07-27"
+            },
+            {"@id": "data.txt", "@type": "File", "name": "Unreachable"}
+        ]
+    })
+    .to_string();
+    custom_archive(
+        json,
+        ZipEntryBuilder::new("data.txt".to_string().into(), Compression::Deflate),
+        false,
+    )
+    .await
 }
 
 async fn pair_archive() -> Result<Vec<u8>, Box<dyn std::error::Error>> {

--- a/operations/tests/topology/mod.rs
+++ b/operations/tests/topology/mod.rs
@@ -17,6 +17,7 @@
 
 #![allow(dead_code)]
 
+use aruna_core::keys::generate_signing_key;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -113,7 +114,7 @@ impl Topology {
              management={management} replication_factor={replication_factor}"
         );
 
-        let signing_key = SigningKey::generate(&mut jsonwebtoken::signature::rand_core::OsRng);
+        let signing_key = generate_signing_key();
         let realm_id = RealmId::from_bytes(signing_key.verifying_key().to_bytes());
         let user_id = UserId::local(Ulid::generate(), realm_id);
 

--- a/scripts/compute-helper/src/main.rs
+++ b/scripts/compute-helper/src/main.rs
@@ -6,6 +6,9 @@ use std::path::{Component, Path, PathBuf};
 const MAX_TRANSFER_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 /// Bounds one output listing well above the caller's match limit.
 const MAX_LISTED_FILES: u64 = 100_000;
+/// Mirrors the listing bound the caller reads with, so an oversized listing
+/// fails here instead of being cut short in transit.
+const MAX_LISTING_BYTES: u64 = 16 * 1024 * 1024;
 
 fn main() {
     if let Err(error) = run() {
@@ -146,8 +149,9 @@ fn fetch_archive(workspace: &Path, path: &str, writer: impl Write) -> io::Result
 }
 
 /// Emit every regular file below `prefix` as a NUL-terminated absolute
-/// container path. Symlinks are skipped, so a listing stays inside the
-/// workspace; the caller applies the output pattern.
+/// container path, then an empty record and the decimal path count. The
+/// terminator lets the caller reject a listing that was cut short; symlinks are
+/// skipped, so a listing stays inside the workspace.
 fn list_files(workspace: &Path, prefix: &str, mut writer: impl Write) -> io::Result<()> {
     use std::os::unix::ffi::OsStrExt;
 
@@ -155,6 +159,8 @@ fn list_files(workspace: &Path, prefix: &str, mut writer: impl Write) -> io::Res
     let root = workspace.canonicalize()?;
     let mut pending = vec![root.join(&relative)];
     let mut listed = 0u64;
+    // Starts at the widest terminator record so it always fits under the bound.
+    let mut written = 32u64;
     while let Some(directory) = pending.pop() {
         let entries = match std::fs::read_dir(&directory) {
             Ok(entries) => entries,
@@ -182,11 +188,21 @@ fn list_files(workspace: &Path, prefix: &str, mut writer: impl Write) -> io::Res
             let relative = path
                 .strip_prefix(&root)
                 .map_err(|_| io::Error::other("listing escaped workspace"))?;
+            let bytes = relative.as_os_str().as_bytes();
+            written = written
+                .checked_add(bytes.len() as u64 + 2)
+                .ok_or_else(|| io::Error::other("listing size overflows"))?;
+            if written > MAX_LISTING_BYTES {
+                return Err(io::Error::other("listing byte limit exceeded"));
+            }
             writer.write_all(b"/")?;
-            writer.write_all(relative.as_os_str().as_bytes())?;
+            writer.write_all(bytes)?;
             writer.write_all(&[0])?;
         }
     }
+    writer.write_all(&[0])?;
+    writer.write_all(listed.to_string().as_bytes())?;
+    writer.write_all(&[0])?;
     writer.flush()
 }
 
@@ -374,9 +390,16 @@ mod tests {
         let mut listed = Vec::new();
         list_files(&workspace, "/out", &mut listed).unwrap();
 
-        let mut paths: Vec<_> = listed
+        // The stream ends with an empty record and the decimal path count.
+        let mut records: Vec<&[u8]> = listed
+            .strip_suffix(&[0])
+            .expect("listing ends with the terminator")
             .split(|byte| *byte == 0)
-            .filter(|path| !path.is_empty())
+            .collect();
+        assert_eq!(records.pop(), Some(&b"2"[..]));
+        assert_eq!(records.pop(), Some(&b""[..]));
+        let mut paths: Vec<_> = records
+            .into_iter()
             .map(|path| String::from_utf8(path.to_vec()).unwrap())
             .collect();
         paths.sort();
@@ -385,7 +408,7 @@ mod tests {
         // A missing prefix directory lists nothing instead of failing.
         let mut empty = Vec::new();
         list_files(&workspace, "/absent", &mut empty).unwrap();
-        assert!(empty.is_empty());
+        assert_eq!(empty, b"\x000\x00");
     }
 
     #[test]

--- a/scripts/compute-helper/src/main.rs
+++ b/scripts/compute-helper/src/main.rs
@@ -4,6 +4,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 
 const MAX_TRANSFER_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+/// Bounds one output listing well above the caller's match limit.
+const MAX_LISTED_FILES: u64 = 100_000;
 
 fn main() {
     if let Err(error) = run() {
@@ -22,6 +24,7 @@ fn run() -> Result<(), String> {
     match command.as_str() {
         "stage" => stage_command(&arguments),
         "fetch" => fetch_command(&arguments),
+        "list" => list_command(&arguments),
         "probe" => probe_command(&arguments),
         _ => Err(format!("unknown helper command `{command}`")),
     }
@@ -40,6 +43,13 @@ fn fetch_command(arguments: &[std::ffi::OsString]) -> Result<(), String> {
     let path = required_value(arguments, "--path")?;
     fetch_archive(&workspace, &path, io::stdout().lock())
         .map_err(|error| format!("fetch failed: {error}"))
+}
+
+fn list_command(arguments: &[std::ffi::OsString]) -> Result<(), String> {
+    let workspace = required_path(arguments, "--workspace")?;
+    let prefix = required_value(arguments, "--prefix")?;
+    list_files(&workspace, &prefix, io::stdout().lock())
+        .map_err(|error| format!("list failed: {error}"))
 }
 
 fn probe_command(arguments: &[std::ffi::OsString]) -> Result<(), String> {
@@ -133,6 +143,51 @@ fn fetch_archive(workspace: &Path, path: &str, writer: impl Write) -> io::Result
     let mut archive = tar::Builder::new(writer);
     archive.append_data(&mut header, relative, File::open(source)?)?;
     archive.finish()
+}
+
+/// Emit every regular file below `prefix` as a NUL-terminated absolute
+/// container path. Symlinks are skipped, so a listing stays inside the
+/// workspace; the caller applies the output pattern.
+fn list_files(workspace: &Path, prefix: &str, mut writer: impl Write) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let relative = safe_absolute(prefix)?;
+    let root = workspace.canonicalize()?;
+    let mut pending = vec![root.join(&relative)];
+    let mut listed = 0u64;
+    while let Some(directory) = pending.pop() {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                pending.push(entry.path());
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            listed += 1;
+            if listed > MAX_LISTED_FILES {
+                return Err(io::Error::other("listing limit exceeded"));
+            }
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(&root)
+                .map_err(|_| io::Error::other("listing escaped workspace"))?;
+            writer.write_all(b"/")?;
+            writer.write_all(relative.as_os_str().as_bytes())?;
+            writer.write_all(&[0])?;
+        }
+    }
+    writer.flush()
 }
 
 fn compare_marker(marker: &Path, sentinel: &Path) -> io::Result<()> {
@@ -305,6 +360,32 @@ mod tests {
         assert!(compare_marker(&marker, &sentinel).is_ok());
         std::fs::write(&sentinel, br#"{"epoch":2}"#).unwrap();
         assert!(compare_marker(&marker, &sentinel).is_err());
+    }
+
+    #[test]
+    fn lists_workspace_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let workspace = directory.path().join("workspace");
+        std::fs::create_dir_all(workspace.join("out/sub")).unwrap();
+        std::fs::write(workspace.join("out/a.txt"), b"a").unwrap();
+        std::fs::write(workspace.join("out/sub/b.txt"), b"b").unwrap();
+        std::fs::write(workspace.join("other.txt"), b"c").unwrap();
+
+        let mut listed = Vec::new();
+        list_files(&workspace, "/out", &mut listed).unwrap();
+
+        let mut paths: Vec<_> = listed
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+            .map(|path| String::from_utf8(path.to_vec()).unwrap())
+            .collect();
+        paths.sort();
+        assert_eq!(paths, vec!["/out/a.txt", "/out/sub/b.txt"]);
+
+        // A missing prefix directory lists nothing instead of failing.
+        let mut empty = Vec::new();
+        list_files(&workspace, "/absent", &mut empty).unwrap();
+        assert!(empty.is_empty());
     }
 
     #[test]

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -2182,6 +2182,62 @@ mod tests {
         }
     }
 
+    #[test]
+    fn bulk_full_rejects() {
+        // A saturated bulk read pool rejects with QueueFull instead of running
+        // the read inline on the write actor thread.
+        let dir = tempdir().unwrap();
+        let db = fjall::OptimisticTxDatabase::builder(dir.path())
+            .manual_journal_persist(true)
+            .open()
+            .unwrap();
+        let (bulk_sender, _bulk_receiver) = crossfire::mpsc::bounded_blocking(1);
+        let mut storage = super::FjallStorage {
+            store: super::Store::new(db),
+            persist_policy: FjallPersistPolicy::default(),
+            txns: std::collections::HashMap::new(),
+            read_pool: Vec::new(),
+            next_reader: 0,
+            bulk_read_pool: vec![bulk_sender],
+            next_bulk_reader: 0,
+        };
+        let metrics = std::sync::Arc::new(super::StorageMetrics::default());
+        let read_effect = || StorageEffect::Read {
+            key_space: "node_state".to_string(),
+            key: b"missing".to_vec().into(),
+            txn_id: None,
+        };
+
+        let filler = read_effect();
+        let span = super::storage_effect_span(&filler);
+        let guard = super::InFlightGuard::acquire(&metrics);
+        let (filler_tx, _filler_rx) = crossfire::oneshot::oneshot();
+        assert!(
+            storage.bulk_read_pool[0]
+                .try_send((filler, filler_tx, span, Instant::now(), guard))
+                .is_ok(),
+            "saturate bulk read pool"
+        );
+
+        let target = read_effect();
+        let span = super::storage_effect_span(&target);
+        let guard = super::InFlightGuard::acquire(&metrics);
+        let (target_tx, mut target_rx) = crossfire::oneshot::oneshot();
+        let mut slow = super::SlowQueueAggregator::default();
+        storage.forward_to_read_pool(
+            (target, target_tx, span, Instant::now(), guard),
+            StoragePriority::Bulk,
+            &mut slow,
+        );
+
+        match target_rx.try_recv() {
+            Ok(StorageEvent::Error {
+                error: StorageError::QueueFull,
+            }) => {}
+            other => panic!("expected QueueFull rejection, got {other:?}"),
+        }
+    }
+
     fn assert_write_result(event: Event, expected_key: &[u8]) {
         match event {
             Event::Storage(StorageEvent::WriteResult { key }) => {

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -13,7 +13,8 @@ use aruna_core::telemetry::{LatencyAggregator, duration_ms, record_stage};
 use aruna_core::util::prefix_upper_bound;
 use async_trait::async_trait;
 use byteview::ByteView;
-use crossfire::{RecvError, RecvTimeoutError, TryRecvError, TrySendError, mpsc, oneshot};
+use crossfire::select::Select;
+use crossfire::{RecvError, TryRecvError, TrySendError, mpsc, oneshot};
 use fjall::{
     KeyspaceCreateOptions, OptimisticTxDatabase, OptimisticTxKeyspace, PersistMode, Readable,
 };
@@ -1647,25 +1648,43 @@ fn recv_prioritized(
         if let Ok(item) = foreground {
             return Ok((item, StoragePriority::Foreground));
         }
-        match receivers.bulk.try_recv() {
-            Ok(item) => return Ok((item, StoragePriority::Bulk)),
-            Err(TryRecvError::Disconnected)
-                if matches!(foreground, Err(TryRecvError::Disconnected)) =>
-            {
+        let bulk = receivers.bulk.try_recv();
+        if let Ok(item) = bulk {
+            return Ok((item, StoragePriority::Bulk));
+        }
+        match (foreground, bulk) {
+            (Err(TryRecvError::Disconnected), Err(TryRecvError::Disconnected)) => {
                 return Err(RecvError);
             }
-            Err(_) => {}
-        }
-        if matches!(foreground, Err(TryRecvError::Disconnected)) {
-            match receivers.bulk.recv_timeout(Duration::from_millis(1)) {
-                Ok(item) => return Ok((item, StoragePriority::Bulk)),
-                Err(RecvTimeoutError::Timeout) => continue,
-                Err(RecvTimeoutError::Disconnected) => return Err(RecvError),
+            (Err(TryRecvError::Disconnected), _) => {
+                return receivers.bulk.recv().map(|item| (item, StoragePriority::Bulk));
             }
+            (_, Err(TryRecvError::Disconnected)) => {
+                return receivers
+                    .foreground
+                    .recv()
+                    .map(|item| (item, StoragePriority::Foreground));
+            }
+            _ => {}
         }
-        match receivers.foreground.recv_timeout(Duration::from_millis(1)) {
-            Ok(item) => return Ok((item, StoragePriority::Foreground)),
-            Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => continue,
+        // Both lanes are open but empty: block on a biased select so an idle
+        // node sleeps with zero wakeups and foreground stays preferred.
+        let mut select = Select::new_bias();
+        select.add(&receivers.foreground);
+        select.add(&receivers.bulk);
+        let received = match select.select() {
+            Ok(result) if result == receivers.foreground => receivers
+                .foreground
+                .read_select(result)
+                .map(|item| (item, StoragePriority::Foreground)),
+            Ok(result) => receivers
+                .bulk
+                .read_select(result)
+                .map(|item| (item, StoragePriority::Bulk)),
+            Err(RecvError) => return Err(RecvError),
+        };
+        if let Ok(pair) = received {
+            return Ok(pair);
         }
     }
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use aruna_core::effects::{Effect, IterStart, StorageEffect};
+use aruna_core::effects::{Effect, IterStart, StorageEffect, StoragePriority};
 use aruna_core::errors::StorageError;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::handle::Handle;
@@ -13,7 +13,7 @@ use aruna_core::telemetry::{LatencyAggregator, duration_ms, record_stage};
 use aruna_core::util::prefix_upper_bound;
 use async_trait::async_trait;
 use byteview::ByteView;
-use crossfire::{TrySendError, mpsc, oneshot};
+use crossfire::{RecvError, RecvTimeoutError, TryRecvError, TrySendError, mpsc, oneshot};
 use fjall::{
     KeyspaceCreateOptions, OptimisticTxDatabase, OptimisticTxKeyspace, PersistMode, Readable,
 };
@@ -32,6 +32,9 @@ pub type EffectSender = crossfire::MTx<mpsc::Array<EffectHandle>>;
 pub type EffectReceiver = crossfire::Rx<mpsc::Array<EffectHandle>>;
 
 const STORAGE_EFFECT_QUEUE_CAPACITY: usize = 65_536;
+// Bulk lane queues are small so background work hits QueueFull backpressure early
+// instead of building an unbounded backlog ahead of foreground sync traffic.
+const BULK_EFFECT_QUEUE_CAPACITY: usize = 4_096;
 
 enum Txn {
     Read(fjall::Snapshot),
@@ -84,6 +87,7 @@ fn storage_effect_key_space(effect: &StorageEffect) -> Option<&str> {
 }
 const MAX_GROUP_COMMIT: usize = 256;
 const READ_POOL_THREADS: usize = 4;
+const BULK_READ_POOL_THREADS: usize = 2;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum FjallPersistPolicy {
@@ -166,6 +170,8 @@ pub struct FjallStorage {
     txns: HashMap<Ulid, Txn>,
     read_pool: Vec<EffectSender>,
     next_reader: usize,
+    bulk_read_pool: Vec<EffectSender>,
+    next_bulk_reader: usize,
 }
 
 #[derive(Debug, Default)]
@@ -213,22 +219,49 @@ pub struct StorageMetricsSnapshot {
     pub last_error: Option<String>,
 }
 
+/// Write-actor receivers, one per dispatch lane. Foreground is drained before
+/// bulk so background work never starves sync traffic.
+pub struct StorageReceivers {
+    pub foreground: EffectReceiver,
+    pub bulk: EffectReceiver,
+}
+
 #[derive(Clone, Debug)]
 pub struct StorageHandle {
     write_channel: EffectSender,
+    bulk_channel: EffectSender,
+    priority: StoragePriority,
     metrics: Arc<StorageMetrics>,
 }
 
 impl StorageHandle {
-    pub fn new() -> (Self, EffectReceiver) {
-        let (sender, receiver) = mpsc::bounded_blocking(STORAGE_EFFECT_QUEUE_CAPACITY);
+    pub fn new() -> (Self, StorageReceivers) {
+        let (sender, foreground) = mpsc::bounded_blocking(STORAGE_EFFECT_QUEUE_CAPACITY);
+        let (bulk_sender, bulk) = mpsc::bounded_blocking(BULK_EFFECT_QUEUE_CAPACITY);
         (
             StorageHandle {
                 write_channel: sender,
+                bulk_channel: bulk_sender,
+                priority: StoragePriority::Foreground,
                 metrics: Arc::new(StorageMetrics::default()),
             },
-            receiver,
+            StorageReceivers { foreground, bulk },
         )
+    }
+
+    /// A handle whose effects dispatch on the bulk lane, served only when the
+    /// foreground lane is idle.
+    pub fn bulk(&self) -> StorageHandle {
+        let mut handle = self.clone();
+        handle.priority = StoragePriority::Bulk;
+        handle
+    }
+
+    fn channel(&self) -> &EffectSender {
+        match self.priority {
+            StoragePriority::Foreground => &self.write_channel,
+            StoragePriority::Bulk => &self.bulk_channel,
+        }
     }
 
     pub fn get_errors(&self) -> u64 {
@@ -302,7 +335,7 @@ impl StorageHandle {
         let span = storage_effect_span(&effect);
         let in_flight = InFlightGuard::acquire(&self.metrics);
         match self
-            .write_channel
+            .channel()
             .try_send((effect, response_tx, span, Instant::now(), in_flight))
         {
             Ok(()) => {}
@@ -350,7 +383,7 @@ impl StorageHandle {
         let span = storage_effect_span(&effect);
         let in_flight = InFlightGuard::acquire(&self.metrics);
         match self
-            .write_channel
+            .channel()
             .try_send((effect, response_tx, span, Instant::now(), in_flight))
         {
             Ok(()) => {}
@@ -488,9 +521,12 @@ impl FjallStorage {
             .manual_journal_persist(true)
             .open()?;
 
-        let (sender, receiver) = StorageHandle::new();
+        let (sender, receivers) = StorageHandle::new();
         let store = Store::new(db);
-        let read_pool = spawn_read_pool(store.clone(), READ_POOL_THREADS);
+        let read_pool =
+            spawn_read_pool(store.clone(), READ_POOL_THREADS, STORAGE_EFFECT_QUEUE_CAPACITY);
+        let bulk_read_pool =
+            spawn_read_pool(store.clone(), BULK_READ_POOL_THREADS, BULK_EFFECT_QUEUE_CAPACITY);
         let channel_closed = sender.metrics.channel_closed.clone();
 
         thread::spawn(move || {
@@ -501,8 +537,10 @@ impl FjallStorage {
                 txns: HashMap::new(),
                 read_pool,
                 next_reader: 0,
+                bulk_read_pool,
+                next_bulk_reader: 0,
             };
-            storage.receive_loop(receiver);
+            storage.receive_loop(receivers);
         });
 
         Ok(sender)
@@ -543,61 +581,107 @@ impl FjallStorage {
         }
     }
 
-    #[tracing::instrument(name = "storage.receive_loop", level = "debug", skip(self, receiver))]
-    pub fn receive_loop(&mut self, receiver: EffectReceiver) {
+    #[tracing::instrument(name = "storage.receive_loop", level = "debug", skip(self, receivers))]
+    pub fn receive_loop(&mut self, receivers: StorageReceivers) {
         let mut slow_queue = SlowQueueAggregator::default();
-        let mut group: Vec<EffectHandle> = Vec::new();
-        let mut group_index: Option<PendingWriteIndex> = None;
         loop {
-            let Ok(first) = receiver.recv() else {
-                tracing::warn!("Storage receiver channel closed, shutting down storage thread.");
-                break;
+            let (first, priority) = match recv_prioritized(&receivers) {
+                Ok(pair) => pair,
+                Err(_) => {
+                    tracing::warn!(
+                        "Storage receiver channel closed, shutting down storage thread."
+                    );
+                    break;
+                }
             };
-            let mut pending = Vec::with_capacity(8);
-            pending.push(first);
-            while pending.len() < MAX_GROUP_COMMIT {
-                match receiver.try_recv() {
-                    Ok(item) => pending.push(item),
-                    Err(_) => break,
+            match priority {
+                StoragePriority::Foreground => {
+                    self.serve_foreground_batch(&receivers, first, &mut slow_queue)
+                }
+                StoragePriority::Bulk => {
+                    if is_poolable_read(&first.0) {
+                        self.forward_to_read_pool(first, StoragePriority::Bulk, &mut slow_queue);
+                    } else {
+                        self.process_single(first, &mut slow_queue);
+                    }
                 }
             }
-
-            for item in pending {
-                if is_groupable_write(&item.0) {
-                    if let Some(index) = &mut group_index {
-                        index.insert(&item.0);
-                    }
-                    group.push(item);
-                    continue;
-                }
-                if is_poolable_read(&item.0) {
-                    let conflicts = !group.is_empty()
-                        && group_index
-                            .get_or_insert_with(|| PendingWriteIndex::from_group(&group))
-                            .conflicts_with_read(&item.0);
-                    if conflicts {
-                        self.flush_write_group(&mut group, &mut slow_queue);
-                        group_index = None;
-                    }
-                    self.forward_to_read_pool(item, &mut slow_queue);
-                    continue;
-                }
-                self.flush_write_group(&mut group, &mut slow_queue);
-                group_index = None;
-                self.process_single(item, &mut slow_queue);
-            }
-            self.flush_write_group(&mut group, &mut slow_queue);
-            group_index = None;
         }
     }
 
-    fn forward_to_read_pool(&mut self, item: EffectHandle, slow_queue: &mut SlowQueueAggregator) {
-        let reader = self.next_reader % self.read_pool.len();
-        self.next_reader = self.next_reader.wrapping_add(1);
-        match self.read_pool[reader].try_send(item) {
-            Ok(()) => {}
-            Err(TrySendError::Full(item)) | Err(TrySendError::Disconnected(item)) => {
-                self.process_single(item, slow_queue);
+    fn serve_foreground_batch(
+        &mut self,
+        receivers: &StorageReceivers,
+        first: EffectHandle,
+        slow_queue: &mut SlowQueueAggregator,
+    ) {
+        let mut pending = Vec::with_capacity(8);
+        pending.push(first);
+        while pending.len() < MAX_GROUP_COMMIT {
+            match receivers.foreground.try_recv() {
+                Ok(item) => pending.push(item),
+                Err(_) => break,
+            }
+        }
+
+        let mut group: Vec<EffectHandle> = Vec::new();
+        let mut group_index: Option<PendingWriteIndex> = None;
+        for item in pending {
+            if is_groupable_write(&item.0) {
+                if let Some(index) = &mut group_index {
+                    index.insert(&item.0);
+                }
+                group.push(item);
+                continue;
+            }
+            if is_poolable_read(&item.0) {
+                let conflicts = !group.is_empty()
+                    && group_index
+                        .get_or_insert_with(|| PendingWriteIndex::from_group(&group))
+                        .conflicts_with_read(&item.0);
+                if conflicts {
+                    self.flush_write_group(&mut group, slow_queue);
+                    group_index = None;
+                }
+                self.forward_to_read_pool(item, StoragePriority::Foreground, slow_queue);
+                continue;
+            }
+            self.flush_write_group(&mut group, slow_queue);
+            group_index = None;
+            self.process_single(item, slow_queue);
+        }
+        self.flush_write_group(&mut group, slow_queue);
+    }
+
+    fn forward_to_read_pool(
+        &mut self,
+        item: EffectHandle,
+        priority: StoragePriority,
+        slow_queue: &mut SlowQueueAggregator,
+    ) {
+        match priority {
+            StoragePriority::Foreground => {
+                let reader = self.next_reader % self.read_pool.len();
+                self.next_reader = self.next_reader.wrapping_add(1);
+                match self.read_pool[reader].try_send(item) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(item)) | Err(TrySendError::Disconnected(item)) => {
+                        self.process_single(item, slow_queue);
+                    }
+                }
+            }
+            StoragePriority::Bulk => {
+                let reader = self.next_bulk_reader % self.bulk_read_pool.len();
+                self.next_bulk_reader = self.next_bulk_reader.wrapping_add(1);
+                match self.bulk_read_pool[reader].try_send(item) {
+                    Ok(()) => {}
+                    // A full bulk read queue backpressures rather than stealing
+                    // the write actor thread from foreground sync traffic.
+                    Err(TrySendError::Full(item)) => reject_bulk_read(item),
+                    Err(TrySendError::Disconnected(item)) => {
+                        self.process_single(item, slow_queue)
+                    }
+                }
             }
         }
     }
@@ -1542,10 +1626,61 @@ fn iter_may_include_key(
     }
 }
 
-fn spawn_read_pool(store: Store, threads: usize) -> Vec<EffectSender> {
+// Foreground before bulk: return an immediately available foreground item, else
+// an available bulk item, else block briefly on foreground so an idle actor
+// still wakes to serve bulk work. The 1ms poll is the documented alternative to
+// a blocking two-channel select and keeps the same lane-priority contract.
+fn recv_prioritized(
+    receivers: &StorageReceivers,
+) -> Result<(EffectHandle, StoragePriority), RecvError> {
+    loop {
+        let foreground = receivers.foreground.try_recv();
+        if let Ok(item) = foreground {
+            return Ok((item, StoragePriority::Foreground));
+        }
+        match receivers.bulk.try_recv() {
+            Ok(item) => return Ok((item, StoragePriority::Bulk)),
+            Err(TryRecvError::Disconnected)
+                if matches!(foreground, Err(TryRecvError::Disconnected)) =>
+            {
+                return Err(RecvError);
+            }
+            Err(_) => {}
+        }
+        if matches!(foreground, Err(TryRecvError::Disconnected)) {
+            match receivers.bulk.recv_timeout(Duration::from_millis(1)) {
+                Ok(item) => return Ok((item, StoragePriority::Bulk)),
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(RecvTimeoutError::Disconnected) => return Err(RecvError),
+            }
+        }
+        match receivers.foreground.recv_timeout(Duration::from_millis(1)) {
+            Ok(item) => return Ok((item, StoragePriority::Foreground)),
+            Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => continue,
+        }
+    }
+}
+
+fn reject_bulk_read(item: EffectHandle) {
+    let (effect, response_tx, span, _enqueued_at, in_flight) = item;
+    let _guard = span.enter();
+    warn!(
+        event = "storage.bulk_read.queue_full",
+        operation = storage_effect_kind(&effect),
+        "Rejecting bulk read: bulk read pool queue full"
+    );
+    drop(in_flight);
+    if !response_tx.is_disconnected() {
+        response_tx.send(StorageEvent::Error {
+            error: StorageError::QueueFull,
+        });
+    }
+}
+
+fn spawn_read_pool(store: Store, threads: usize, capacity: usize) -> Vec<EffectSender> {
     let mut senders = Vec::with_capacity(threads);
     for _ in 0..threads {
-        let (sender, receiver) = mpsc::bounded_blocking(STORAGE_EFFECT_QUEUE_CAPACITY);
+        let (sender, receiver) = mpsc::bounded_blocking(capacity);
         let store = store.clone();
         thread::spawn(move || read_pool_loop(store, receiver));
         senders.push(sender);
@@ -1885,7 +2020,7 @@ fn collect_page(iter: fjall::Iter, limit: usize) -> Result<PageResult, StorageEr
 #[cfg(test)]
 mod tests {
     use super::{FjallPersistPolicy, FjallStorage, StorageHandle};
-    use aruna_core::effects::{Effect, IterStart, StorageEffect};
+    use aruna_core::effects::{Effect, IterStart, StorageEffect, StoragePriority};
     use aruna_core::errors::StorageError;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::handle::Handle;
@@ -1898,6 +2033,82 @@ mod tests {
     const RESTART_CHILD_PATH_ENV: &str = "ARUNA_STORAGE_RESTART_CHILD_PATH";
     const RESTART_CHILD_MODE_ENV: &str = "ARUNA_STORAGE_RESTART_CHILD_MODE";
     const RESTART_CHILD_TEST: &str = "storage::tests::buffered_persistence_restart_child_process";
+
+    #[test]
+    fn foreground_precedes_bulk() {
+        // All four effects are enqueued before the first recv, so lane order is
+        // deterministic: the single foreground effect precedes the three bulk.
+        let (handle, receivers) = StorageHandle::new();
+        let read = |key_space: &str| StorageEffect::Read {
+            key_space: key_space.to_string(),
+            key: b"k".to_vec().into(),
+            txn_id: None,
+        };
+        let mut keep = Vec::new();
+        for key_space in ["b1", "b2", "b3"] {
+            let (tx, rx) = crossfire::oneshot::oneshot();
+            let effect = read(key_space);
+            let span = super::storage_effect_span(&effect);
+            let in_flight = super::InFlightGuard::acquire(&handle.metrics);
+            handle
+                .bulk_channel
+                .try_send((effect, tx, span, Instant::now(), in_flight))
+                .ok()
+                .expect("bulk enqueue");
+            keep.push(rx);
+        }
+        let (tx, rx) = crossfire::oneshot::oneshot();
+        let effect = read("fg");
+        let span = super::storage_effect_span(&effect);
+        let in_flight = super::InFlightGuard::acquire(&handle.metrics);
+        handle
+            .write_channel
+            .try_send((effect, tx, span, Instant::now(), in_flight))
+            .ok()
+            .expect("foreground enqueue");
+        keep.push(rx);
+
+        let (first, priority) = super::recv_prioritized(&receivers).expect("first item");
+        assert_eq!(priority, StoragePriority::Foreground);
+        assert_eq!(super::storage_effect_key_space(&first.0), Some("fg"));
+        for _ in 0..3 {
+            let (_, priority) = super::recv_prioritized(&receivers).expect("bulk item");
+            assert_eq!(priority, StoragePriority::Bulk);
+        }
+        drop(keep);
+    }
+
+    #[tokio::test]
+    async fn bulk_lane_works() {
+        let dir = tempdir().unwrap();
+        let handle = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let bulk = handle.bulk();
+        let write = bulk
+            .send_storage_effect(StorageEffect::Write {
+                key_space: "node_state".to_string(),
+                key: b"k".to_vec().into(),
+                value: b"v".to_vec().into(),
+                txn_id: None,
+            })
+            .await;
+        assert!(matches!(
+            write,
+            Event::Storage(StorageEvent::WriteResult { .. })
+        ));
+        let read = bulk
+            .send_storage_effect(StorageEffect::Read {
+                key_space: "node_state".to_string(),
+                key: b"k".to_vec().into(),
+                txn_id: None,
+            })
+            .await;
+        match read {
+            Event::Storage(StorageEvent::ReadResult {
+                value: Some(value), ..
+            }) => assert_eq!(value.as_ref(), b"v"),
+            other => panic!("unexpected storage event: {other:?}"),
+        }
+    }
 
     fn assert_write_result(event: Event, expected_key: &[u8]) {
         match event {
@@ -2011,7 +2222,8 @@ mod tests {
 
     #[tokio::test]
     async fn cancelled_stays_counted() {
-        let (handle, receiver) = StorageHandle::new();
+        let (handle, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         let mut probe = Box::pin(handle.send_storage_effect(StorageEffect::Read {
             key_space: "node_state".to_string(),
             key: b"node_state".to_vec().into(),
@@ -2036,7 +2248,8 @@ mod tests {
 
     #[tokio::test]
     async fn failed_enqueue_balances() {
-        let (handle, receiver) = StorageHandle::new();
+        let (handle, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         drop(receiver);
 
         let event = handle
@@ -2063,11 +2276,14 @@ mod tests {
             FjallStorage::open(dir.path().to_str().expect("utf-8 path")).expect("storage opens");
         let StorageHandle {
             write_channel,
+            bulk_channel,
+            priority: _,
             metrics,
         } = handle;
 
         assert!(!metrics.channel_closed.load(Ordering::Relaxed));
         drop(write_channel);
+        drop(bulk_channel);
 
         let deadline = Instant::now() + Duration::from_secs(5);
         while !metrics.channel_closed.load(Ordering::Relaxed) && Instant::now() < deadline {
@@ -2079,7 +2295,8 @@ mod tests {
 
     #[tokio::test]
     async fn sync_all_handle_surfaces_persist_errors() {
-        let (handle, receiver) = StorageHandle::new();
+        let (handle, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         thread::spawn(move || {
             let (effect, response_tx, _span, _enqueued_at, _in_flight) =
                 receiver.recv().expect("sync_all effect should arrive");
@@ -2719,7 +2936,8 @@ mod tests {
 
     #[tokio::test]
     async fn send_effect_counts_conflicts_separately_from_errors() {
-        let (handle, receiver) = StorageHandle::new();
+        let (handle, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
         thread::spawn(move || {
             let (effect, response_tx, _span, _enqueued_at, _in_flight) =
                 receiver.recv().expect("first effect should arrive");

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -340,10 +340,13 @@ impl StorageHandle {
         let active_txn_id = active_txn_id_for_effect(&effect);
         let span = storage_effect_span(&effect);
         let in_flight = InFlightGuard::acquire(&self.metrics);
-        match self
-            .channel_for(&effect)
-            .try_send((effect, response_tx, span, Instant::now(), in_flight))
-        {
+        match self.channel_for(&effect).try_send((
+            effect,
+            response_tx,
+            span,
+            Instant::now(),
+            in_flight,
+        )) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
                 if let Some(txn_id) = active_txn_id {
@@ -388,10 +391,13 @@ impl StorageHandle {
         let effect = StorageEffect::AbortTransaction { txn_id };
         let span = storage_effect_span(&effect);
         let in_flight = InFlightGuard::acquire(&self.metrics);
-        match self
-            .channel_for(&effect)
-            .try_send((effect, response_tx, span, Instant::now(), in_flight))
-        {
+        match self.channel_for(&effect).try_send((
+            effect,
+            response_tx,
+            span,
+            Instant::now(),
+            in_flight,
+        )) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => warn!(
                 event = "storage.transaction.abort_enqueue_full",
@@ -1657,7 +1663,10 @@ fn recv_prioritized(
                 return Err(RecvError);
             }
             (Err(TryRecvError::Disconnected), _) => {
-                return receivers.bulk.recv().map(|item| (item, StoragePriority::Bulk));
+                return receivers
+                    .bulk
+                    .recv()
+                    .map(|item| (item, StoragePriority::Bulk));
             }
             (_, Err(TryRecvError::Disconnected)) => {
                 return receivers
@@ -2146,7 +2155,10 @@ mod tests {
             effect,
             StorageEffect::AbortTransaction { txn_id: got } if got == txn_id
         ));
-        assert!(receivers.bulk.try_recv().is_ok(), "bulk lane still saturated");
+        assert!(
+            receivers.bulk.try_recv().is_ok(),
+            "bulk lane still saturated"
+        );
         drop(keep);
     }
 

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -89,6 +89,9 @@ fn storage_effect_key_space(effect: &StorageEffect) -> Option<&str> {
 const MAX_GROUP_COMMIT: usize = 256;
 const READ_POOL_THREADS: usize = 4;
 const BULK_READ_POOL_THREADS: usize = 2;
+// Foreground batches served before one bulk item is admitted. Bounds bulk queue
+// latency under sustained ingest so background drains cannot stall indefinitely.
+const MAX_FOREGROUND_STREAK: usize = 8;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum FjallPersistPolicy {
@@ -602,8 +605,9 @@ impl FjallStorage {
     #[tracing::instrument(name = "storage.receive_loop", level = "debug", skip(self, receivers))]
     pub fn receive_loop(&mut self, receivers: StorageReceivers) {
         let mut slow_queue = SlowQueueAggregator::default();
+        let mut lanes = LaneScheduler::default();
         loop {
-            let (first, priority) = match recv_prioritized(&receivers) {
+            let (first, priority) = match lanes.next(&receivers) {
                 Ok(pair) => pair,
                 Err(_) => {
                     tracing::warn!(
@@ -1642,58 +1646,79 @@ fn iter_may_include_key(
     }
 }
 
-// Foreground before bulk: return an immediately available foreground item, else
-// an available bulk item, else block briefly on foreground so an idle actor
-// still wakes to serve bulk work. The 1ms poll is the documented alternative to
-// a blocking two-channel select and keeps the same lane-priority contract.
-fn recv_prioritized(
-    receivers: &StorageReceivers,
-) -> Result<(EffectHandle, StoragePriority), RecvError> {
-    loop {
-        let foreground = receivers.foreground.try_recv();
-        if let Ok(item) = foreground {
-            return Ok((item, StoragePriority::Foreground));
-        }
-        let bulk = receivers.bulk.try_recv();
-        if let Ok(item) = bulk {
-            return Ok((item, StoragePriority::Bulk));
-        }
-        match (foreground, bulk) {
-            (Err(TryRecvError::Disconnected), Err(TryRecvError::Disconnected)) => {
-                return Err(RecvError);
+/// Lane picker for the write actor: foreground is preferred, but a bulk item is
+/// admitted after [`MAX_FOREGROUND_STREAK`] foreground batches so background work
+/// keeps draining while ingest saturates the foreground lane.
+#[derive(Debug, Default)]
+struct LaneScheduler {
+    foreground_streak: usize,
+}
+
+impl LaneScheduler {
+    fn next(
+        &mut self,
+        receivers: &StorageReceivers,
+    ) -> Result<(EffectHandle, StoragePriority), RecvError> {
+        loop {
+            if self.foreground_streak >= MAX_FOREGROUND_STREAK
+                && let Ok(item) = receivers.bulk.try_recv()
+            {
+                self.foreground_streak = 0;
+                return Ok((item, StoragePriority::Bulk));
             }
-            (Err(TryRecvError::Disconnected), _) => {
-                return receivers
-                    .bulk
-                    .recv()
-                    .map(|item| (item, StoragePriority::Bulk));
+            let foreground = receivers.foreground.try_recv();
+            if let Ok(item) = foreground {
+                self.foreground_streak = self.foreground_streak.saturating_add(1);
+                return Ok((item, StoragePriority::Foreground));
             }
-            (_, Err(TryRecvError::Disconnected)) => {
-                return receivers
+            let bulk = receivers.bulk.try_recv();
+            if let Ok(item) = bulk {
+                self.foreground_streak = 0;
+                return Ok((item, StoragePriority::Bulk));
+            }
+            match (foreground, bulk) {
+                (Err(TryRecvError::Disconnected), Err(TryRecvError::Disconnected)) => {
+                    return Err(RecvError);
+                }
+                (Err(TryRecvError::Disconnected), _) => {
+                    self.foreground_streak = 0;
+                    return receivers
+                        .bulk
+                        .recv()
+                        .map(|item| (item, StoragePriority::Bulk));
+                }
+                (_, Err(TryRecvError::Disconnected)) => {
+                    self.foreground_streak = 0;
+                    return receivers
+                        .foreground
+                        .recv()
+                        .map(|item| (item, StoragePriority::Foreground));
+                }
+                _ => {}
+            }
+            // Both lanes are open but empty: block on a biased select so an idle
+            // node sleeps with zero wakeups and foreground stays preferred.
+            self.foreground_streak = 0;
+            let mut select = Select::new_bias();
+            select.add(&receivers.foreground);
+            select.add(&receivers.bulk);
+            let received = match select.select() {
+                Ok(result) if result == receivers.foreground => receivers
                     .foreground
-                    .recv()
-                    .map(|item| (item, StoragePriority::Foreground));
+                    .read_select(result)
+                    .map(|item| (item, StoragePriority::Foreground)),
+                Ok(result) => receivers
+                    .bulk
+                    .read_select(result)
+                    .map(|item| (item, StoragePriority::Bulk)),
+                Err(RecvError) => return Err(RecvError),
+            };
+            if let Ok(pair) = received {
+                if matches!(pair.1, StoragePriority::Foreground) {
+                    self.foreground_streak = 1;
+                }
+                return Ok(pair);
             }
-            _ => {}
-        }
-        // Both lanes are open but empty: block on a biased select so an idle
-        // node sleeps with zero wakeups and foreground stays preferred.
-        let mut select = Select::new_bias();
-        select.add(&receivers.foreground);
-        select.add(&receivers.bulk);
-        let received = match select.select() {
-            Ok(result) if result == receivers.foreground => receivers
-                .foreground
-                .read_select(result)
-                .map(|item| (item, StoragePriority::Foreground)),
-            Ok(result) => receivers
-                .bulk
-                .read_select(result)
-                .map(|item| (item, StoragePriority::Bulk)),
-            Err(RecvError) => return Err(RecvError),
-        };
-        if let Ok(pair) = received {
-            return Ok(pair);
         }
     }
 }
@@ -2109,13 +2134,60 @@ mod tests {
         );
         keep.push(rx);
 
-        let (first, priority) = super::recv_prioritized(&receivers).expect("first item");
+        let mut lanes = super::LaneScheduler::default();
+        let (first, priority) = lanes.next(&receivers).expect("first item");
         assert_eq!(priority, StoragePriority::Foreground);
         assert_eq!(super::storage_effect_key_space(&first.0), Some("fg"));
         for _ in 0..3 {
-            let (_, priority) = super::recv_prioritized(&receivers).expect("bulk item");
+            let (_, priority) = lanes.next(&receivers).expect("bulk item");
             assert_eq!(priority, StoragePriority::Bulk);
         }
+        drop(keep);
+    }
+
+    #[test]
+    fn bulk_survives_foreground() {
+        // A foreground lane that never runs dry must still yield the bulk lane a
+        // slot, otherwise background drains stall until the node goes idle.
+        let (handle, receivers) = StorageHandle::new();
+        let read = |key_space: &str| StorageEffect::Read {
+            key_space: key_space.to_string(),
+            key: b"k".to_vec().into(),
+            txn_id: None,
+        };
+        let mut keep = Vec::new();
+        let mut enqueue = |channel: &super::EffectSender, key_space: &str| {
+            let (tx, rx) = crossfire::oneshot::oneshot();
+            let effect = read(key_space);
+            let span = super::storage_effect_span(&effect);
+            let in_flight = super::InFlightGuard::acquire(&handle.metrics);
+            assert!(
+                channel
+                    .try_send((effect, tx, span, Instant::now(), in_flight))
+                    .is_ok(),
+                "enqueue {key_space}"
+            );
+            keep.push(rx);
+        };
+        for _ in 0..(super::MAX_FOREGROUND_STREAK * 2) {
+            enqueue(&handle.write_channel, "fg");
+        }
+        enqueue(&handle.bulk_channel, "bulk");
+
+        let mut lanes = super::LaneScheduler::default();
+        let mut served = Vec::new();
+        for _ in 0..(super::MAX_FOREGROUND_STREAK + 1) {
+            let (_, priority) = lanes.next(&receivers).expect("item");
+            served.push(priority);
+        }
+        assert_eq!(
+            served
+                .iter()
+                .filter(|p| **p == StoragePriority::Bulk)
+                .count(),
+            1,
+            "bulk served within one streak: {served:?}"
+        );
         drop(keep);
     }
 

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -257,7 +257,12 @@ impl StorageHandle {
         handle
     }
 
-    fn channel(&self) -> &EffectSender {
+    fn channel_for(&self, effect: &StorageEffect) -> &EffectSender {
+        // Aborts free resources and must never wait behind bulk backpressure, so
+        // they always dispatch on the foreground lane regardless of priority.
+        if matches!(effect, StorageEffect::AbortTransaction { .. }) {
+            return &self.write_channel;
+        }
         match self.priority {
             StoragePriority::Foreground => &self.write_channel,
             StoragePriority::Bulk => &self.bulk_channel,
@@ -335,7 +340,7 @@ impl StorageHandle {
         let span = storage_effect_span(&effect);
         let in_flight = InFlightGuard::acquire(&self.metrics);
         match self
-            .channel()
+            .channel_for(&effect)
             .try_send((effect, response_tx, span, Instant::now(), in_flight))
         {
             Ok(()) => {}
@@ -383,7 +388,7 @@ impl StorageHandle {
         let span = storage_effect_span(&effect);
         let in_flight = InFlightGuard::acquire(&self.metrics);
         match self
-            .channel()
+            .channel_for(&effect)
             .try_send((effect, response_tx, span, Instant::now(), in_flight))
         {
             Ok(()) => {}
@@ -2083,6 +2088,46 @@ mod tests {
             let (_, priority) = super::recv_prioritized(&receivers).expect("bulk item");
             assert_eq!(priority, StoragePriority::Bulk);
         }
+        drop(keep);
+    }
+
+    #[test]
+    fn abort_routes_foreground() {
+        // A saturated bulk lane must not swallow a bulk handle's abort; aborts
+        // free resources and always dispatch on the foreground lane.
+        let (handle, receivers) = StorageHandle::new();
+        let mut keep = Vec::new();
+        loop {
+            let (tx, rx) = crossfire::oneshot::oneshot();
+            let effect = StorageEffect::Read {
+                key_space: "b".to_string(),
+                key: b"k".to_vec().into(),
+                txn_id: None,
+            };
+            let span = super::storage_effect_span(&effect);
+            let in_flight = super::InFlightGuard::acquire(&handle.metrics);
+            if handle
+                .bulk_channel
+                .try_send((effect, tx, span, Instant::now(), in_flight))
+                .is_err()
+            {
+                break;
+            }
+            keep.push(rx);
+        }
+
+        let txn_id = Ulid::from_parts(1, 1);
+        handle.bulk().enqueue_abort_transaction(txn_id, "test");
+
+        let (effect, ..) = receivers
+            .foreground
+            .try_recv()
+            .expect("abort routed to foreground");
+        assert!(matches!(
+            effect,
+            StorageEffect::AbortTransaction { txn_id: got } if got == txn_id
+        ));
+        assert!(receivers.bulk.try_recv().is_ok(), "bulk lane still saturated");
         drop(keep);
     }
 

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -89,9 +89,11 @@ fn storage_effect_key_space(effect: &StorageEffect) -> Option<&str> {
 const MAX_GROUP_COMMIT: usize = 256;
 const READ_POOL_THREADS: usize = 4;
 const BULK_READ_POOL_THREADS: usize = 2;
-// Foreground batches served before one bulk item is admitted. Bounds bulk queue
-// latency under sustained ingest so background drains cannot stall indefinitely.
-const MAX_FOREGROUND_STREAK: usize = 8;
+// Foreground effects served per admitted bulk effect. Counting effects rather
+// than batches keeps the bulk share constant under load: a batch may carry up to
+// MAX_GROUP_COMMIT effects, so per-batch credit would shrink the share to
+// nothing exactly when the queue is deepest.
+const FOREGROUND_PER_BULK: usize = 8;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum FjallPersistPolicy {
@@ -618,7 +620,8 @@ impl FjallStorage {
             };
             match priority {
                 StoragePriority::Foreground => {
-                    self.serve_foreground_batch(&receivers, first, &mut slow_queue)
+                    let served = self.serve_foreground_batch(&receivers, first, &mut slow_queue);
+                    lanes.record_foreground(served);
                 }
                 StoragePriority::Bulk => {
                     if is_poolable_read(&first.0) {
@@ -631,12 +634,14 @@ impl FjallStorage {
         }
     }
 
+    /// Returns how many foreground effects were served, which is what the lane
+    /// scheduler credits the bulk lane against.
     fn serve_foreground_batch(
         &mut self,
         receivers: &StorageReceivers,
         first: EffectHandle,
         slow_queue: &mut SlowQueueAggregator,
-    ) {
+    ) -> usize {
         let mut pending = Vec::with_capacity(8);
         pending.push(first);
         while pending.len() < MAX_GROUP_COMMIT {
@@ -645,6 +650,7 @@ impl FjallStorage {
                 Err(_) => break,
             }
         }
+        let served = pending.len();
 
         let mut group: Vec<EffectHandle> = Vec::new();
         let mut group_index: Option<PendingWriteIndex> = None;
@@ -673,6 +679,7 @@ impl FjallStorage {
             self.process_single(item, slow_queue);
         }
         self.flush_write_group(&mut group, slow_queue);
+        served
     }
 
     fn forward_to_read_pool(
@@ -1646,34 +1653,37 @@ fn iter_may_include_key(
     }
 }
 
-/// Lane picker for the write actor: foreground is preferred, but a bulk item is
-/// admitted after [`MAX_FOREGROUND_STREAK`] foreground batches so background work
-/// keeps draining while ingest saturates the foreground lane.
+/// Lane picker for the write actor. Foreground is preferred, and every
+/// [`FOREGROUND_PER_BULK`] foreground effects earn one bulk effect, so the drain
+/// keeps a fixed share of the actor no matter how deep the foreground queue is.
 #[derive(Debug, Default)]
 struct LaneScheduler {
-    foreground_streak: usize,
+    credit: usize,
 }
 
 impl LaneScheduler {
+    fn record_foreground(&mut self, served: usize) {
+        self.credit = self.credit.saturating_add(served);
+    }
+
     fn next(
         &mut self,
         receivers: &StorageReceivers,
     ) -> Result<(EffectHandle, StoragePriority), RecvError> {
         loop {
-            if self.foreground_streak >= MAX_FOREGROUND_STREAK
+            if self.credit >= FOREGROUND_PER_BULK
                 && let Ok(item) = receivers.bulk.try_recv()
             {
-                self.foreground_streak = 0;
+                self.credit = self.credit.saturating_sub(FOREGROUND_PER_BULK);
                 return Ok((item, StoragePriority::Bulk));
             }
             let foreground = receivers.foreground.try_recv();
             if let Ok(item) = foreground {
-                self.foreground_streak = self.foreground_streak.saturating_add(1);
                 return Ok((item, StoragePriority::Foreground));
             }
             let bulk = receivers.bulk.try_recv();
             if let Ok(item) = bulk {
-                self.foreground_streak = 0;
+                self.credit = 0;
                 return Ok((item, StoragePriority::Bulk));
             }
             match (foreground, bulk) {
@@ -1681,14 +1691,14 @@ impl LaneScheduler {
                     return Err(RecvError);
                 }
                 (Err(TryRecvError::Disconnected), _) => {
-                    self.foreground_streak = 0;
+                    self.credit = 0;
                     return receivers
                         .bulk
                         .recv()
                         .map(|item| (item, StoragePriority::Bulk));
                 }
                 (_, Err(TryRecvError::Disconnected)) => {
-                    self.foreground_streak = 0;
+                    self.credit = 0;
                     return receivers
                         .foreground
                         .recv()
@@ -1698,7 +1708,7 @@ impl LaneScheduler {
             }
             // Both lanes are open but empty: block on a biased select so an idle
             // node sleeps with zero wakeups and foreground stays preferred.
-            self.foreground_streak = 0;
+            self.credit = 0;
             let mut select = Select::new_bias();
             select.add(&receivers.foreground);
             select.add(&receivers.bulk);
@@ -1714,9 +1724,6 @@ impl LaneScheduler {
                 Err(RecvError) => return Err(RecvError),
             };
             if let Ok(pair) = received {
-                if matches!(pair.1, StoragePriority::Foreground) {
-                    self.foreground_streak = 1;
-                }
                 return Ok(pair);
             }
         }
@@ -2146,9 +2153,10 @@ mod tests {
     }
 
     #[test]
-    fn bulk_survives_foreground() {
-        // A foreground lane that never runs dry must still yield the bulk lane a
-        // slot, otherwise background drains stall until the node goes idle.
+    fn bulk_keeps_share() {
+        // Credit is earned per foreground effect, not per batch: one batch may
+        // swallow the whole foreground queue, and it must still buy the bulk
+        // lane its proportional slots or a deep queue starves the drain.
         let (handle, receivers) = StorageHandle::new();
         let read = |key_space: &str| StorageEffect::Read {
             key_space: key_space.to_string(),
@@ -2169,24 +2177,31 @@ mod tests {
             );
             keep.push(rx);
         };
-        for _ in 0..(super::MAX_FOREGROUND_STREAK * 2) {
+        let batch = super::MAX_GROUP_COMMIT;
+        let expected_bulk = batch / super::FOREGROUND_PER_BULK;
+        for _ in 0..batch {
             enqueue(&handle.write_channel, "fg");
         }
-        enqueue(&handle.bulk_channel, "bulk");
+        for _ in 0..expected_bulk {
+            enqueue(&handle.bulk_channel, "bulk");
+        }
 
         let mut lanes = super::LaneScheduler::default();
-        let mut served = Vec::new();
-        for _ in 0..(super::MAX_FOREGROUND_STREAK + 1) {
+        let (_, priority) = lanes.next(&receivers).expect("first item");
+        assert_eq!(priority, StoragePriority::Foreground);
+        // The actor drains the rest of the foreground queue as one batch.
+        lanes.record_foreground(batch);
+
+        let mut bulk_served = 0usize;
+        for _ in 0..expected_bulk {
             let (_, priority) = lanes.next(&receivers).expect("item");
-            served.push(priority);
+            if priority == StoragePriority::Bulk {
+                bulk_served += 1;
+            }
         }
         assert_eq!(
-            served
-                .iter()
-                .filter(|p| **p == StoragePriority::Bulk)
-                .count(),
-            1,
-            "bulk served within one streak: {served:?}"
+            bulk_served, expected_bulk,
+            "a full foreground batch buys {expected_bulk} bulk slots"
         );
         drop(keep);
     }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -523,10 +523,16 @@ impl FjallStorage {
 
         let (sender, receivers) = StorageHandle::new();
         let store = Store::new(db);
-        let read_pool =
-            spawn_read_pool(store.clone(), READ_POOL_THREADS, STORAGE_EFFECT_QUEUE_CAPACITY);
-        let bulk_read_pool =
-            spawn_read_pool(store.clone(), BULK_READ_POOL_THREADS, BULK_EFFECT_QUEUE_CAPACITY);
+        let read_pool = spawn_read_pool(
+            store.clone(),
+            READ_POOL_THREADS,
+            STORAGE_EFFECT_QUEUE_CAPACITY,
+        );
+        let bulk_read_pool = spawn_read_pool(
+            store.clone(),
+            BULK_READ_POOL_THREADS,
+            BULK_EFFECT_QUEUE_CAPACITY,
+        );
         let channel_closed = sender.metrics.channel_closed.clone();
 
         thread::spawn(move || {
@@ -678,9 +684,7 @@ impl FjallStorage {
                     // A full bulk read queue backpressures rather than stealing
                     // the write actor thread from foreground sync traffic.
                     Err(TrySendError::Full(item)) => reject_bulk_read(item),
-                    Err(TrySendError::Disconnected(item)) => {
-                        self.process_single(item, slow_queue)
-                    }
+                    Err(TrySendError::Disconnected(item)) => self.process_single(item, slow_queue),
                 }
             }
         }
@@ -2050,22 +2054,26 @@ mod tests {
             let effect = read(key_space);
             let span = super::storage_effect_span(&effect);
             let in_flight = super::InFlightGuard::acquire(&handle.metrics);
-            handle
-                .bulk_channel
-                .try_send((effect, tx, span, Instant::now(), in_flight))
-                .ok()
-                .expect("bulk enqueue");
+            assert!(
+                handle
+                    .bulk_channel
+                    .try_send((effect, tx, span, Instant::now(), in_flight))
+                    .is_ok(),
+                "bulk enqueue"
+            );
             keep.push(rx);
         }
         let (tx, rx) = crossfire::oneshot::oneshot();
         let effect = read("fg");
         let span = super::storage_effect_span(&effect);
         let in_flight = super::InFlightGuard::acquire(&handle.metrics);
-        handle
-            .write_channel
-            .try_send((effect, tx, span, Instant::now(), in_flight))
-            .ok()
-            .expect("foreground enqueue");
+        assert!(
+            handle
+                .write_channel
+                .try_send((effect, tx, span, Instant::now(), in_flight))
+                .is_ok(),
+            "foreground enqueue"
+        );
         keep.push(rx);
 
         let (first, priority) = super::recv_prioritized(&receivers).expect("first item");


### PR DESCRIPTION
A 3-node stress test (10,000 `POST /metadata` per node) produced 6,506 `TransactionConflict` responses and a node that never reconverged. Both causes are fixed here, along with the failure modes that kept a loaded node from recovering on its own.

Creates conflicted with each other because the create transaction rewrote the unchanged `realm_config` row inside its own SSI transaction, putting every concurrent create in the same write set. The inbound sync path in `net/src/irokle.rs` did the same thing on every admitted batch. Both write-backs are gone; the remaining read is a fence, so two creates now conflict only when they race the same document or path.

Materialization never caught up because the drain rescanned the whole queue keyspace per job and saturated the storage actor, which starved everything else on the node. The queue is now sidecar-authoritative with sliced scans and batched lookups, storage has a bulk lane with fair-share aging so background work always gets service, and the batch finish is write-only and chunked so it cannot conflict or lose committed work.

Convergence under a long storm also required that no valid work is ever dropped. Failures are classified as terminal, transient, or application, and only application failures spend the budget that parks a job, so an overloaded node backs off instead of parking documents it could still finish. A parked job becomes a durable dead letter that the node requeues on an escalating backoff, revalidated inside the requeue transaction so a newer event cannot be resurrected.

Measured on a release gate that ingests 12,000 documents across 3 nodes at ~600 per second: zero conflicts, every document converges in ~43s, and ERROR events during the run drop from 19,926 to 0.

This branch also includes massive craqle performance upgrades that drastically improve ingest and materialisation as well as query performance.

## Changes

- Drop the realm config write-back from the create path and from the inbound placement fence
- Retry create conflicts with jitter and map an exhausted retry to 409
- Add a two-lane storage actor with fair-share aging so background work cannot be starved
- Make the materialization queue sidecar-authoritative, with sliced scans and batched lookups
- Chunk the batch finish into write-only transactions so partial progress always survives
- Classify materialization failures and charge only application failures against the park budget
- Park exhausted jobs as durable dead letters with escalating requeue backoff and supersession checks
- Park a failed index prune for the next drain instead of losing the cleanup
- Type storage and craqle infrastructure errors so overload never parks valid work
- Log expected operation outcomes at debug so client polling cannot flood the error stream
- Upgrade workspace dependencies, including craqle and irokle to their current main
