### PR TITLE
feat: dedicated portal listener and stable presence reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,10 +69,16 @@ PORTAL_ARTIFACT_URL=
 PORTAL_ARTIFACT_SHA256=
 PORTAL_DIR=
 
-# Portal responses carry a Content-Security-Policy whose connect-src allows this
-# node's REST origin, its advertised S3 endpoint and the realm's OIDC provider
-# origins. Add comma-separated origins here when the portal must reach anything
-# else from the browser, such as the S3 endpoints of other realm nodes.
+# Bind address of the portal listener. The portal serves the SPA on its own
+# origin, so this is required whenever PORTAL_MODE is not disabled, and
+# API_PUBLIC_URL is then required too: the served portal config advertises it as
+# the absolute API base and CORS_ALLOWED_ORIGINS must contain the portal origin.
+PORTAL_SOCKET_ADDRESS=127.0.0.1:3003
+
+# Portal responses carry a Content-Security-Policy whose connect-src allows the
+# configured API origin, this node's advertised S3 endpoint and the realm's OIDC
+# provider origins. Add comma-separated origins here when the portal must reach
+# anything else from the browser, such as the S3 endpoints of other realm nodes.
 PORTAL_CSP_EXTRA_ORIGINS=
 
 # Maximum REST request body size in bytes (default 1 MiB). Oversized bodies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,20 +384,32 @@ jobs:
             fi
           }
 
+          # The portal owns its own listener, so it is probed there without
+          # following redirects: the REST root only redirects to swagger and
+          # must never pass for a served portal.
           assert_portal() {
             local nodes=$1
-            local index port body
+            local index rest_port portal_port code config
             for index in $(seq 1 "$nodes"); do
-              port=$((BASE_PORT + (index - 1) * 10 + 1))
-              expect_status "http://127.0.0.1:$port/" 200
-              expect_status "http://127.0.0.1:$port/api-docs/openapi.json" 200
-              body="$(curl -s -L --max-time 10 "http://127.0.0.1:$port/")"
-              case "$body" in
-                *"<html"*) ;;
-                *) die "node-$index served no portal document" ;;
+              rest_port=$((BASE_PORT + (index - 1) * 10 + 1))
+              portal_port=$((BASE_PORT + (index - 1) * 10 + 5))
+              expect_status "http://127.0.0.1:$rest_port/" 200
+              expect_status "http://127.0.0.1:$rest_port/api-docs/openapi.json" 200
+              code="$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' \
+                "http://127.0.0.1:$portal_port/" || true)"
+              [ "$code" = "200" ] \
+                || die "node-$index answered $code on portal port $portal_port"
+              config="$(curl -s --max-time 10 \
+                "http://127.0.0.1:$portal_port/portal-config.json" || true)"
+              case "$(printf '%s' "$config" | tr -d ' \t\r\n')" in
+                *"\"apiBaseUrl\":\"http://127.0.0.1:$rest_port/api/v1\""*) ;;
+                *) die "node-$index served no portal config: ${config:-empty}" ;;
               esac
             done
-            grep -q '^portal dir=' "$DEPLOY_ROOT/summary.txt" || die "no portal summary entry"
+            [ "$(grep -c '^  Portal  ' "$DEPLOY_ROOT/summary.txt")" = "$nodes" ] \
+              || die "summary lists no portal url per node"
+            grep -q '^  Dist directory  ' "$DEPLOY_ROOT/summary.txt" \
+              || die "no portal dist directory in the summary"
           }
 
           assert_stopped() {

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This demo deployment:
 - builds the workspace in release mode
 - launches 3 local Aruna nodes
 - waits for readiness at `http://127.0.0.1:<port>/swagger-ui`
-- writes per-node logs and `summary.txt` to `target/test-deploy/`
+- writes per-node logs, `summary.txt` and a private `credentials.txt` to `target/test-deploy/`
 - prints an `ADMIN_TOKEN=...` line for use in authenticated API calls during the session
 - prints a summary listing every node's API, portal, S3 and ops url next to the test logins
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ This demo deployment:
 - waits for readiness at `http://127.0.0.1:<port>/swagger-ui`
 - writes per-node logs and `summary.txt` to `target/test-deploy/`
 - prints an `ADMIN_TOKEN=...` line for use in authenticated API calls during the session
+- prints a summary listing every node's API, portal, S3 and ops url next to the test logins
+
+`just preview` additionally serves the portal. The portal has its own listener,
+so each node exposes the SPA on a separate port from the REST API; the REST port
+redirects `/` to the Swagger UI.
 
 Useful overrides:
 

--- a/api/src/cors.rs
+++ b/api/src/cors.rs
@@ -93,7 +93,9 @@ impl CorsConfig {
                     Method::OPTIONS,
                 ])
                 .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
-                .expose_headers([header::CONTENT_DISPOSITION])
+                // The portal is always cross-origin now, so its retry backoff
+                // and download filenames depend on these being readable.
+                .expose_headers([header::CONTENT_DISPOSITION, header::RETRY_AFTER])
                 .max_age(CORS_MAX_AGE),
         )
     }
@@ -219,7 +221,7 @@ mod tests {
                 .headers()
                 .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
                 .unwrap(),
-            "content-disposition"
+            "content-disposition,retry-after"
         );
     }
 

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -57,7 +57,7 @@ impl PortalCspConfig {
     /// The API now answers on its own origin, so the portal document has to be
     /// allowed to reach it without the operator repeating it in the extras.
     pub fn with_api_url(mut self, api_url: &str) -> Self {
-        self.api_origin = normalize_origin(api_url);
+        self.api_origin = api_origin(api_url);
         self
     }
 }
@@ -314,6 +314,22 @@ fn normalize_origin(value: &str) -> Option<String> {
     (origin != "null").then_some(origin)
 }
 
