### PR TITLE
test: make convergence waits resilient to slow machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    # Hang cap, not a performance budget: far above the minutes a healthy run
+    # takes, so only a deadlocked or unbounded-wait test trips it.
+    timeout-minutes: 45
 
     steps:
       - name: Check out repository
@@ -43,6 +46,8 @@ jobs:
 
   s3-backend:
     runs-on: ubuntu-latest
+    # Hang cap for the MinIO-backed suite, not a performance budget.
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,6 +17,9 @@ jobs:
     name: Generate Coverage Report
     environment: coverage
     runs-on: ubuntu-latest
+    # Hang cap, not a performance budget. The instrumented build is several times
+    # slower than the plain suite, so this ceiling is higher than the CI tests job.
+    timeout-minutes: 60
     env:
       CARGO_TERM_COLOR: always
       CARGO_INCREMENTAL: 0

--- a/operations/tests/convergence/mod.rs
+++ b/operations/tests/convergence/mod.rs
@@ -1,0 +1,70 @@
+//! Progress-detecting convergence waits and a per-poll hang cap, shared by the
+//! multi-node integration tests. A slow-but-converging run keeps waiting; a
+//! stuck run fails after a lost-progress window, and a deadlocked poll panics
+//! naming its own context instead of hanging until the CI job timeout.
+
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use tokio::time::{Instant, sleep, timeout};
+
+pub type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// A single poll that never returns is a deadlock, not slowness: no honest check
+/// against local state takes minutes. Elapsing panics and names the culprit.
+pub const HANG_CAP: Duration = Duration::from_secs(300);
+
+/// Lost-progress window, not a total budget: it resets on every observed step
+/// forward, so a slow run is never failed for slowness, only for being stuck.
+pub const NO_PROGRESS_TIMEOUT: Duration = Duration::from_secs(120);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Polls `check` until it reports zero still-pending units. The lost-progress
+/// deadline resets whenever the pending count strictly decreases, so the wait
+/// fails only after `NO_PROGRESS_TIMEOUT` with no step forward, never at a fixed
+/// wall-clock budget. `context` names the wait in the lost-progress error. A
+/// single poll exceeding `HANG_CAP` is treated as a deadlock and panics.
+///
+/// Generic over the caller's error so both `Box<dyn Error>` and its `Send + Sync`
+/// variant can flow through unchanged.
+pub async fn wait_for_convergence<F, Fut, E>(context: &str, check: F) -> Result<(), E>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<usize, E>>,
+    E: From<String>,
+{
+    let mut best = usize::MAX;
+    let mut deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
+    loop {
+        let pending = match timeout(HANG_CAP, check()).await {
+            Ok(result) => result?,
+            Err(_) => panic!("hang cap fired: `{context}` poll exceeded {HANG_CAP:?}"),
+        };
+        if pending == 0 {
+            return Ok(());
+        }
+        if pending < best {
+            best = pending;
+            deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("{context} (still pending: {pending})").into());
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Bounds a one-shot harness operation that could block forever under starvation.
+/// On elapse it panics naming `context` so a deadlock is reported against its
+/// culprit rather than hanging. `HANG_CAP` is a deadlock cap, not a deadline.
+pub async fn hang_cap<F, T>(context: &str, op: F) -> T
+where
+    F: Future<Output = T>,
+{
+    match timeout(HANG_CAP, op).await {
+        Ok(value) => value,
+        Err(_) => panic!("hang cap fired: `{context}` did not finish within {HANG_CAP:?}"),
+    }
+}

--- a/operations/tests/group_replication.rs
+++ b/operations/tests/group_replication.rs
@@ -1,7 +1,6 @@
 // Fresh builds overflow the default query depth in nested async layouts.
 #![recursion_limit = "256"]
 use std::sync::Arc;
-use std::time::Duration;
 
 use aruna_core::NodeId;
 use aruna_core::document::DocumentSyncTarget;
@@ -25,10 +24,10 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+mod convergence;
+use convergence::wait_for_convergence;
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -283,12 +282,8 @@ async fn wait_for_group_convergence(
     expected_group: &Group,
     expected_auth: &GroupAuthorizationDocument,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    let mut last_states = Vec::new();
-
-    loop {
-        let mut converged = true;
-        last_states.clear();
+    wait_for_convergence("group state did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(
                 GetGroupOperation::new(GetGroupConfig { group_id }),
@@ -296,37 +291,13 @@ async fn wait_for_group_convergence(
             )
             .await
             {
-                Ok((group, auth)) if group == *expected_group && auth == *expected_auth => {
-                    last_states.push(format!("node={} converged", node.net.node_id()));
-                }
-                Ok((group, auth)) => {
-                    last_states.push(format!(
-                        "node={} group={group:?} auth={auth:?}",
-                        node.net.node_id()
-                    ));
-                    converged = false;
-                    break;
-                }
-                Err(error) => {
-                    last_states.push(format!("node={} error={error:?}", node.net.node_id()));
-                    converged = false;
-                    break;
-                }
+                Ok((group, auth)) if group == *expected_group && auth == *expected_auth => {}
+                _ => pending += 1,
             }
         }
-
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "group state did not converge; expected_group={expected_group:?}; expected_auth={expected_auth:?}; last_states={last_states:?}"
-            )
-            .into());
-        }
-
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/metadata_propagation_tail.rs
+++ b/operations/tests/metadata_propagation_tail.rs
@@ -39,7 +39,9 @@ use ulid::Ulid;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-const SETUP_TIMEOUT: Duration = Duration::from_secs(30);
+mod convergence;
+use convergence::{NO_PROGRESS_TIMEOUT, wait_for_convergence};
+
 const PROJECTION_BATCH: usize = 32;
 
 const WRITERS: usize = 24;
@@ -48,7 +50,6 @@ const WRITER_PERIOD: Duration = Duration::from_millis(40);
 const PROBE_PERIOD: Duration = Duration::from_millis(500);
 const PROBE_POLL: Duration = Duration::from_millis(50);
 const PROBE_TIMEOUT: Duration = Duration::from_secs(60);
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(300);
 const P95_TARGET_MS: u128 = 5000;
 
 struct TestNode {
@@ -122,15 +123,8 @@ fn propagation_tail_under_sustained_load() -> Result<(), BoxError> {
             .map(|(group_id, document_id, _)| (*group_id, *document_id))
             .collect();
         let convergence = async {
-            wait_for_visibility(
-                &contexts,
-                &pairs,
-                Duration::from_millis(200),
-                CONVERGENCE_TIMEOUT,
-                started,
-            )
-            .await?;
-            wait_for_empty_materialization_queues(&contexts, CONVERGENCE_TIMEOUT, started).await?;
+            wait_for_visibility(&contexts, &pairs, Duration::from_millis(200), started).await?;
+            wait_for_empty_materialization_queues(&contexts).await?;
             Ok::<f64, BoxError>(started.elapsed().as_secs_f64())
         };
         let (sampler_result, convergence_result) = tokio::join!(sampler, convergence);
@@ -418,15 +412,18 @@ async fn flush_projection_batches(
     Ok(())
 }
 
+// Keeps the per-node pruning and elapsed-time return, but fails on a lost-progress
+// window rather than a fixed budget so a slow-but-converging run is not flunked.
 async fn wait_for_visibility(
     contexts: &[Arc<DriverContext>],
     pairs: &[(GroupId, Ulid)],
     poll_interval: Duration,
-    timeout: Duration,
     t0: Instant,
 ) -> Result<f64, BoxError> {
     let mut remaining: Vec<Vec<(GroupId, Ulid)>> =
         contexts.iter().map(|_| pairs.to_vec()).collect();
+    let mut best = usize::MAX;
+    let mut deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
 
     loop {
         for (context, missing) in contexts.iter().zip(remaining.iter_mut()) {
@@ -444,15 +441,17 @@ async fn wait_for_visibility(
             }
             *missing = still_missing;
         }
-        if remaining.iter().all(Vec::is_empty) {
+        let pending: usize = remaining.iter().map(Vec::len).sum();
+        if pending == 0 {
             return Ok(t0.elapsed().as_secs_f64());
         }
-        if t0.elapsed() > timeout {
+        if pending < best {
+            best = pending;
+            deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
+        }
+        if Instant::now() >= deadline {
             let counts: Vec<usize> = remaining.iter().map(Vec::len).collect();
-            return Err(format!(
-                "visibility timeout after {timeout:?}; missing per node: {counts:?}"
-            )
-            .into());
+            return Err(format!("visibility stalled; missing per node: {counts:?}").into());
         }
         sleep(poll_interval).await;
     }
@@ -460,10 +459,8 @@ async fn wait_for_visibility(
 
 async fn wait_for_empty_materialization_queues(
     contexts: &[Arc<DriverContext>],
-    timeout: Duration,
-    t0: Instant,
 ) -> Result<(), BoxError> {
-    loop {
+    wait_for_convergence("materialization queues never drained", || async {
         let mut busy = 0usize;
         for context in contexts {
             if metadata_materialization_jobs_exist(&context.storage_handle)
@@ -473,17 +470,9 @@ async fn wait_for_empty_materialization_queues(
                 busy += 1;
             }
         }
-        if busy == 0 {
-            return Ok(());
-        }
-        if t0.elapsed() > timeout {
-            return Err(format!(
-                "materialization queues still busy on {busy} nodes after {timeout:?}"
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(200)).await;
-    }
+        Ok(busy)
+    })
+    .await
 }
 
 async fn build_realm_nodes(realm_id: &RealmId, count: usize) -> Result<Vec<TestNode>, BoxError> {
@@ -636,10 +625,8 @@ async fn wait_for_realm_node_convergence(
     realm_id: &RealmId,
 ) -> Result<(), BoxError> {
     let expected: HashSet<_> = nodes.iter().map(|node| node.net.node_id()).collect();
-    let deadline = Instant::now() + SETUP_TIMEOUT;
-
-    loop {
-        let mut converged = true;
+    wait_for_convergence("realm nodes did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(
                 GetRealmNodesOperation::new(*realm_id),
@@ -648,20 +635,12 @@ async fn wait_for_realm_node_convergence(
             .await
             {
                 Ok(realm_nodes) if realm_nodes == expected => {}
-                _ => {
-                    converged = false;
-                    break;
-                }
+                _ => pending += 1,
             }
         }
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("realm nodes did not converge".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/metadata_replication.rs
+++ b/operations/tests/metadata_replication.rs
@@ -64,8 +64,11 @@ use aruna_operations::update_metadata_document::{
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::{Instant, sleep};
+use tokio::time::sleep;
 use ulid::Ulid;
+
+mod convergence;
+use convergence::wait_for_convergence;
 
 /// Mints the held-bucket structured id a local create embeds on `node_id`.
 fn mint_local(
@@ -96,13 +99,6 @@ fn doc_id(seed: u64) -> Ulid {
         .unwrap()
         .as_ulid()
 }
-
-// Every wait below polls to a condition; the ceiling only bounds a genuine
-// hang. Post-replan convergence measures ~1s (registry row) to ~10s (event
-// log behind a holder-transition graph sync) under tenfold contention, but a
-// loaded CI runner can stall consecutive peer syncs for the full 30s peer-sync
-// timeout each, so the backstop is 2-3x that timeout, not the expected latency.
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -423,22 +419,12 @@ async fn publish_before_drain() -> Result<(), Box<dyn std::error::Error>> {
 // push that loses a race under load is retried instead of stranding the record;
 // an undeliverable record is retained forever and trips the deadline.
 async fn drain_until_empty(node: &TestNode) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
+    wait_for_convergence("outbox never drained", || async {
         drive_document_sync_outbox_drain(node.context.clone()).await;
         let remaining = read_outbox_records(&node.context.storage_handle, &[], None, 16).await?;
-        if remaining.records.is_empty() {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "outbox never drained: {} records remain",
-                remaining.records.len()
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(remaining.records.len())
+    })
+    .await
 }
 
 // Creates a document on the hand-driven origin (index 0), replicates the create
@@ -1390,20 +1376,21 @@ async fn wait_for_event_log_value(
     document_id: Ulid,
     event_id: Ulid,
 ) -> Result<aruna_core::types::Value, Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        if let Some(value) = read_metadata_event_log_value(node, document_id, event_id).await? {
-            return Ok(value);
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "node={} never persisted metadata event {event_id} of document {document_id}",
-                node.net.node_id()
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+    let context = format!(
+        "node={} never persisted metadata event {event_id} of document {document_id}",
+        node.net.node_id()
+    );
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(&context, || async {
+        Ok(usize::from(
+            read_metadata_event_log_value(node, document_id, event_id)
+                .await?
+                .is_none(),
+        ))
+    })
+    .await?;
+    read_metadata_event_log_value(node, document_id, event_id)
+        .await?
+        .ok_or_else(|| context.into())
 }
 
 async fn wait_for_persisted_update(
@@ -1412,23 +1399,25 @@ async fn wait_for_persisted_update(
     document_id: Ulid,
     expected_event_id: Ulid,
 ) -> Result<MetadataRegistryRecord, Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        let last = match read_persisted_holder_set(node, group_id, document_id).await? {
-            Some((registry, _)) if registry.last_event_id == expected_event_id => {
-                return Ok(registry);
-            }
-            Some((registry, _)) => format!("last_event_id={}", registry.last_event_id),
-            None => "missing".to_string(),
-        };
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "replacement did not converge to update {expected_event_id}: {last}"
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        &format!("replacement did not converge to update {expected_event_id}"),
+        || async {
+            Ok(
+                match read_persisted_holder_set(node, group_id, document_id).await? {
+                    Some((registry, _)) if registry.last_event_id == expected_event_id => 0,
+                    _ => 1,
+                },
             )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        },
+    )
+    .await?;
+    let (registry, _) = read_persisted_holder_set(node, group_id, document_id)
+        .await?
+        .filter(|(registry, _)| registry.last_event_id == expected_event_id)
+        .ok_or_else(|| -> Box<dyn std::error::Error> {
+            format!("replacement did not converge to update {expected_event_id}").into()
+        })?;
+    Ok(registry)
 }
 
 async fn wait_for_persisted_holder_set(
@@ -1438,47 +1427,26 @@ async fn wait_for_persisted_holder_set(
     document_id: Ulid,
     expected_holders: &[aruna_core::NodeId],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    let mut last = Vec::new();
-    loop {
-        let mut converged = true;
-        last.clear();
-        for node_id in node_ids {
-            let node = nodes
-                .iter()
-                .find(|node| node.net.node_id() == *node_id)
-                .ok_or("holder fixture node missing")?;
-            match read_persisted_holder_set(node, group_id, document_id).await? {
-                Some((registry, holders))
-                    if same_holder_set(&registry.holder_node_ids, expected_holders)
-                        && same_holder_set(&holders, expected_holders) =>
-                {
-                    last.push(format!("{node_id}=converged"));
-                }
-                Some((registry, holders)) => {
-                    last.push(format!(
-                        "{node_id}=registry:{:?},holders:{holders:?}",
-                        registry.holder_node_ids
-                    ));
-                    converged = false;
-                }
-                None => {
-                    last.push(format!("{node_id}=missing"));
-                    converged = false;
+    wait_for_convergence(
+        &format!("metadata holder indexes did not converge to {expected_holders:?}"),
+        || async {
+            let mut pending = 0;
+            for node_id in node_ids {
+                let node = nodes
+                    .iter()
+                    .find(|node| node.net.node_id() == *node_id)
+                    .ok_or("holder fixture node missing")?;
+                match read_persisted_holder_set(node, group_id, document_id).await? {
+                    Some((registry, holders))
+                        if same_holder_set(&registry.holder_node_ids, expected_holders)
+                            && same_holder_set(&holders, expected_holders) => {}
+                    _ => pending += 1,
                 }
             }
-        }
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "metadata holder indexes did not converge to {expected_holders:?}: {last:?}"
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+            Ok(pending)
+        },
+    )
+    .await
 }
 
 fn same_holder_set(left: &[aruna_core::NodeId], right: &[aruna_core::NodeId]) -> bool {
@@ -1492,10 +1460,8 @@ async fn wait_for_realm_node_convergence(
     realm_id: &RealmId,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let expected: HashSet<_> = nodes.iter().map(|node| node.net.node_id()).collect();
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-
-    loop {
-        let mut converged = true;
+    wait_for_convergence("realm nodes did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(
                 GetRealmNodesOperation::new(*realm_id),
@@ -1504,21 +1470,12 @@ async fn wait_for_realm_node_convergence(
             .await
             {
                 Ok(realm_nodes) if realm_nodes == expected => {}
-                _ => {
-                    converged = false;
-                    break;
-                }
+                _ => pending += 1,
             }
         }
-
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("realm nodes did not converge".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn wait_for_metadata_convergence(
@@ -1546,21 +1503,13 @@ async fn wait_for_metadata_state(
     expected_holder_count: usize,
     expected_text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
     let expected_holders = nodes
         .iter()
         .map(|node| node.net.node_id())
         .collect::<HashSet<_>>();
-    let mut last_states = Vec::new();
-
-    loop {
-        let mut converged = true;
-        last_states.clear();
-
+    wait_for_convergence("metadata state did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
-            if !converged {
-                break;
-            }
             match drive(
                 GetMetadataDocumentOperation::new(group_id, document_id),
                 node.context.as_ref(),
@@ -1577,56 +1526,13 @@ async fn wait_for_metadata_state(
                             .copied()
                             .collect::<HashSet<_>>()
                             == expected_holders
-                        && document.jsonld.contains(expected_text) =>
-                {
-                    last_states.push(format!("node={} converged", node.net.node_id()));
-                }
-                Ok(document) => {
-                    last_states.push(format!(
-                        "node={} graph={} holders={} jsonld_contains={}",
-                        node.net.node_id(),
-                        document.record.graph_iri,
-                        document.record.holder_node_ids.len(),
-                        document.jsonld.contains(expected_text)
-                    ));
-                    converged = false;
-                    break;
-                }
-                Err(error) => {
-                    let graph_state = match node
-                        .context
-                        .metadata_handle
-                        .as_ref()
-                        .unwrap()
-                        .send_effect(Effect::Metadata(MetadataEffect::ExportRoCrate {
-                            graph_iri: graph_iri.to_string(),
-                        }))
-                        .await
-                    {
-                        Event::Metadata(MetadataEvent::RoCrateExportResult { .. }) => {
-                            "graph-present"
-                        }
-                        Event::Metadata(MetadataEvent::Error { .. }) => "graph-missing",
-                        _ => "graph-unknown",
-                    };
-                    last_states.push(format!(
-                        "node={} error={error:?} {graph_state}",
-                        node.net.node_id()
-                    ));
-                    converged = false;
-                    break;
-                }
+                        && document.jsonld.contains(expected_text) => {}
+                _ => pending += 1,
             }
         }
-
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!("metadata state did not converge: {last_states:?}").into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn wait_for_metadata_absence(
@@ -1635,66 +1541,33 @@ async fn wait_for_metadata_absence(
     document_id: Ulid,
     graph_iri: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    let mut last_states = Vec::new();
-
-    loop {
-        let mut converged = true;
-        last_states.clear();
-
+    wait_for_convergence("metadata deletion did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
-            if !converged {
-                break;
-            }
-            match drive(
+            let document_absent = drive(
                 GetMetadataDocumentOperation::new(group_id, document_id),
                 node.context.as_ref(),
             )
             .await
-            {
-                Err(error) => {
-                    let graph_state = match node
-                        .context
-                        .metadata_handle
-                        .as_ref()
-                        .unwrap()
-                        .send_effect(Effect::Metadata(MetadataEffect::ExportRoCrate {
-                            graph_iri: graph_iri.to_string(),
-                        }))
-                        .await
-                    {
-                        Event::Metadata(MetadataEvent::Error { .. }) => "graph-missing",
-                        _ => "graph-present",
-                    };
-                    if graph_state != "graph-missing" {
-                        last_states.push(format!(
-                            "node={} error={error:?} graph still present",
-                            node.net.node_id()
-                        ));
-                        converged = false;
-                        break;
-                    }
-                    last_states.push(format!("node={} absent", node.net.node_id()));
-                }
-                Ok(_) => {
-                    last_states.push(format!(
-                        "node={} document still present",
-                        node.net.node_id()
-                    ));
-                    converged = false;
-                    break;
-                }
+            .is_err();
+            let graph_absent = matches!(
+                node.context
+                    .metadata_handle
+                    .as_ref()
+                    .unwrap()
+                    .send_effect(Effect::Metadata(MetadataEffect::ExportRoCrate {
+                        graph_iri: graph_iri.to_string(),
+                    }))
+                    .await,
+                Event::Metadata(MetadataEvent::Error { .. })
+            );
+            if !(document_absent && graph_absent) {
+                pending += 1;
             }
         }
-
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!("metadata deletion did not converge: {last_states:?}").into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn wait_for_batched_metadata_projection(
@@ -1702,58 +1575,33 @@ async fn wait_for_batched_metadata_projection(
     group_id: Ulid,
     events: &[MetadataCreateEventRecord],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    let mut last_states = Vec::new();
-
-    loop {
-        let mut converged = true;
-        last_states.clear();
-
-        for event in events {
-            let document_id = event.record.document_id;
-            let expected_name = match &event.payload {
-                MetadataCreateEventPayload::Scaffold { name, .. } => name.as_str(),
-                _ => "",
-            };
-            match drive(
-                GetMetadataDocumentOperation::new(group_id, document_id),
-                node.context.as_ref(),
-            )
-            .await
-            {
-                Ok(document)
-                    if document.record.graph_iri == event.record.graph_iri
-                        && document.record.holder_node_ids == vec![node.net.node_id()]
-                        && document.jsonld.contains(expected_name) => {}
-                Ok(document) => {
-                    last_states.push(format!(
-                        "document={} holders={} jsonld_contains={}",
-                        document_id,
-                        document.record.holder_node_ids.len(),
-                        document.jsonld.contains(expected_name)
-                    ));
-                    converged = false;
-                    break;
-                }
-                Err(error) => {
-                    last_states.push(format!("document={document_id} error={error:?}"));
-                    converged = false;
-                    break;
+    wait_for_convergence(
+        "batched metadata projection did not materialize",
+        || async {
+            let mut pending = 0;
+            for event in events {
+                let document_id = event.record.document_id;
+                let expected_name = match &event.payload {
+                    MetadataCreateEventPayload::Scaffold { name, .. } => name.as_str(),
+                    _ => "",
+                };
+                match drive(
+                    GetMetadataDocumentOperation::new(group_id, document_id),
+                    node.context.as_ref(),
+                )
+                .await
+                {
+                    Ok(document)
+                        if document.record.graph_iri == event.record.graph_iri
+                            && document.record.holder_node_ids == vec![node.net.node_id()]
+                            && document.jsonld.contains(expected_name) => {}
+                    _ => pending += 1,
                 }
             }
-        }
-
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "batched metadata projection did not materialize: {last_states:?}"
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+            Ok(pending)
+        },
+    )
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/metadata_throughput.rs
+++ b/operations/tests/metadata_throughput.rs
@@ -39,7 +39,9 @@ use ulid::Ulid;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-const SETUP_TIMEOUT: Duration = Duration::from_secs(30);
+mod convergence;
+use convergence::{NO_PROGRESS_TIMEOUT, wait_for_convergence};
+
 const PROJECTION_BATCH: usize = 32;
 const TOTAL_CREATES: usize = 2000;
 
@@ -165,14 +167,7 @@ fn convergence_gate() -> Result<(), BoxError> {
             .collect();
 
         let contexts: Vec<Arc<DriverContext>> = nodes.iter().map(|n| n.context.clone()).collect();
-        let result = wait_for_visibility(
-            &contexts,
-            &last,
-            Duration::from_millis(200),
-            Duration::from_secs(60),
-            t0,
-        )
-        .await;
+        let result = wait_for_visibility(&contexts, &last, Duration::from_millis(200), t0).await;
         shutdown_nodes(nodes).await;
         result
     })?;
@@ -226,15 +221,8 @@ fn production_path_convergence_gate() -> Result<(), BoxError> {
             .map(|(group_id, document_id, _)| (*group_id, *document_id))
             .collect();
         let contexts: Vec<Arc<DriverContext>> = nodes.iter().map(|n| n.context.clone()).collect();
-        wait_for_visibility(
-            &contexts,
-            &pairs,
-            Duration::from_millis(200),
-            Duration::from_secs(300),
-            started,
-        )
-        .await?;
-        wait_for_empty_materialization_queues(&contexts, Duration::from_secs(300), started).await?;
+        wait_for_visibility(&contexts, &pairs, Duration::from_millis(200), started).await?;
+        wait_for_empty_materialization_queues(&contexts).await?;
         let seconds = started.elapsed().as_secs_f64();
         shutdown_nodes(nodes).await;
         Ok::<(f64, usize), BoxError>((seconds, total))
@@ -253,10 +241,8 @@ fn production_path_convergence_gate() -> Result<(), BoxError> {
 
 async fn wait_for_empty_materialization_queues(
     contexts: &[Arc<DriverContext>],
-    timeout: Duration,
-    t0: Instant,
 ) -> Result<(), BoxError> {
-    loop {
+    wait_for_convergence("materialization queues never drained", || async {
         let mut busy = 0usize;
         for context in contexts {
             if metadata_materialization_jobs_exist(&context.storage_handle)
@@ -266,17 +252,9 @@ async fn wait_for_empty_materialization_queues(
                 busy += 1;
             }
         }
-        if busy == 0 {
-            return Ok(());
-        }
-        if t0.elapsed() > timeout {
-            return Err(format!(
-                "materialization queues still busy on {busy} nodes after {timeout:?}"
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(200)).await;
-    }
+        Ok(busy)
+    })
+    .await
 }
 
 #[test]
@@ -345,7 +323,6 @@ async fn churn_convergence_body() -> Result<f64, BoxError> {
             &contexts,
             &initial_pair,
             Duration::from_millis(200),
-            SETUP_TIMEOUT,
             Instant::now(),
         )
         .await?;
@@ -385,7 +362,6 @@ async fn churn_convergence_body() -> Result<f64, BoxError> {
         std::slice::from_ref(&node2.context),
         &pairs,
         Duration::from_millis(500),
-        Duration::from_secs(60),
         t0,
     )
     .await;
@@ -515,15 +491,18 @@ async fn flush_projection_batches(
     Ok(())
 }
 
+// Keeps the per-node pruning and elapsed-time return, but fails on a lost-progress
+// window rather than a fixed budget so a slow-but-converging run is not flunked.
 async fn wait_for_visibility(
     contexts: &[Arc<DriverContext>],
     pairs: &[(GroupId, Ulid)],
     poll_interval: Duration,
-    timeout: Duration,
     t0: Instant,
 ) -> Result<f64, BoxError> {
     let mut remaining: Vec<Vec<(GroupId, Ulid)>> =
         contexts.iter().map(|_| pairs.to_vec()).collect();
+    let mut best = usize::MAX;
+    let mut deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
 
     loop {
         for (context, missing) in contexts.iter().zip(remaining.iter_mut()) {
@@ -541,15 +520,17 @@ async fn wait_for_visibility(
             }
             *missing = still_missing;
         }
-        if remaining.iter().all(Vec::is_empty) {
+        let pending: usize = remaining.iter().map(Vec::len).sum();
+        if pending == 0 {
             return Ok(t0.elapsed().as_secs_f64());
         }
-        if t0.elapsed() > timeout {
+        if pending < best {
+            best = pending;
+            deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
+        }
+        if Instant::now() >= deadline {
             let counts: Vec<usize> = remaining.iter().map(Vec::len).collect();
-            return Err(format!(
-                "visibility timeout after {timeout:?}; missing per node: {counts:?}"
-            )
-            .into());
+            return Err(format!("visibility stalled; missing per node: {counts:?}").into());
         }
         sleep(poll_interval).await;
     }
@@ -724,10 +705,8 @@ async fn wait_for_realm_node_convergence(
     realm_id: &RealmId,
 ) -> Result<(), BoxError> {
     let expected: HashSet<_> = nodes.iter().map(|node| node.net.node_id()).collect();
-    let deadline = Instant::now() + SETUP_TIMEOUT;
-
-    loop {
-        let mut converged = true;
+    wait_for_convergence("realm nodes did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(
                 GetRealmNodesOperation::new(*realm_id),
@@ -736,20 +715,12 @@ async fn wait_for_realm_node_convergence(
             .await
             {
                 Ok(realm_nodes) if realm_nodes == expected => {}
-                _ => {
-                    converged = false;
-                    break;
-                }
+                _ => pending += 1,
             }
         }
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("realm nodes did not converge".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/notification_delivery.rs
+++ b/operations/tests/notification_delivery.rs
@@ -30,11 +30,12 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::{FjallStorage, StorageHandle};
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::{Instant, sleep};
+use tokio::time::sleep;
 use ulid::Ulid;
 
-const POLL_TIMEOUT: Duration = Duration::from_secs(60);
-const RESPAWN_POLL_TIMEOUT: Duration = Duration::from_secs(120);
+mod convergence;
+use convergence::wait_for_convergence;
+
 const LIST_LIMIT: u32 = LIST_NOTIFICATIONS_MAX_LIMIT as u32;
 
 struct TestNode {
@@ -55,7 +56,7 @@ async fn notification_emitted_on_a_is_visible_via_b() -> Result<(), Box<dyn std:
 
     emit_on(&nodes[0], vec![record]).await?;
 
-    wait_for(POLL_TIMEOUT, || {
+    wait_for(|| {
         let nodes = &nodes;
         async move {
             list_via(&nodes[1], recipient)
@@ -111,7 +112,7 @@ async fn delivery_retries_through_holder_outage() -> Result<(), Box<dyn std::err
     mesh_nodes(&nodes).await;
     install_realm_config(&nodes, realm_id).await?;
 
-    wait_for(RESPAWN_POLL_TIMEOUT, || {
+    wait_for(|| {
         let nodes = &nodes;
         async move {
             let delivered = list_via(&nodes[2], recipient)
@@ -138,7 +139,7 @@ async fn duplicate_delivery_is_idempotent_across_nodes() -> Result<(), Box<dyn s
     let target = record.notification_id;
 
     emit_on(&nodes[0], vec![record.clone()]).await?;
-    wait_for(POLL_TIMEOUT, || {
+    wait_for(|| {
         let nodes = &nodes;
         async move {
             list_via(&nodes[2], recipient)
@@ -153,7 +154,7 @@ async fn duplicate_delivery_is_idempotent_across_nodes() -> Result<(), Box<dyn s
     assert_eq!(marked, 1);
 
     emit_on(&nodes[0], vec![record]).await?;
-    wait_for(POLL_TIMEOUT, || {
+    wait_for(|| {
         let nodes = &nodes;
         async move { outbox_records(&nodes[0]).await.is_empty() }
     })
@@ -193,7 +194,7 @@ async fn unread_and_mark_read_across_nodes() -> Result<(), Box<dyn std::error::E
     let ids: Vec<Ulid> = vec![records[0].notification_id, records[1].notification_id];
 
     emit_on(&nodes[0], records).await?;
-    wait_for(POLL_TIMEOUT, || {
+    wait_for(|| {
         let nodes = &nodes;
         async move { list_via(&nodes[1], recipient).await.len() >= 3 }
     })
@@ -258,7 +259,7 @@ async fn dispatch_proxies_inbox_ops_from_non_holder() -> Result<(), Box<dyn std:
     let ids: Vec<Ulid> = vec![records[0].notification_id, records[1].notification_id];
 
     emit_on(&nodes[0], records).await?;
-    wait_for(POLL_TIMEOUT, || {
+    wait_for(|| {
         let reader_ctx = reader_ctx.clone();
         async move {
             list_notifications_for_user(
@@ -323,23 +324,26 @@ async fn wait_for_dispatch_error(
     local_node_id: NodeId,
     recipient: UserId,
 ) -> NotificationDispatchError {
-    let deadline = Instant::now() + POLL_TIMEOUT;
-    loop {
-        match list_notifications_for_user(
-            context,
-            local_node_id,
-            recipient,
-            None,
-            LIST_LIMIT as usize,
-        )
+    wait_for_convergence("holder never became unreachable", || async {
+        Ok::<usize, Box<dyn std::error::Error>>(usize::from(
+            list_notifications_for_user(
+                context,
+                local_node_id,
+                recipient,
+                None,
+                LIST_LIMIT as usize,
+            )
+            .await
+            .is_ok(),
+        ))
+    })
+    .await
+    .expect("holder never became unreachable");
+    match list_notifications_for_user(context, local_node_id, recipient, None, LIST_LIMIT as usize)
         .await
-        {
-            Err(error) => return error,
-            Ok(_) => {
-                assert!(Instant::now() < deadline, "holder never became unreachable");
-                sleep(Duration::from_millis(100)).await;
-            }
-        }
+    {
+        Err(error) => error,
+        Ok(_) => panic!("holder never became unreachable"),
     }
 }
 
@@ -580,24 +584,15 @@ async fn install_realm_config(
     Ok(())
 }
 
-async fn wait_for<F, Fut>(
-    timeout: Duration,
-    mut condition: F,
-) -> Result<(), Box<dyn std::error::Error>>
+async fn wait_for<F, Fut>(condition: F) -> Result<(), Box<dyn std::error::Error>>
 where
-    F: FnMut() -> Fut,
+    F: Fn() -> Fut,
     Fut: std::future::Future<Output = bool>,
 {
-    let deadline = Instant::now() + timeout;
-    loop {
-        if condition().await {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("condition not met before deadline".into());
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
+    wait_for_convergence("condition not met before deadline", || async {
+        Ok(usize::from(!condition().await))
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/placement_determinism.rs
+++ b/operations/tests/placement_determinism.rs
@@ -2,7 +2,6 @@
 #![recursion_limit = "256"]
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use aruna_core::admin_document_reducer::AdminDocumentReducerState;
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
@@ -37,10 +36,10 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+mod convergence;
+use convergence::wait_for_convergence;
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -190,20 +189,22 @@ async fn shared_node_info_topic_propagates_placement_authoritative_document()
     .find(|node| node.node_id == publisher_id)
     .expect("publisher should be present in placement view")
     .labels;
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    let received = loop {
-        if let Some(document) = read_node_info_document(&peer.context.storage_handle, publisher_id)
-            .await
-            .map_err(std::io::Error::other)?
-        {
-            break document;
-        }
-        if Instant::now() >= deadline {
-            shutdown_nodes(nodes).await;
-            return Err("node info document did not propagate over the shared topic".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    };
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "node info document did not propagate over the shared topic",
+        || async {
+            Ok(usize::from(
+                read_node_info_document(&peer.context.storage_handle, publisher_id)
+                    .await
+                    .map_err(std::io::Error::other)?
+                    .is_none(),
+            ))
+        },
+    )
+    .await?;
+    let received = read_node_info_document(&peer.context.storage_handle, publisher_id)
+        .await
+        .map_err(std::io::Error::other)?
+        .expect("node info document present after convergence");
 
     assert_eq!(received.node_id, publisher_id);
     assert_eq!(received.executors.len(), 1);
@@ -277,8 +278,8 @@ async fn wait_for_document(
     node: &TestNode,
     target: &DocumentSyncTarget,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
+    let context = format!("document did not reach final holder {}", node.net.node_id());
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(&context, || async {
         match node
             .context
             .storage_handle
@@ -289,17 +290,12 @@ async fn wait_for_document(
             }))
             .await
         {
-            Event::Storage(StorageEvent::ReadResult { value: Some(_), .. }) => return Ok(()),
-            Event::Storage(StorageEvent::ReadResult { value: None, .. }) => {}
-            other => return Err(format!("unexpected document read event: {other:?}").into()),
+            Event::Storage(StorageEvent::ReadResult { value: Some(_), .. }) => Ok(0),
+            Event::Storage(StorageEvent::ReadResult { value: None, .. }) => Ok(1),
+            other => Err(format!("unexpected document read event: {other:?}").into()),
         }
-        if Instant::now() >= deadline {
-            return Err(
-                format!("document did not reach final holder {}", node.net.node_id()).into(),
-            );
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+    })
+    .await
 }
 
 async fn wait_for_policy_convergence(
@@ -308,34 +304,43 @@ async fn wait_for_policy_convergence(
     draining_node: aruna_core::NodeId,
     replica_count: u32,
 ) -> Result<Vec<RealmConfigDocument>, Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        let mut configs = Vec::with_capacity(nodes.len());
-        let mut converged = true;
-        for node in nodes {
-            let config = drive(
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "placement policy did not converge on all nodes",
+        || async {
+            let mut pending = 0;
+            for node in nodes {
+                let config = drive(
+                    GetRealmConfigOperation::new(realm_id),
+                    node.context.as_ref(),
+                )
+                .await?;
+                let strategy_matches = config
+                    .default_strategy_id
+                    .and_then(|strategy_id| config.strategy(&strategy_id))
+                    .is_some_and(|strategy| strategy.replica_count == Some(replica_count));
+                let node_matches = config
+                    .placement_entry(draining_node)
+                    .is_some_and(|entry| entry.draining);
+                if !(strategy_matches && node_matches) {
+                    pending += 1;
+                }
+            }
+            Ok(pending)
+        },
+    )
+    .await?;
+
+    let mut configs = Vec::with_capacity(nodes.len());
+    for node in nodes {
+        configs.push(
+            drive(
                 GetRealmConfigOperation::new(realm_id),
                 node.context.as_ref(),
             )
-            .await?;
-            let strategy_matches = config
-                .default_strategy_id
-                .and_then(|strategy_id| config.strategy(&strategy_id))
-                .is_some_and(|strategy| strategy.replica_count == Some(replica_count));
-            let node_matches = config
-                .placement_entry(draining_node)
-                .is_some_and(|entry| entry.draining);
-            converged &= strategy_matches && node_matches;
-            configs.push(config);
-        }
-        if converged {
-            return Ok(configs);
-        }
-        if Instant::now() >= deadline {
-            return Err("placement policy did not converge on all nodes".into());
-        }
-        sleep(Duration::from_millis(100)).await;
+            .await?,
+        );
     }
+    Ok(configs)
 }
 
 fn assert_weighted_distinct_resolution(nodes: &[TestNode], config: &RealmConfigDocument) {

--- a/operations/tests/resource_watch_delivery.rs
+++ b/operations/tests/resource_watch_delivery.rs
@@ -42,15 +42,12 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::Instant;
 use tokio::time::sleep;
 use ulid::Ulid;
 
-// Positive delivery waits poll to a condition; the ceiling only bounds a
-// genuine hang. Delivery measures single-digit seconds, but a loaded CI runner
-// can stall consecutive peer syncs for the full 30s peer-sync timeout each, so
-// the backstop is 2-3x that timeout, not the expected latency.
-const POLL_TIMEOUT: Duration = Duration::from_secs(120);
+mod convergence;
+use convergence::wait_for_convergence;
+
 const LIST_LIMIT: usize = LIST_NOTIFICATIONS_MAX_LIMIT;
 // Interest publication is debounced by 2s, so a few seconds comfortably bounds
 // the window an erroneous delivery would need to land in for negative assertions.
@@ -128,7 +125,7 @@ async fn watch_on_node_a_fires_for_upload_on_node_b_visible_via_node_c()
     emit_resource_watch_event(nodes[1].context.as_ref(), event).await;
 
     let expected_id = watch_notification_id(event_id, subscription.watch_id);
-    wait_for(POLL_TIMEOUT, || {
+    wait_for(|| {
         let node_c = &nodes[2];
         async move {
             list_via(node_c, watcher)
@@ -246,7 +243,7 @@ async fn same_node_delivery() -> Result<(), Box<dyn std::error::Error>> {
     emit_resource_watch_event(nodes[0].context.as_ref(), event).await;
 
     let expected_id = watch_notification_id(event_id, subscription.watch_id);
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         list_via(&nodes[0], watcher)
             .await
             .iter()
@@ -269,7 +266,7 @@ async fn same_node_delivery() -> Result<(), Box<dyn std::error::Error>> {
 
     // Deleting through the creating node retracts its local registration.
     delete_watch_via(&nodes[0], watcher, subscription.watch_id).await?;
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         list_watches_for_user(nodes[0].context.as_ref(), nodes[0].net.node_id(), watcher)
             .await
             .is_ok_and(|rows| rows.is_empty())
@@ -379,7 +376,7 @@ async fn self_event_delivers() -> Result<(), Box<dyn std::error::Error>> {
     emit_resource_watch_event(nodes[1].context.as_ref(), event).await;
 
     let expected_id = watch_notification_id(event_id, subscription.watch_id);
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         list_via(&nodes[2], watcher)
             .await
             .iter()
@@ -523,7 +520,7 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
     )
     .await?;
     let old_holder_node = node_by_id(&nodes, old_holder);
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         list_watch_subscriptions(&old_holder_node.context.storage_handle, watcher)
             .await
             .is_ok_and(|rows| rows.contains(&subscription))
@@ -531,10 +528,8 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
     .await?;
     // The row and outbox record commit atomically; wait until the record has
     // published into topic history before changing which node holds the inbox.
-    wait_for(POLL_TIMEOUT, || async {
-        iter_len(old_holder_node, DOCUMENT_SYNC_OUTBOX_KEYSPACE).await == 0
-    })
-    .await?;
+    wait_for(|| async { iter_len(old_holder_node, DOCUMENT_SYNC_OUTBOX_KEYSPACE).await == 0 })
+        .await?;
 
     install_config_document(&nodes, realm_id, &full_config).await?;
     let new_holder_node = node_by_id(&nodes, new_holder);
@@ -563,13 +558,13 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
         mark_watch_interest_dirty(node.context.as_ref(), realm_id).await?;
     }
 
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         list_watch_subscriptions(&new_holder_node.context.storage_handle, watcher)
             .await
             .is_ok_and(|rows| rows.contains(&subscription))
     })
     .await?;
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         nodes[1].net.watch_interest_snapshot().matching_nodes(
             realm_id,
             &probe,
@@ -600,7 +595,7 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
     )
     .await;
     let expected_id = watch_notification_id(event_id, subscription.watch_id);
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         list_via(&nodes[0], watcher)
             .await
             .iter()
@@ -609,7 +604,7 @@ async fn subscription_survives_inbox_holder_rerank() -> Result<(), Box<dyn std::
     .await?;
 
     delete_watch_via(&nodes[0], watcher, subscription.watch_id).await?;
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         list_watches_for_user(nodes[1].context.as_ref(), nodes[1].net.node_id(), watcher)
             .await
             .is_ok_and(|rows| rows.is_empty())
@@ -691,7 +686,7 @@ async fn wait_for_holder(
     holder: NodeId,
     present: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    wait_for(POLL_TIMEOUT, || async {
+    wait_for(|| async {
         node.net
             .watch_interest_snapshot()
             .matching_nodes(realm_id, probe_path, kind)
@@ -964,7 +959,7 @@ async fn bootstrap_watch_interest_topic(
         // next node writes so concurrent outbox drains cannot race topic setup.
         let key = watch_interest_node_key(realm_id, node_id);
         for peer in nodes {
-            wait_for(POLL_TIMEOUT, || async {
+            wait_for(|| async {
                 read_watch_interest_digest(peer, key.clone())
                     .await
                     .is_some()
@@ -994,24 +989,15 @@ async fn read_watch_interest_digest(node: &TestNode, key: Vec<u8>) -> Option<Wat
     }
 }
 
-async fn wait_for<F, Fut>(
-    timeout: Duration,
-    mut condition: F,
-) -> Result<(), Box<dyn std::error::Error>>
+async fn wait_for<F, Fut>(condition: F) -> Result<(), Box<dyn std::error::Error>>
 where
-    F: FnMut() -> Fut,
+    F: Fn() -> Fut,
     Fut: std::future::Future<Output = bool>,
 {
-    let deadline = Instant::now() + timeout;
-    loop {
-        if condition().await {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("condition not met before deadline".into());
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
+    wait_for_convergence("condition not met before deadline", || async {
+        Ok(usize::from(!condition().await))
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/restart_traffic.rs
+++ b/operations/tests/restart_traffic.rs
@@ -37,12 +37,9 @@ use ulid::Ulid;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-// Realm-node and document convergence poll to a condition; the ceilings only
-// bound a genuine hang. Convergence measures single-digit seconds, but a
-// loaded CI runner can stall consecutive peer syncs for the full 30s peer-sync
-// timeout each, so the backstop is 2-3x that timeout, not the expected latency.
-const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
+mod convergence;
+use convergence::{HANG_CAP, NO_PROGRESS_TIMEOUT, wait_for_convergence};
+
 const PROJECTION_BATCH: usize = 32;
 const SEED_DOCUMENTS: usize = 500;
 
@@ -117,13 +114,7 @@ async fn restart_traffic_body() -> Result<(), BoxError> {
         .take(40)
         .map(|(group_id, document_id)| (*group_id, *document_id))
         .collect();
-    wait_for_any_visibility(
-        &nodes[2].context,
-        &sample,
-        Duration::from_millis(200),
-        CONVERGENCE_TIMEOUT,
-    )
-    .await?;
+    wait_for_any_visibility(&nodes[2].context, &sample).await?;
     println!(
         "seeded {} docs, node 2 holds replicated state",
         created.len()
@@ -184,13 +175,7 @@ async fn restart_traffic_body() -> Result<(), BoxError> {
     })
     .await?;
     let contexts: Vec<Arc<DriverContext>> = nodes.iter().map(|node| node.context.clone()).collect();
-    wait_for_visibility(
-        &contexts,
-        &fresh,
-        Duration::from_millis(200),
-        CONVERGENCE_TIMEOUT,
-    )
-    .await?;
+    wait_for_visibility(&contexts, &fresh, Duration::from_millis(200)).await?;
     println!("fresh write converged to all nodes after restart");
 
     shutdown_nodes(nodes).await;
@@ -230,7 +215,7 @@ impl AuxRuntime {
     async fn shutdown(mut self) -> Result<(), BoxError> {
         if let Some(runtime) = self.0.take() {
             let shutdown = tokio::task::spawn_blocking(move || drop(runtime));
-            tokio::time::timeout(CONVERGENCE_TIMEOUT, shutdown)
+            tokio::time::timeout(HANG_CAP, shutdown)
                 .await
                 .map_err(|_| "aux runtime shutdown timed out")?
                 .map_err(|error| format!("aux runtime shutdown failed: {error}"))?;
@@ -328,15 +313,17 @@ async fn flush_projection_batches(
     Ok(())
 }
 
+// Keeps per-node pruning, but fails on a lost-progress window rather than a fixed
+// budget so a slow-but-converging run is not flunked.
 async fn wait_for_visibility(
     contexts: &[Arc<DriverContext>],
     pairs: &[(GroupId, Ulid)],
     poll_interval: Duration,
-    timeout: Duration,
 ) -> Result<(), BoxError> {
-    let t0 = Instant::now();
     let mut remaining: Vec<Vec<(GroupId, Ulid)>> =
         contexts.iter().map(|_| pairs.to_vec()).collect();
+    let mut best = usize::MAX;
+    let mut deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
 
     loop {
         for (context, missing) in contexts.iter().zip(remaining.iter_mut()) {
@@ -354,12 +341,17 @@ async fn wait_for_visibility(
             }
             *missing = still_missing;
         }
-        if remaining.iter().all(Vec::is_empty) {
+        let pending: usize = remaining.iter().map(Vec::len).sum();
+        if pending == 0 {
             return Ok(());
         }
-        if t0.elapsed() > timeout {
+        if pending < best {
+            best = pending;
+            deadline = Instant::now() + NO_PROGRESS_TIMEOUT;
+        }
+        if Instant::now() >= deadline {
             let counts: Vec<usize> = remaining.iter().map(Vec::len).collect();
-            return Err(format!("visibility timeout; missing per node: {counts:?}").into());
+            return Err(format!("visibility stalled; missing per node: {counts:?}").into());
         }
         sleep(poll_interval).await;
     }
@@ -368,27 +360,25 @@ async fn wait_for_visibility(
 async fn wait_for_any_visibility(
     context: &Arc<DriverContext>,
     pairs: &[(GroupId, Ulid)],
-    poll_interval: Duration,
-    timeout: Duration,
 ) -> Result<(), BoxError> {
-    let t0 = Instant::now();
-    loop {
-        for &(group_id, document_id) in pairs {
-            if drive(
-                GetMetadataDocumentOperation::new(group_id, document_id),
-                context.as_ref(),
-            )
-            .await
-            .is_ok()
-            {
-                return Ok(());
+    wait_for_convergence(
+        "visibility timeout; no sampled documents visible",
+        || async {
+            for &(group_id, document_id) in pairs {
+                if drive(
+                    GetMetadataDocumentOperation::new(group_id, document_id),
+                    context.as_ref(),
+                )
+                .await
+                .is_ok()
+                {
+                    return Ok(0);
+                }
             }
-        }
-        if t0.elapsed() > timeout {
-            return Err("visibility timeout; no sampled documents visible".into());
-        }
-        sleep(poll_interval).await;
-    }
+            Ok(1)
+        },
+    )
+    .await
 }
 
 async fn spawn_node(realm_id: RealmId) -> Result<TestNode, BoxError> {
@@ -535,10 +525,8 @@ async fn wait_for_realm_node_convergence(
 ) -> Result<(), BoxError> {
     let expected: std::collections::HashSet<_> =
         nodes.iter().map(|node| node.net.node_id()).collect();
-    let deadline = Instant::now() + SETUP_TIMEOUT;
-
-    loop {
-        let mut converged = true;
+    wait_for_convergence("realm nodes did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(
                 GetRealmNodesOperation::new(*realm_id),
@@ -547,20 +535,12 @@ async fn wait_for_realm_node_convergence(
             .await
             {
                 Ok(realm_nodes) if realm_nodes == expected => {}
-                _ => {
-                    converged = false;
-                    break;
-                }
+                _ => pending += 1,
             }
         }
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("realm nodes did not converge".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/shard_manifest_convergence.rs
+++ b/operations/tests/shard_manifest_convergence.rs
@@ -1,7 +1,6 @@
 // Fresh builds overflow the default query depth in nested async layouts.
 #![recursion_limit = "256"]
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use aruna_core::document::{DocumentSyncTarget, ShardManifest, ShardManifestEntry};
 use aruna_core::effects::{Effect, StorageEffect};
@@ -34,8 +33,10 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::sleep;
 use ulid::Ulid;
+
+mod convergence;
+use convergence::wait_for_convergence;
 
 /// A fixed structured id (handle 1, bucket 0) for the strategy-resolution sample,
 /// which does not exercise the create-mint flow.
@@ -44,13 +45,6 @@ fn doc_id(seed: u64) -> Ulid {
         .unwrap()
         .as_ulid()
 }
-
-// Realm-node and manifest convergence poll to a condition; the ceilings only
-// bound a genuine hang. Convergence measures single-digit seconds, but a
-// loaded CI runner can stall consecutive peer syncs for the full 30s peer-sync
-// timeout each, so the backstop is 2-3x that timeout, not the expected latency.
-const SETUP_TIMEOUT: Duration = Duration::from_secs(120);
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -130,40 +124,39 @@ async fn interleaved_writes_to_one_shard_converge_on_both_holders()
     )
     .await?;
 
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        let left = assemble_shard_manifest(nodes[0].context.as_ref(), realm_id, placement).await?;
-        let right = assemble_shard_manifest(nodes[1].context.as_ref(), realm_id, placement).await?;
-        let left_tomb = left
-            .entries
-            .iter()
-            .find(|entry| entry.target == deleted_target)
-            .map(|entry| entry.revision);
-        let right_tomb = right
-            .entries
-            .iter()
-            .find(|entry| entry.target == deleted_target)
-            .map(|entry| entry.revision);
-        if left_tomb.is_some() && left_tomb == right_tomb {
-            // Both holders now carry the same tombstone row: the whole entry set
-            // (tombstone included) and the digest must be identical.
-            assert_eq!(
-                left.entries.len(),
-                document_ids.len(),
-                "the delete keeps a tombstone row"
-            );
-            assert_eq!(sorted_entries(&left), sorted_entries(&right));
-            assert_eq!(left.digest, right.digest);
-            break;
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "delete tombstone did not converge across holders: left={left_tomb:?} right={right_tomb:?}"
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(150)).await;
-    }
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "delete tombstone did not converge across holders",
+        || async {
+            let left =
+                assemble_shard_manifest(nodes[0].context.as_ref(), realm_id, placement).await?;
+            let right =
+                assemble_shard_manifest(nodes[1].context.as_ref(), realm_id, placement).await?;
+            let left_tomb = left
+                .entries
+                .iter()
+                .find(|entry| entry.target == deleted_target)
+                .map(|entry| entry.revision);
+            let right_tomb = right
+                .entries
+                .iter()
+                .find(|entry| entry.target == deleted_target)
+                .map(|entry| entry.revision);
+            if left_tomb.is_some() && left_tomb == right_tomb {
+                // Both holders now carry the same tombstone row: the whole entry set
+                // (tombstone included) and the digest must be identical.
+                assert_eq!(
+                    left.entries.len(),
+                    document_ids.len(),
+                    "the delete keeps a tombstone row"
+                );
+                assert_eq!(sorted_entries(&left), sorted_entries(&right));
+                assert_eq!(left.digest, right.digest);
+                return Ok(0);
+            }
+            Ok(1)
+        },
+    )
+    .await?;
 
     shutdown_nodes(nodes).await;
     Ok(())
@@ -250,29 +243,18 @@ async fn wait_for_manifest_agreement(
     placement: PlacementRef,
     expected: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
+    wait_for_convergence("manifests did not converge", || async {
         let left_manifest =
             assemble_shard_manifest(left.context.as_ref(), realm_id, placement).await?;
         let right_manifest =
             assemble_shard_manifest(right.context.as_ref(), realm_id, placement).await?;
-        if left_manifest.entries.len() == expected
-            && right_manifest.entries.len() == expected
-            && left_manifest.digest == right_manifest.digest
-        {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "manifests did not converge: left={} right={} digest_eq={}",
-                left_manifest.entries.len(),
-                right_manifest.entries.len(),
-                left_manifest.digest == right_manifest.digest
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(150)).await;
-    }
+        Ok(usize::from(
+            !(left_manifest.entries.len() == expected
+                && right_manifest.entries.len() == expected
+                && left_manifest.digest == right_manifest.digest),
+        ))
+    })
+    .await
 }
 
 async fn build_realm_nodes(
@@ -408,9 +390,8 @@ async fn wait_for_realm_node_convergence(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let expected: std::collections::HashSet<NodeId> =
         nodes.iter().map(|node| node.net.node_id()).collect();
-    let deadline = Instant::now() + SETUP_TIMEOUT;
-    loop {
-        let mut converged = true;
+    wait_for_convergence("realm nodes did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(
                 GetRealmNodesOperation::new(*realm_id),
@@ -419,20 +400,12 @@ async fn wait_for_realm_node_convergence(
             .await
             {
                 Ok(realm_nodes) if realm_nodes == expected => {}
-                _ => {
-                    converged = false;
-                    break;
-                }
+                _ => pending += 1,
             }
         }
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("realm nodes did not converge".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/shard_manifest_protocol.rs
+++ b/operations/tests/shard_manifest_protocol.rs
@@ -1,7 +1,6 @@
 // Fresh builds overflow the default query depth in nested async layouts.
 #![recursion_limit = "256"]
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use aruna_core::StructuredId;
 use aruna_core::document::{DocumentSyncTarget, ShardManifest};
@@ -32,8 +31,10 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::sleep;
 use ulid::Ulid;
+
+mod convergence;
+use convergence::wait_for_convergence;
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -356,17 +357,14 @@ async fn wait_for_manifest_entry(
     placement: PlacementRef,
     target: &DocumentSyncTarget,
 ) -> Result<ShardManifest, Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + Duration::from_secs(30);
-    loop {
+    wait_for_convergence("timed out waiting for manifest entry", || async {
         let manifest = assemble_shard_manifest(node.context.as_ref(), realm_id, placement).await?;
-        if manifest.entries.iter().any(|entry| &entry.target == target) {
-            return Ok(manifest);
-        }
-        if Instant::now() >= deadline {
-            return Err("timed out waiting for manifest entry".into());
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
+        Ok::<_, Box<dyn std::error::Error>>(usize::from(
+            !manifest.entries.iter().any(|entry| &entry.target == target),
+        ))
+    })
+    .await?;
+    Ok(assemble_shard_manifest(node.context.as_ref(), realm_id, placement).await?)
 }
 
 async fn build_realm_nodes(
@@ -499,9 +497,8 @@ async fn wait_for_realm_node_convergence(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let expected: std::collections::HashSet<NodeId> =
         nodes.iter().map(|node| node.net.node_id()).collect();
-    let deadline = Instant::now() + Duration::from_secs(30);
-    loop {
-        let mut converged = true;
+    wait_for_convergence("realm nodes did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(
                 GetRealmNodesOperation::new(*realm_id),
@@ -510,20 +507,12 @@ async fn wait_for_realm_node_convergence(
             .await
             {
                 Ok(realm_nodes) if realm_nodes == expected => {}
-                _ => {
-                    converged = false;
-                    break;
-                }
+                _ => pending += 1,
             }
         }
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("realm nodes did not converge".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
 async fn shutdown_nodes(nodes: Vec<TestNode>) {

--- a/operations/tests/topology/mod.rs
+++ b/operations/tests/topology/mod.rs
@@ -17,10 +17,12 @@
 
 #![allow(dead_code)]
 
+#[path = "../convergence/mod.rs"]
+mod convergence;
+
 use aruna_core::keys::generate_signing_key;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
 
 use aruna_core::auth::TRUSTED_REALMS_LIST_KEY;
 use aruna_core::document::DocumentSyncTarget;
@@ -56,14 +58,11 @@ use ed25519_dalek::pkcs8::EncodePrivateKey;
 use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use tempfile::TempDir;
-use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
-pub type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+use convergence::{hang_cap, wait_for_convergence};
 
-/// Lost-progress detection, not a speed limit: one queue retry alone backs off
-/// to 30s, and an instrumented run is several times slower than a plain one.
-pub const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
+pub type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
 
 /// Two stable locations, so `distinct_locations` strategies stay satisfiable
 /// and location ranking is exercised rather than degenerate.
@@ -134,13 +133,16 @@ impl Topology {
         mesh(&nodes).await;
 
         for node in &nodes {
-            drive(
-                AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
-                    realm_id,
-                    node_id: node.node_id(),
-                    schedule_refresh: true,
-                }),
-                node.context.as_ref(),
+            hang_cap(
+                "announce realm presence",
+                drive(
+                    AnnounceRealmPresenceOperation::new(AnnounceRealmPresenceConfig {
+                        realm_id,
+                        node_id: node.node_id(),
+                        schedule_refresh: true,
+                    }),
+                    node.context.as_ref(),
+                ),
             )
             .await?;
         }
@@ -225,32 +227,33 @@ impl Topology {
     /// node. The holder of a forwarded write re-runs the caller's permission check
     /// against this group's authorization document, read from its own keyspace.
     pub async fn seed_group(&self) -> TestResult<Ulid> {
-        let (group, _auth) = drive(
-            CreateGroupOperation::new(CreateGroupConfig {
-                actor: self.actor(self.node(0)),
-                display_name: "topology group".to_string(),
-                owner_cap: None,
-            }),
-            self.node(0).context.as_ref(),
+        let (group, _auth) = hang_cap(
+            "seed_group create",
+            drive(
+                CreateGroupOperation::new(CreateGroupConfig {
+                    actor: self.actor(self.node(0)),
+                    display_name: "topology group".to_string(),
+                    owner_cap: None,
+                }),
+                self.node(0).context.as_ref(),
+            ),
         )
         .await?;
 
-        let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-        loop {
-            let mut pending = false;
-            for node in self.nodes.iter().filter(|node| node.is_sync_eligible()) {
-                if read_group_auth(node, group.group_id).await?.is_none() {
-                    pending = true;
+        wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+            "the seeded group never reached every sync-eligible node",
+            || async {
+                let mut pending = 0;
+                for node in self.nodes.iter().filter(|node| node.is_sync_eligible()) {
+                    if read_group_auth(node, group.group_id).await?.is_none() {
+                        pending += 1;
+                    }
                 }
-            }
-            if !pending {
-                return Ok(group.group_id);
-            }
-            if Instant::now() >= deadline {
-                return Err("the seeded group never reached every sync-eligible node".into());
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
+                Ok(pending)
+            },
+        )
+        .await?;
+        Ok(group.group_id)
     }
 
     /// The bucket a create on `origin` stamps (D3): the best-ranked bucket the
@@ -394,7 +397,7 @@ impl Topology {
 
     pub async fn shutdown(self) {
         for node in self.nodes {
-            node.net.shutdown().await;
+            hang_cap("node shutdown", node.net.shutdown()).await;
         }
     }
 }
@@ -550,34 +553,35 @@ async fn install_realm_config(
     // genesis, so without this every write onto a bucket defers forever. A node
     // whose rank-0 co-holder has not minted one yet leaves it for the next pass, so
     // run until the reconciler reports clean rather than a fixed number of passes.
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        for node in nodes {
-            aruna_operations::startup::restore_shard_subscriptions(
-                &node.context,
-                node.node_id(),
-                realm_id,
-            )
-            .await;
-        }
-        let mut retry = false;
-        for node in nodes {
-            retry |= aruna_operations::process_placements::process_shard_placements(
-                &node.context,
-                realm_id,
-                node.node_id(),
-            )
-            .await
-            .retry_scheduled;
-        }
-        if !retry {
-            return Ok(config);
-        }
-        if Instant::now() >= deadline {
-            return Err("shard placement reconciliation never reported clean".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "shard placement reconciliation never reported clean",
+        || async {
+            for node in nodes {
+                aruna_operations::startup::restore_shard_subscriptions(
+                    &node.context,
+                    node.node_id(),
+                    realm_id,
+                )
+                .await;
+            }
+            let mut pending = 0;
+            for node in nodes {
+                if aruna_operations::process_placements::process_shard_placements(
+                    &node.context,
+                    realm_id,
+                    node.node_id(),
+                )
+                .await
+                .retry_scheduled
+                {
+                    pending += 1;
+                }
+            }
+            Ok(pending)
+        },
+    )
+    .await?;
+    Ok(config)
 }
 
 async fn write(node: &TestNode, key_space: &str, key: Vec<u8>, value: Vec<u8>) -> TestResult<()> {
@@ -638,42 +642,26 @@ async fn read_realm_config(node: &TestNode, realm_id: RealmId) -> TestResult<Rea
 
 async fn wait_for_realm_nodes(nodes: &[TestNode], realm_id: RealmId) -> TestResult<()> {
     let expected: HashSet<NodeId> = nodes.iter().map(TestNode::node_id).collect();
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        let mut converged = true;
+    wait_for_convergence("realm nodes did not converge", || async {
+        let mut pending = 0;
         for node in nodes {
             match drive(GetRealmNodesOperation::new(realm_id), node.context.as_ref()).await {
                 Ok(realm_nodes) if realm_nodes == expected => {}
-                _ => {
-                    converged = false;
-                    break;
-                }
+                _ => pending += 1,
             }
         }
-        if converged {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("realm nodes did not converge".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(pending)
+    })
+    .await
 }
 
-/// Polls `predicate` until it holds or the convergence budget expires.
+/// Polls `predicate` until it holds, resilient to a slow-but-converging run via
+/// the shared lost-progress wait rather than a fixed wall-clock budget.
 pub async fn wait_until<F, Fut>(label: &str, node_id: NodeId, predicate: F) -> TestResult<()>
 where
     F: Fn() -> Fut,
     Fut: Future<Output = bool>,
 {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        if predicate().await {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(format!("{label} did not converge on node {node_id}").into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+    let context = format!("{label} did not converge on node {node_id}");
+    wait_for_convergence(&context, || async { Ok(usize::from(!predicate().await)) }).await
 }

--- a/operations/tests/usage_replication.rs
+++ b/operations/tests/usage_replication.rs
@@ -1,7 +1,6 @@
 // Fresh builds overflow the default query depth in nested async layouts.
 #![recursion_limit = "256"]
 use std::sync::Arc;
-use std::time::Duration;
 
 use aruna_core::document::DocumentSyncTarget;
 use aruna_core::effects::{Effect, StorageEffect};
@@ -27,13 +26,10 @@ use aruna_operations::usage_stats::{RealmUsageScope, load_realm_usage, publish_u
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
-// Comfortably above the durable re-arm interval (5s) plus the publish debounce
-// (2s) so the steady-state publish is observed without flaking.
-const STEADY_STATE_TIMEOUT: Duration = Duration::from_secs(30);
+mod convergence;
+use convergence::wait_for_convergence;
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -83,36 +79,32 @@ async fn node_usage_snapshot_reaches_peer_realm_aggregate() -> Result<(), Box<dy
     // Node B receives A's snapshots over the sync layer and folds them into the
     // realm aggregate (global and per-group).
     let a_snapshot_key = node_usage_global_key(node_a.net.node_id());
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        let received = read_node_stats(node_b, a_snapshot_key.clone())
-            .await
-            .is_some();
-        let global = load_realm_usage(
-            node_b.context.as_ref(),
-            node_b.net.node_id(),
-            RealmUsageScope::Global,
-        )
-        .await
-        .unwrap_or_default();
-        let group = load_realm_usage(
-            node_b.context.as_ref(),
-            node_b.net.node_id(),
-            RealmUsageScope::Group(group_id),
-        )
-        .await
-        .unwrap_or_default();
-        if received && global.buckets == 1 && group.buckets == 1 {
-            break;
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "node B never observed A's usage snapshot; received={received} global={global:?} group={group:?}"
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "node B never observed A's usage snapshot",
+        || async {
+            let received = read_node_stats(node_b, a_snapshot_key.clone())
+                .await
+                .is_some();
+            let global = load_realm_usage(
+                node_b.context.as_ref(),
+                node_b.net.node_id(),
+                RealmUsageScope::Global,
             )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+            .await
+            .unwrap_or_default();
+            let group = load_realm_usage(
+                node_b.context.as_ref(),
+                node_b.net.node_id(),
+                RealmUsageScope::Group(group_id),
+            )
+            .await
+            .unwrap_or_default();
+            Ok(usize::from(
+                !(received && global.buckets == 1 && group.buckets == 1),
+            ))
+        },
+    )
+    .await?;
 
     // Realm aggregate on B includes A's bucket even though B created nothing.
     let realm_global = load_realm_usage(
@@ -178,36 +170,32 @@ async fn rich_node_usage_snapshot_ingest_is_counter_neutral()
     .await?;
 
     let a_snapshot_key = node_usage_global_key(node_a.net.node_id());
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        let received = read_node_stats(node_b, a_snapshot_key.clone())
-            .await
-            .is_some();
-        let global = load_realm_usage(
-            node_b.context.as_ref(),
-            node_b.net.node_id(),
-            RealmUsageScope::Global,
-        )
-        .await
-        .unwrap_or_default();
-        let group = load_realm_usage(
-            node_b.context.as_ref(),
-            node_b.net.node_id(),
-            RealmUsageScope::Group(group_id),
-        )
-        .await
-        .unwrap_or_default();
-        if received && global.objects == rich.objects && group.objects == rich.objects {
-            break;
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "node B never observed A's rich usage snapshot; received={received} global={global:?} group={group:?}"
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "node B never observed A's rich usage snapshot",
+        || async {
+            let received = read_node_stats(node_b, a_snapshot_key.clone())
+                .await
+                .is_some();
+            let global = load_realm_usage(
+                node_b.context.as_ref(),
+                node_b.net.node_id(),
+                RealmUsageScope::Global,
             )
-            .into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+            .await
+            .unwrap_or_default();
+            let group = load_realm_usage(
+                node_b.context.as_ref(),
+                node_b.net.node_id(),
+                RealmUsageScope::Group(group_id),
+            )
+            .await
+            .unwrap_or_default();
+            Ok(usize::from(
+                !(received && global.objects == rich.objects && group.objects == rich.objects),
+            ))
+        },
+    )
+    .await?;
 
     // Every field of A's snapshot surfaces in B's realm aggregate.
     let realm_global = load_realm_usage(
@@ -276,23 +264,17 @@ async fn steady_state_write_publishes_snapshot_without_restart()
     .unwrap();
 
     let snapshot_key = node_usage_global_key(node.net.node_id());
-    let deadline = Instant::now() + STEADY_STATE_TIMEOUT;
-    loop {
-        let published = read_node_stats(node, snapshot_key.clone()).await.is_some();
-        let dirty_cleared = read_node_stats(node, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
-            .await
-            .is_none();
-        if published && dirty_cleared {
-            break;
-        }
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "steady-state write never published a snapshot; published={published} dirty_cleared={dirty_cleared}"
-            )
-            .into());
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "steady-state write never published a snapshot",
+        || async {
+            let published = read_node_stats(node, snapshot_key.clone()).await.is_some();
+            let dirty_cleared = read_node_stats(node, NODE_USAGE_DIRTY_GLOBAL_KEY.to_vec())
+                .await
+                .is_none();
+            Ok(usize::from(!(published && dirty_cleared)))
+        },
+    )
+    .await?;
 
     shutdown_nodes(nodes).await;
     Ok(())
@@ -357,19 +339,17 @@ async fn bootstrap_node_usage_genesis(
     )
     .await?;
 
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
-        if read_node_stats(subscriber, snapshot_key.clone())
-            .await
-            .is_some()
-        {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err("bootstrap node-usage genesis did not reach peer".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+    wait_for_convergence(
+        "bootstrap node-usage genesis did not reach peer",
+        || async {
+            Ok(usize::from(
+                read_node_stats(subscriber, snapshot_key.clone())
+                    .await
+                    .is_none(),
+            ))
+        },
+    )
+    .await
 }
 async fn read_node_stats(node: &TestNode, key: Vec<u8>) -> Option<Vec<u8>> {
     match node

--- a/operations/tests/user_access_replication.rs
+++ b/operations/tests/user_access_replication.rs
@@ -19,10 +19,10 @@ use aruna_operations::task_incoming::initialize_task_incoming;
 use aruna_storage::FjallStorage;
 use aruna_tasks::TaskHandle;
 use tempfile::TempDir;
-use tokio::time::{Instant, sleep};
 use ulid::Ulid;
 
-const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+mod convergence;
+use convergence::wait_for_convergence;
 
 struct TestNode {
     _temp_dir: TempDir,
@@ -106,8 +106,7 @@ async fn wait_for_access(
     access_key: &str,
     predicate: impl Fn(&aruna_core::structs::UserAccess) -> bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + CONVERGENCE_TIMEOUT;
-    loop {
+    wait_for_convergence("user access did not converge before timeout", || async {
         if let Ok(Some(Ok(access))) = drive(
             GetUserAccessOperation::new(access_key.to_string()),
             node.context.as_ref(),
@@ -115,13 +114,11 @@ async fn wait_for_access(
         .await
             && predicate(&access)
         {
-            return Ok(());
+            return Ok(0);
         }
-        if Instant::now() >= deadline {
-            return Err("user access did not converge before timeout".into());
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
+        Ok(1)
+    })
+    .await
 }
 
 async fn build_realm_nodes(


### PR DESCRIPTION
Makes the multi-node test suite resilient to CPU contention and slow machines, and guarantees no test can hang indefinitely. A test previously ran for hours under heavy load because nothing bounded a hung wait, and the copy-pasted convergence loops used a fixed wall-clock budget that false-fails when the machine is slow.

## Changes

- Hang detection so no test runs forever: a generous per-poll cap (`tokio::time::timeout`) that panics naming the wait's context when a poll deadlocks, a `hang_cap` wrapper applied to the topology harness's blocking node operations, and job-level `timeout-minutes` on the CI test jobs (well above healthy runtime, as a hang cap rather than a performance budget).
- A shared `wait_for_convergence(context, check)` helper whose `check` returns the pending count. Its deadline resets on every strict decrease in that count and it fails only after a no-progress window, so a slow-but-converging run keeps waiting while a genuinely stuck one fails. This distinguishes lost progress from a slow system instead of asserting wall-clock speed.
- Replaced the copy-pasted fixed-deadline convergence loops across the topology harness and the multi-node test files with the shared helper, removing the per-file timeout constants.
