### PR TITLE
[fix] Bound compute job retries and surface the real exec failure

### DIFF
--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::future::Future;
 use std::io::{self, Read, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -754,13 +755,15 @@ impl KubernetesBackend {
             })?;
             let mut listing = Vec::new();
             // A helper wedged mid-listing must not stall the capture forever.
-            tokio::time::timeout(
+            let read = tokio::time::timeout(
                 EXEC_JOIN_TIMEOUT,
                 stdout.take(MAX_LISTING_BYTES).read_to_end(&mut listing),
             )
             .await
-            .map_err(|_| BackendError::Timeout("output listing read timed out".to_string()))?
-            .map_err(io_error)?;
+            .map_err(|_| BackendError::Timeout("output listing read timed out".to_string()))?;
+            if let Err(error) = read {
+                return Err(joined_error(join_exec(attached), io_error(error)).await);
+            }
             join_exec(attached).await?;
             select_listed(&listing, glob)
         }
@@ -802,33 +805,20 @@ impl KubernetesBackend {
         let mut stdout = attached.stdout().ok_or_else(|| {
             BackendError::Api("fetch exec did not expose standard output".to_string())
         })?;
-        let mut header_bytes = [0u8; 512];
-        stdout
-            .read_exact(&mut header_bytes)
-            .await
-            .map_err(io_error)?;
-        let header = tar::Header::from_byte_slice(&header_bytes);
-        let size = header
-            .size()
-            .map_err(|error| BackendError::Api(format!("invalid fetch archive size: {error}")))?;
-        if size > MAX_TRANSFER_BYTES || !header.entry_type().is_file() {
-            return Err(BackendError::InvalidSpec(
-                "fetch archive is not a bounded regular file".to_string(),
-            ));
-        }
-        let archive_path = header
-            .path()
-            .map_err(|error| BackendError::Api(format!("invalid fetch archive path: {error}")))?;
-        let expected = normalize_container_path(path).map_err(BackendError::InvalidSpec)?;
-        if archive_path.as_ref() != expected.strip_prefix("/").unwrap_or(&expected) {
-            return Err(BackendError::Conflict(
-                "fetch helper returned a different output path".to_string(),
-            ));
-        }
+        // A stream that dies before the header reports EOF or a torn read; the exec
+        // status holds the real cause, and the helper Pod still has to go.
+        let size = match read_header(&mut stdout, path).await {
+            Ok(size) => size,
+            Err(error) => {
+                let error = joined_error(join_exec(attached), error).await;
+                let _ = self.delete_pod(&pod).await;
+                return Err(error);
+            }
+        };
         let (tx, rx) = mpsc::channel(4);
         let backend = self.clone();
         tokio::spawn(async move {
-            stream_output(stdout, attached, size, tx).await;
+            stream_output(stdout, join_exec(attached), size, tx).await;
             let _ = backend.delete_pod(&pod).await;
         });
         Ok(TaskOutput {
@@ -1971,9 +1961,41 @@ fn select_listed(listing: &[u8], glob: &OutputMatcher) -> Result<Vec<String>, Ba
     Ok(matched)
 }
 
+/// Read the leading tar header the fetch helper emits and check it describes the
+/// requested file within the transfer bound. Returns the declared body size.
+async fn read_header<R: AsyncRead + Unpin>(
+    stdout: &mut R,
+    path: &str,
+) -> Result<u64, BackendError> {
+    let mut header_bytes = [0u8; 512];
+    stdout
+        .read_exact(&mut header_bytes)
+        .await
+        .map_err(io_error)?;
+    let header = tar::Header::from_byte_slice(&header_bytes);
+    let size = header
+        .size()
+        .map_err(|error| BackendError::Api(format!("invalid fetch archive size: {error}")))?;
+    if size > MAX_TRANSFER_BYTES || !header.entry_type().is_file() {
+        return Err(BackendError::InvalidSpec(
+            "fetch archive is not a bounded regular file".to_string(),
+        ));
+    }
+    let archive_path = header
+        .path()
+        .map_err(|error| BackendError::Api(format!("invalid fetch archive path: {error}")))?;
+    let expected = normalize_container_path(path).map_err(BackendError::InvalidSpec)?;
+    if archive_path.as_ref() != expected.strip_prefix("/").unwrap_or(&expected) {
+        return Err(BackendError::Conflict(
+            "fetch helper returned a different output path".to_string(),
+        ));
+    }
+    Ok(size)
+}
+
 async fn stream_output<R: AsyncRead + Unpin>(
     mut stdout: R,
-    attached: kube::api::AttachedProcess,
+    join: impl Future<Output = Result<(), BackendError>>,
     size: u64,
     tx: mpsc::Sender<Result<Bytes, BackendError>>,
 ) {
@@ -1984,17 +2006,12 @@ async fn stream_output<R: AsyncRead + Unpin>(
             .unwrap_or(usize::MAX)
             .min(buffer.len());
         match stdout.read(&mut buffer[..limit]).await {
-            // kube-rs reports a websocket failure or an unexpected close as a plain
-            // EOF, so the real cause survives only in the exec status.
             Ok(0) => {
                 let transferred = size - remaining;
-                let _ = tx
-                    .send(Err(join_exec(attached).await.err().unwrap_or_else(|| {
-                        BackendError::Api(format!(
-                            "fetch archive ended after {transferred} of {size} bytes"
-                        ))
-                    })))
-                    .await;
+                let short = BackendError::Api(format!(
+                    "fetch archive ended after {transferred} of {size} bytes"
+                ));
+                let _ = tx.send(Err(joined_error(join, short).await)).await;
                 return;
             }
             Ok(read) => {
@@ -2009,19 +2026,26 @@ async fn stream_output<R: AsyncRead + Unpin>(
             }
             Err(error) => {
                 let _ = tx
-                    .send(Err(join_exec(attached)
-                        .await
-                        .err()
-                        .unwrap_or_else(|| io_error(error))))
+                    .send(Err(joined_error(join, io_error(error)).await))
                     .await;
                 return;
             }
         }
     }
     let _ = tokio::io::copy(&mut stdout, &mut tokio::io::sink()).await;
-    if let Err(error) = join_exec(attached).await {
+    if let Err(error) = join.await {
         let _ = tx.send(Err(error)).await;
     }
+}
+
+/// kube-rs reports a websocket failure or an unexpected close as a plain EOF or IO
+/// error, so the real cause survives only in the exec status. `fallback` is reported
+/// when the status itself is clean.
+async fn joined_error(
+    join: impl Future<Output = Result<(), BackendError>>,
+    fallback: BackendError,
+) -> BackendError {
+    join.await.err().unwrap_or(fallback)
 }
 
 async fn join_exec(mut attached: kube::api::AttachedProcess) -> Result<(), BackendError> {
@@ -2756,5 +2780,74 @@ mod tests {
 
         assert!(tails.stdout.is_empty());
         assert_eq!(tails.stdout_total, 0);
+    }
+
+    async fn drain_stream(
+        mut rx: mpsc::Receiver<Result<Bytes, BackendError>>,
+    ) -> Vec<Result<Bytes, BackendError>> {
+        let mut items = Vec::new();
+        while let Some(item) = rx.recv().await {
+            items.push(item);
+        }
+        items
+    }
+
+    // A dead websocket reaches the reader as a plain EOF, so the exec status must win
+    // over the truncation the reader sees.
+    #[tokio::test]
+    async fn truncation_prefers_status() {
+        let (mut writer, reader) = tokio::io::duplex(64);
+        writer.write_all(b"abc").await.unwrap();
+        drop(writer);
+        let (tx, rx) = mpsc::channel(4);
+
+        let join = std::future::ready(Err(BackendError::Api("websocket reset".to_string())));
+        stream_output(reader, join, 8, tx).await;
+
+        let items = drain_stream(rx).await;
+        assert_eq!(items.len(), 2);
+        assert!(items[0].is_ok());
+        match items[1].as_ref().expect_err("the stream must fail") {
+            BackendError::Api(message) => assert_eq!(message, "websocket reset"),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // A clean exec status leaves the shortfall as the only evidence.
+    #[tokio::test]
+    async fn truncation_reports_shortfall() {
+        let (mut writer, reader) = tokio::io::duplex(64);
+        writer.write_all(b"abc").await.unwrap();
+        drop(writer);
+        let (tx, rx) = mpsc::channel(4);
+
+        stream_output(reader, std::future::ready(Ok(())), 8, tx).await;
+
+        let items = drain_stream(rx).await;
+        match items[1].as_ref().expect_err("the stream must fail") {
+            BackendError::Api(message) => {
+                assert_eq!(message, "fetch archive ended after 3 of 8 bytes")
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // A complete body still fails when the helper exits non-zero afterwards.
+    #[tokio::test]
+    async fn complete_reports_status() {
+        let (mut writer, reader) = tokio::io::duplex(64);
+        writer.write_all(b"abcdefgh").await.unwrap();
+        drop(writer);
+        let (tx, rx) = mpsc::channel(4);
+
+        let join = std::future::ready(Err(BackendError::Api("helper exited 1".to_string())));
+        stream_output(reader, join, 8, tx).await;
+
+        let items = drain_stream(rx).await;
+        assert!(items[..items.len() - 1].iter().all(Result::is_ok));
+        assert!(
+            items.last().unwrap().is_err(),
+            "the exec status must surface"
+        );
     }
 }

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -806,12 +806,10 @@ impl KubernetesBackend {
         let mut stdout = attached.stdout().ok_or_else(|| {
             BackendError::Api("fetch exec did not expose standard output".to_string())
         })?;
-        // A stream that dies before the header reports EOF or a torn read; the exec
-        // status holds the real cause, and the helper Pod still has to go.
-        let size = match read_header(&mut stdout, path).await {
-            Ok(size) => size,
+        // The helper Pod still has to go on either failure.
+        let (size, join) = match read_header(&mut stdout, path, join_exec(attached)).await {
+            Ok(header) => header,
             Err(error) => {
-                let error = joined_error(join_exec(attached), error).await;
                 let _ = self.delete_pod(&pod).await;
                 return Err(error);
             }
@@ -819,7 +817,7 @@ impl KubernetesBackend {
         let (tx, rx) = mpsc::channel(4);
         let backend = self.clone();
         tokio::spawn(async move {
-            stream_output(stdout, join_exec(attached), size, tx).await;
+            stream_output(stdout, join, size, tx).await;
             let _ = backend.delete_pod(&pod).await;
         });
         Ok(TaskOutput {
@@ -1962,18 +1960,24 @@ fn select_listed(listing: &[u8], glob: &OutputMatcher) -> Result<Vec<String>, Ba
     Ok(matched)
 }
 
-/// Read the leading tar header the fetch helper emits and check it describes the
-/// requested file within the transfer bound. Returns the declared body size.
-async fn read_header<R: AsyncRead + Unpin>(
-    stdout: &mut R,
-    path: &str,
-) -> Result<u64, BackendError> {
+/// Read the leading tar header the fetch helper emits, returning the unpolled `join`
+/// beside the declared body size. A torn read reports the exec status, which holds
+/// its real cause; an intact but invalid header keeps its own error and drops `join`.
+async fn read_header<R, F>(stdout: &mut R, path: &str, join: F) -> Result<(u64, F), BackendError>
+where
+    R: AsyncRead + Unpin,
+    F: Future<Output = Result<(), BackendError>>,
+{
     let mut header_bytes = [0u8; 512];
-    stdout
-        .read_exact(&mut header_bytes)
-        .await
-        .map_err(io_error)?;
-    let header = tar::Header::from_byte_slice(&header_bytes);
+    if let Err(error) = stdout.read_exact(&mut header_bytes).await {
+        return Err(joined_error(join, io_error(error)).await);
+    }
+    Ok((parse_header(&header_bytes, path)?, join))
+}
+
+/// Check the header describes the requested file within the transfer bound.
+fn parse_header(header_bytes: &[u8; 512], path: &str) -> Result<u64, BackendError> {
+    let header = tar::Header::from_byte_slice(header_bytes);
     let size = header
         .size()
         .map_err(|error| BackendError::Api(format!("invalid fetch archive size: {error}")))?;
@@ -2850,5 +2854,46 @@ mod tests {
             items.last().unwrap().is_err(),
             "the exec status must surface"
         );
+    }
+
+    fn header_bytes(path: &str, size: u64) -> [u8; 512] {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_size(size);
+        header.set_path(path).expect("header path");
+        header.set_cksum();
+        *header.as_bytes()
+    }
+
+    // A deterministic protocol mismatch must keep its own error: joining an undrained
+    // exec would block until the timeout and reclassify it as retryable.
+    #[tokio::test(start_paused = true)]
+    async fn invalid_header_survives() {
+        let bytes = header_bytes("workspace/other.txt", 4);
+        let join = std::future::pending::<Result<(), BackendError>>();
+        let read = tokio::time::timeout(
+            EXEC_JOIN_TIMEOUT * 4,
+            read_header(&mut &bytes[..], "/workspace/data.txt", join),
+        )
+        .await
+        .expect("validation must not wait on the exec");
+
+        let Err(error) = read else {
+            panic!("a mismatched archive path must fail");
+        };
+        assert!(matches!(error, BackendError::Conflict(_)));
+    }
+
+    // A header that never arrives in full is a transport failure: the exec status
+    // holds the real cause.
+    #[tokio::test]
+    async fn torn_header_joins() {
+        let bytes = header_bytes("workspace/data.txt", 4);
+        let join = std::future::ready(Err(BackendError::Api("websocket closed".to_string())));
+
+        let Err(error) = read_header(&mut &bytes[..16], "/workspace/data.txt", join).await else {
+            panic!("a short header must fail");
+        };
+        assert!(matches!(&error, BackendError::Api(message) if message == "websocket closed"));
     }
 }

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -60,10 +60,10 @@ const DEFAULT_WORKSPACE_BYTES: u64 = 10 * 1024 * 1024 * 1024;
 const MAX_LISTING_BYTES: u64 = 16 * 1024 * 1024;
 /// Bounds the wait for an exec status so a stalled helper cannot hang a capture.
 const EXEC_JOIN_TIMEOUT: Duration = Duration::from_secs(120);
-/// Attach buffer for helper standard output, several times the archive read size.
-/// kube-rs otherwise defaults to 1 KiB, which throttles a transfer to a trickle and
-/// blocks the frame reader that also drives its keepalive ping.
-const EXEC_STDOUT_BUF_BYTES: usize = 512 * 1024;
+/// Attach buffer for the helper standard streams, several times the archive read
+/// size. kube-rs otherwise defaults to 1 KiB, which throttles a transfer to a trickle
+/// and, on the read side, blocks the frame loop that drives its keepalive ping.
+const EXEC_STREAM_BUF_BYTES: usize = 512 * 1024;
 
 #[derive(Clone)]
 pub struct KubernetesBackend {
@@ -486,7 +486,8 @@ impl KubernetesBackend {
             .container("helper")
             .stdin(true)
             .stdout(false)
-            .stderr(false);
+            .stderr(false)
+            .max_stdin_buf_size(EXEC_STREAM_BUF_BYTES);
         let mut attached = self
             .pods()
             .exec(
@@ -732,7 +733,7 @@ impl KubernetesBackend {
             .stdin(false)
             .stdout(true)
             .stderr(false)
-            .max_stdout_buf_size(EXEC_STDOUT_BUF_BYTES);
+            .max_stdout_buf_size(EXEC_STREAM_BUF_BYTES);
         let listed = async {
             let mut attached = self
                 .pods()
@@ -785,7 +786,7 @@ impl KubernetesBackend {
             .stdin(false)
             .stdout(true)
             .stderr(false)
-            .max_stdout_buf_size(EXEC_STDOUT_BUF_BYTES);
+            .max_stdout_buf_size(EXEC_STREAM_BUF_BYTES);
         let mut attached = self
             .pods()
             .exec(

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -1978,11 +1978,16 @@ async fn stream_output<R: AsyncRead + Unpin>(
             .unwrap_or(usize::MAX)
             .min(buffer.len());
         match stdout.read(&mut buffer[..limit]).await {
+            // kube-rs reports a websocket failure or an unexpected close as a plain
+            // EOF, so the real cause survives only in the exec status.
             Ok(0) => {
+                let transferred = size - remaining;
                 let _ = tx
-                    .send(Err(BackendError::Api(
-                        "fetch archive ended before its declared size".to_string(),
-                    )))
+                    .send(Err(join_exec(attached).await.err().unwrap_or_else(|| {
+                        BackendError::Api(format!(
+                            "fetch archive ended after {transferred} of {size} bytes"
+                        ))
+                    })))
                     .await;
                 return;
             }
@@ -1997,7 +2002,12 @@ async fn stream_output<R: AsyncRead + Unpin>(
                 }
             }
             Err(error) => {
-                let _ = tx.send(Err(io_error(error))).await;
+                let _ = tx
+                    .send(Err(join_exec(attached)
+                        .await
+                        .err()
+                        .unwrap_or_else(|| io_error(error))))
+                    .await;
                 return;
             }
         }

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -59,6 +59,10 @@ const DEFAULT_WORKSPACE_BYTES: u64 = 10 * 1024 * 1024 * 1024;
 const MAX_LISTING_BYTES: u64 = 16 * 1024 * 1024;
 /// Bounds the wait for an exec status so a stalled helper cannot hang a capture.
 const EXEC_JOIN_TIMEOUT: Duration = Duration::from_secs(120);
+/// Attach buffer for helper standard output, several times the archive read size.
+/// kube-rs otherwise defaults to 1 KiB, which throttles a transfer to a trickle and
+/// blocks the frame reader that also drives its keepalive ping.
+const EXEC_STDOUT_BUF_BYTES: usize = 512 * 1024;
 
 #[derive(Clone)]
 pub struct KubernetesBackend {
@@ -726,7 +730,8 @@ impl KubernetesBackend {
             .container("helper")
             .stdin(false)
             .stdout(true)
-            .stderr(false);
+            .stderr(false)
+            .max_stdout_buf_size(EXEC_STDOUT_BUF_BYTES);
         let listed = async {
             let mut attached = self
                 .pods()
@@ -776,7 +781,8 @@ impl KubernetesBackend {
             .container("helper")
             .stdin(false)
             .stdout(true)
-            .stderr(false);
+            .stderr(false)
+            .max_stdout_buf_size(EXEC_STDOUT_BUF_BYTES);
         let mut attached = self
             .pods()
             .exec(

--- a/operations/src/jobs/drain.rs
+++ b/operations/src/jobs/drain.rs
@@ -20,7 +20,7 @@ use tracing::warn;
 use super::reconcile::ExternalReconciler;
 use super::store::{
     ClaimOutcome, JobMutationError, RequeueOutcome, batch_delete, claim_job, first_schedule_entry,
-    iter_prefix_page, park_unreconciled, read_job_record, requeue_job,
+    iter_prefix_page, read_job_record, requeue_job,
 };
 use super::{JOB_DRAIN_BATCH_SIZE, JOB_RECONCILE_REARM};
 
@@ -108,12 +108,12 @@ pub async fn process_job_queue_batch(
                         )
                         .await
                         {
+                            // A node without a reconciler leaves the attempt for one that
+                            // has it: charging here would terminalize a healthy container
+                            // this node cannot even observe.
                             Ok(RequeueOutcome::NeedsReconcile(record)) => {
-                                match reconciler {
-                                    Some(reconciler) => {
-                                        reconciler.reconcile_lost_attempt(storage, record).await;
-                                    }
-                                    None => park_unreconciled(storage, &record, now_ms).await,
+                                if let Some(reconciler) = reconciler {
+                                    reconciler.reconcile_lost_attempt(storage, record).await;
                                 }
                                 result.reconciled = result.reconciled.saturating_add(1);
                             }

--- a/operations/src/jobs/drain.rs
+++ b/operations/src/jobs/drain.rs
@@ -20,7 +20,7 @@ use tracing::warn;
 use super::reconcile::ExternalReconciler;
 use super::store::{
     ClaimOutcome, JobMutationError, RequeueOutcome, batch_delete, claim_job, first_schedule_entry,
-    iter_prefix_page, read_job_record, requeue_job,
+    iter_prefix_page, park_unreconciled, read_job_record, requeue_job,
 };
 use super::{JOB_DRAIN_BATCH_SIZE, JOB_RECONCILE_REARM};
 
@@ -109,8 +109,11 @@ pub async fn process_job_queue_batch(
                         .await
                         {
                             Ok(RequeueOutcome::NeedsReconcile(record)) => {
-                                if let Some(reconciler) = reconciler {
-                                    reconciler.reconcile_lost_attempt(storage, record).await;
+                                match reconciler {
+                                    Some(reconciler) => {
+                                        reconciler.reconcile_lost_attempt(storage, record).await;
+                                    }
+                                    None => park_unreconciled(storage, &record, now_ms).await,
                                 }
                                 result.reconciled = result.reconciled.saturating_add(1);
                             }
@@ -572,9 +575,8 @@ mod tests {
     }
 
     // An external attempt with an expired lease routes to the reconcile hook and is
-    // NOT requeued: no second container can be spawned. It still spends an attempt,
-    // and its lease row stays in place, so the re-arm must be floored to a non-zero
-    // delay instead of busy-looping.
+    // NOT requeued: no second container can be spawned. Its lease row stays in place,
+    // so the re-arm must be floored to a non-zero delay instead of busy-looping.
     #[tokio::test]
     async fn external_lease_reconciled() {
         let dir = tempdir().unwrap();
@@ -615,7 +617,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.state, JobState::Running, "not requeued");
-        assert_eq!(stored.attempts, 1, "the sweep charges the attempt");
+        assert_eq!(stored.attempts, 0, "the sweep charges nothing");
         assert!(stored.claim.is_some());
         // The hook saw exactly this job, proving no blind re-run path was taken.
         assert_eq!(recorder.seen.lock().unwrap().as_slice(), &[job_id]);

--- a/operations/src/jobs/drain.rs
+++ b/operations/src/jobs/drain.rs
@@ -572,8 +572,9 @@ mod tests {
     }
 
     // An external attempt with an expired lease routes to the reconcile hook and is
-    // NOT requeued: no second container can be spawned. Its lease row stays in place,
-    // so the re-arm must be floored to a non-zero delay instead of busy-looping.
+    // NOT requeued: no second container can be spawned. It still spends an attempt,
+    // and its lease row stays in place, so the re-arm must be floored to a non-zero
+    // delay instead of busy-looping.
     #[tokio::test]
     async fn external_lease_reconciled() {
         let dir = tempdir().unwrap();
@@ -614,7 +615,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.state, JobState::Running, "not requeued");
-        assert_eq!(stored.attempts, 0);
+        assert_eq!(stored.attempts, 1, "the sweep charges the attempt");
         assert!(stored.claim.is_some());
         // The hook saw exactly this job, proving no blind re-run path was taken.
         assert_eq!(recorder.seen.lock().unwrap().as_slice(), &[job_id]);

--- a/operations/src/jobs/runtime.rs
+++ b/operations/src/jobs/runtime.rs
@@ -26,8 +26,8 @@ use super::executor::{JobContext, JobRunOutcome, ProgressReporter, dispatch_payl
 use super::reconcile::ExternalReconciler;
 use super::store::{
     JobMutationError, ReleaseOutcome, RequeueOutcome, cancel_running_job, complete_job, fail_job,
-    flush_progress, handoff_external_attempt, iter_prefix_page, read_job_record, release_job,
-    renew_lease, requeue_job, transition_to_running,
+    flush_progress, handoff_external_attempt, iter_prefix_page, park_unreconciled, read_job_record,
+    release_job, renew_lease, requeue_job, transition_to_running,
 };
 use super::submit::schedule_job_drain_effect;
 use super::{
@@ -480,6 +480,7 @@ impl JobsRuntime {
     /// At startup every claimed/running holder is definitionally dead: re-queue the
     /// in-process ones. External attempts route to the reconcile hook instead, since a
     /// blind requeue would spawn a second container for a job that may still be running.
+    /// The restart itself costs them no attempt; only an adoption that fails does.
     pub async fn recover_stale_jobs(&self, storage: &StorageHandle) -> Result<usize, String> {
         let now_ms = unix_timestamp_millis();
         let mut job_ids = Vec::new();
@@ -534,11 +535,10 @@ impl JobsRuntime {
             )
             .await
             {
-                Ok(RequeueOutcome::NeedsReconcile(record)) => {
-                    if let Some(reconciler) = self.reconciler() {
-                        reconciler.reconcile_lost_attempt(storage, record).await;
-                    }
-                }
+                Ok(RequeueOutcome::NeedsReconcile(record)) => match self.reconciler() {
+                    Some(reconciler) => reconciler.reconcile_lost_attempt(storage, record).await,
+                    None => park_unreconciled(storage, &record, now_ms).await,
+                },
                 Ok(_) => recovered += 1,
                 Err(JobMutationError::NotFound) => {}
                 Err(error) => return Err(error.to_string()),
@@ -838,7 +838,8 @@ mod tests {
     use super::*;
     use crate::jobs::JOB_MAX_ATTEMPTS;
     use crate::jobs::store::{
-        ClaimOutcome, claim_job, complete_job, insert_job, list_job_entries, set_cancel_requested,
+        AdoptOutcome, ClaimOutcome, JobMutation, adopt_external_attempt, claim_job, complete_job,
+        insert_job, list_job_entries, mutate_job, record_attempt_intent, set_cancel_requested,
     };
     use aruna_core::effects::StorageEffect;
     use aruna_core::keyspaces::ROCRATE_JOB_STATE_KEYSPACE;
@@ -1699,8 +1700,82 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(after.state, JobState::Running, "not requeued");
-        assert_eq!(after.attempts, 1, "the restart still spends an attempt");
+        assert_eq!(after.attempts, 0, "the restart spends no attempt");
         assert!(after.claim.is_some());
         assert_eq!(recorder.seen.lock().unwrap().as_slice(), &[job_id]);
+    }
+
+    struct AdoptingReconciler;
+
+    #[async_trait::async_trait]
+    impl ExternalReconciler for AdoptingReconciler {
+        async fn reconcile_lost_attempt(&self, storage: &StorageHandle, record: JobRecord) {
+            let outcome = adopt_external_attempt(
+                storage,
+                record.job_id,
+                record.owner_node_id,
+                unix_timestamp_millis(),
+            )
+            .await
+            .unwrap();
+            assert!(matches!(outcome, AdoptOutcome::Adopted(..)), "must adopt");
+        }
+    }
+
+    // Rolling restarts must never exhaust JOB_MAX_ATTEMPTS on an external attempt whose
+    // container is still healthy and gets re-adopted every time.
+    #[tokio::test]
+    async fn recovery_spares_attempts() {
+        let (_dir, storage) = temp_storage();
+        let runtime = JobsRuntime::with_reconciler(Arc::new(AdoptingReconciler));
+        let job_id = JobId::from_bytes([0xE8; 16]);
+        let token = Ulid::generate();
+        let mut record = probe_record(job_id, 3, 0, None);
+        record.execution_class = JobExecutionClass::ExternalAttempt;
+        record.state = JobState::Running;
+        record.claim = Some(JobClaim {
+            holder_node_id: node_id(3),
+            claim_token: token,
+            lease_expires_at_ms: unix_timestamp_millis() + 60_000,
+        });
+        insert_job(&storage, &record).await.unwrap();
+        record_attempt_intent(
+            &storage,
+            job_id,
+            token,
+            AttemptIntent {
+                attempt_no: 1,
+                external_name: "attempt".to_string(),
+                executor_kind: "docker".to_string(),
+                pinned_image: "alpine@sha256:digest".to_string(),
+                attempt_epoch: 0,
+            },
+            unix_timestamp_millis(),
+        )
+        .await
+        .unwrap();
+
+        for restart in 0..(JOB_MAX_ATTEMPTS + 2) {
+            expire_lease(&storage, job_id).await;
+            assert_eq!(runtime.recover_stale_jobs(&storage).await.unwrap(), 0);
+            let after = read_job_record(&storage, job_id, None)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(after.state, JobState::Running, "restart {restart}");
+            assert_eq!(after.attempts, 0, "restart {restart}");
+            assert!(after.claim.is_some(), "restart {restart}");
+        }
+    }
+
+    async fn expire_lease(storage: &StorageHandle, job_id: JobId) {
+        mutate_job(storage, job_id, |record| {
+            if let Some(claim) = record.claim.as_mut() {
+                claim.lease_expires_at_ms = 1;
+            }
+            Ok(JobMutation::Persist)
+        })
+        .await
+        .unwrap();
     }
 }

--- a/operations/src/jobs/runtime.rs
+++ b/operations/src/jobs/runtime.rs
@@ -26,8 +26,8 @@ use super::executor::{JobContext, JobRunOutcome, ProgressReporter, dispatch_payl
 use super::reconcile::ExternalReconciler;
 use super::store::{
     JobMutationError, ReleaseOutcome, RequeueOutcome, cancel_running_job, complete_job, fail_job,
-    flush_progress, handoff_external_attempt, iter_prefix_page, park_unreconciled, read_job_record,
-    release_job, renew_lease, requeue_job, transition_to_running,
+    flush_progress, handoff_external_attempt, iter_prefix_page, read_job_record, release_job,
+    renew_lease, requeue_job, transition_to_running,
 };
 use super::submit::schedule_job_drain_effect;
 use super::{
@@ -535,10 +535,11 @@ impl JobsRuntime {
             )
             .await
             {
-                Ok(RequeueOutcome::NeedsReconcile(record)) => match self.reconciler() {
-                    Some(reconciler) => reconciler.reconcile_lost_attempt(storage, record).await,
-                    None => park_unreconciled(storage, &record, now_ms).await,
-                },
+                Ok(RequeueOutcome::NeedsReconcile(record)) => {
+                    if let Some(reconciler) = self.reconciler() {
+                        reconciler.reconcile_lost_attempt(storage, record).await;
+                    }
+                }
                 Ok(_) => recovered += 1,
                 Err(JobMutationError::NotFound) => {}
                 Err(error) => return Err(error.to_string()),

--- a/operations/src/jobs/runtime.rs
+++ b/operations/src/jobs/runtime.rs
@@ -1699,7 +1699,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(after.state, JobState::Running, "not requeued");
-        assert_eq!(after.attempts, 0);
+        assert_eq!(after.attempts, 1, "the restart still spends an attempt");
         assert!(after.claim.is_some());
         assert_eq!(recorder.seen.lock().unwrap().as_slice(), &[job_id]);
     }

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -978,6 +978,25 @@ pub enum RequeueOutcome {
     Skipped,
 }
 
+/// Terminal `Failed` once `JOB_MAX_ATTEMPTS` is spent. An execution keeps a result
+/// payload so terminal cleanup and the run crate still see its workspace.
+fn fail_capped(record: &mut JobRecord, now_ms: u64) {
+    record.state = JobState::Failed;
+    record.finished_at_ms = Some(now_ms);
+    record.claim = None;
+    if record.result.is_some() || !matches!(record.payload, JobPayload::Execution(_)) {
+        return;
+    }
+    let result = JobResultPayload::Execution {
+        exit_code: None,
+        workspace_bucket: record.workspace_bucket.clone(),
+        outputs: Vec::new(),
+        stdout: String::new(),
+        stderr: String::new(),
+    };
+    record.result = Some(result);
+}
+
 /// Re-queue with backoff, or fail once `JOB_MAX_ATTEMPTS` is spent. `token` is `None`
 /// for the lease sweep and startup recovery. `require_expired_before` makes the sweep
 /// re-check, in-txn, that the job still holds an expired lease: a revived renew is not
@@ -1016,8 +1035,20 @@ pub async fn requeue_job(
         if record.execution_class == JobExecutionClass::ExternalAttempt
             && record.attempt_intent.is_some()
         {
-            needs_reconcile = true;
-            return Ok(JobMutation::Skip);
+            if let Some(error) = error.clone() {
+                record.last_error = Some(error);
+            }
+            // Re-queuing would double-run the container, so the attempt is charged
+            // and routed to reconcile instead. The cap still terminalizes it.
+            record.attempts = record.attempts.saturating_add(1);
+            record.updated_at_ms = now_ms;
+            if record.attempts >= JOB_MAX_ATTEMPTS {
+                fail_capped(record, now_ms);
+            } else {
+                needs_reconcile = true;
+            }
+            persisted = true;
+            return Ok(JobMutation::Persist);
         }
         if let Some(error) = error.clone() {
             record.last_error = Some(error);
@@ -1527,23 +1558,47 @@ pub async fn transition_to_cancelling(
     .await
 }
 
+#[derive(Debug)]
+pub enum ParkOutcome {
+    Parked(JobRecord),
+    /// The park spent the last attempt, so the job is terminal `Failed` instead.
+    Failed(JobRecord),
+}
+
 /// Park an ambiguous external attempt in `Indeterminate`, keeping the claim so the
-/// lease sweep later re-routes it to reconciliation. Exits only on evidence.
+/// lease sweep later re-routes it to reconciliation. Exits only on evidence, or on
+/// the attempt cap: charging an attempt is what stops a condition that parks on
+/// every reconcile pass from retrying forever.
 pub async fn mark_indeterminate(
     storage: &StorageHandle,
     job_id: JobId,
     token: Ulid,
     error: JobError,
     now_ms: u64,
-) -> Result<JobRecord, JobMutationError> {
-    mutate_job(storage, job_id, |record| {
+) -> Result<ParkOutcome, JobMutationError> {
+    let mut capped = false;
+    let record = mutate_job(storage, job_id, |record| {
+        capped = false;
         guard_token(record, token)?;
-        record.state = JobState::Indeterminate;
-        record.updated_at_ms = now_ms;
         record.last_error = Some(error.clone());
+        record.attempts = record.attempts.saturating_add(1);
+        record.updated_at_ms = now_ms;
+        if record.attempts >= JOB_MAX_ATTEMPTS {
+            fail_capped(record, now_ms);
+            capped = true;
+        } else {
+            record.state = JobState::Indeterminate;
+            record.due_at_ms = now_ms.saturating_add(queue_retry_after_ms(record.attempts));
+        }
         Ok(JobMutation::Persist)
     })
-    .await
+    .await?;
+
+    Ok(if capped {
+        ParkOutcome::Failed(record)
+    } else {
+        ParkOutcome::Parked(record)
+    })
 }
 
 /// Terminal `Failed` for an execution job, capturing the exit evidence in the
@@ -3248,7 +3303,8 @@ mod tests {
         );
     }
 
-    // An external attempt with an expired lease is never requeued; it is reconciled.
+    // An external attempt with an expired lease is never requeued; it is reconciled,
+    // but the sweep still charges the attempt so the cap can terminalize it.
     #[tokio::test]
     async fn external_never_requeued() {
         let (_dir, storage) = temp_storage();
@@ -3273,8 +3329,98 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.state, JobState::Running, "not requeued");
-        assert_eq!(stored.attempts, 0, "attempt count untouched");
+        assert_eq!(stored.attempts, 1, "attempt charged");
         assert!(stored.claim.is_some(), "claim untouched");
+    }
+
+    // The reconcile route must not exempt an attempt from the cap: once the last
+    // attempt is spent the sweep terminalizes it instead of routing it again.
+    #[tokio::test]
+    async fn external_sweep_caps() {
+        let (_dir, storage) = temp_storage();
+        let job_id = JobId::from_bytes([0xE4; 16]);
+        let mut record = execution_record(job_id, Ulid::generate(), JobState::Running);
+        record.claim.as_mut().unwrap().lease_expires_at_ms = 1;
+        record.attempts = JOB_MAX_ATTEMPTS - 1;
+        record.workspace_bucket = Some("ws-test".to_string());
+        record.attempt_intent = Some(AttemptIntent {
+            attempt_no: 1,
+            external_name: "attempt".to_string(),
+            executor_kind: "docker".to_string(),
+            pinned_image: "alpine@sha256:digest".to_string(),
+            attempt_epoch: 1,
+        });
+        insert_job(&storage, &record).await.unwrap();
+
+        let outcome = requeue_job(&storage, job_id, None, 9_000, Some(9_000), None)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, RequeueOutcome::Failed(_)));
+        let stored = read_job_record(&storage, job_id, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.state, JobState::Failed);
+        assert_eq!(stored.attempts, JOB_MAX_ATTEMPTS);
+        assert!(stored.claim.is_none());
+        assert!(
+            matches!(stored.result, Some(JobResultPayload::Execution { .. })),
+            "cleanup and the run crate need a result"
+        );
+    }
+
+    // Parking spends an attempt and terminalizes at the cap; without that a failure
+    // repeating on every reconcile pass re-drives the job forever.
+    #[tokio::test]
+    async fn park_spends_attempt() {
+        let (_dir, storage) = temp_storage();
+        let job_id = JobId::from_bytes([0xE5; 16]);
+        let token = Ulid::generate();
+        let mut record = execution_record(job_id, token, JobState::Running);
+        record.workspace_bucket = Some("ws-test".to_string());
+        insert_job(&storage, &record).await.unwrap();
+
+        for attempt in 1..JOB_MAX_ATTEMPTS {
+            let ParkOutcome::Parked(parked) = mark_indeterminate(
+                &storage,
+                job_id,
+                token,
+                JobError::retryable("output capture failed"),
+                6_000,
+            )
+            .await
+            .unwrap() else {
+                panic!("a park below the cap must stay Indeterminate");
+            };
+            assert_eq!(parked.state, JobState::Indeterminate);
+            assert_eq!(parked.attempts, attempt);
+            assert_eq!(
+                parked.due_at_ms,
+                6_000 + queue_retry_after_ms(attempt),
+                "each park backs the retry off"
+            );
+        }
+
+        let ParkOutcome::Failed(failed) = mark_indeterminate(
+            &storage,
+            job_id,
+            token,
+            JobError::retryable("output capture failed"),
+            7_000,
+        )
+        .await
+        .unwrap() else {
+            panic!("the capped park must terminalize");
+        };
+        assert_eq!(failed.state, JobState::Failed);
+        assert_eq!(failed.attempts, JOB_MAX_ATTEMPTS);
+        assert_eq!(failed.finished_at_ms, Some(7_000));
+        assert!(failed.claim.is_none());
+        assert!(
+            matches!(failed.result, Some(JobResultPayload::Execution { .. })),
+            "cleanup and the run crate need a result"
+        );
     }
 
     #[tokio::test]

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -1030,18 +1030,17 @@ pub async fn requeue_job(
                 return Ok(JobMutation::Skip);
             }
         }
+        if let Some(error) = error.clone() {
+            record.last_error = Some(error);
+        }
+        record.attempts = record.attempts.saturating_add(1);
+        record.updated_at_ms = now_ms;
         // Checked AFTER the expired-lease re-check: a live renewed attempt is a
-        // plain Skip and must not be routed to the reconciler.
+        // plain Skip and must not be routed to the reconciler. Re-queuing would
+        // double-run the container, so a charged attempt goes to reconcile instead.
         if record.execution_class == JobExecutionClass::ExternalAttempt
             && record.attempt_intent.is_some()
         {
-            if let Some(error) = error.clone() {
-                record.last_error = Some(error);
-            }
-            // Re-queuing would double-run the container, so the attempt is charged
-            // and routed to reconcile instead. The cap still terminalizes it.
-            record.attempts = record.attempts.saturating_add(1);
-            record.updated_at_ms = now_ms;
             if record.attempts >= JOB_MAX_ATTEMPTS {
                 fail_capped(record, now_ms);
             } else {
@@ -1050,11 +1049,6 @@ pub async fn requeue_job(
             persisted = true;
             return Ok(JobMutation::Persist);
         }
-        if let Some(error) = error.clone() {
-            record.last_error = Some(error);
-        }
-        record.attempts = record.attempts.saturating_add(1);
-        record.updated_at_ms = now_ms;
         record.claim = None;
         if record.attempts >= JOB_MAX_ATTEMPTS
             && !matches!(&record.payload, JobPayload::TerminalCleanup { .. })

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -1049,8 +1049,7 @@ pub async fn requeue_job(
         if record.attempts >= JOB_MAX_ATTEMPTS
             && !matches!(&record.payload, JobPayload::TerminalCleanup { .. })
         {
-            record.state = JobState::Failed;
-            record.finished_at_ms = Some(now_ms);
+            fail_capped(record, now_ms);
         } else {
             record.state = JobState::Queued;
             record.due_at_ms = now_ms.saturating_add(queue_retry_after_ms(record.attempts));
@@ -1722,8 +1721,7 @@ pub async fn requeue_before_attempt(
         record.claim = None;
         record.attempt_intent = None;
         if record.attempts >= JOB_MAX_ATTEMPTS {
-            record.state = JobState::Failed;
-            record.finished_at_ms = Some(now_ms);
+            fail_capped(record, now_ms);
         } else {
             record.state = JobState::Queued;
             record.due_at_ms = now_ms.saturating_add(queue_retry_after_ms(record.attempts));
@@ -3448,6 +3446,52 @@ mod tests {
             matches!(failed.result, Some(JobResultPayload::Execution { .. })),
             "cleanup and the run crate need a result"
         );
+    }
+
+    // Every cap site must leave the result payload terminal cleanup and the run crate
+    // read, not just the park that `fail_capped` was introduced for.
+    #[tokio::test]
+    async fn cap_sites_result() {
+        let (_dir, storage) = temp_storage();
+        let swept = JobId::from_bytes([0xE6; 16]);
+        let token = Ulid::generate();
+        let mut record = execution_record(swept, token, JobState::Ready);
+        record.claim.as_mut().unwrap().lease_expires_at_ms = 1;
+        record.attempts = JOB_MAX_ATTEMPTS - 1;
+        record.workspace_bucket = Some("ws-test".to_string());
+        insert_job(&storage, &record).await.unwrap();
+        let presubmit = JobId::from_bytes([0xE9; 16]);
+        let mut record = execution_record(presubmit, token, JobState::Ready);
+        record.attempts = JOB_MAX_ATTEMPTS - 1;
+        record.workspace_bucket = Some("ws-test".to_string());
+        insert_job(&storage, &record).await.unwrap();
+
+        let RequeueOutcome::Failed(failed) =
+            requeue_job(&storage, swept, None, 9_000, Some(9_000), None)
+                .await
+                .unwrap()
+        else {
+            panic!("the sweep must terminalize at the cap");
+        };
+        assert!(matches!(
+            failed.result,
+            Some(JobResultPayload::Execution { .. })
+        ));
+
+        let failed = requeue_before_attempt(
+            &storage,
+            presubmit,
+            token,
+            9_000,
+            JobError::retryable("image pull failed"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(failed.state, JobState::Failed);
+        assert!(matches!(
+            failed.result,
+            Some(JobResultPayload::Execution { .. })
+        ));
     }
 
     #[tokio::test]

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -1589,25 +1589,6 @@ pub async fn mark_indeterminate(
     })
 }
 
-/// Park an external attempt this node has no reconciler for. Without the charge its
-/// expired lease would be re-routed by every sweep forever.
-pub async fn park_unreconciled(storage: &StorageHandle, record: &JobRecord, now_ms: u64) {
-    let Some(token) = record.claim.as_ref().map(|claim| claim.claim_token) else {
-        return;
-    };
-    if let Err(error) = mark_indeterminate(
-        storage,
-        record.job_id,
-        token,
-        JobError::retryable("no external reconciler is available"),
-        now_ms,
-    )
-    .await
-    {
-        warn!(job_id = %record.job_id, error = %error, "Unreconciled attempt park failed");
-    }
-}
-
 /// Terminal `Failed` for an execution job, capturing the exit evidence in the
 /// result so a failed run still yields a crate.
 pub async fn fail_execution(

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -1001,8 +1001,10 @@ fn fail_capped(record: &mut JobRecord, now_ms: u64) {
 /// for the lease sweep and startup recovery. `require_expired_before` makes the sweep
 /// re-check, in-txn, that the job still holds an expired lease: a revived renew is not
 /// revoked, and a claim-less record (already requeued) is not charged a second attempt.
-/// A submitted external attempt that passes those checks is never requeued here; it
-/// returns `NeedsReconcile` untouched.
+/// A submitted external attempt that passes those checks is never requeued or charged
+/// here; it returns `NeedsReconcile` untouched, so a restart or hand-off whose adoption
+/// succeeds costs it nothing. Its cap is spent by the park that follows a failed
+/// adoption, which is what bounds a repeating failure.
 pub async fn requeue_job(
     storage: &StorageHandle,
     job_id: JobId,
@@ -1030,25 +1032,19 @@ pub async fn requeue_job(
                 return Ok(JobMutation::Skip);
             }
         }
+        // Checked AFTER the expired-lease re-check: a live renewed attempt is a
+        // plain Skip and must not be routed to the reconciler.
+        if record.execution_class == JobExecutionClass::ExternalAttempt
+            && record.attempt_intent.is_some()
+        {
+            needs_reconcile = true;
+            return Ok(JobMutation::Skip);
+        }
         if let Some(error) = error.clone() {
             record.last_error = Some(error);
         }
         record.attempts = record.attempts.saturating_add(1);
         record.updated_at_ms = now_ms;
-        // Checked AFTER the expired-lease re-check: a live renewed attempt is a
-        // plain Skip and must not be routed to the reconciler. Re-queuing would
-        // double-run the container, so a charged attempt goes to reconcile instead.
-        if record.execution_class == JobExecutionClass::ExternalAttempt
-            && record.attempt_intent.is_some()
-        {
-            if record.attempts >= JOB_MAX_ATTEMPTS {
-                fail_capped(record, now_ms);
-            } else {
-                needs_reconcile = true;
-            }
-            persisted = true;
-            return Ok(JobMutation::Persist);
-        }
         record.claim = None;
         if record.attempts >= JOB_MAX_ATTEMPTS
             && !matches!(&record.payload, JobPayload::TerminalCleanup { .. })
@@ -1561,8 +1557,8 @@ pub enum ParkOutcome {
 
 /// Park an ambiguous external attempt in `Indeterminate`, keeping the claim so the
 /// lease sweep later re-routes it to reconciliation. Exits only on evidence, or on
-/// the attempt cap: charging an attempt is what stops a condition that parks on
-/// every reconcile pass from retrying forever.
+/// the attempt cap. The park is the single charge point of a supervision cycle: an
+/// adoption that resumes supervision is free, one that fails here terminalizes.
 pub async fn mark_indeterminate(
     storage: &StorageHandle,
     job_id: JobId,
@@ -1582,7 +1578,6 @@ pub async fn mark_indeterminate(
             capped = true;
         } else {
             record.state = JobState::Indeterminate;
-            record.due_at_ms = now_ms.saturating_add(queue_retry_after_ms(record.attempts));
         }
         Ok(JobMutation::Persist)
     })
@@ -1593,6 +1588,25 @@ pub async fn mark_indeterminate(
     } else {
         ParkOutcome::Parked(record)
     })
+}
+
+/// Park an external attempt this node has no reconciler for. Without the charge its
+/// expired lease would be re-routed by every sweep forever.
+pub async fn park_unreconciled(storage: &StorageHandle, record: &JobRecord, now_ms: u64) {
+    let Some(token) = record.claim.as_ref().map(|claim| claim.claim_token) else {
+        return;
+    };
+    if let Err(error) = mark_indeterminate(
+        storage,
+        record.job_id,
+        token,
+        JobError::retryable("no external reconciler is available"),
+        now_ms,
+    )
+    .await
+    {
+        warn!(job_id = %record.job_id, error = %error, "Unreconciled attempt park failed");
+    }
 }
 
 /// Terminal `Failed` for an execution job, capturing the exit evidence in the
@@ -3298,7 +3312,7 @@ mod tests {
     }
 
     // An external attempt with an expired lease is never requeued; it is reconciled,
-    // but the sweep still charges the attempt so the cap can terminalize it.
+    // and the sweep leaves it untouched so a restart whose adoption succeeds is free.
     #[tokio::test]
     async fn external_never_requeued() {
         let (_dir, storage) = temp_storage();
@@ -3323,19 +3337,19 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.state, JobState::Running, "not requeued");
-        assert_eq!(stored.attempts, 1, "attempt charged");
+        assert_eq!(stored.attempts, 0, "attempt untouched");
         assert!(stored.claim.is_some(), "claim untouched");
     }
 
-    // The reconcile route must not exempt an attempt from the cap: once the last
-    // attempt is spent the sweep terminalizes it instead of routing it again.
+    // The effective retry budget of a park that repeats: one attempt per supervision
+    // cycle, because the sweep that re-routes the parked job never charges a second.
     #[tokio::test]
-    async fn external_sweep_caps() {
+    async fn park_sweep_budget() {
         let (_dir, storage) = temp_storage();
         let job_id = JobId::from_bytes([0xE4; 16]);
-        let mut record = execution_record(job_id, Ulid::generate(), JobState::Running);
+        let token = Ulid::generate();
+        let mut record = execution_record(job_id, token, JobState::Running);
         record.claim.as_mut().unwrap().lease_expires_at_ms = 1;
-        record.attempts = JOB_MAX_ATTEMPTS - 1;
         record.workspace_bucket = Some("ws-test".to_string());
         record.attempt_intent = Some(AttemptIntent {
             attempt_no: 1,
@@ -3346,25 +3360,49 @@ mod tests {
         });
         insert_job(&storage, &record).await.unwrap();
 
-        let outcome = requeue_job(&storage, job_id, None, 9_000, Some(9_000), None)
+        for cycle in 1..JOB_MAX_ATTEMPTS {
+            let parked = mark_indeterminate(
+                &storage,
+                job_id,
+                token,
+                JobError::retryable("attempt unobservable"),
+                6_000,
+            )
             .await
             .unwrap();
+            assert!(matches!(parked, ParkOutcome::Parked(_)), "cycle {cycle}");
+            let swept = requeue_job(&storage, job_id, None, 9_000, Some(9_000), None)
+                .await
+                .unwrap();
+            assert!(
+                matches!(swept, RequeueOutcome::NeedsReconcile(_)),
+                "cycle {cycle}"
+            );
+            let stored = read_job_record(&storage, job_id, None)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(stored.attempts, cycle, "one charge per cycle");
+            assert_eq!(stored.state, JobState::Indeterminate);
+        }
 
-        assert!(matches!(outcome, RequeueOutcome::Failed(_)));
-        let stored = read_job_record(&storage, job_id, None)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(stored.state, JobState::Failed);
-        assert_eq!(stored.attempts, JOB_MAX_ATTEMPTS);
-        assert!(stored.claim.is_none());
-        assert!(
-            matches!(stored.result, Some(JobResultPayload::Execution { .. })),
-            "cleanup and the run crate need a result"
-        );
+        let capped = mark_indeterminate(
+            &storage,
+            job_id,
+            token,
+            JobError::retryable("attempt unobservable"),
+            7_000,
+        )
+        .await
+        .unwrap();
+        let ParkOutcome::Failed(failed) = capped else {
+            panic!("the last cycle must terminalize");
+        };
+        assert_eq!(failed.state, JobState::Failed);
+        assert_eq!(failed.attempts, JOB_MAX_ATTEMPTS);
     }
 
-    // Parking spends an attempt and terminalizes at the cap; without that a failure
+    // Parking spends the attempt and terminalizes at the cap; without that a failure
     // repeating on every reconcile pass re-drives the job forever.
     #[tokio::test]
     async fn park_spends_attempt() {
@@ -3389,11 +3427,6 @@ mod tests {
             };
             assert_eq!(parked.state, JobState::Indeterminate);
             assert_eq!(parked.attempts, attempt);
-            assert_eq!(
-                parked.due_at_ms,
-                6_000 + queue_retry_after_ms(attempt),
-                "each park backs the retry off"
-            );
         }
 
         let ParkOutcome::Failed(failed) = mark_indeterminate(

--- a/operations/src/jobs/workflow/mod.rs
+++ b/operations/src/jobs/workflow/mod.rs
@@ -29,7 +29,7 @@ use tracing::{info, warn};
 
 use super::JOB_HEARTBEAT_MS;
 use super::store::{
-    ExecutionCompleteOutcome, JobMutationError, cancel_execution, cancel_running_job,
+    ExecutionCompleteOutcome, JobMutationError, ParkOutcome, cancel_execution, cancel_running_job,
     complete_execution, complete_job, fail_execution, mark_indeterminate, read_job_record,
     record_attempt_intent, record_attempt_started, record_attempt_tombstone, renew_lease,
     requeue_before_attempt, set_workspace_bucket, transition_external_to_running,
@@ -793,14 +793,35 @@ async fn park_failed_submit(
     token: ulid::Ulid,
     error: &BackendError,
 ) {
-    let _ = mark_indeterminate(
-        &context.storage_handle,
+    park_attempt(
+        context,
         job_id,
         token,
         JobError::retryable(format!("submit failed ambiguously: {error}")),
-        unix_timestamp_millis(),
     )
     .await;
+}
+
+/// Park an ambiguous attempt for a later reconcile pass. The park charges an
+/// attempt, so a failure that repeats on every pass terminalizes at the cap
+/// instead of re-driving the job forever.
+async fn park_attempt(context: &DriverContext, job_id: JobId, token: ulid::Ulid, error: JobError) {
+    match mark_indeterminate(
+        &context.storage_handle,
+        job_id,
+        token,
+        error,
+        unix_timestamp_millis(),
+    )
+    .await
+    {
+        Ok(ParkOutcome::Parked(_)) => {}
+        Ok(ParkOutcome::Failed(record)) => {
+            warn!(job_id = %job_id, "Indeterminate attempts exhausted; failing job");
+            Box::pin(cleanup_and_crate(context, job_id, Some(record))).await;
+        }
+        Err(error) => warn!(job_id = %job_id, error = %error, "Attempt park write failed"),
+    }
 }
 
 /// Heartbeat + backend wait race, then evidence-based terminalization. Shared by
@@ -905,13 +926,12 @@ async fn finalize_walltime(
         }
         Ok(CancelEvidence::AlreadyGone) => LogTails::default(),
         Ok(CancelEvidence::Requested) | Err(_) => {
-            let _ = mark_indeterminate(
-                storage,
+            Box::pin(park_attempt(
+                context,
                 job_id,
                 token,
                 JobError::retryable("walltime stop lacks evidence"),
-                unix_timestamp_millis(),
-            )
+            ))
             .await;
             return;
         }
@@ -1007,13 +1027,12 @@ pub(crate) async fn finalize_attempt(
         // Post-submit NotFound / unreachable backend is ambiguous: park in
         // Indeterminate, never requeue (spec 16.7).
         Err(error) => {
-            let _ = mark_indeterminate(
-                storage,
+            Box::pin(park_attempt(
+                context,
                 job_id,
                 token,
                 JobError::retryable(format!("attempt unobservable: {error}")),
-                unix_timestamp_millis(),
-            )
+            ))
             .await;
             return;
         }
@@ -1125,13 +1144,12 @@ pub(crate) async fn finalize_attempt(
             .await;
         }
         AttemptPhase::Submitted | AttemptPhase::Running => {
-            let _ = mark_indeterminate(
-                storage,
+            Box::pin(park_attempt(
+                context,
                 job_id,
                 token,
                 JobError::retryable("attempt returned non-terminal"),
-                unix_timestamp_millis(),
-            )
+            ))
             .await;
         }
     }
@@ -1240,13 +1258,12 @@ async fn finalize_cancel(
         }
         // No definitive stop evidence yet: park in Indeterminate.
         Ok(CancelEvidence::Requested) | Err(_) => {
-            let _ = mark_indeterminate(
-                storage,
+            Box::pin(park_attempt(
+                context,
                 job_id,
                 token,
                 JobError::retryable("cancel requested without stop evidence"),
-                unix_timestamp_millis(),
-            )
+            ))
             .await;
         }
     }
@@ -1473,14 +1490,7 @@ async fn collect_or_park(
         }
         Err(error) => {
             warn!(job_id = %job_id, bucket = %bucket, error = ?error, "Output inventory failed; parking");
-            let _ = mark_indeterminate(
-                &context.storage_handle,
-                job_id,
-                token,
-                error,
-                unix_timestamp_millis(),
-            )
-            .await;
+            Box::pin(park_attempt(context, job_id, token, error)).await;
             None
         }
     }
@@ -1491,16 +1501,7 @@ async fn collect_or_park(
 async fn fail_or_park(context: &DriverContext, job_id: JobId, token: ulid::Ulid, error: JobError) {
     match read_job_record(&context.storage_handle, job_id, None).await {
         Ok(Some(record)) => Box::pin(fail_and_crate(context, job_id, token, &record, error)).await,
-        _ => {
-            let _ = mark_indeterminate(
-                &context.storage_handle,
-                job_id,
-                token,
-                error,
-                unix_timestamp_millis(),
-            )
-            .await;
-        }
+        _ => Box::pin(park_attempt(context, job_id, token, error)).await,
     }
 }
 
@@ -1540,13 +1541,12 @@ async fn export_or_park(
         Ok(Some(record)) => record,
         Ok(None) => return None,
         Err(error) => {
-            let _ = mark_indeterminate(
-                &context.storage_handle,
+            Box::pin(park_attempt(
+                context,
                 job_id,
                 token,
                 JobError::retryable(format!("output job lookup failed: {error}")),
-                unix_timestamp_millis(),
-            )
+            ))
             .await;
             return None;
         }
@@ -1573,14 +1573,7 @@ async fn export_or_park(
         Ok(outputs) => Some(outputs),
         Err(error) if error.kind == aruna_core::structs::JobErrorKind::Retryable => {
             warn!(job_id = %job_id, error = ?error, "Output capture failed; parking");
-            let _ = mark_indeterminate(
-                &context.storage_handle,
-                job_id,
-                token,
-                error,
-                unix_timestamp_millis(),
-            )
-            .await;
+            Box::pin(park_attempt(context, job_id, token, error)).await;
             None
         }
         Err(error) => {
@@ -1639,13 +1632,12 @@ async fn capture_or_park(
         Ok(logs) => Some(logs),
         Err(error) => {
             warn!(job_id = %job_id, error = %error, "Container log capture failed");
-            let _ = mark_indeterminate(
-                &context.storage_handle,
+            Box::pin(park_attempt(
+                context,
                 job_id,
                 token,
                 JobError::retryable(format!("container log capture failed: {error}")),
-                unix_timestamp_millis(),
-            )
+            ))
             .await;
             None
         }
@@ -1665,6 +1657,7 @@ fn log_tail(bytes: Vec<u8>, truncated: bool) -> String {
 mod tests {
     use super::*;
     use crate::driver::drive;
+    use crate::jobs::JOB_MAX_ATTEMPTS;
     use crate::jobs::executor::{JobContext, JobRunOutcome, ProgressReporter};
     use crate::jobs::store::{
         ClaimOutcome, claim_job, insert_job, put_run_crate_status, set_cancel_requested,
@@ -1678,7 +1671,7 @@ mod tests {
     use aruna_storage::{FjallStorage, StorageHandle};
     use aruna_tasks::TaskHandle;
     use std::sync::Mutex;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tempfile::tempdir;
     use tokio::sync::Notify;
     use ulid::Ulid;
@@ -1694,6 +1687,7 @@ mod tests {
         submits: Mutex<Vec<String>>,
         logs_started: Notify,
         logs_release: Notify,
+        logs_fail: AtomicBool,
         cancels: AtomicUsize,
     }
 
@@ -1704,6 +1698,7 @@ mod tests {
                 submits: Mutex::new(Vec::new()),
                 logs_started: Notify::new(),
                 logs_release: Notify::new(),
+                logs_fail: AtomicBool::new(false),
                 cancels: AtomicUsize::new(0),
             })
         }
@@ -1773,6 +1768,9 @@ mod tests {
             _limits: &LogLimits,
             _sink: &dyn LogSink,
         ) -> Result<LogTails, BackendError> {
+            if self.logs_fail.load(Ordering::Relaxed) {
+                return Err(BackendError::Api("log stream truncated".to_string()));
+            }
             self.logs_started.notify_one();
             self.logs_release.notified().await;
             Ok(LogTails::default())
@@ -1979,7 +1977,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.state, JobState::Indeterminate);
-        assert_eq!(stored.attempts, 0, "no attempt charged");
+        assert_eq!(stored.attempts, 1, "the park charges an attempt");
         let intent = stored.attempt_intent.expect("intent retained");
         assert_eq!(intent.external_name, attempt.external_name());
     }
@@ -2042,6 +2040,56 @@ mod tests {
             .unwrap();
         assert_eq!(stored.state, JobState::Indeterminate);
         assert!(stored.result.is_none(), "no false-empty manifest recorded");
+    }
+
+    // A capture failing retryably on every pass must terminalize at the attempt cap.
+    // Without the charge it parks Indeterminate forever and the lease sweep re-drives
+    // the same attempt at the lease cadence.
+    #[tokio::test]
+    async fn capture_failure_caps() {
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let mut ctx = context(storage.clone());
+        Arc::get_mut(&mut ctx).unwrap().task_handle = None;
+        let (record, token, attempt) = ready_with_intent(&storage).await;
+        let job_id = record.job_id;
+        transition_external_to_running(&storage, job_id, token, Some(1), 6)
+            .await
+            .unwrap();
+        let stub = StubBackend::new(StubReconcile::NotFound);
+        stub.logs_fail.store(true, Ordering::Relaxed);
+        let backend: Arc<dyn ExecutorBackend> = stub;
+
+        for _ in 0..JOB_MAX_ATTEMPTS {
+            Box::pin(finalize_attempt(
+                &ctx,
+                job_id,
+                token,
+                &backend,
+                &fence(&attempt),
+                &execution_spec(),
+                "ws-test",
+                Ok(AttemptStatus {
+                    phase: AttemptPhase::Exited { code: 0 },
+                    backend_ref: "c1".to_string(),
+                    started_at_ms: Some(1),
+                    finished_at_ms: Some(2),
+                }),
+            ))
+            .await;
+        }
+
+        let stored = read_job_record(&storage, job_id, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.state, JobState::Failed);
+        assert_eq!(stored.attempts, JOB_MAX_ATTEMPTS);
+        assert!(stored.claim.is_none());
+        assert!(
+            matches!(stored.result, Some(JobResultPayload::Execution { .. })),
+            "cleanup and the run crate need a result"
+        );
     }
 
     #[tokio::test]
@@ -2305,7 +2353,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.state, JobState::Indeterminate);
-        assert_eq!(stored.attempts, 0);
+        assert_eq!(stored.attempts, 1);
         assert!(stored.attempt_intent.is_some());
     }
 

--- a/operations/src/jobs/workflow/mod.rs
+++ b/operations/src/jobs/workflow/mod.rs
@@ -1796,7 +1796,7 @@ mod tests {
         }
     }
 
-    fn node_id(seed: u8) -> NodeId {
+    pub(super) fn node_id(seed: u8) -> NodeId {
         let mut bytes = [0u8; 32];
         bytes[0] = seed;
         iroh::SecretKey::from_bytes(&bytes).public()
@@ -1821,7 +1821,7 @@ mod tests {
         })
     }
 
-    fn execution_spec() -> ExecutionSpec {
+    pub(super) fn execution_spec() -> ExecutionSpec {
         ExecutionSpec {
             group_id: Ulid::from_bytes([3u8; 16]),
             name: None,

--- a/operations/src/jobs/workflow/reconcile.rs
+++ b/operations/src/jobs/workflow/reconcile.rs
@@ -108,8 +108,17 @@ impl ExternalReconciler for ComputeReconciler {
             attempt_epoch: intent.attempt_epoch,
             controller_generation: control.controller_generation,
         };
+        // Every unresolved exit below parks: the sweep that routed us here spends no
+        // attempt, so the park is what bounds a condition that never resolves.
         if let Err(error) = backend.fence(&fence).await {
             warn!(job_id = %job_id, error = %error, "Backend fence failed");
+            park_attempt(
+                &self.context,
+                job_id,
+                token,
+                JobError::retryable(format!("reconcile fence failed: {error}")),
+            )
+            .await;
             return;
         }
 
@@ -142,6 +151,13 @@ impl ExternalReconciler for ComputeReconciler {
             && let Err(error) = record_attempt_started(storage, job_id, token, started_at_ms).await
         {
             warn!(job_id = %job_id, error = %error, "Attempt start evidence write failed during adoption");
+            park_attempt(
+                &self.context,
+                job_id,
+                token,
+                JobError::retryable(format!("start evidence write failed: {error}")),
+            )
+            .await;
             return;
         }
         if matches!(
@@ -160,7 +176,16 @@ impl ExternalReconciler for ComputeReconciler {
             .await
             {
                 Ok(record) => record,
-                Err(_) => return,
+                Err(error) => {
+                    park_attempt(
+                        &self.context,
+                        job_id,
+                        token,
+                        JobError::retryable(format!("adopted attempt cannot run: {error}")),
+                    )
+                    .await;
+                    return;
+                }
             };
             if running.cancel_requested {
                 let _ = with_execution_heartbeat(

--- a/operations/src/jobs/workflow/reconcile.rs
+++ b/operations/src/jobs/workflow/reconcile.rs
@@ -12,13 +12,12 @@ use tracing::{info, warn};
 use super::super::reconcile::ExternalReconciler;
 use super::super::runtime::JobsRuntime;
 use super::super::store::{
-    AdoptOutcome, adopt_external_attempt, handoff_external_attempt, mark_indeterminate,
-    read_job_record, record_attempt_started, record_attempt_tombstone, release_job,
-    transition_external_to_running,
+    AdoptOutcome, adopt_external_attempt, handoff_external_attempt, read_job_record,
+    record_attempt_started, record_attempt_tombstone, release_job, transition_external_to_running,
 };
 use super::{
     DEFAULT_WALLTIME, build_task_spec, fail_and_crate, finalize_attempt, finalize_cancel,
-    job_bucket, reload_task, requeue_after_tombstone, supervise_and_finalize,
+    job_bucket, park_attempt, reload_task, requeue_after_tombstone, supervise_and_finalize,
     with_execution_heartbeat,
 };
 use crate::driver::DriverContext;
@@ -86,15 +85,14 @@ impl ExternalReconciler for ComputeReconciler {
             .cloned()
         else {
             warn!(job_id = %job_id, kind = %intent.executor_kind, "Reconcile backend unavailable; parking");
-            let _ = mark_indeterminate(
-                storage,
+            park_attempt(
+                &self.context,
                 job_id,
                 token,
                 JobError::retryable(format!(
                     "reconcile backend unavailable: {}",
                     intent.executor_kind
                 )),
-                unix_timestamp_millis(),
             )
             .await;
             return;
@@ -249,12 +247,11 @@ impl ExternalReconciler for ComputeReconciler {
                 .await;
             }
             ReconcileEvidence::Unavailable(error) => {
-                let _ = mark_indeterminate(
-                    storage,
+                park_attempt(
+                    &self.context,
                     job_id,
                     token,
                     JobError::retryable(format!("backend unavailable: {error}")),
-                    unix_timestamp_millis(),
                 )
                 .await;
             }
@@ -262,12 +259,11 @@ impl ExternalReconciler for ComputeReconciler {
                 if artifact.exact_identity {
                     let _ = backend.cancel(&fence).await;
                 }
-                let _ = mark_indeterminate(
-                    storage,
+                park_attempt(
+                    &self.context,
                     job_id,
                     token,
                     JobError::retryable("backend artifact is not adoptable"),
-                    unix_timestamp_millis(),
                 )
                 .await;
             }
@@ -410,13 +406,12 @@ pub(super) async fn resume_attempt(
                     .filter(|intent| intent.attempt_epoch == fence.attempt_epoch)
                     .map(|intent| intent.pinned_image.as_str())
                 else {
-                    let _ = mark_indeterminate(
-                        &context.storage_handle,
+                    Box::pin(park_attempt(
+                        &context,
                         job_id,
                         token,
                         JobError::retryable("attempt intent mismatch"),
-                        unix_timestamp_millis(),
-                    )
+                    ))
                     .await;
                     return false;
                 };
@@ -496,14 +491,7 @@ async fn fail_or_park(
     if error.kind == JobErrorKind::Permanent {
         fail_and_crate(context, job_id, token, record, error).await;
     } else {
-        let _ = mark_indeterminate(
-            &context.storage_handle,
-            job_id,
-            token,
-            error,
-            unix_timestamp_millis(),
-        )
-        .await;
+        park_attempt(context, job_id, token, error).await;
     }
 }
 

--- a/operations/src/jobs/workflow/reconcile.rs
+++ b/operations/src/jobs/workflow/reconcile.rs
@@ -84,17 +84,15 @@ impl ExternalReconciler for ComputeReconciler {
             .and_then(|registry| registry.get(&kind))
             .cloned()
         else {
-            warn!(job_id = %job_id, kind = %intent.executor_kind, "Reconcile backend unavailable; parking");
-            park_attempt(
-                &self.context,
-                job_id,
-                token,
-                JobError::retryable(format!(
-                    "reconcile backend unavailable: {}",
-                    intent.executor_kind
-                )),
-            )
-            .await;
+            // A node without this backend cannot observe the attempt: charging here
+            // would terminalize a healthy container it can never see. Hand it back
+            // with an expired lease so a node that has the backend can reconcile it.
+            warn!(job_id = %job_id, kind = %intent.executor_kind, "Reconcile backend unavailable; handing back");
+            if let Err(error) =
+                handoff_external_attempt(storage, job_id, token, unix_timestamp_millis()).await
+            {
+                warn!(job_id = %job_id, error = %error, "Failed to hand back an unreconciled attempt");
+            }
             return;
         };
 
@@ -526,4 +524,85 @@ fn holder(context: &DriverContext) -> aruna_core::types::NodeId {
         .as_ref()
         .map(|net| net.node_id())
         .unwrap_or_else(|| iroh::SecretKey::from_bytes(&[0u8; 32]).public())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jobs::JOB_MAX_ATTEMPTS;
+    use crate::jobs::store::{insert_job, record_attempt_intent};
+    use crate::jobs::workflow::tests::{execution_spec, node_id};
+    use aruna_compute::ExecutorRegistry;
+    use aruna_core::structs::{AttemptIntent, JobClaim, JobId, RealmId};
+    use aruna_core::types::UserId;
+    use aruna_storage::FjallStorage;
+    use aruna_tasks::TaskHandle;
+    use tempfile::tempdir;
+    use ulid::Ulid;
+
+    // A node whose registry lacks the executor cannot observe the container, so no
+    // number of sweeps by it may spend an attempt or terminalize the job.
+    #[tokio::test]
+    async fn missing_backend_spares() {
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let context = Arc::new(DriverContext {
+            storage_handle: storage.clone(),
+            net_handle: None,
+            blob_handle: None,
+            metadata_handle: None,
+            task_handle: Some(TaskHandle::new()),
+            compute_handle: Some(Arc::new(ExecutorRegistry::new())),
+        });
+        let job_id = JobId::new();
+        let token = Ulid::generate();
+        let mut record = JobRecord::new(
+            job_id,
+            JobPayload::Execution(execution_spec()),
+            UserId::new(Ulid::from_bytes([2u8; 16]), RealmId([1u8; 32])),
+            node_id(7),
+            1,
+            1,
+            None,
+        );
+        record.state = JobState::Running;
+        record.claim = Some(JobClaim {
+            holder_node_id: node_id(7),
+            claim_token: token,
+            lease_expires_at_ms: 1,
+        });
+        insert_job(&storage, &record).await.unwrap();
+        record_attempt_intent(
+            &storage,
+            job_id,
+            token,
+            AttemptIntent {
+                attempt_no: 1,
+                external_name: job_id.to_string().to_lowercase(),
+                executor_kind: "kubernetes".to_string(),
+                pinned_image: "alpine@sha256:digest".to_string(),
+                attempt_epoch: 0,
+            },
+            unix_timestamp_millis(),
+        )
+        .await
+        .unwrap();
+
+        let runtime = JobsRuntime::new();
+        let reconciler = ComputeReconciler::new(context, Arc::downgrade(&runtime));
+        for sweep in 0..(JOB_MAX_ATTEMPTS + 2) {
+            let lost = read_job_record(&storage, job_id, None)
+                .await
+                .unwrap()
+                .unwrap();
+            reconciler.reconcile_lost_attempt(&storage, lost).await;
+            let after = read_job_record(&storage, job_id, None)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(after.state, JobState::Running, "sweep {sweep}");
+            assert_eq!(after.attempts, 0, "sweep {sweep}");
+            assert!(after.attempt_intent.is_some(), "sweep {sweep}");
+        }
+    }
 }


### PR DESCRIPTION
A compute job whose container output could not be read failed with `container output read failed: backend api error: fetch archive ended before its declared size` and then retried forever at a flat 60 second cadence, re-running the capture from byte zero each time.

Two independent bugs. The retry never terminated because `JOB_MAX_ATTEMPTS` was never consulted for compute jobs: parking a job left `attempts` untouched, and the lease sweep took an early return for `ExternalAttempt` records before the line that increments the counter. The job was re-driven purely by lease expiry, which is why the cadence matched `JOB_LEASE_MS` exactly and the helper pod kept the same attempt-0 name on every cycle.

The truncation itself was undiagnosable. kube-rs turns any WebSocket error or unexpected close into an ordinary `Ok(0)` EOF on the duplex, so the real cause survives only in the exec task's join handle, and `stream_output` returned from its short-read path without joining, letting `AttachedProcess::drop` abort the task and destroy it. The same masking applied to the tar header read, where a stream dying before the first 512 bytes reported nothing useful either.

## Changes

- Enforce the job attempt cap on external attempts. The lease sweep no longer exempts compute and TES jobs from the cap, and a parked job charges an attempt, so a repeating failure terminalizes instead of looping.
- Charge an attempt only when adoption fails. A node restart, lease handoff, or a node over the external concurrency cap is free, so a rolling restart or a saturated node can no longer terminalize healthy still-running containers.
- Hand back an attempt no local backend can observe. A node whose registry lacks the attempt's executor kind cannot see the container, so it hands the lease back immediately rather than spending an attempt, and a node that does have the backend picks it up from the shared index.
- Route every cap site through one shared failure path so a capped job always lands in `Failed` with a result payload, keeping the terminal cleanup and run-crate obligations intact.
- Report the real exec failure behind a truncated fetch. Both the short-read and error paths join the exec task first and surface its error, falling back to a message carrying the transferred and declared byte counts. The tar header read gets the same treatment for transport failures.
- Keep an invalid fetch header out of the exec join. Joining is right for a torn stream, but a complete header with invalid contents is a deterministic protocol error, and joining on that path blocks behind an undrained stdout until the join timeout reclassifies it as retryable. Header parsing is now split from header transport so a validation error surfaces as itself.
- Widen the helper exec stdout and stdin buffers. `AttachParams::default()` leaves `max_stdout_buf_size` unset, so kube-rs falls back to 1 KiB for multi-megabyte transfers, which starves its own keepalive ping while the write is blocked.
- Make `stream_output` generic over the join future so the EOF versus exec-status priority is unit testable.