+/// The API url is deliberate operator configuration and the portal is served
+/// over the same scheme, so a plain-http LAN origin is admitted with a warning
+/// instead of blocking every fetch the SPA makes.
+fn api_origin(api_url: &str) -> Option<String> {
+    let url = Url::parse(api_url.trim()).ok()?;
+    if !matches!(url.scheme(), "http" | "https") {
+        warn!(origin = %api_url, "Portal CSP ignores a non-HTTP API url");
+        return None;
+    }
+    if !is_secure_origin(&url) {
+        warn!(origin = %api_url, "Portal CSP admits an insecure API origin");
+    }
+    let origin = url.origin().ascii_serialization();
+    (origin != "null").then_some(origin)
+}
+
 fn is_secure_origin(url: &Url) -> bool {
     match url.scheme() {
         "https" => true,
@@ -334,7 +350,8 @@ fn is_loopback_host(host: Option<Host<&str>>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        NPM_ORIGIN, PYPI_ORIGIN, ResolvedOrigins, content_security_policy, normalize_origin,
+        NPM_ORIGIN, PYPI_ORIGIN, PortalCspConfig, ResolvedOrigins, content_security_policy,
+        normalize_origin,
     };
 
     fn origins(connect: &[&str], img: &[&str]) -> ResolvedOrigins {
@@ -375,6 +392,25 @@ mod tests {
         assert_eq!(
             normalize_origin("http://[::1]:9000"),
             Some("http://[::1]:9000".to_string())
+        );
+    }
+
+    #[test]
+    fn admits_http_api() {
+        // A plain-http LAN API url is operator config, so it stays allowed
+        // while the same origin in the extras list is still dropped.
+        let config = PortalCspConfig::default().with_api_url("http://lan-host:8080/api/v1");
+        assert_eq!(config.api_origin.as_deref(), Some("http://lan-host:8080"));
+        assert!(
+            PortalCspConfig::new(vec!["http://lan-host:8080".to_string()])
+                .extra_connect_origins
+                .is_empty()
+        );
+        assert_eq!(
+            PortalCspConfig::default()
+                .with_api_url("ftp://lan-host")
+                .api_origin,
+            None
         );
     }
 

--- a/api/src/csp.rs
+++ b/api/src/csp.rs
@@ -37,6 +37,7 @@ const CROSS_ORIGIN_OPENER_POLICY: HeaderName =
 #[derive(Clone, Debug, Default)]
 pub struct PortalCspConfig {
     extra_connect_origins: Vec<String>,
+    api_origin: Option<String>,
 }
 
 impl PortalCspConfig {
@@ -49,7 +50,15 @@ impl PortalCspConfig {
         }
         Self {
             extra_connect_origins,
+            api_origin: None,
         }
+    }
+
+    /// The API now answers on its own origin, so the portal document has to be
+    /// allowed to reach it without the operator repeating it in the extras.
+    pub fn with_api_url(mut self, api_url: &str) -> Self {
+        self.api_origin = normalize_origin(api_url);
+        self
     }
 }
 
@@ -100,13 +109,15 @@ impl PortalSecurity {
 
     async fn resolve(&self) -> ResolvedOrigins {
         let s3 = self.s3_origin().await;
+        let api = self.config.api_origin.clone();
         let mut connect = BTreeSet::new();
         connect.extend(s3.iter().cloned());
+        connect.extend(api.iter().cloned());
         connect.extend(self.oidc_origins().await);
         connect.extend(self.config.extra_connect_origins.iter().cloned());
         ResolvedOrigins {
             connect,
-            img: s3.into_iter().collect(),
+            img: s3.into_iter().chain(api).collect(),
         }
     }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -10,7 +10,7 @@ pub mod error;
 pub mod forwarded;
 pub mod openapi;
 pub mod ops;
-mod portal;
+pub mod portal;
 pub mod rate_limit;
 pub mod routes;
 pub mod s3;

--- a/api/src/portal.rs
+++ b/api/src/portal.rs
@@ -1,50 +1,90 @@
 use crate::csp::{PortalCspConfig, PortalSecurity, portal_security_headers};
+use crate::error::ServerSetupError;
 use crate::server_state::{PortalRuntimeState, ServerState};
 use axum::body::Body;
 use axum::extract::{Request, State};
 use axum::http::{HeaderValue, Method, StatusCode, header};
-use axum::middleware::from_fn_with_state;
+use axum::middleware::{from_fn, from_fn_with_state};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
 use tower_http::services::{ServeDir, ServeFile};
 
-const API_BASE_URL: &str = "/api/v1";
+const API_PATH: &str = "/api/v1";
 const ASSETS_PREFIX: &str = "/assets/";
 const IMMUTABLE_CACHE: &str = "public, max-age=31536000, immutable";
 const NO_CACHE: &str = "no-cache";
 
-pub fn router(state: Arc<ServerState>, csp: PortalCspConfig) -> Router {
-    let security = PortalSecurity::new(state.clone(), csp);
+/// The portal listener serves the SPA on its own origin, so the document has to
+/// be told where the API lives instead of assuming its own.
+#[derive(Clone, Debug)]
+pub struct PortalConfig {
+    pub api_public_url: String,
+    pub csp: PortalCspConfig,
+}
+
+#[derive(Clone)]
+struct PortalState {
+    server: Arc<ServerState>,
+    api_base_url: Arc<str>,
+}
+
+pub fn router(state: Arc<ServerState>, config: PortalConfig) -> Router {
+    let api_base_url = api_base_url(&config.api_public_url);
+    let security = PortalSecurity::new(state.clone(), config.csp.with_api_url(&api_base_url));
     Router::new()
         .route("/portal-config.json", get(portal_config))
         .fallback(serve_portal)
         .layer(from_fn_with_state(security, portal_security_headers))
-        .with_state(state)
+        .layer(from_fn(crate::csp::baseline_security_headers))
+        .with_state(PortalState {
+            server: state,
+            api_base_url: Arc::from(api_base_url),
+        })
+}
+
+/// Serves until `shutdown` is cancelled: the listener stops accepting and
+/// requests already in flight run to completion before this returns.
+pub async fn serve(
+    listener: TcpListener,
+    state: Arc<ServerState>,
+    config: PortalConfig,
+    shutdown: CancellationToken,
+) -> Result<(), ServerSetupError> {
+    axum::serve(listener, router(state, config).into_make_service())
+        .with_graceful_shutdown(async move { shutdown.cancelled().await })
+        .await
+        .map_err(|error| ServerSetupError::Runtime(error.to_string()))
+}
+
+fn api_base_url(api_public_url: &str) -> String {
+    format!("{}{API_PATH}", api_public_url.trim_end_matches('/'))
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PortalRuntimeConfig {
-    api_base_url: &'static str,
+struct PortalRuntimeConfig<'a> {
+    api_base_url: &'a str,
 }
 
-async fn portal_config(State(state): State<Arc<ServerState>>) -> Response {
-    match portal_dir(&state).await {
+async fn portal_config(State(state): State<PortalState>) -> Response {
+    match portal_dir(&state.server).await {
         Ok(_) => Json(PortalRuntimeConfig {
-            api_base_url: API_BASE_URL,
+            api_base_url: &state.api_base_url,
         })
         .into_response(),
         Err(error) => error.into_response(),
     }
 }
 
-async fn serve_portal(State(state): State<Arc<ServerState>>, request: Request) -> Response {
-    serve_portal_request(&state, request).await
+async fn serve_portal(State(state): State<PortalState>, request: Request) -> Response {
+    serve_portal_request(&state.server, request).await
 }
 
 async fn serve_portal_request(state: &ServerState, request: Request) -> Response {
@@ -158,7 +198,7 @@ impl IntoResponse for PortalServeError {
 
 #[cfg(test)]
 mod tests {
-    use super::{IMMUTABLE_CACHE, NO_CACHE, serve_portal_request};
+    use super::{IMMUTABLE_CACHE, NO_CACHE, PortalConfig, serve_portal_request};
     use crate::cors::CorsConfig;
     use crate::csp::PortalCspConfig;
     use crate::server::{DEFAULT_MAX_HTTP_BODY_SIZE, Server, ServerConfig};
@@ -213,6 +253,8 @@ mod tests {
         (state, tempdir)
     }
 
+    const TEST_API_URL: &str = "http://127.0.0.1:8080";
+
     /// Realm config with an OIDC provider, an S3 interface and an installed
     /// portal: everything the served policy derives its origins from.
     async fn setup_serving_node(portal_dir: &std::path::Path) -> (Router, TempDir, String) {
@@ -263,18 +305,31 @@ mod tests {
         std::fs::write(portal_dir.join("assets/app.js"), "console.log('portal');").unwrap();
         enable_portal(&state, portal_dir).await;
 
+        let router = super::router(
+            state,
+            PortalConfig {
+                api_public_url: TEST_API_URL.to_string(),
+                csp: PortalCspConfig::new(vec!["https://peer.test/".to_string()]),
+            },
+        );
+
+        (router, tempdir, discovery_origin)
+    }
+
+    /// The REST listener no longer merges the portal, so its baseline headers
+    /// need a router of their own.
+    async fn setup_api_router() -> (Router, TempDir) {
+        let (state, tempdir) = setup_state().await;
         let router = Server::new(
             state,
             ServerConfig {
                 http_addr: "127.0.0.1:0".parse().unwrap(),
                 max_http_body_size: DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: CorsConfig::default(),
-                portal_csp: PortalCspConfig::new(vec!["https://peer.test/".to_string()]),
             },
         )
         .build_router();
-
-        (router, tempdir, discovery_origin)
+        (router, tempdir)
     }
 
     async fn enable_portal(state: &ServerState, dir: &std::path::Path) {
@@ -375,19 +430,42 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn portal_config_returns_api_base_url_when_portal_is_available() {
-        let (state, tempdir) = setup_state().await;
-        let portal_dir = tempdir.path().join("portal");
-        std::fs::create_dir_all(&portal_dir).unwrap();
-        std::fs::write(portal_dir.join("index.html"), "<html>portal</html>").unwrap();
-        enable_portal(&state, &portal_dir).await;
+    async fn carries_api_url() {
+        // The SPA is served from its own origin, so the advertised API base has
+        // to be absolute and the root has to answer with the SPA document.
+        let tempdir = tempdir().unwrap();
+        let (router, _state_dir, _discovery_origin) =
+            setup_serving_node(&tempdir.path().join("portal")).await;
 
-        let response = super::portal_config(axum::extract::State(state)).await;
-
+        let response = router
+            .clone()
+            .oneshot(request(Method::GET, "/portal-config.json"))
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let config: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(config, serde_json::json!({ "apiBaseUrl": "/api/v1" }));
+        assert_eq!(
+            config,
+            serde_json::json!({ "apiBaseUrl": format!("{TEST_API_URL}/api/v1") })
+        );
+
+        let index = router.oneshot(request(Method::GET, "/")).await.unwrap();
+        assert_eq!(index.status(), StatusCode::OK);
+        let body = to_bytes(index.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], b"<html>portal</html>");
+    }
+
+    #[test]
+    fn api_url_joins_once() {
+        assert_eq!(
+            super::api_base_url("https://api.test/"),
+            "https://api.test/api/v1"
+        );
+        assert_eq!(
+            super::api_base_url("https://api.test"),
+            "https://api.test/api/v1"
+        );
     }
 
     #[tokio::test]
@@ -512,6 +590,7 @@ mod tests {
         assert!(connect_src.contains(&discovery_origin), "{connect_src}");
         assert!(connect_src.contains("https://tokens.test"), "{connect_src}");
         assert!(connect_src.contains("https://peer.test"), "{connect_src}");
+        assert!(connect_src.contains(TEST_API_URL), "{connect_src}");
 
         let img_src = policy
             .split("; ")
@@ -519,14 +598,13 @@ mod tests {
             .unwrap();
         assert!(img_src.contains("blob:"), "{img_src}");
         assert!(img_src.contains("https://s3.test"), "{img_src}");
+        assert!(img_src.contains(TEST_API_URL), "{img_src}");
     }
 
     #[tokio::test]
     async fn api_routes_baseline() {
         // API and swagger get the anti-clickjacking baseline, but not the strict portal CSP.
-        let tempdir = tempdir().unwrap();
-        let (router, _state_dir, _discovery_origin) =
-            setup_serving_node(&tempdir.path().join("portal")).await;
+        let (router, _state_dir) = setup_api_router().await;
 
         for path in ["/api/v1/info", "/api-docs/openapi.json"] {
             let response = router

--- a/api/src/portal.rs
+++ b/api/src/portal.rs
@@ -457,7 +457,8 @@ mod tests {
     }
 
     #[test]
-    fn api_url_joins_once() {
+    fn url_joins_once() {
+        // The API base keeps exactly one /api/v1, with or without a trailing slash.
         assert_eq!(
             super::api_base_url("https://api.test/"),
             "https://api.test/api/v1"

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -1597,7 +1597,6 @@ mod tests {
                 http_addr: addr,
                 max_http_body_size: crate::server::DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: crate::cors::CorsConfig::default(),
-                portal_csp: crate::csp::PortalCspConfig::default(),
             },
         )
         .build_router();

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,12 +1,11 @@
 use crate::cors::CorsConfig;
-use crate::csp::{PortalCspConfig, baseline_security_headers};
+use crate::csp::baseline_security_headers;
 use crate::error::ServerSetupError;
-use crate::portal;
 use crate::routes::rest_router;
 pub(crate) use crate::server_state::{ServerState, swagger_ui};
 use axum::Router;
-use axum::extract::{DefaultBodyLimit, MatchedPath, Request, State};
-use axum::http::{Method, StatusCode, Uri, header};
+use axum::extract::{DefaultBodyLimit, MatchedPath, Request};
+use axum::http::{Method, StatusCode};
 use axum::middleware::{Next, from_fn, from_fn_with_state};
 use axum::response::{IntoResponse, Redirect, Response};
 use std::net::SocketAddr;
@@ -41,7 +40,6 @@ pub struct ServerConfig {
     pub http_addr: SocketAddr,
     pub max_http_body_size: usize,
     pub cors: CorsConfig,
-    pub portal_csp: PortalCspConfig,
 }
 
 impl Server {
@@ -62,11 +60,6 @@ impl Server {
         let api_v1 = Router::new()
             .merge(rest_router(self.state.clone()))
             .layer(from_fn(rest_timeout));
-        let api_authority = self
-            .api_public_url
-            .as_deref()
-            .and_then(|url| url.parse::<Uri>().ok())
-            .and_then(|url| url.authority().map(ToString::to_string));
 
         // Build the root router with body size limit for REST API
 
@@ -74,11 +67,7 @@ impl Server {
             .nest("/api/v1", api_v1)
             .layer(DefaultBodyLimit::max(self.config.max_http_body_size))
             .merge(swagger_ui())
-            .merge(portal::router(
-                self.state.clone(),
-                self.config.portal_csp.clone(),
-            ))
-            .layer(from_fn_with_state(api_authority, redirect_swagger))
+            .layer(from_fn(redirect_swagger))
             .layer(from_fn(baseline_security_headers));
         if let Some(cors_layer) = self.config.cors.rest_layer() {
             router = router.layer(cors_layer);
@@ -159,24 +148,9 @@ async fn rest_timeout(request: Request, next: Next) -> Response {
     }
 }
 
-async fn redirect_swagger(
-    State(api_authority): State<Option<String>>,
-    request: Request,
-    next: Next,
-) -> Response {
+async fn redirect_swagger(request: Request, next: Next) -> Response {
     let is_alias = matches!(request.uri().path(), "/" | "/api/v1" | "/swagger");
-    let is_api_host = api_authority.as_deref().is_some_and(|authority| {
-        request
-            .headers()
-            .get(header::HOST)
-            .and_then(|host| host.to_str().ok())
-            .is_some_and(|host| host.eq_ignore_ascii_case(authority))
-    });
-
-    if (request.method() == Method::GET || request.method() == Method::HEAD)
-        && is_alias
-        && is_api_host
-    {
+    if (request.method() == Method::GET || request.method() == Method::HEAD) && is_alias {
         return Redirect::temporary("/swagger-ui/").into_response();
     }
 
@@ -191,9 +165,9 @@ mod tests {
     use axum::Router;
     use axum::body::Body;
     use axum::extract::MatchedPath;
-    use axum::http::{Method, Request, StatusCode};
+    use axum::http::{Method, Request, StatusCode, header};
     use axum::middleware::{Next, from_fn};
-    use axum::routing::post;
+    use axum::routing::{get, post};
     use std::sync::{Arc, Mutex};
     use tower::ServiceExt;
 
@@ -241,7 +215,6 @@ mod tests {
                 http_addr: "127.0.0.1:0".parse().unwrap(),
                 max_http_body_size: DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: crate::cors::CorsConfig::default(),
-                portal_csp: crate::csp::PortalCspConfig::default(),
             },
         )
         .build_router();
@@ -258,6 +231,35 @@ mod tests {
         let _second = router.clone().oneshot(request()).await.unwrap();
         let third = router.oneshot(request()).await.unwrap();
         assert_eq!(third.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn root_redirects_swagger() {
+        // The portal has its own listener, so the API origin no longer depends
+        // on a Host header to decide that `/` belongs to swagger.
+        let router = Router::new()
+            .route("/swagger-ui/", get(|| async { StatusCode::OK }))
+            .layer(from_fn(super::redirect_swagger));
+
+        for path in ["/", "/api/v1", "/swagger"] {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .header(header::HOST, "portal.test")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::TEMPORARY_REDIRECT, "{path}");
+            assert_eq!(
+                response.headers().get(header::LOCATION).unwrap(),
+                "/swagger-ui/"
+            );
+        }
     }
 
     #[test]

--- a/aruna-doctor/src/info.rs
+++ b/aruna-doctor/src/info.rs
@@ -439,7 +439,6 @@ mod tests {
                 http_addr: addr,
                 max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: aruna_api::cors::CorsConfig::default(),
-                portal_csp: aruna_api::csp::PortalCspConfig::default(),
             },
         );
         let server_task = tokio::spawn(async move {

--- a/aruna-doctor/src/tokens.rs
+++ b/aruna-doctor/src/tokens.rs
@@ -903,7 +903,6 @@ mod tests {
                 http_addr: addr,
                 max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
                 cors: aruna_api::cors::CorsConfig::default(),
-                portal_csp: aruna_api::csp::PortalCspConfig::default(),
             },
         )
         .build_router();

--- a/aruna/src/config.rs
+++ b/aruna/src/config.rs
@@ -2118,6 +2118,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn requires_portal_address() {
+        // An enabled portal has its own listener, so a missing address is an
+        // error rather than a silent default.
+        let _guard = env_lock().lock().await;
+        let previous: Vec<_> = portal_env_keys()
+            .iter()
+            .map(|key| ((*key).to_string(), std::env::var(key).ok()))
+            .collect();
+        let portal_dir = tempdir().unwrap();
+        clear_portal_env();
+        unsafe {
+            std::env::set_var("PORTAL_MODE", "artifact");
+            std::env::set_var("PORTAL_DIR", portal_dir.path());
+        }
+
+        let error = portal_config_env().expect_err("missing portal address should fail");
+        assert!(matches!(
+            error,
+            super::SetupError::MissingConfigValue("PORTAL_SOCKET_ADDRESS")
+        ));
+
+        restore_env(previous);
+    }
+
+    #[tokio::test]
     async fn portal_config_allows_existing_portal_without_download_fields() {
         let _guard = env_lock().lock().await;
         let previous: Vec<_> = portal_env_keys()

--- a/aruna/src/config.rs
+++ b/aruna/src/config.rs
@@ -128,7 +128,12 @@ impl Default for RateLimitSettings {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PortalConfig {
     Disabled,
-    Artifact(PortalArtifactConfig),
+    /// The portal serves the SPA on its own listener, so an enabled portal
+    /// without an address is a configuration error rather than a default.
+    Artifact {
+        artifact: PortalArtifactConfig,
+        socket_addr: SocketAddr,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -427,6 +432,11 @@ pub async fn load() -> Result<(Config, StorageHandle), SetupError> {
         .filter(|value| !value.trim().is_empty());
     let oidc_providers = load_oidc_providers_from_env()?;
     let portal = portal_config_env()?;
+    // The SPA is served from another origin than the API, so it cannot reach a
+    // relative API path and needs the advertised one.
+    if matches!(portal, PortalConfig::Artifact { .. }) && api_public_url.is_none() {
+        return Err(SetupError::MissingConfigValue("API_PUBLIC_URL"));
+    }
 
     let storage_handle =
         FjallStorage::open_with_persist_policy(&storage_path, fjall_persist_policy)?;
@@ -721,11 +731,18 @@ fn portal_config_env() -> Result<PortalConfig, SetupError> {
                 .map(|value| normalize_sha256_env("PORTAL_ARTIFACT_SHA256", &value))
                 .transpose()?;
             let portal_dir = PathBuf::from(required_nonempty_env("PORTAL_DIR")?);
-            Ok(PortalConfig::Artifact(PortalArtifactConfig {
-                artifact_url,
-                artifact_sha256,
-                portal_dir,
-            }))
+            const ADDRESS_KEY: &str = "PORTAL_SOCKET_ADDRESS";
+            let address = required_nonempty_env(ADDRESS_KEY)?;
+            let socket_addr = SocketAddr::from_str(address.trim())
+                .map_err(|error| invalid_config_value(ADDRESS_KEY, address, error))?;
+            Ok(PortalConfig::Artifact {
+                artifact: PortalArtifactConfig {
+                    artifact_url,
+                    artifact_sha256,
+                    portal_dir,
+                },
+                socket_addr,
+            })
         }
         _ => Err(invalid_config_value(
             MODE_KEY,
@@ -1572,12 +1589,13 @@ mod tests {
         }
     }
 
-    fn portal_env_keys() -> [&'static str; 4] {
+    fn portal_env_keys() -> [&'static str; 5] {
         [
             "PORTAL_MODE",
             "PORTAL_ARTIFACT_URL",
             "PORTAL_ARTIFACT_SHA256",
             "PORTAL_DIR",
+            "PORTAL_SOCKET_ADDRESS",
         ]
     }
 
@@ -2056,11 +2074,17 @@ mod tests {
                 "0DCA71F9A1193B09A55843B1D5ABC1E99445A9E1226CE42FBA05EDBC80B5DB61",
             );
             std::env::set_var("PORTAL_DIR", portal_dir.path());
+            std::env::set_var("PORTAL_SOCKET_ADDRESS", "127.0.0.1:3005");
         }
 
-        let PortalConfig::Artifact(config) = portal_config_env().unwrap() else {
+        let PortalConfig::Artifact {
+            artifact: config,
+            socket_addr,
+        } = portal_config_env().unwrap()
+        else {
             panic!("expected artifact portal config");
         };
+        assert_eq!(socket_addr, "127.0.0.1:3005".parse().unwrap());
         assert_eq!(
             config.artifact_url.as_deref(),
             Some("https://example.test/portal.tar.gz")
@@ -2105,9 +2129,13 @@ mod tests {
         unsafe {
             std::env::set_var("PORTAL_MODE", "artifact");
             std::env::set_var("PORTAL_DIR", portal_dir.path());
+            std::env::set_var("PORTAL_SOCKET_ADDRESS", "127.0.0.1:3005");
         }
 
-        let PortalConfig::Artifact(config) = portal_config_env().unwrap() else {
+        let PortalConfig::Artifact {
+            artifact: config, ..
+        } = portal_config_env().unwrap()
+        else {
             panic!("expected artifact portal config");
         };
         assert_eq!(config.artifact_url, None);

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -7,7 +7,9 @@ use aruna::bootstrap::{
     prepare_core_documents, publish_core_documents, realm_bootstrap_exists,
     wait_for_onboarding_placement,
 };
-use aruna::config::{Config, StartupMode, load, mark_node_state_complete, mark_onboarding_phase};
+use aruna::config::{
+    Config, PortalConfig, StartupMode, load, mark_node_state_complete, mark_onboarding_phase,
+};
 use aruna::portal;
 use aruna::shutdown::{NodeShutdown, arm_signal_exit, shutdown_grace_env, wait_for_signal};
 use aruna::telemetry::{init_tracing, shutdown_tracing};
@@ -547,6 +549,7 @@ async fn provision_realm(
 struct ServerBindings {
     rest_handle: tokio::task::JoinHandle<Result<(), aruna_api::error::ServerSetupError>>,
     s3_handle: tokio::task::JoinHandle<()>,
+    portal_handle: Option<tokio::task::JoinHandle<()>>,
     realm_id: aruna_core::structs::RealmId,
     node_id: iroh::PublicKey,
     is_initial_boot: bool,
@@ -592,10 +595,18 @@ async fn bind_servers(
         http_addr: config.http_socket_addr,
         max_http_body_size: config.max_http_body_size,
         cors: cors.clone(),
-        portal_csp: PortalCspConfig::new(config.portal_csp_extra_origins.clone()),
     };
     let server = Server::new(state.clone(), server_config)
         .with_api_public_url(config.api_public_url.clone());
+
+    let portal_handle = bind_portal(
+        &config.portal,
+        config.api_public_url.as_deref(),
+        PortalCspConfig::new(config.portal_csp_extra_origins.clone()),
+        state.clone(),
+        shutdown,
+    )
+    .await?;
 
     let s3_server = S3Server::new(
         &config.s3_address,
@@ -641,10 +652,44 @@ async fn bind_servers(
     Ok(ServerBindings {
         rest_handle,
         s3_handle,
+        portal_handle,
         realm_id: config.realm_id,
         node_id: config.node_id,
         is_initial_boot,
     })
+}
+
+/// Binds the portal SPA listener when a portal is configured. `API_PUBLIC_URL`
+/// is required alongside it, so the served config always carries an absolute
+/// API base.
+async fn bind_portal(
+    portal: &PortalConfig,
+    api_public_url: Option<&str>,
+    csp: PortalCspConfig,
+    state: Arc<ServerState>,
+    shutdown: &Shutdown,
+) -> Result<Option<tokio::task::JoinHandle<()>>, Box<dyn std::error::Error>> {
+    let PortalConfig::Artifact { socket_addr, .. } = portal else {
+        return Ok(None);
+    };
+    let Some(api_public_url) = api_public_url else {
+        return Ok(None);
+    };
+
+    let listener = TcpListener::bind(socket_addr).await?;
+    let bound = listener.local_addr()?;
+    let portal_config = aruna_api::portal::PortalConfig {
+        api_public_url: api_public_url.to_string(),
+        csp,
+    };
+    let token = shutdown.token();
+    let handle = tokio::spawn(async move {
+        if let Err(error) = aruna_api::portal::serve(listener, state, portal_config, token).await {
+            error!(error = %error, "Portal server stopped");
+        }
+    });
+    info!(portal_address = %bound, "Portal server listening");
+    Ok(Some(handle))
 }
 
 struct Background {
@@ -757,6 +802,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let ServerBindings {
         rest_handle,
         s3_handle,
+        portal_handle,
         realm_id,
         node_id,
         is_initial_boot,
@@ -831,6 +877,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         readiness,
         rest: rest_handle,
         s3: s3_handle,
+        portal: portal_handle,
         task_handle,
         jobs_runtime,
         net_handle: driver_ctx.net_handle.clone(),

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -692,6 +692,19 @@ async fn bind_portal(
     Ok(Some(handle))
 }
 
+/// Resolves when a configured portal listener exits, and never without one, so
+/// a portal is supervised like the other ingress listeners while an unconfigured
+/// portal never fails the node.
+async fn portal_exit(handle: Option<&mut tokio::task::JoinHandle<()>>) -> String {
+    match handle {
+        Some(handle) => match handle.await {
+            Ok(()) => "Portal server stopped unexpectedly".to_string(),
+            Err(error) => format!("Portal server panicked: {error}"),
+        },
+        None => std::future::pending().await,
+    }
+}
+
 struct Background {
     realm_id: aruna_core::structs::RealmId,
     node_id: iroh::PublicKey,
@@ -802,7 +815,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let ServerBindings {
         rest_handle,
         s3_handle,
-        portal_handle,
+        mut portal_handle,
         realm_id,
         node_id,
         is_initial_boot,
@@ -853,6 +866,10 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(Err(error)) => format!("REST server failed: {error}"),
                 Err(error) => format!("REST server panicked: {error}"),
             });
+        }
+        message = portal_exit(portal_handle.as_mut()) => {
+            portal_handle = None;
+            failure = Some(message);
         }
         _ = &mut signal => {}
     }
@@ -1276,6 +1293,29 @@ mod tests {
         assert_eq!(parse_disk_limit(None), Ok(None));
         assert!(parse_disk_limit(Some("invalid")).is_err());
         assert!(parse_disk_limit(Some("0")).is_err());
+    }
+
+    #[tokio::test]
+    async fn portal_exit_reports() {
+        // A dead portal is a node failure, and a panic must not lose its error.
+        let mut stopped = tokio::spawn(async {});
+        assert_eq!(
+            portal_exit(Some(&mut stopped)).await,
+            "Portal server stopped unexpectedly"
+        );
+
+        let mut panicked = tokio::spawn(async { panic!("portal panicked") });
+        assert!(portal_exit(Some(&mut panicked)).await.contains("panicked"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn portal_exit_pends() {
+        // Without a configured portal the failure select must never fire for it.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(60), portal_exit(None))
+                .await
+                .is_err()
+        );
     }
 
     #[cfg(feature = "kubernetes")]

--- a/aruna/src/portal.rs
+++ b/aruna/src/portal.rs
@@ -21,7 +21,9 @@ pub async fn initialize(config: PortalConfig, state: Arc<ServerState>) {
         PortalConfig::Disabled => {
             state.set_portal_status(PortalStatus::default()).await;
         }
-        PortalConfig::Artifact(config) => {
+        PortalConfig::Artifact {
+            artifact: config, ..
+        } => {
             state
                 .set_portal_status(artifact_status_base(&config, false))
                 .await;

--- a/aruna/src/shutdown.rs
+++ b/aruna/src/shutdown.rs
@@ -103,6 +103,9 @@ pub struct NodeShutdown {
     /// `None` once a server has already terminated on its own.
     pub rest: Option<JoinHandle<Result<(), ServerSetupError>>>,
     pub s3: Option<JoinHandle<()>>,
+    /// Portal SPA listener; drains with the other ingress listeners and is
+    /// absent when no portal is configured.
+    pub portal: Option<JoinHandle<()>>,
     pub task_handle: TaskHandle,
     pub jobs_runtime: Arc<JobsRuntime>,
     pub net_handle: Option<NetHandle>,
@@ -130,6 +133,7 @@ impl NodeShutdown {
         let ingress = ingress_budget(self.grace, budget.remaining());
         let mut rest = self.rest;
         let mut s3 = self.s3;
+        let mut portal = self.portal;
         let mut ingress_complete = false;
         phase("ingress", ingress, async {
             if let Some(rest) = rest.as_mut() {
@@ -140,6 +144,10 @@ impl NodeShutdown {
                 let _ = s3.await;
             }
             s3 = None;
+            if let Some(portal) = portal.as_mut() {
+                let _ = portal.await;
+            }
+            portal = None;
             ingress_complete = true;
         })
         .await;
@@ -150,11 +158,17 @@ impl NodeShutdown {
             if let Some(s3) = s3.as_ref() {
                 s3.abort();
             }
+            if let Some(portal) = portal.as_ref() {
+                portal.abort();
+            }
             if let Some(rest) = rest {
                 let _ = rest.await;
             }
             if let Some(s3) = s3 {
                 let _ = s3.await;
+            }
+            if let Some(portal) = portal {
+                let _ = portal.await;
             }
         }
 
@@ -446,6 +460,7 @@ mod tests {
             readiness: Readiness::new(),
             rest: None,
             s3: None,
+            portal: None,
             task_handle: TaskHandle::new(),
             jobs_runtime: JobsRuntime::new(),
             net_handle: None,

--- a/aruna/tests/oidc_registration.rs
+++ b/aruna/tests/oidc_registration.rs
@@ -275,7 +275,6 @@ async fn spawn_test_node(provider: OidcProviderConfig) -> TestNode {
             http_addr: addr,
             max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
             cors: aruna_api::cors::CorsConfig::default(),
-            portal_csp: aruna_api::csp::PortalCspConfig::default(),
         },
     )
     .build_router();

--- a/aruna/tests/shared/mod.rs
+++ b/aruna/tests/shared/mod.rs
@@ -919,7 +919,6 @@ async fn spawn_rest_server(
             http_addr: addr,
             max_http_body_size: aruna_api::server::DEFAULT_MAX_HTTP_BODY_SIZE,
             cors: test_cors_config(),
-            portal_csp: aruna_api::csp::PortalCspConfig::default(),
         },
     );
     let router = server.build_router();

--- a/justfile
+++ b/justfile
@@ -1,19 +1,23 @@
+# Single-node compose stack with Keycloak; prints the REST, Swagger and Keycloak urls plus ADMIN_TOKEN.
 local:
 	bash scripts/local_deploy.sh
 
+# Same compose stack from a wiped state directory; prints the same urls and a fresh ADMIN_TOKEN.
 local-new:
 	bash scripts/local_deploy.sh --new
 
+# Realm of N local nodes without OIDC; prints per-node API, S3 and ops urls plus the admin credentials.
 local-cluster nodes="3":
 	bash scripts/local_cluster_deploy.sh --node-count {{nodes}}
 
+# Realm of N local nodes with Keycloak; adds the OIDC issuer and the test logins to the printed summary.
 local-cluster-oidc nodes="3":
 	bash scripts/local_cluster_deploy.sh --with-keycloak --node-count {{nodes}}
 
-# 3-node realm + Keycloak, portal served from every node's REST port.
+# Realm of N local nodes with Keycloak and the portal on its own port per node; prints every url and login.
 preview portal_dir=env_var_or_default("ARUNA_TEST_DEPLOY_PORTAL_DIR", "") nodes="3":
 	bash scripts/local_cluster_deploy.sh --with-keycloak --node-count {{nodes}} --auto-portal-dir --portal-dir "{{portal_dir}}"
 
-# Same without Keycloak (portal in guest mode, no login).
+# Same without Keycloak, so the portal runs in guest mode; prints every url and the admin credentials.
 preview-no-oidc portal_dir=env_var_or_default("ARUNA_TEST_DEPLOY_PORTAL_DIR", "") nodes="3":
 	bash scripts/local_cluster_deploy.sh --node-count {{nodes}} --auto-portal-dir --portal-dir "{{portal_dir}}"

--- a/net/src/effect_handlers.rs
+++ b/net/src/effect_handlers.rs
@@ -284,10 +284,9 @@ async fn run_get(
     }
 }
 
-/// Serves realm presence from the snapshot when it is young enough. A stale
-/// snapshot starts one refresh that every stale reader awaits inside its own
-/// deadline, so a peer is only reported as unseen when the refresh cannot
-/// answer in time.
+/// Serves realm presence from a young snapshot. A stale one starts a single
+/// refresh that every stale reader awaits inside its own deadline, so a peer
+/// is reported unseen only when that refresh cannot answer in time.
 async fn serve_presence(
     ctx: &NetEffectContext,
     realm_id: RealmId,

--- a/net/src/effect_handlers.rs
+++ b/net/src/effect_handlers.rs
@@ -391,6 +391,12 @@ fn spawn_refresh_task<F, Fut>(
     let presence = presence.clone();
     let shutdown = shutdown.clone();
     tasks.spawn(async move {
+        // Released on drop, so a panicking refresh cannot park stale readers
+        // behind a slot that is never handed back.
+        let _slot = RefreshSlot {
+            presence: presence.clone(),
+            realm_id,
+        };
         match refresh(shutdown).await {
             Some(Ok(values)) => presence.store(realm_id, values, Instant::now()),
             Some(Err(error)) => {
@@ -398,8 +404,18 @@ fn spawn_refresh_task<F, Fut>(
             }
             None => {}
         }
-        presence.release(realm_id);
     });
+}
+
+struct RefreshSlot {
+    presence: RealmPresenceCache,
+    realm_id: RealmId,
+}
+
+impl Drop for RefreshSlot {
+    fn drop(&mut self) {
+        self.presence.release(self.realm_id);
+    }
 }
 
 #[tracing::instrument(
@@ -729,6 +745,32 @@ mod tests {
             None
         });
         shutdown.cancel();
+        tasks.close();
+        tasks.wait().await;
+
+        assert!(matches!(
+            cache.serve(realm_id, Instant::now()),
+            PresenceServe::Stale { refresh: true, .. }
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn refresh_panic() {
+        // A panicking refresh must still hand the single-flight slot back.
+        let cache = RealmPresenceCache::default();
+        let tasks = TaskTracker::new();
+        let shutdown = CancellationToken::new();
+        let realm_id = RealmId::from_bytes([12u8; 32]);
+        cache.store(realm_id, vec![make_entry(12, realm_id)], Instant::now());
+        tokio::time::advance(Duration::from_secs(20)).await;
+        assert!(matches!(
+            cache.serve(realm_id, Instant::now()),
+            PresenceServe::Stale { refresh: true, .. }
+        ));
+
+        spawn_refresh_task(&cache, &tasks, &shutdown, realm_id, |_| async {
+            panic!("refresh panicked")
+        });
         tasks.close();
         tasks.wait().await;
 

--- a/net/src/effect_handlers.rs
+++ b/net/src/effect_handlers.rs
@@ -70,7 +70,8 @@ struct PresenceSnapshot {
 pub struct RealmPresenceCache {
     snapshots: Arc<Mutex<HashMap<RealmId, PresenceSnapshot>>>,
     /// Token per in-flight refresh, cancelled when it settles so every stale
-    /// reader can join the one refresh instead of starting its own.
+    /// reader can join the one refresh instead of starting its own. Locked
+    /// before `snapshots` whenever both are needed.
     refreshing: Arc<Mutex<HashMap<RealmId, CancellationToken>>>,
 }
 
@@ -112,7 +113,17 @@ impl RealmPresenceCache {
             snapshot.values.clone()
         };
 
+        self.claim_slot(realm_id, now, values)
+    }
+
+    /// Joins or opens the single-flight slot for a stale read. The in-flight
+    /// refresh may have stored and released since that read, so freshness is
+    /// re-checked under this lock instead of starting a redundant refresh.
+    fn claim_slot(&self, realm_id: RealmId, now: Instant, values: Vec<DhtEntry>) -> PresenceServe {
         let mut refreshing = self.refreshing.lock();
+        if let Some(fresh) = self.fresh(realm_id, now) {
+            return PresenceServe::Fresh(fresh);
+        }
         match refreshing.get(&realm_id) {
             Some(settled) => PresenceServe::Stale {
                 values,
@@ -778,6 +789,26 @@ mod tests {
             cache.serve(realm_id, Instant::now()),
             PresenceServe::Stale { refresh: true, .. }
         ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recheck_before_claim() {
+        // The refresh stores and releases between the stale read and the slot.
+        let cache = RealmPresenceCache::default();
+        let realm_id = RealmId::from_bytes([13u8; 32]);
+        let start = Instant::now();
+        cache.store(realm_id, vec![make_entry(13, realm_id)], start);
+        let stale_now = start + Duration::from_secs(20);
+        let stale_values = vec![make_entry(13, realm_id)];
+
+        cache.store(realm_id, vec![make_entry(14, realm_id)], stale_now);
+        let served = cache.claim_slot(realm_id, stale_now, stale_values);
+
+        assert!(matches!(
+            served,
+            PresenceServe::Fresh(values) if values[0].node_id == make_node(14)
+        ));
+        assert!(cache.refreshing.lock().is_empty());
     }
 
     #[tokio::test(start_paused = true)]

--- a/net/src/effect_handlers.rs
+++ b/net/src/effect_handlers.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +24,9 @@ const PRESENCE_FRESH: Duration = Duration::from_secs(10);
 /// Beyond this age the snapshot is not served at all and the caller waits for a
 /// bounded cold lookup.
 const PRESENCE_MAX_STALE: Duration = Duration::from_secs(60);
+/// A stale reader gives up this long before its own deadline, so a refresh that
+/// cannot finish still yields the snapshot instead of an expired read.
+const PRESENCE_ANSWER_MARGIN: Duration = Duration::from_millis(250);
 
 /// Everything a net effect needs besides the effect itself.
 pub struct NetEffectContext {
@@ -40,6 +43,7 @@ pub struct NetEffectContext {
 pub(crate) struct RefreshProbe {
     started: Notify,
     release: Notify,
+    starts: std::sync::atomic::AtomicUsize,
 }
 
 #[cfg(test)]
@@ -48,6 +52,7 @@ impl RefreshProbe {
         Self {
             started: Notify::new(),
             release: Notify::new(),
+            starts: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 }
@@ -64,7 +69,9 @@ struct PresenceSnapshot {
 #[derive(Clone, Default)]
 pub struct RealmPresenceCache {
     snapshots: Arc<Mutex<HashMap<RealmId, PresenceSnapshot>>>,
-    refreshing: Arc<Mutex<HashSet<RealmId>>>,
+    /// Token per in-flight refresh, cancelled when it settles so every stale
+    /// reader can join the one refresh instead of starting its own.
+    refreshing: Arc<Mutex<HashMap<RealmId, CancellationToken>>>,
 }
 
 impl std::fmt::Debug for RealmPresenceCache {
@@ -75,33 +82,62 @@ impl std::fmt::Debug for RealmPresenceCache {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 enum PresenceServe {
     Fresh(Vec<DhtEntry>),
     Stale {
         values: Vec<DhtEntry>,
+        /// True for the reader that has to start the refresh.
         refresh: bool,
+        /// Cancelled once that refresh settled.
+        settled: CancellationToken,
     },
     Cold,
 }
 
 impl RealmPresenceCache {
     fn serve(&self, realm_id: RealmId, now: Instant) -> PresenceServe {
-        let snapshots = self.snapshots.lock();
-        let Some(snapshot) = snapshots.get(&realm_id) else {
-            return PresenceServe::Cold;
+        let values = {
+            let snapshots = self.snapshots.lock();
+            let Some(snapshot) = snapshots.get(&realm_id) else {
+                return PresenceServe::Cold;
+            };
+            let age = now.saturating_duration_since(snapshot.observed);
+            if age <= PRESENCE_FRESH {
+                return PresenceServe::Fresh(snapshot.values.clone());
+            }
+            if age > PRESENCE_MAX_STALE {
+                return PresenceServe::Cold;
+            }
+            snapshot.values.clone()
         };
-        let age = now.saturating_duration_since(snapshot.observed);
-        if age <= PRESENCE_FRESH {
-            return PresenceServe::Fresh(snapshot.values.clone());
+
+        let mut refreshing = self.refreshing.lock();
+        match refreshing.get(&realm_id) {
+            Some(settled) => PresenceServe::Stale {
+                values,
+                refresh: false,
+                settled: settled.clone(),
+            },
+            None => {
+                let settled = CancellationToken::new();
+                refreshing.insert(realm_id, settled.clone());
+                PresenceServe::Stale {
+                    values,
+                    refresh: true,
+                    settled,
+                }
+            }
         }
-        if age > PRESENCE_MAX_STALE {
-            return PresenceServe::Cold;
-        }
-        PresenceServe::Stale {
-            values: snapshot.values.clone(),
-            refresh: self.refreshing.lock().insert(realm_id),
-        }
+    }
+
+    /// Side-effect free freshness check: a reader that waited for a refresh
+    /// must not claim the next single-flight slot while re-reading.
+    fn fresh(&self, realm_id: RealmId, now: Instant) -> Option<Vec<DhtEntry>> {
+        let snapshots = self.snapshots.lock();
+        let snapshot = snapshots.get(&realm_id)?;
+        (now.saturating_duration_since(snapshot.observed) <= PRESENCE_FRESH)
+            .then(|| snapshot.values.clone())
     }
 
     /// An empty answer holds no candidate to serve, so caching it would only
@@ -121,7 +157,9 @@ impl RealmPresenceCache {
     }
 
     fn release(&self, realm_id: RealmId) {
-        self.refreshing.lock().remove(&realm_id);
+        if let Some(settled) = self.refreshing.lock().remove(&realm_id) {
+            settled.cancel();
+        }
     }
 }
 
@@ -246,8 +284,10 @@ async fn run_get(
     }
 }
 
-/// Serves realm presence from the snapshot when it is young enough, refreshing
-/// a stale one exactly once in the background instead of blocking the caller.
+/// Serves realm presence from the snapshot when it is young enough. A stale
+/// snapshot starts one refresh that every stale reader awaits inside its own
+/// deadline, so a peer is only reported as unseen when the refresh cannot
+/// answer in time.
 async fn serve_presence(
     ctx: &NetEffectContext,
     realm_id: RealmId,
@@ -261,9 +301,25 @@ async fn serve_presence(
             values,
             stale: false,
         }),
-        PresenceServe::Stale { values, refresh } => {
+        PresenceServe::Stale {
+            values,
+            refresh,
+            settled,
+        } => {
             if refresh {
                 spawn_refresh(ctx, realm_id, key, realm_filter, options);
+            }
+            let wait = options.deadline.saturating_sub(PRESENCE_ANSWER_MARGIN);
+            if tokio::time::timeout(wait, settled.cancelled())
+                .await
+                .is_ok()
+                && let Some(values) = ctx.presence.fresh(realm_id, Instant::now())
+            {
+                return NetEvent::Dht(DhtEvent::GetResult {
+                    key,
+                    values,
+                    stale: false,
+                });
             }
             NetEvent::Dht(DhtEvent::GetResult {
                 key,
@@ -304,6 +360,9 @@ fn spawn_refresh(
         move |shutdown| async move {
             #[cfg(test)]
             if let Some(probe) = refresh_probe {
+                probe
+                    .starts
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 probe.started.notify_one();
                 tokio::select! {
                     _ = shutdown.cancelled() => return None,
@@ -620,7 +679,10 @@ mod tests {
         tasks.close();
         tasks.wait().await;
 
-        assert_eq!(cache.serve(realm_id, Instant::now()), PresenceServe::Cold);
+        assert!(matches!(
+            cache.serve(realm_id, Instant::now()),
+            PresenceServe::Cold
+        ));
     }
 
     #[tokio::test(start_paused = true)]
@@ -645,7 +707,7 @@ mod tests {
 
         assert!(matches!(
             cache.serve(realm_id, Instant::now()),
-            PresenceServe::Stale { refresh: true, values } if values[0].node_id == make_node(7)
+            PresenceServe::Stale { refresh: true, values, .. } if values[0].node_id == make_node(7)
         ));
     }
 
@@ -729,21 +791,19 @@ mod tests {
             vec![stale_entry(realm_id, 12)],
             Instant::now() - Duration::from_secs(20),
         );
+        // The stale reader waits for the refresh instead of flapping the peer
+        // to unseen for a whole freshness window.
         let event = handle_net_effect(&context, presence_effect(realm_id)).await;
         assert!(matches!(
             event,
             NetEvent::Dht(DhtEvent::GetResult {
-                stale: true,
+                stale: false,
                 values,
                 ..
-            }) if values[0].node_id == make_node(12)
+            }) if values.iter().any(|entry| entry.node_id == handle.node_id())
         ));
 
         finish_tasks(&context).await;
-        assert!(matches!(
-            context.presence.serve(realm_id, Instant::now()),
-            PresenceServe::Fresh(values) if values.iter().any(|entry| entry.node_id == handle.node_id())
-        ));
         handle.shutdown().await;
     }
 
@@ -767,10 +827,10 @@ mod tests {
             }) if values.len() == 1
         ));
         finish_tasks(&context).await;
-        assert_eq!(
+        assert!(matches!(
             context.presence.serve(realm_id, Instant::now()),
             PresenceServe::Cold
-        );
+        ));
         handle.shutdown().await;
         peer.shutdown().await;
     }
@@ -797,7 +857,7 @@ mod tests {
         finish_tasks(&context).await;
         assert!(matches!(
             context.presence.serve(realm_id, Instant::now()),
-            PresenceServe::Stale { refresh: true, values } if values.len() == 1
+            PresenceServe::Stale { refresh: true, values, .. } if values.len() == 1
         ));
     }
 
@@ -825,34 +885,87 @@ mod tests {
 
     #[tokio::test]
     async fn single_flight_handler() {
+        // Concurrent stale readers join one refresh and both answer fresh.
         let (handle, mut context, _directory, realm_id) = handler_context(16).await;
         let probe = Arc::new(RefreshProbe::new());
         context.refresh_probe = Some(probe.clone());
+        let put = handle_net_effect(
+            &context,
+            NetEffect::Dht(DhtEffect::Put {
+                key: realm_presence_key(&realm_id),
+                realm_id,
+                value: Vec::new(),
+                ttl: Duration::from_secs(300),
+            }),
+        )
+        .await;
+        assert!(matches!(put, NetEvent::Dht(DhtEvent::PutComplete { .. })));
         context.presence.store(
             realm_id,
             vec![stale_entry(realm_id, 16)],
             Instant::now() - Duration::from_secs(20),
         );
 
-        let started = probe.started.notified();
-        let first = handle_net_effect(&context, presence_effect(realm_id)).await;
-        tokio::time::timeout(Duration::from_secs(30), started)
-            .await
-            .expect("presence refresh must start");
-        let second = handle_net_effect(&context, presence_effect(realm_id)).await;
+        let releaser = {
+            let probe = probe.clone();
+            tokio::spawn(async move {
+                probe.started.notified().await;
+                probe.release.notify_one();
+            })
+        };
+        let (first, second) = tokio::join!(
+            handle_net_effect(&context, presence_effect(realm_id)),
+            handle_net_effect(&context, presence_effect(realm_id)),
+        );
+        releaser.await.expect("releaser joins");
+
+        for event in [first, second] {
+            assert!(matches!(
+                event,
+                NetEvent::Dht(DhtEvent::GetResult {
+                    stale: false,
+                    values,
+                    ..
+                }) if values.iter().any(|entry| entry.node_id == handle.node_id())
+            ));
+        }
+        assert_eq!(probe.starts.load(Ordering::SeqCst), 1);
+        finish_tasks(&context).await;
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn deadline_keeps_stale() {
+        // A refresh that outlives the caller's deadline still answers from the
+        // snapshot rather than reporting the realm as unseen.
+        let (handle, mut context, _directory, realm_id) = handler_context(19).await;
+        let probe = Arc::new(RefreshProbe::new());
+        context.refresh_probe = Some(probe.clone());
+        context.presence.store(
+            realm_id,
+            vec![stale_entry(realm_id, 19)],
+            Instant::now() - Duration::from_secs(20),
+        );
+
+        let event = handle_net_effect(
+            &context,
+            NetEffect::Dht(DhtEffect::Get {
+                key: realm_presence_key(&realm_id),
+                realm_filter: Some(realm_id),
+                options: DhtGetOptions::presence(Duration::from_millis(300), realm_id),
+            }),
+        )
+        .await;
         assert!(matches!(
-            first,
-            NetEvent::Dht(DhtEvent::GetResult { stale: true, .. })
+            event,
+            NetEvent::Dht(DhtEvent::GetResult {
+                stale: true,
+                values,
+                ..
+            }) if values[0].node_id == make_node(19)
         ));
-        assert!(matches!(
-            second,
-            NetEvent::Dht(DhtEvent::GetResult { stale: true, .. })
-        ));
-        assert!(matches!(
-            context.presence.serve(realm_id, Instant::now()),
-            PresenceServe::Stale { refresh: false, .. }
-        ));
-        probe.release.notify_one();
+
+        context.shutdown.cancel();
         finish_tasks(&context).await;
         handle.shutdown().await;
     }
@@ -899,10 +1012,10 @@ mod tests {
             }) if values.is_empty()
         ));
         finish_tasks(&context).await;
-        assert_eq!(
+        assert!(matches!(
             context.presence.serve(realm_id, Instant::now()),
             PresenceServe::Cold
-        );
+        ));
         handle.shutdown().await;
         peer.shutdown().await;
     }
@@ -914,17 +1027,17 @@ mod tests {
         let start = Instant::now();
         cache.store(realm_id, vec![make_entry(3, realm_id)], start);
 
-        assert_eq!(
+        assert!(matches!(
             cache.serve(
                 realm_id,
                 start + PRESENCE_MAX_STALE + Duration::from_secs(1)
             ),
             PresenceServe::Cold
-        );
-        assert_eq!(
+        ));
+        assert!(matches!(
             cache.serve(RealmId::from_bytes([9u8; 32]), start),
             PresenceServe::Cold
-        );
+        ));
     }
 
     #[tokio::test(start_paused = true)]
@@ -935,11 +1048,11 @@ mod tests {
         let realm_id = RealmId::from_bytes([4u8; 32]);
         let start = Instant::now();
         cache.store(realm_id, Vec::new(), start);
-        assert_eq!(cache.serve(realm_id, start), PresenceServe::Cold);
+        assert!(matches!(cache.serve(realm_id, start), PresenceServe::Cold));
 
         cache.store(realm_id, vec![make_entry(4, realm_id)], start);
         cache.store(realm_id, Vec::new(), start);
-        assert_eq!(cache.serve(realm_id, start), PresenceServe::Cold);
+        assert!(matches!(cache.serve(realm_id, start), PresenceServe::Cold));
     }
 
     #[test]

--- a/operations/tests/persistent_id_authority.rs
+++ b/operations/tests/persistent_id_authority.rs
@@ -29,6 +29,7 @@ use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_metadata_document::load_metadata_record_by_document;
 use aruna_operations::jobs::service::{read_job_routed, submit_mint_pid};
 use aruna_operations::jobs::store::{find_dedup_job, read_job_record};
+use aruna_operations::jobs::submit::{SubmitJobError, SubmitJobResult};
 use aruna_operations::metadata::PersistentIdResolution;
 use aruna_operations::metadata::api::MetadataApiError;
 use aruna_operations::metadata::forward::{
@@ -56,8 +57,9 @@ async fn mint_routes_holder() -> TestResult<()> {
     let forwarder = realm.non_holder(&placement);
     let holders = realm.assert_not_holder(forwarder.node_id(), &placement);
 
-    let (mapping, minted) = mint_routed(&realm, forwarder, document_id).await?;
-    assert!(minted);
+    // A retried mint whose first attempt lost its response reports no change, so
+    // the flag is covered without I/O in `persistent_id::tests` instead.
+    let (mapping, _) = mint_routed(&realm, forwarder, document_id).await?;
     assert_eq!(mapping.status, PersistentIdStatus::Active);
 
     for holder in &holders {
@@ -98,18 +100,7 @@ async fn withdraw_precedes_mint() -> TestResult<()> {
 
     // The submitted job is accepted here; the worker's mint runs after the
     // withdrawal below, exactly as the race orders it.
-    let submitted = submit_mint_pid(
-        &realm.node(0).context,
-        MintPersistentIdSpec {
-            document_id,
-            minted_by: realm.user_id,
-        },
-        realm.node(0).node_id(),
-        JOB_RETENTION_MS,
-        Some(realm.bearer_token()),
-    )
-    .await?;
-    assert!(submitted.created);
+    submit_routed(&realm, realm.node(0), document_id, realm.user_id).await?;
 
     let withdrawn = withdraw_routed(&realm, forwarder, document_id).await?;
     assert_eq!(withdrawn.status, PersistentIdStatus::Withdrawn);
@@ -160,14 +151,7 @@ async fn delete_withdraws_mapping() -> TestResult<()> {
     let record = registry_record(holder, document_id)
         .await
         .expect("the holder carries the registry row");
-    delete_metadata_document_routed(
-        &holder.context,
-        realm.actor(holder),
-        Some(&record),
-        document_id,
-        Some(realm.bearer_token()),
-    )
-    .await?;
+    delete_until_applied(&realm, holder, &record, document_id).await?;
 
     let mapping = read_mapping(holder.context.as_ref(), document_id)
         .await?
@@ -213,14 +197,7 @@ async fn replica_delete_routes_to_pid_authority() -> TestResult<()> {
     let record = registry_record(replica, document_id)
         .await
         .expect("the replica carries the registry row");
-    delete_metadata_document_routed(
-        &replica.context,
-        realm.actor(replica),
-        Some(&record),
-        document_id,
-        Some(realm.bearer_token()),
-    )
-    .await?;
+    delete_until_applied(&realm, replica, &record, document_id).await?;
 
     let mapping = read_mapping(authority.context.as_ref(), document_id)
         .await?
@@ -352,30 +329,11 @@ async fn mint_dedups_ingress() -> TestResult<()> {
     let ingress = realm.non_holder_ids(&placement);
     let (first_node, second_node) = (realm.find(ingress[0]), realm.find(ingress[1]));
 
-    let first = submit_mint_pid(
-        &first_node.context,
-        MintPersistentIdSpec {
-            document_id,
-            minted_by: realm.user_id,
-        },
-        first_node.node_id(),
-        JOB_RETENTION_MS,
-        Some(realm.bearer_token()),
-    )
-    .await?;
-    let second = submit_mint_pid(
-        &second_node.context,
-        MintPersistentIdSpec {
-            document_id,
-            minted_by: other,
-        },
-        second_node.node_id(),
-        JOB_RETENTION_MS,
-        Some(realm.bearer_for(other)),
-    )
-    .await?;
+    let first = submit_routed(&realm, first_node, document_id, realm.user_id).await?;
+    let second = submit_routed(&realm, second_node, document_id, other).await?;
 
-    assert!(first.created);
+    // A retried submission joins its own lost attempt, so only the second
+    // submitter's join carries the dedup contract.
     assert!(!second.created, "the second user joins the first job");
     assert_eq!(first.job_id, second.job_id);
 
@@ -614,6 +572,42 @@ async fn routed_delete(
     .await
 }
 
+/// A routed delete, retried while the forward reports it undeliverable: a
+/// response lost on a starved machine leaves the write possibly sent. The frozen
+/// record routes the first attempt only, so a replay can still answer
+/// `NotFound` once the row is gone from the current holders.
+async fn delete_until_applied(
+    realm: &Topology,
+    node: &TestNode,
+    record: &aruna_core::structs::MetadataRegistryRecord,
+    document_id: Ulid,
+) -> TestResult<()> {
+    let attempted = std::cell::Cell::new(false);
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "no routed delete reached the authority",
+        || async {
+            let replay = attempted.replace(true);
+            match delete_metadata_document_routed(
+                &node.context,
+                realm.actor(node),
+                (!replay).then_some(record),
+                document_id,
+                Some(realm.bearer_token()),
+            )
+            .await
+            {
+                Err(MetadataWriteError::Undeliverable(_)) => Ok(1),
+                Err(MetadataWriteError::NotFound) if replay => Ok(0),
+                other => {
+                    other?;
+                    Ok(0)
+                }
+            }
+        },
+    )
+    .await
+}
+
 fn revision(occurred_at_ms: u64) -> PersistentIdRevision {
     PersistentIdRevision {
         event_id: Ulid::generate(),
@@ -673,35 +667,113 @@ async fn write_entry(
     }
 }
 
+/// A routed mint submission, retried while the authority reports it
+/// unavailable: the document-global dedup key makes a replay join the job the
+/// lost attempt created rather than open a second one.
+async fn submit_routed(
+    realm: &Topology,
+    node: &TestNode,
+    document_id: Ulid,
+    minted_by: aruna_core::UserId,
+) -> TestResult<SubmitJobResult> {
+    let submitted = std::cell::RefCell::new(None);
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "no mint submission reached the authority",
+        || async {
+            match submit_mint_pid(
+                &node.context,
+                MintPersistentIdSpec {
+                    document_id,
+                    minted_by,
+                },
+                node.node_id(),
+                JOB_RETENTION_MS,
+                Some(realm.bearer_for(minted_by)),
+            )
+            .await
+            {
+                Err(SubmitJobError::PlacementUnavailable(_)) => Ok(1),
+                other => {
+                    *submitted.borrow_mut() = Some(other?);
+                    Ok(0)
+                }
+            }
+        },
+    )
+    .await?;
+    Ok(submitted
+        .into_inner()
+        .ok_or("the mint submission produced no job")?)
+}
+
+/// A routed mint, retried while the fan-out reports it unavailable: the mint is
+/// idempotent on the authority, so a replay after a lost response returns the
+/// existing mapping instead of a second one.
 async fn mint_routed(
     realm: &Topology,
     node: &TestNode,
     document_id: Ulid,
 ) -> TestResult<(aruna_core::structs::PersistentIdMapping, bool)> {
-    Ok(mint_pid_routed(
-        &node.context,
-        realm.realm_id,
-        document_id,
-        realm.user_id,
-        aruna_core::util::unix_timestamp_millis(),
-        Some(realm.bearer_token()),
+    let minted = std::cell::RefCell::new(None);
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "no routed mint reached the authority",
+        || async {
+            match mint_pid_routed(
+                &node.context,
+                realm.realm_id,
+                document_id,
+                realm.user_id,
+                aruna_core::util::unix_timestamp_millis(),
+                Some(realm.bearer_token()),
+            )
+            .await
+            {
+                Err(MetadataApiError::ServiceUnavailable) => Ok(1),
+                other => {
+                    *minted.borrow_mut() = Some(other?);
+                    Ok(0)
+                }
+            }
+        },
     )
-    .await?)
+    .await?;
+    Ok(minted
+        .into_inner()
+        .ok_or("the routed mint produced no mapping")?)
 }
 
+/// A routed withdrawal, retried on the same terms as the mint: withdrawing an
+/// already withdrawn mapping returns it unchanged.
 async fn withdraw_routed(
     realm: &Topology,
     node: &TestNode,
     document_id: Ulid,
 ) -> TestResult<aruna_core::structs::PersistentIdMapping> {
-    Ok(withdraw_pid_routed(
-        &node.context,
-        realm.realm_id,
-        document_id,
-        aruna_core::util::unix_timestamp_millis(),
-        Some(realm.bearer_token()),
+    let withdrawn = std::cell::RefCell::new(None);
+    wait_for_convergence::<_, _, Box<dyn std::error::Error>>(
+        "no routed withdrawal reached the authority",
+        || async {
+            match withdraw_pid_routed(
+                &node.context,
+                realm.realm_id,
+                document_id,
+                aruna_core::util::unix_timestamp_millis(),
+                Some(realm.bearer_token()),
+            )
+            .await
+            {
+                Err(MetadataApiError::ServiceUnavailable) => Ok(1),
+                other => {
+                    *withdrawn.borrow_mut() = Some(other?);
+                    Ok(0)
+                }
+            }
+        },
     )
-    .await?)
+    .await?;
+    Ok(withdrawn
+        .into_inner()
+        .ok_or("the routed withdrawal produced no mapping")?)
 }
 
 /// A routed resolve, retried while the fan-out reports it unavailable: the first

--- a/scripts/local_cluster_deploy.sh
+++ b/scripts/local_cluster_deploy.sh
@@ -586,6 +586,7 @@ summary_entry() {
 
 write_summary_file() {
   local summary_file=$1
+  local credentials_file=$2
   local node_index
 
   : >"$summary_file"
@@ -604,18 +605,8 @@ write_summary_file() {
       printf '\n'
     done
 
-    printf 'Test credentials\n'
-    summary_entry "Aruna admin token" "$INITIAL_ADMIN_TOKEN"
-    summary_entry "Aruna admin secret" "$INITIAL_LOCAL_ONBOARDING_SECRET"
-    if [[ "$WITH_KEYCLOAK" == "1" ]]; then
-      summary_entry "Keycloak admin" "$KEYCLOAK_ADMIN_USER / $KEYCLOAK_ADMIN_PASSWORD"
-      summary_entry "Keycloak console" "http://127.0.0.1:$KEYCLOAK_HTTP_PORT/admin"
-      summary_entry "OIDC test user" "$KEYCLOAK_OIDC_USERNAME / $KEYCLOAK_OIDC_PASSWORD"
-      summary_entry "OIDC issuer" "$KEYCLOAK_ISSUER"
-      summary_entry "OIDC discovery" "$KEYCLOAK_DISCOVERY_URL"
-    else
-      summary_entry "OIDC" "not configured, started without --with-keycloak"
-    fi
+    printf 'Credentials\n'
+    summary_entry "File" "$credentials_file"
 
     if [[ -n "$PORTAL_DIR" ]]; then
       printf '\nPortal\n'
@@ -624,13 +615,37 @@ write_summary_file() {
   } >>"$summary_file"
 }
 
-print_summary() {
-  local summary_file=$1
+# The token and the OIDC logins stay out of the retained summary; a private file
+# keeps them readable for the caller alone.
+write_credentials_file() {
+  local credentials_file=$1
+
+  (
+    umask 077
+    rm -f "$credentials_file"
+    {
+      printf 'Test credentials\n'
+      summary_entry "Aruna admin token" "$INITIAL_ADMIN_TOKEN"
+      if [[ "$WITH_KEYCLOAK" == "1" ]]; then
+        summary_entry "Keycloak admin" "$KEYCLOAK_ADMIN_USER / $KEYCLOAK_ADMIN_PASSWORD"
+        summary_entry "Keycloak console" "http://127.0.0.1:$KEYCLOAK_HTTP_PORT/admin"
+        summary_entry "OIDC test user" "$KEYCLOAK_OIDC_USERNAME / $KEYCLOAK_OIDC_PASSWORD"
+        summary_entry "OIDC issuer" "$KEYCLOAK_ISSUER"
+        summary_entry "OIDC discovery" "$KEYCLOAK_DISCOVERY_URL"
+      else
+        summary_entry "OIDC" "not configured, started without --with-keycloak"
+      fi
+    } >"$credentials_file"
+  )
+}
+
+print_file() {
+  local file=$1
   local line
 
   while IFS= read -r line; do
     printf '%s\n' "$line"
-  done <"$summary_file"
+  done <"$file"
 }
 
 monitor_nodes() {
@@ -838,7 +853,8 @@ if [[ "$WITH_KEYCLOAK" == "1" ]]; then
   verify_oidc_issuer
 fi
 
-write_summary_file "$DEPLOY_ROOT/summary.txt"
+write_credentials_file "$DEPLOY_ROOT/credentials.txt"
+write_summary_file "$DEPLOY_ROOT/summary.txt" "$DEPLOY_ROOT/credentials.txt"
 
 if [[ "$WITH_KEYCLOAK" == "1" ]]; then
   log "$NODE_COUNT aruna nodes and Keycloak are up"
@@ -847,7 +863,9 @@ else
 fi
 
 log "Deployment summary:"
-print_summary "$DEPLOY_ROOT/summary.txt"
+print_file "$DEPLOY_ROOT/summary.txt"
+printf '\n'
+print_file "$DEPLOY_ROOT/credentials.txt"
 
 if [[ "$EXIT_AFTER_READY" == "1" ]]; then
   log "Exiting after readiness because ARUNA_TEST_DEPLOY_EXIT_AFTER_READY=1"

--- a/scripts/local_cluster_deploy.sh
+++ b/scripts/local_cluster_deploy.sh
@@ -573,7 +573,8 @@ assert_node_ports_free() {
     assert_port_free "${NODE_P2P_PORTS[$node_index]}"
     assert_port_free "${NODE_S3_PORTS[$node_index]}"
     assert_port_free "${NODE_OPS_PORTS[$node_index]}"
-    assert_port_free "${NODE_PORTAL_PORTS[$node_index]}"
+    # The portal port is only bound when a portal dist is deployed.
+    [[ -z "$PORTAL_DIR" ]] || assert_port_free "${NODE_PORTAL_PORTS[$node_index]}"
   done
 }
 

--- a/scripts/local_cluster_deploy.sh
+++ b/scripts/local_cluster_deploy.sh
@@ -40,6 +40,8 @@ NODE_HTTP_PORTS=()
 NODE_P2P_PORTS=()
 NODE_S3_PORTS=()
 NODE_OPS_PORTS=()
+NODE_PORTAL_PORTS=()
+NODE_PORTAL_URLS=()
 STARTED_PID=""
 LAST_READY_CODE=""
 LAST_READY_BODY=""
@@ -62,8 +64,9 @@ Behavior:
   default          Build the workspace in release mode and launch 3 local Aruna nodes.
   --with-keycloak  Start a local Keycloak instance and configure every node for OIDC.
   --node-count N   Launch N total Aruna nodes. Defaults to 3. Also --node-count=N.
-  --portal-dir P   Serve the portal dist at P from every node's REST port and
-                   allow the node origins via CORS on REST and S3. Also --portal-dir=P.
+  --portal-dir P   Serve the portal dist at P on every node's own portal port,
+                   separate from the REST port, and allow the portal origins via
+                   CORS on REST and S3. Also --portal-dir=P.
   --auto-portal-dir
                    If no portal dir is set, download the latest portal prerelease
                    from arunaengine/website into the deployment temp directory.
@@ -258,7 +261,8 @@ write_node_env() {
   local p2p_port=$3
   local s3_port=$4
   local ops_port=$5
-  local onboarding_secret=${6:-}
+  local portal_port=$6
+  local onboarding_secret=${7:-}
   local max_concurrent_uni_streams="${MAX_CONCURRENT_UNI_STREAMS:-}"
   local max_concurrent_bidi_streams="${MAX_CONCURRENT_BIDI_STREAMS:-}"
   local compute_var
@@ -300,8 +304,9 @@ write_node_env() {
     if [[ -n "$PORTAL_DIR" ]]; then
       printf 'PORTAL_MODE=artifact\n'
       printf 'PORTAL_DIR=%s\n' "$(env_quote "$PORTAL_DIR")"
-      printf 'CORS_ALLOWED_ORIGINS=%s\n' "$PORTAL_CORS_ORIGINS"
-      printf 'PORTAL_CSP_EXTRA_ORIGINS=%s\n' "$PORTAL_CORS_ORIGINS"
+      printf 'PORTAL_SOCKET_ADDRESS=127.0.0.1:%s\n' "$portal_port"
+      printf 'CORS_ALLOWED_ORIGINS=%s\n' "$(env_quote "$PORTAL_CORS_ORIGINS")"
+      printf 'PORTAL_CSP_EXTRA_ORIGINS=%s\n' "$(env_quote "$PORTAL_CORS_ORIGINS")"
     fi
     if [[ "$WITH_KEYCLOAK" == "1" ]]; then
       printf 'OIDC_PROVIDER_IDS=main\n'
@@ -398,19 +403,29 @@ wait_for_ready() {
   done
 }
 
-# The portal is a separate contract from node readiness: a healthy ops endpoint
-# must never be reported as a served portal.
+# The portal is a separate contract from node readiness. Redirects are not
+# followed, so a REST listener answering with the swagger redirect can never be
+# mistaken for a served portal, and the config payload is checked as well.
 verify_portal_route() {
   local name=$1
-  local base_url=$2
+  local portal_url=$2
+  local api_url=$3
   local code
+  local config
 
   code="$(
-    curl --silent --location --max-time "$READY_ATTEMPT_TIMEOUT_SECS" \
-      --output /dev/null --write-out '%{http_code}' "$base_url/" 2>/dev/null || true
+    curl --silent --max-time "$READY_ATTEMPT_TIMEOUT_SECS" \
+      --output /dev/null --write-out '%{http_code}' "$portal_url/" 2>/dev/null || true
   )"
   [[ "$code" == "200" ]] \
-    || die "$name does not serve the portal at $base_url/ (status ${code:-none}); check PORTAL_DIR=$PORTAL_DIR"
+    || die "$name does not serve the portal at $portal_url/ (status ${code:-none}); check PORTAL_DIR=$PORTAL_DIR"
+
+  config="$(
+    curl --silent --max-time "$READY_ATTEMPT_TIMEOUT_SECS" \
+      "$portal_url/portal-config.json" 2>/dev/null || true
+  )"
+  [[ "$(compact_json "$config")" == *"\"apiBaseUrl\":\"$api_url/api/v1\""* ]] \
+    || die "$name serves an unexpected portal config at $portal_url/portal-config.json: ${config:-empty}"
 }
 
 wait_for_keycloak() {
@@ -485,10 +500,12 @@ onboard_server_node() {
   local p2p_port=$4
   local s3_port=$5
   local ops_port=$6
+  local portal_port=$7
   local secret
 
   secret="$(create_server_onboarding_secret)"
-  write_node_env "$node_dir" "$http_port" "$p2p_port" "$s3_port" "$ops_port" "$secret"
+  write_node_env "$node_dir" "$http_port" "$p2p_port" "$s3_port" "$ops_port" \
+    "$portal_port" "$secret"
   start_node "$name" "$node_dir"
   wait_for_ready "$name" "$ops_port" "$STARTED_PID"
 }
@@ -523,6 +540,7 @@ prepare_nodes() {
   local p2p_port
   local s3_port
   local ops_port
+  local portal_port
 
   for ((node_index = 1; node_index <= NODE_COUNT; node_index++)); do
     offset=$(((node_index - 1) * 10))
@@ -532,6 +550,7 @@ prepare_nodes() {
     p2p_port=$((BASE_PORT + offset + 2))
     s3_port=$((BASE_PORT + offset + 3))
     ops_port=$((BASE_PORT + offset + 4))
+    portal_port=$((BASE_PORT + offset + 5))
 
     mkdir -p "$node_dir"
     NODE_NAMES+=("$node_name")
@@ -541,6 +560,8 @@ prepare_nodes() {
     NODE_P2P_PORTS+=("$p2p_port")
     NODE_S3_PORTS+=("$s3_port")
     NODE_OPS_PORTS+=("$ops_port")
+    NODE_PORTAL_PORTS+=("$portal_port")
+    NODE_PORTAL_URLS+=("http://127.0.0.1:$portal_port")
   done
 }
 
@@ -552,7 +573,14 @@ assert_node_ports_free() {
     assert_port_free "${NODE_P2P_PORTS[$node_index]}"
     assert_port_free "${NODE_S3_PORTS[$node_index]}"
     assert_port_free "${NODE_OPS_PORTS[$node_index]}"
+    assert_port_free "${NODE_PORTAL_PORTS[$node_index]}"
   done
+}
+
+# One labelled value per line so anything here can be copied straight into a
+# browser, a curl call or an .env file.
+summary_entry() {
+  printf '  %-22s %s\n' "$1" "$2"
 }
 
 write_summary_file() {
@@ -560,31 +588,39 @@ write_summary_file() {
   local node_index
 
   : >"$summary_file"
-  for node_index in "${!NODE_NAMES[@]}"; do
-    printf '%s http=%s s3=http://127.0.0.1:%s dir=%s log=%s\n' \
-      "${NODE_NAMES[$node_index]}" \
-      "${NODE_BASE_URLS[$node_index]}" \
-      "${NODE_S3_PORTS[$node_index]}" \
-      "${NODE_DIRS[$node_index]}" \
-      "${NODE_DIRS[$node_index]}/${NODE_NAMES[$node_index]}.log" \
-      >>"$summary_file"
-  done
+  {
+    for node_index in "${!NODE_NAMES[@]}"; do
+      printf '%s\n' "${NODE_NAMES[$node_index]}"
+      summary_entry "API and Swagger UI" "${NODE_BASE_URLS[$node_index]}/"
+      if [[ -n "$PORTAL_DIR" ]]; then
+        summary_entry "Portal" "${NODE_PORTAL_URLS[$node_index]}/"
+      fi
+      summary_entry "S3" "http://127.0.0.1:${NODE_S3_PORTS[$node_index]}"
+      summary_entry "Ops readiness" "http://127.0.0.1:${NODE_OPS_PORTS[$node_index]}/readyz"
+      summary_entry "Ops metrics" "http://127.0.0.1:${NODE_OPS_PORTS[$node_index]}/metrics"
+      summary_entry "Directory" "${NODE_DIRS[$node_index]}"
+      summary_entry "Log" "${NODE_DIRS[$node_index]}/${NODE_NAMES[$node_index]}.log"
+      printf '\n'
+    done
 
-  if [[ "$WITH_KEYCLOAK" == "1" ]]; then
-    printf 'keycloak issuer=%s discovery=%s admin=%s/%s\n' \
-      "$KEYCLOAK_ISSUER" \
-      "$KEYCLOAK_DISCOVERY_URL" \
-      "$KEYCLOAK_ADMIN_USER" \
-      "$KEYCLOAK_ADMIN_PASSWORD" \
-      >>"$summary_file"
-  fi
+    printf 'Test credentials\n'
+    summary_entry "Aruna admin token" "$INITIAL_ADMIN_TOKEN"
+    summary_entry "Aruna admin secret" "$INITIAL_LOCAL_ONBOARDING_SECRET"
+    if [[ "$WITH_KEYCLOAK" == "1" ]]; then
+      summary_entry "Keycloak admin" "$KEYCLOAK_ADMIN_USER / $KEYCLOAK_ADMIN_PASSWORD"
+      summary_entry "Keycloak console" "http://127.0.0.1:$KEYCLOAK_HTTP_PORT/admin"
+      summary_entry "OIDC test user" "$KEYCLOAK_OIDC_USERNAME / $KEYCLOAK_OIDC_PASSWORD"
+      summary_entry "OIDC issuer" "$KEYCLOAK_ISSUER"
+      summary_entry "OIDC discovery" "$KEYCLOAK_DISCOVERY_URL"
+    else
+      summary_entry "OIDC" "not configured, started without --with-keycloak"
+    fi
 
-  if [[ -n "$PORTAL_DIR" ]]; then
-    printf 'portal dir=%s urls=%s\n' \
-      "$PORTAL_DIR" \
-      "$(IFS=,; printf '%s' "${NODE_BASE_URLS[*]}")" \
-      >>"$summary_file"
-  fi
+    if [[ -n "$PORTAL_DIR" ]]; then
+      printf '\nPortal\n'
+      summary_entry "Dist directory" "$PORTAL_DIR"
+    fi
+  } >>"$summary_file"
 }
 
 print_summary() {
@@ -700,7 +736,9 @@ mkdir -p "$DEPLOY_ROOT"
 prepare_nodes
 
 if [[ -n "$PORTAL_DIR" ]]; then
-  PORTAL_CORS_ORIGINS="$(IFS=,; printf '%s' "${NODE_BASE_URLS[*]}"),$(printf 'http://127.0.0.1:%s,' "${NODE_S3_PORTS[@]}")http://localhost:5173"
+  # The browser now loads the SPA from the portal origins, so those are the
+  # origins the REST and S3 listeners have to admit.
+  PORTAL_CORS_ORIGINS="$(IFS=,; printf '%s' "${NODE_PORTAL_URLS[*]}"),$(IFS=,; printf '%s' "${NODE_BASE_URLS[*]}"),$(printf 'http://127.0.0.1:%s,' "${NODE_S3_PORTS[@]}")http://localhost:5173"
 fi
 
 assert_node_ports_free
@@ -733,7 +771,8 @@ if [[ "$WITH_KEYCLOAK" == "1" ]]; then
   start_keycloak
 fi
 
-write_node_env "${NODE_DIRS[0]}" "${NODE_HTTP_PORTS[0]}" "${NODE_P2P_PORTS[0]}" "${NODE_S3_PORTS[0]}" "${NODE_OPS_PORTS[0]}"
+write_node_env "${NODE_DIRS[0]}" "${NODE_HTTP_PORTS[0]}" "${NODE_P2P_PORTS[0]}" \
+  "${NODE_S3_PORTS[0]}" "${NODE_OPS_PORTS[0]}" "${NODE_PORTAL_PORTS[0]}"
 
 start_node "${NODE_NAMES[0]}" "${NODE_DIRS[0]}"
 NODE_1_PID="$STARTED_PID"
@@ -779,13 +818,17 @@ for node_index in "${!NODE_NAMES[@]}"; do
     "${NODE_HTTP_PORTS[$node_index]}" \
     "${NODE_P2P_PORTS[$node_index]}" \
     "${NODE_S3_PORTS[$node_index]}" \
-    "${NODE_OPS_PORTS[$node_index]}"
+    "${NODE_OPS_PORTS[$node_index]}" \
+    "${NODE_PORTAL_PORTS[$node_index]}"
 done
 
 if [[ -n "$PORTAL_DIR" ]]; then
   log "Verifying the portal route on every node"
   for node_index in "${!NODE_NAMES[@]}"; do
-    verify_portal_route "${NODE_NAMES[$node_index]}" "${NODE_BASE_URLS[$node_index]}"
+    verify_portal_route \
+      "${NODE_NAMES[$node_index]}" \
+      "${NODE_PORTAL_URLS[$node_index]}" \
+      "${NODE_BASE_URLS[$node_index]}"
   done
 fi
 


### PR DESCRIPTION
The portal now runs on its own listener per node instead of sharing the REST port behind a Host header check: the REST root always redirects to the Swagger UI, unknown API paths return plain 404 instead of SPA HTML, and the portal serves the SPA at its own origin. Stale realm presence reads now wait for the in-flight refresh before answering, which removes the periodic flapping of healthy peers to "configured" in realm views. The local cluster deploy prints a reworked summary with labeled per node URLs and test credentials. Enabling the portal now requires PORTAL_SOCKET_ADDRESS and API_PUBLIC_URL, the portal CSP derives the API origin automatically, and CORS_ALLOWED_ORIGINS must include the portal origin.

Changes:
- Serve the portal from a dedicated listener with its own socket address, wired into the ingress shutdown phase
- Redirect the REST root, /api/v1, and /swagger to the Swagger UI unconditionally
- Serve an absolute apiBaseUrl in portal-config.json derived from API_PUBLIC_URL
- Derive the portal CSP connect-src and img-src from the configured API origin, admitting explicit http origins with a startup warning
- Expose Retry-After to cross-origin callers
- Await the single-flight presence refresh within the caller deadline before answering stale, releasing the refresh slot through a drop guard
- Allocate a per node portal port in the cluster deploy script and verify portal-config.json on it, only when a portal is deployed
- Rework the deploy summary with labeled per node URLs and a test credentials section, and improve the just recipe docs
- Update the CI cluster checks to probe the portal listener and the new summary format