### PR TITLE
fix: Structured OpenAPI docs and hardening residuals

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,8 @@
+# Throwaway local development environment, loaded by dotenvy for `cargo run -p aruna`.
+# It is committed on purpose so a fresh checkout starts; `.env.example` is the template.
+# Nothing deployed reads it: `just local*` uses scripts/compose.aruna.env, `just local-cluster`
+# and `just preview` generate a per-node .env, and clusters provision their own secrets.
+# The REALM_*/NODE_* key entries below are leftovers that no code reads.
 STORAGE_PATH=/dev/shm/aruna-test
 BLOB_ROOT=/dev/shm/aruna-test/blobstore
 BLOB_MULTIPART_BUCKET=uploaded-parts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ aws-sdk-s3 = { version = "1.140.0", default-features = false, features = [
     "rt-tokio",
 ] }
 axum = "0.8.9"
-axum-extra = { version = "0.12.6", features = ["query"] }
 bao-tree = "0.16.0"
 base64 = "0.23.0"
 blake3 = { version = "=1.8.7", features = ["serde"] }
@@ -67,7 +66,6 @@ cel-interpreter = "0.10.0"
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.4", features = ["derive", "env"] }
-console-subscriber = "0.5.0"
 craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", features = [
     "iroh",
     "shacl-core",
@@ -75,7 +73,6 @@ craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", featu
 crc-fast = "1.10.0"
 crossfire = "3.1.19"
 crypto_box = "0.9.1"
-data-encoding = "2.11.0"
 dotenvy = "0.15.7"
 ed25519-dalek = { version = "3.0.0", features = ["pem"] }
 fjall = "3.1.8"
@@ -99,14 +96,12 @@ hyper-util = { version = "0.1.20", features = [
 ] }
 ipnet = "2.12.0"
 iroh = "1.0.3"
-iroh-base = "1.0.3"
 # Pinned to the exact revision craqle uses so one irokle crate is resolved.
 irokle = { git = "https://github.com/arunaengine/irokle.git", rev = "ebd4abd142f66816a16492c615525809f6c8b663", features = [
     "fjall",
     "iroh",
 ] }
 iroh-io = "0.6.2"
-iroh-quinn = "0.16.1"
 jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
 json-patch = "4.2.0"
 lru = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ bytes = "1.12.1"
 cel-interpreter = "0.10.0"
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.45", features = ["serde"] }
-clap = { version = "4.6.4", features = ["derive"] }
+clap = { version = "4.6.4", features = ["derive", "env"] }
 console-subscriber = "0.5.0"
 craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", features = [
     "iroh",

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Rust](https://img.shields.io/badge/built_with-Rust-dca282.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-brightgreen.svg)](https://github.com/arunaengine/aruna/blob/main/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/arunaengine/aruna/blob/main/LICENSE-MIT)
-![CI](https://github.com/arunaengine/aruna/actions/workflows/test.yml/badge.svg)
-[![Codecov](https://codecov.io/github/arunaengine/aruna/coverage.svg?branch=main)](https://codecov.io/gh/ArunaStorage/aruna)
-[![dependency status](https://deps.rs/repo/github/ArunaStorage/aruna/status.svg?path=components%2Fserver)](https://deps.rs/repo/github/ArunaStorage/aruna?path=components%2Fserver)
+![CI](https://github.com/arunaengine/aruna/actions/workflows/ci.yml/badge.svg)
+[![Codecov](https://codecov.io/github/arunaengine/aruna/coverage.svg?branch=main)](https://codecov.io/gh/arunaengine/aruna)
+[![dependency status](https://deps.rs/repo/github/arunaengine/aruna/status.svg)](https://deps.rs/repo/github/arunaengine/aruna)
 ___
 
 <p align="center">
@@ -72,7 +72,7 @@ The quickest way to try Aruna is a local 3-node demo deployment.
 
 #### For local builds:
 
-- Rust `1.95.0+` (for source builds)
+- Rust `1.97.1` (see [rust-toolchain.toml](rust-toolchain.toml), for source builds)
 - OpenSSL development headers
 - `mold` linker
 
@@ -150,7 +150,7 @@ Additional nodes join an existing realm by setting `ONBOARDING_SECRET` on their 
 
 Onboarding only takes effect on a fresh data directory. Once a node has persisted state, later `.env` changes — including a new `ONBOARDING_SECRET` — do not re-bootstrap or re-onboard it. To repeat an onboarding or bootstrap flow, point the node at a fresh `STORAGE_PATH`.
 
-For a ready-made multi-node onboarding flow, use `just test-deploy` instead of walking through the onboarding APIs manually.
+For a ready-made multi-node onboarding flow, use `just local-cluster` instead of walking through the onboarding APIs manually.
 
 ## Durability Configuration
 

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -615,12 +615,14 @@ mod test {
     use crate::auth::{
         OIDC_PROVIDER_METADATA_CACHE_TTL_SECS, OidcValidator, bucket_blob_permission_path,
         extract_auth_context, extract_auth_context_and_bearer_token, handle_token,
+        map_authorize_error,
     };
-    use crate::error::TokenError;
+    use crate::error::{ServerError, TokenError};
     use crate::server::ServerState;
     use aruna_core::UserId;
     use aruna_core::auth::bearer_token_hash;
     use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::errors::StorageError;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::handle::Handle;
     use aruna_core::keys::generate_signing_key;
@@ -636,6 +638,7 @@ mod test {
     use aruna_operations::register_or_get_oidc_user::{
         RegisterOrGetOidcUserInput, RegisterOrGetOidcUserOperation,
     };
+    use aruna_operations::request_authorization::AuthorizeError;
     use aruna_operations::revoke_token::{
         RevokeTokenAdmission, RevokeTokenConfig, RevokeTokenOperation,
     };
@@ -660,6 +663,23 @@ mod test {
     use tokio::net::TcpListener;
     use tokio::sync::RwLock;
     use ulid::Ulid;
+
+    #[test]
+    fn capacity_is_retryable() {
+        // The choke point must not hide a storage fault behind 403 or 500.
+        assert!(matches!(
+            map_authorize_error(AuthorizeError::Storage(StorageError::CleanupCapacity)),
+            ServerError::ServiceUnavailableReason(_)
+        ));
+        assert!(matches!(
+            map_authorize_error(AuthorizeError::Storage(StorageError::DeleteError)),
+            ServerError::InternalError(_)
+        ));
+        assert!(matches!(
+            map_authorize_error(AuthorizeError::PermissionDenied),
+            ServerError::Forbidden
+        ));
+    }
 
     #[tokio::test]
     async fn bucket_blob_permission_path_matches_canonical_blob_object_path() {

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -1,13 +1,14 @@
 use crate::error::{OidcError, ServerError, ServerResult, TokenError};
 use crate::server_state::ServerState;
 use crate::telemetry::record_auth_context;
-use aruna_core::errors::ConversionError;
+use aruna_core::errors::{ConversionError, StorageError};
 use aruna_core::structs::{
     AuthContext, OidcProviderConfig, Permission, TokenClaims, blob_object_permission_path,
 };
 use aruna_operations::auth::{
     ArunaBearerTokenError, ArunaBearerTokenValidationState, decode_aruna_bearer_token,
 };
+use aruna_operations::request_authorization::AuthorizeError;
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
@@ -559,12 +560,23 @@ pub(crate) async fn ensure_permission_with(
         ),
     )
     .await
-    .map_err(|error| match error {
-        aruna_operations::request_authorization::AuthorizeError::CheckFailed(message) => {
-            ServerError::InternalError(message)
+    .map_err(map_authorize_error)
+}
+
+/// An infrastructure fault inside the permission check is not a verdict:
+/// exhausted transaction-cleanup capacity stays retryable, every other storage
+/// fault stays internal, and only real denials become `Forbidden`.
+fn map_authorize_error(error: AuthorizeError) -> ServerError {
+    match error {
+        AuthorizeError::Storage(StorageError::CleanupCapacity) => {
+            ServerError::ServiceUnavailableReason(
+                "storage cleanup capacity exhausted; retry".to_string(),
+            )
         }
-        _ => ServerError::Forbidden,
-    })
+        AuthorizeError::Storage(error) => ServerError::InternalError(error.to_string()),
+        AuthorizeError::CheckFailed(message) => ServerError::InternalError(message),
+        AuthorizeError::PermissionDenied | AuthorizeError::Policy(_) => ServerError::Forbidden,
+    }
 }
 
 /// Boolean form of [`ensure_permission`] for the routes that grade a caller

--- a/api/src/openapi/mod.rs
+++ b/api/src/openapi/mod.rs
@@ -11,7 +11,21 @@ use utoipa::{Modify, OpenApi};
     info(
         title = "Aruna Server API",
         version = env!("CARGO_PKG_VERSION"),
-        description = "REST API for the Aruna federated data orchestration network",
+        description = r#"REST API for the Aruna federated data orchestration network.
+
+**Authentication**: most operations take a realm bearer token; the GA4GH TES facade also accepts
+HTTP Basic with an access key and secret issued by this node, and public routes carry an empty
+security requirement.
+
+**Conventions**
+- Errors answer `application/json` with `ErrorResponse` (`error` plus an optional `code`); the
+  GA4GH DRS and TES facades use their own error payloads.
+- Every operation may answer 429 with a `Retry-After` header.
+- An operation may answer 408 when the request exceeds the REST time limit; the streaming RO-Crate
+  upload does not.
+- An operation with a request body may answer 413 when the body exceeds the configured limit.
+- An operation that reports errors as a body may answer 500 on an unexpected internal failure.
+- Paths are relative to the `/api/v1` base path."#,
         license(name = "Apache-2.0", url = "https://www.apache.org/licenses/LICENSE-2.0"),
         contact(name = "Aruna Team", url = "https://github.com/arunaengine/aruna")
     ),
@@ -192,6 +206,18 @@ mod tests {
     const METHODS: &[&str] = &[
         "get", "put", "post", "delete", "options", "head", "patch", "trace",
     ];
+
+    /// Section labels a description may carry, in their only allowed order.
+    const SECTIONS: &[&str] = &[
+        "**Authentication**",
+        "**Behavior**",
+        "**Limits**",
+        "**Errors**",
+    ];
+
+    const MAX_SUMMARY_WORDS: usize = 8;
+    const MAX_LEAD: usize = 200;
+    const MAX_PARAGRAPH: usize = 400;
 
     /// Example values that would mean a real credential leaked into the document.
     const FORBIDDEN: &[&str] = &[
@@ -438,7 +464,26 @@ mod tests {
             !value.is_null()
                 && !value.as_str().is_some_and(|text| text.is_empty())
                 && schema_matches(doc, schema, value)
+                && non_empty(doc, schema, value)
         })
+    }
+
+    /// An example that shows nothing: `{}` where the schema promises fields, `[]`
+    /// for an array. A free-form object body may legitimately carry `{}`.
+    fn non_empty(doc: &Value, schema: &Value, value: &Value) -> bool {
+        let Some(schema) = resolve(doc, schema) else {
+            return true;
+        };
+        let promises_fields = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .is_some_and(|properties| !properties.is_empty())
+            || schema.get("required").is_some();
+        if promises_fields && value.as_object().is_some_and(|fields| fields.is_empty()) {
+            return false;
+        }
+        schema.get("type") != Some(&json!("array"))
+            || !value.as_array().is_some_and(|items| items.is_empty())
     }
 
     /// Operations missing a summary, description, parameter or response text.
@@ -482,8 +527,160 @@ mod tests {
         gaps
     }
 
-    /// JSON bodies without an example. Exemptions follow from the status and the
-    /// media type, never from a list of endpoints.
+    /// Tag names the document describes, so an operation cannot reference a bare tag.
+    fn described_tags(doc: &Value) -> BTreeSet<&str> {
+        doc.get("tags")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter(|tag| filled(tag.get("description")))
+            .filter_map(|tag| tag.get("name").and_then(Value::as_str))
+            .collect()
+    }
+
+    /// Blank-line separated paragraphs, keeping each paragraph's own line breaks.
+    fn split_paragraphs(text: &str) -> Vec<String> {
+        let mut paragraphs = Vec::new();
+        let mut current: Vec<&str> = Vec::new();
+        for line in text.lines() {
+            if line.trim().is_empty() {
+                if !current.is_empty() {
+                    paragraphs.push(current.join("\n"));
+                    current.clear();
+                }
+            } else {
+                current.push(line);
+            }
+        }
+        if !current.is_empty() {
+            paragraphs.push(current.join("\n"));
+        }
+        paragraphs
+    }
+
+    fn snippet(text: &str) -> String {
+        text.chars().take(40).collect()
+    }
+
+    /// A long paragraph is only allowed as a bullet list under its label.
+    fn bulleted(paragraph: &str) -> bool {
+        paragraph.lines().all(|line| {
+            let body = line.trim_start();
+            body.starts_with("- ") || body.starts_with("**") || line.starts_with("  ")
+        })
+    }
+
+    fn prose_gaps(name: &str, field: &str, text: &str, gaps: &mut Vec<String>) {
+        if text.contains('\u{2014}') {
+            gaps.push(format!("{name}: {field} contains an em dash"));
+        }
+        if text.contains(['\u{2018}', '\u{2019}', '\u{201c}', '\u{201d}']) {
+            gaps.push(format!("{name}: {field} contains curly quotes"));
+        }
+    }
+
+    fn summary_gaps(name: &str, summary: &str, gaps: &mut Vec<String>) {
+        let words = summary.split_whitespace().count();
+        if !(1..=MAX_SUMMARY_WORDS).contains(&words) {
+            gaps.push(format!(
+                "{name}: summary has {words} words (allowed 1 to {MAX_SUMMARY_WORDS})"
+            ));
+        }
+        if summary.trim_end().ends_with('.') {
+            gaps.push(format!("{name}: summary ends with a period"));
+        }
+        prose_gaps(name, "summary", summary, gaps);
+    }
+
+    fn section_gaps(name: &str, paragraphs: &[String], gaps: &mut Vec<String>) {
+        let mut found = Vec::new();
+        for paragraph in paragraphs {
+            let paragraph = paragraph.trim_start();
+            if !paragraph.starts_with("**") {
+                continue;
+            }
+            match SECTIONS
+                .iter()
+                .position(|label| paragraph.starts_with(*label))
+            {
+                Some(label) => found.push(label),
+                None => gaps.push(format!(
+                    "{name}: unknown section label: {}",
+                    snippet(paragraph)
+                )),
+            }
+        }
+        if !found.contains(&0) {
+            gaps.push(format!("{name}: missing **Authentication** section"));
+        }
+        if found.windows(2).any(|pair| pair[0] >= pair[1]) {
+            let labels: Vec<&str> = found.iter().map(|label| SECTIONS[*label]).collect();
+            gaps.push(format!(
+                "{name}: sections out of order or repeated: {}",
+                labels.join(" ")
+            ));
+        }
+    }
+
+    fn description_gaps(name: &str, description: &str, gaps: &mut Vec<String>) {
+        prose_gaps(name, "description", description, gaps);
+        let paragraphs = split_paragraphs(description);
+        let Some(lead) = paragraphs.first().map(|lead| lead.trim()) else {
+            gaps.push(format!("{name}: description is empty"));
+            return;
+        };
+        let length = lead.chars().count();
+        if lead.contains('\n')
+            || !lead.ends_with('.')
+            || length > MAX_LEAD
+            || lead.starts_with("**")
+        {
+            gaps.push(format!(
+                "{name}: lead must be one sentence of at most {MAX_LEAD} chars ending with '.' \
+                 ({length} chars)"
+            ));
+        }
+        for paragraph in &paragraphs {
+            if paragraph.chars().count() > MAX_PARAGRAPH && !bulleted(paragraph) {
+                gaps.push(format!(
+                    "{name}: paragraph over {MAX_PARAGRAPH} chars is not a bullet list: {}",
+                    snippet(paragraph)
+                ));
+            }
+        }
+        section_gaps(name, &paragraphs[1..], gaps);
+    }
+
+    /// Operation prose that does not follow the structured documentation convention.
+    fn structure_gaps(doc: &Value) -> Vec<String> {
+        let described = described_tags(doc);
+        let mut gaps = Vec::new();
+        for (name, operation) in operations(doc) {
+            if let Some(summary) = operation.get("summary").and_then(Value::as_str) {
+                summary_gaps(&name, summary, &mut gaps);
+            }
+            if let Some(description) = operation.get("description").and_then(Value::as_str) {
+                description_gaps(&name, description, &mut gaps);
+            }
+            for tag in operation
+                .get("tags")
+                .and_then(Value::as_array)
+                .map(Vec::as_slice)
+                .unwrap_or_default()
+                .iter()
+                .filter_map(Value::as_str)
+            {
+                if !described.contains(tag) {
+                    gaps.push(format!("{name}: tag {tag} without description"));
+                }
+            }
+        }
+        gaps
+    }
+
+    /// JSON bodies without a usable example. Exemptions follow from the status and
+    /// the media type, never from a list of endpoints.
     fn example_gaps(doc: &Value) -> Vec<String> {
         let mut gaps = Vec::new();
         for (name, operation) in operations(doc) {
@@ -493,7 +690,9 @@ mod tests {
             {
                 for (media_type, media) in json_media(body) {
                     if !has_example(doc, media) {
-                        gaps.push(format!("{name}: request {media_type} without example"));
+                        gaps.push(format!(
+                            "{name}: request {media_type} without a usable example"
+                        ));
                     }
                 }
             }
@@ -511,7 +710,9 @@ mod tests {
                 };
                 for (media_type, media) in json_media(response) {
                     if !has_example(doc, media) {
-                        gaps.push(format!("{name}: {status} {media_type} without example"));
+                        gaps.push(format!(
+                            "{name}: {status} {media_type} without a usable example"
+                        ));
                     }
                 }
             }
@@ -587,6 +788,12 @@ mod tests {
             "undocumented operations:\n{}",
             gaps.join("\n")
         );
+        let gaps = structure_gaps(&doc);
+        assert!(
+            gaps.is_empty(),
+            "operation docs off the convention:\n{}",
+            gaps.join("\n")
+        );
     }
 
     #[test]
@@ -595,7 +802,7 @@ mod tests {
         let gaps = example_gaps(&doc);
         assert!(
             gaps.is_empty(),
-            "bodies without examples:\n{}",
+            "bodies without a usable example:\n{}",
             gaps.join("\n")
         );
     }
@@ -877,7 +1084,7 @@ mod tests {
         assert!(
             example_gaps(&doc)
                 .iter()
-                .any(|gap| gap.contains("without example"))
+                .any(|gap| gap.contains("without a usable example"))
         );
         let null_media = json!({"example": null});
         assert!(!has_example(&doc, &null_media));
@@ -916,7 +1123,7 @@ mod tests {
         assert!(
             example_gaps(&doc)
                 .iter()
-                .any(|gap| gap.contains("without example"))
+                .any(|gap| gap.contains("without a usable example"))
         );
 
         let cyclic = json!({
@@ -929,6 +1136,64 @@ mod tests {
                 .iter()
                 .any(|gap| gap.contains("response 200 without description")),
             "a $ref cycle must not count as documentation"
+        );
+    }
+
+    #[test]
+    fn rejects_flat_docs() {
+        // The structure gate must fail an unwrapped description, a mis-ordered
+        // section list, an overlong summary, a bare tag and an empty example.
+        let lead = "Creates a thing and inlines every rule, limit and status in one paragraph. "
+            .repeat(12);
+        let description = format!(
+            "{lead}Refusals are listed above \u{2014} not below.\n\n\
+             **Limits**: at most one thing.\n\n**Authentication**: bearer token."
+        );
+        let doc = json!({
+            "paths": {
+                "/thing": {
+                    "post": {
+                        "tags": ["thing"],
+                        "summary": "Create a thing and also explain the whole limit story in here.",
+                        "description": description,
+                        "responses": {
+                            "200": {
+                                "description": "Created",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {"id": {"type": "string"}}
+                                        },
+                                        "example": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let gaps = structure_gaps(&doc);
+        assert!(gaps.iter().any(|gap| gap.contains("summary has 12 words")));
+        assert!(
+            gaps.iter()
+                .any(|gap| gap.contains("summary ends with a period"))
+        );
+        assert!(gaps.iter().any(|gap| gap.contains("lead must be one")));
+        assert!(gaps.iter().any(|gap| gap.contains("not a bullet list")));
+        assert!(gaps.iter().any(|gap| gap.contains("out of order")));
+        assert!(gaps.iter().any(|gap| gap.contains("contains an em dash")));
+        assert!(
+            gaps.iter()
+                .any(|gap| gap.contains("tag thing without description"))
+        );
+        assert!(
+            example_gaps(&doc)
+                .iter()
+                .any(|gap| gap.contains("without a usable example")),
+            "an empty object documents no body"
         );
     }
 

--- a/api/src/routes/audit.rs
+++ b/api/src/routes/audit.rs
@@ -91,11 +91,32 @@ fn operation_name(operation: &MetadataAuditOperation) -> &'static str {
     path = "/audit",
     tag = "audit",
     summary = "List a group's metadata audit trail",
-    description = "Requires a bearer token of this realm. On a server or management node the caller needs WRITE on the group's admin path; on a user-kind node the read is forwarded to the realm under the caller's own token and every peer re-checks that same group-admin authority, so a bearer token must be present there. Audit rows are node-local, so a page is a realm fan-out: every sync-eligible realm node is asked for its slice and the slices are merged in trail order under a 30 second deadline. Partial results are part of the contract: `partial` is true when a node did not answer in time, when realm membership or its digest changed under the read, or when a peer's slice was rejected, and a partial page never carries `next_cursor` because a caller must not page over an incomplete merge. `missing_nodes` names up to 64 nodes that did not contribute and `missing_overflow` counts the ones beyond that bound. A complete page without `next_cursor` is the end of the trail. Concurrent audit reads are admission-limited, so a saturated node answers 503 rather than queueing.",
+    description = r#"Returns a group's metadata audit trail as a realm-wide merged page, oldest first.
+
+**Authentication**: bearer token of this realm. On a server or management node the caller needs
+WRITE on the group's admin path; on a user-kind node the read is forwarded to the realm under the
+caller's own token and every peer re-checks that same group-admin authority, so a bearer token must
+be present there.
+
+**Behavior**
+- Audit rows are node-local, so a page is a realm fan-out: every sync-eligible realm node is asked
+  for its slice and the slices are merged in trail order under a 30 second deadline.
+- Partial results are part of the contract: `partial` is true when a node did not answer in time,
+  when realm membership or its digest changed under the read, or when a peer's slice was rejected.
+- A partial page never carries `next_cursor` because a caller must not page over an incomplete
+  merge.
+- `missing_nodes` names up to 64 nodes that did not contribute and `missing_overflow` counts the
+  ones beyond that bound.
+- A complete page without `next_cursor` is the end of the trail.
+- A `cursor` is bound to this realm, the realm membership digest, the group and the document filter.
+
+**Errors**: a cursor whose realm, membership digest, group or document filter no longer matches is
+rejected with 400. Concurrent audit reads are admission-limited, so a saturated node answers 503
+rather than queueing."#,
     params(
         ("group_id" = String, Query, description = "ULID of the group whose audit trail is read; required"),
         ("document_id" = Option<String>, Query, description = "ULID of one metadata document; narrows the trail to that document. Default: the whole group trail"),
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token taken from a previous page's `next_cursor`. It is bound to this realm, the realm membership digest, the group and the document filter, and is rejected with 400 once any of those differ. Absent starts at the beginning of the trail"),
+        ("cursor" = Option<String>, Query, description = "Opaque continuation token from a previous page's `next_cursor`. Absent starts at the beginning of the trail"),
         ("limit" = Option<usize>, Query, description = "Maximum records in one page. Default 50, clamped to 1..=200")
     ),
     responses(

--- a/api/src/routes/blobs.rs
+++ b/api/src/routes/blobs.rs
@@ -97,8 +97,27 @@ async fn load_bucket(state: &ServerState, bucket: &str) -> ServerResult<BucketIn
     post,
     path = "/blobs/replicate",
     tag = "blobs",
-    summary = "Queue a copy of a bucket, object or version onto another node",
-    description = "Requires a bearer token issued by this realm; a token from another realm is refused with 403. The caller needs WRITE on the object when path is given and WRITE on the whole bucket when it is not. The 202 means the replication job was written durably on this node and nothing more: no bytes have been copied, the target node has not been contacted, and the copy may still fail or be retried in the background, so a caller that needs the outcome polls the locations endpoint until the target reports the copy as present. The response echoes the accepted scope rather than any progress. Scope follows the fields: no path replicates the whole bucket, a path replicates that object, and a path with version_id replicates exactly that version; a version_id without a path is rejected with 400, and a bucket that does not exist on this node is reported as 404. Delete markers are included in the queued work. Submitting the same scope again queues the work again, so the request is not idempotent.",
+    summary = "Queue a replication copy onto another node",
+    description = r#"Durably queues replication of a bucket, object or version onto another node.
+
+**Authentication**: bearer token issued by this realm; a token from another realm is refused with
+403. The caller needs WRITE on the object when `path` is given and WRITE on the whole bucket when
+it is not.
+
+**Behavior**
+- The 202 means the replication job was written durably on this node and nothing more: no bytes
+  have been copied, the target node has not been contacted, and the copy may still fail or be
+  retried in the background.
+- A caller that needs the outcome polls the locations endpoint until the target reports the copy as
+  present; the response echoes the accepted scope rather than any progress.
+- Scope follows the fields: no `path` replicates the whole bucket, a `path` replicates that object,
+  and a `path` with `version_id` replicates exactly that version.
+- Delete markers are included in the queued work.
+- Submitting the same scope again queues the work again, so the request is not idempotent.
+
+**Limits**
+- A `version_id` sent without a `path` is rejected with 400.
+- A bucket that does not exist on this node is reported as 404."#,
     request_body(
         content = ReplicateBlobRequest,
         description = "Bucket to replicate from, the optional object path and version that narrow the scope, and the hex id of the destination node",
@@ -352,7 +371,33 @@ fn copy_response(
     path = "/blobs/locations",
     tag = "blobs",
     summary = "List the nodes holding one object version",
-    description = "Requires a bearer token issued by this realm and READ on the object; a token from another realm is refused with 403. The local node resolves the version, then asks every node that might hold a copy: the destinations a sync relationship maps this key to, the bucket's configured replication targets, the destinations with queued replication work, and the nodes the durable holder index names for these bytes. At most 64 destinations are asked, at most 8 at a time, each with a 5 second answer window inside a 30 second budget for the whole request, so a stalled peer costs the deadline once rather than once per node. One entry is returned per destination path, so a node reachable under two bucket-and-key pairs appears twice and only the whole node, bucket and key triple identifies an entry. Per-copy state is present when the node reports the bytes, pending when the copy is expected but not there yet, not-stored when the version carries no bytes anywhere such as a delete marker, denied when the node refused to answer under the caller's identity, and unreachable when it gave no answer at all. An unreachable holder does not fail the request: the answer is still 200 with complete false and unreachable listed in limits, and repeating the request may reach that node and complete the picture. complete is true only when every candidate was enumerated and answered; otherwise limits names each reason, and a copy may be missing from the list rather than genuinely absent. Copies are ordered local first, then by node, bucket and key.",
+    description = r#"Lists every node that holds or is expected to hold one object version.
+
+**Authentication**: bearer token issued by this realm and READ on the object; a token from another
+realm is refused with 403.
+
+**Behavior**
+- The local node resolves the version, then asks every node that might hold a copy: the
+  destinations a sync relationship maps this key to, the bucket's configured replication targets,
+  the destinations with queued replication work, and the nodes the durable holder index names for
+  these bytes.
+- One entry is returned per destination path, so a node reachable under two bucket-and-key pairs
+  appears twice and only the whole node, bucket and key triple identifies an entry.
+- Per-copy `state` is `present` when the node reports the bytes, `pending` when the copy is
+  expected but not there yet, `not-stored` when the version carries no bytes anywhere such as a
+  delete marker, `denied` when the node refused to answer under the caller's identity, and
+  `unreachable` when it gave no answer at all.
+- An unreachable holder does not fail the request: the answer is still 200 with `complete` false
+  and `unreachable` listed in `limits`, and repeating the request may reach that node and complete
+  the picture.
+- `complete` is true only when every candidate was enumerated and answered; otherwise `limits`
+  names each reason, and a copy may be missing from the list rather than genuinely absent.
+- Copies are ordered local first, then by node, bucket and key.
+
+**Limits**
+- At most 64 destinations are asked, at most 8 at a time, each with a 5 second answer window inside
+  a 30 second budget for the whole request, so a stalled peer costs the deadline once rather than
+  once per node."#,
     params(
         ("bucket" = String, Query, description = "Bucket holding the object, as known to this node"),
         ("path" = String, Query, description = "Object key within the bucket, without a leading slash"),

--- a/api/src/routes/compute.rs
+++ b/api/src/routes/compute.rs
@@ -453,15 +453,16 @@ pub async fn put_compute_config(
     Extension(auth): Extension<Option<AuthContext>>,
     Json(request): Json<ComputeConfigBody>,
 ) -> ServerResult<Json<ComputeConfigBody>> {
-    let auth = require_config_admin(&state, auth, Permission::WRITE).await?;
+    let auth = require_realm_auth(&state, auth)?;
     let compute = compute_config(request)?;
     let stored = drive(
         SetRealmComputeOperation::new(SetRealmComputeConfig {
             actor: Actor {
                 node_id: state.get_node_id(),
                 user_id: auth.user_id,
-                realm_id: auth.realm_id,
+                realm_id: state.get_realm_id(),
             },
+            auth_context: auth,
             compute,
         }),
         &state.get_ctx(),
@@ -475,6 +476,7 @@ fn map_compute_error(error: SetRealmComputeError) -> ServerError {
     use aruna_core::errors::StorageError;
     match error {
         SetRealmComputeError::RealmConfigNotFound => ServerError::NotFound,
+        SetRealmComputeError::Unauthorized => ServerError::Forbidden,
         SetRealmComputeError::InvalidCompute { reason } => ServerError::BadRequestReason(reason),
         SetRealmComputeError::StorageError(StorageError::TransactionConflict) => {
             ServerError::Conflict(

--- a/api/src/routes/compute.rs
+++ b/api/src/routes/compute.rs
@@ -445,7 +445,8 @@ and only a management node serves it; every other node answers 403.
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, the caller may not administer the realm configuration, or this is not a management node", body = ErrorResponse),
         (status = 404, description = "This node holds no configuration document for its realm", body = ErrorResponse),
-        (status = 409, description = "Another update of the realm configuration won the race; the caller may retry with the same body", body = ErrorResponse)
+        (status = 409, description = "Another update of the realm configuration won the race; the caller may retry with the same body", body = ErrorResponse),
+        (status = 503, description = "Storage cleanup capacity exhausted, retry later", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -485,6 +486,11 @@ fn map_compute_error(error: SetRealmComputeError) -> ServerError {
         SetRealmComputeError::StorageError(StorageError::TransactionConflict) => {
             ServerError::Conflict(
                 "concurrent realm configuration update conflict; retry".to_string(),
+            )
+        }
+        SetRealmComputeError::StorageError(StorageError::CleanupCapacity) => {
+            ServerError::ServiceUnavailableReason(
+                "storage cleanup capacity exhausted; retry".to_string(),
             )
         }
         other => ServerError::InternalError(other.to_string()),
@@ -762,6 +768,19 @@ mod tests {
                 reason: "zero bandwidth".to_string()
             }),
             ServerError::BadRequestReason(_)
+        ));
+    }
+
+    #[test]
+    fn capacity_is_unavailable() {
+        // Cleanup capacity is transient, so it must not read as an internal error.
+        use aruna_core::errors::StorageError;
+
+        assert!(matches!(
+            map_compute_error(SetRealmComputeError::StorageError(
+                StorageError::CleanupCapacity
+            )),
+            ServerError::ServiceUnavailableReason(_)
         ));
     }
 

--- a/api/src/routes/compute.rs
+++ b/api/src/routes/compute.rs
@@ -454,7 +454,8 @@ pub async fn put_compute_config(
     Extension(auth): Extension<Option<AuthContext>>,
     Json(request): Json<ComputeConfigBody>,
 ) -> ServerResult<Json<ComputeConfigBody>> {
-    let auth = require_realm_auth(&state, auth)?;
+    // Request policies live at this boundary; the operation only checks roles.
+    let auth = require_config_admin(&state, auth, Permission::WRITE).await?;
     let compute = compute_config(request)?;
     let stored = drive(
         SetRealmComputeOperation::new(SetRealmComputeConfig {

--- a/api/src/routes/compute.rs
+++ b/api/src/routes/compute.rs
@@ -356,7 +356,8 @@ pub async fn get_compute_config(
     summary = "Replace the realm compute configuration",
     description = r#"Replaces the stored realm compute configuration with the submitted one.
 
-**Authentication**: bearer token issued for this realm, with WRITE on the realm configuration path.
+**Authentication**: bearer token issued for this realm, with WRITE on the realm configuration path,
+and only a management node serves it; every other node answers 403.
 
 **Behavior**
 - The body replaces the stored configuration wholesale rather than patching it: links and group
@@ -442,7 +443,7 @@ pub async fn get_compute_config(
         })),
         (status = 400, description = "A malformed group id, a duplicate directed link or group entry, an empty or oversized location, a zero bandwidth, or a zero witness delay", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
-        (status = 403, description = "The token belongs to another realm, or the caller may not administer the realm configuration", body = ErrorResponse),
+        (status = 403, description = "The token belongs to another realm, the caller may not administer the realm configuration, or this is not a management node", body = ErrorResponse),
         (status = 404, description = "This node holds no configuration document for its realm", body = ErrorResponse),
         (status = 409, description = "Another update of the realm configuration won the race; the caller may retry with the same body", body = ErrorResponse)
     ),
@@ -476,7 +477,9 @@ fn map_compute_error(error: SetRealmComputeError) -> ServerError {
     use aruna_core::errors::StorageError;
     match error {
         SetRealmComputeError::RealmConfigNotFound => ServerError::NotFound,
-        SetRealmComputeError::Unauthorized => ServerError::Forbidden,
+        SetRealmComputeError::Unauthorized | SetRealmComputeError::NotManagementNode => {
+            ServerError::Forbidden
+        }
         SetRealmComputeError::InvalidCompute { reason } => ServerError::BadRequestReason(reason),
         SetRealmComputeError::StorageError(StorageError::TransactionConflict) => {
             ServerError::Conflict(

--- a/api/src/routes/compute.rs
+++ b/api/src/routes/compute.rs
@@ -285,18 +285,48 @@ async fn require_config_admin(
     path = "/admin/compute/config",
     tag = "compute",
     summary = "Read the realm compute configuration",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path. This is the operator knowledge no node can measure for itself: the directed bandwidth between placement locations the planner estimates transfers with, the bandwidth to assume for a link nobody configured, how long an availability sample still counts for ranking, the per-rank delay of the leaderless witness schedule, and the standing compute quotas new admissions are decided against. It is a node-local read of the replicated realm configuration, so a change written on another node can be missing here until it arrives. A quota dimension that is absent is unbounded, never zero, and a group entry replaces the realm default wholesale rather than merging with it.",
+    description = r#"Returns the realm compute configuration this node currently holds.
+
+**Authentication**: bearer token issued for this realm, with READ on the realm configuration path.
+
+**Behavior**
+- Reports the operator knowledge no node can measure for itself: the directed bandwidth between
+  placement locations the planner estimates transfers with, the bandwidth to assume for a link
+  nobody configured, how long an availability sample still counts for ranking, the per-rank delay
+  of the leaderless witness schedule, and the standing compute quotas new admissions are decided
+  against.
+- A node-local read of the replicated realm configuration, so a change written on another node can
+  be missing here until it arrives.
+- A quota dimension that is absent is unbounded, never zero, and a group entry replaces the realm
+  default wholesale rather than merging with it.
+
+**Errors**: only a genuinely absent document is a 404; a read or decode failure is a 500, because
+absence was never established."#,
     responses(
         (status = 200, description = "The compute configuration this node currently holds", body = ComputeConfigBody, example = json!({
-            "links": [{"from": "eu-west", "to": "us-east", "bandwidth_bytes_per_sec": 125000000_i64}],
+            "links": [
+                {
+                    "from": "eu-west",
+                    "to": "us-east",
+                    "bandwidth_bytes_per_sec": 125000000_i64
+                }
+            ],
             "pessimistic_bandwidth_bytes_per_sec": 12500000_i64,
             "availability_stale_after_ms": 300000,
             "witness_base_delay_ms": 30000,
-            "default_group_quota": {"max_jobs": 32, "max_cpu_cores": 128},
-            "group_quotas": [{
-                "group_id": "01JABCDEF0123456789ABCDEFG",
-                "quota": {"max_jobs": 8, "max_job_walltime_ms": 3600000}
-            }]
+            "default_group_quota": {
+                "max_jobs": 32,
+                "max_cpu_cores": 128
+            },
+            "group_quotas": [
+                {
+                    "group_id": "01JABCDEF0123456789ABCDEFG",
+                    "quota": {
+                        "max_jobs": 8,
+                        "max_job_walltime_ms": 3600000
+                    }
+                }
+            ]
         })),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller may not read the realm configuration", body = ErrorResponse),
@@ -324,39 +354,91 @@ pub async fn get_compute_config(
     path = "/admin/compute/config",
     tag = "compute",
     summary = "Replace the realm compute configuration",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path. The body replaces the stored configuration wholesale rather than patching it: links and group quotas absent from it are dropped, so send the complete intended configuration. Link direction matters, because asymmetric uplinks between sites are the normal case, and both a duplicate directed pair and a zero bandwidth are refused with 400 instead of being clamped, since a zero would make one transfer estimate infinite. `witness_base_delay_ms` must be greater than zero: it is the per-rank fallback delay of the leaderless schedule, and zero would let every witness plan at once. Quotas bound NEW logical admissions only. Lowering one never cancels, pauses or reclaims work that is already admitted, queued, preparing or running, and because the demand view is replicated a concurrent partition may overshoot a cap before it converges; the only consequence of an observed overshoot is that further admissions are refused. The change is published through the shared realm-configuration path, so a concurrent update converges instead of one writer silently winning, and it takes effect on other nodes as the configuration propagates.",
+    description = r#"Replaces the stored realm compute configuration with the submitted one.
+
+**Authentication**: bearer token issued for this realm, with WRITE on the realm configuration path.
+
+**Behavior**
+- The body replaces the stored configuration wholesale rather than patching it: links and group
+  quotas absent from it are dropped, so send the complete intended configuration.
+- Link direction matters, because asymmetric uplinks between sites are the normal case.
+- Quotas bound new logical admissions only. Lowering one never cancels, pauses or reclaims work
+  that is already admitted, queued, preparing or running.
+- The demand view is replicated, so a concurrent partition may overshoot a cap before it converges;
+  the only consequence of an observed overshoot is that further admissions are refused.
+- The change is published through the shared realm-configuration path, so a concurrent update
+  converges instead of one writer silently winning, and it takes effect on other nodes as the
+  configuration propagates.
+
+**Limits** (all refused with 400)
+- A duplicate directed link pair and a zero bandwidth are refused instead of clamped, since a zero
+  would make one transfer estimate infinite.
+- `witness_base_delay_ms` must be greater than zero: it is the per-rank fallback delay of the
+  leaderless schedule, and zero would let every witness plan at once."#,
     request_body(
         content = ComputeConfigBody,
         description = "The complete compute configuration to store",
         example = json!({
             "links": [
-                {"from": "eu-west", "to": "us-east", "bandwidth_bytes_per_sec": 125000000_i64},
-                {"from": "us-east", "to": "eu-west", "bandwidth_bytes_per_sec": 62500000_i64}
+                {
+                    "from": "eu-west",
+                    "to": "us-east",
+                    "bandwidth_bytes_per_sec": 125000000_i64
+                },
+                {
+                    "from": "us-east",
+                    "to": "eu-west",
+                    "bandwidth_bytes_per_sec": 62500000_i64
+                }
             ],
             "pessimistic_bandwidth_bytes_per_sec": 12500000_i64,
             "availability_stale_after_ms": 300000,
             "witness_base_delay_ms": 30000,
-            "default_group_quota": {"max_jobs": 32, "max_cpu_cores": 128},
-            "group_quotas": [{
-                "group_id": "01JABCDEF0123456789ABCDEFG",
-                "quota": {"max_jobs": 8, "max_job_walltime_ms": 3600000}
-            }]
+            "default_group_quota": {
+                "max_jobs": 32,
+                "max_cpu_cores": 128
+            },
+            "group_quotas": [
+                {
+                    "group_id": "01JABCDEF0123456789ABCDEFG",
+                    "quota": {
+                        "max_jobs": 8,
+                        "max_job_walltime_ms": 3600000
+                    }
+                }
+            ]
         })
     ),
     responses(
         (status = 200, description = "The compute configuration now stored in the realm configuration", body = ComputeConfigBody, example = json!({
             "links": [
-                {"from": "eu-west", "to": "us-east", "bandwidth_bytes_per_sec": 125000000_i64},
-                {"from": "us-east", "to": "eu-west", "bandwidth_bytes_per_sec": 62500000_i64}
+                {
+                    "from": "eu-west",
+                    "to": "us-east",
+                    "bandwidth_bytes_per_sec": 125000000_i64
+                },
+                {
+                    "from": "us-east",
+                    "to": "eu-west",
+                    "bandwidth_bytes_per_sec": 62500000_i64
+                }
             ],
             "pessimistic_bandwidth_bytes_per_sec": 12500000_i64,
             "availability_stale_after_ms": 300000,
             "witness_base_delay_ms": 30000,
-            "default_group_quota": {"max_jobs": 32, "max_cpu_cores": 128},
-            "group_quotas": [{
-                "group_id": "01JABCDEF0123456789ABCDEFG",
-                "quota": {"max_jobs": 8, "max_job_walltime_ms": 3600000}
-            }]
+            "default_group_quota": {
+                "max_jobs": 32,
+                "max_cpu_cores": 128
+            },
+            "group_quotas": [
+                {
+                    "group_id": "01JABCDEF0123456789ABCDEFG",
+                    "quota": {
+                        "max_jobs": 8,
+                        "max_job_walltime_ms": 3600000
+                    }
+                }
+            ]
         })),
         (status = 400, description = "A malformed group id, a duplicate directed link or group entry, an empty or oversized location, a zero bandwidth, or a zero witness delay", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
@@ -408,30 +490,69 @@ fn map_compute_error(error: SetRealmComputeError) -> ServerError {
     path = "/admin/compute/snapshots",
     tag = "compute",
     summary = "Read the observed compute demand and reservation snapshots",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path. Two different controls are reported side by side and are never summed: logical admitted demand, which is what the standing group quota is decided against, and exact physical reservations, which is capacity a target actually holds for accepted executions. Every publisher stamps its snapshot with its membership and publisher generations plus the time it observed them, so a stale or superseded advertisement is recognisable rather than silently averaged in. All totals are approximate: they merge what this node has replicated, so a partition may overshoot a cap before convergence, and `demand_truncated` marks a publisher whose snapshot understates it, either because a group holds more nonterminal families than the snapshot names or because whole groups could not be named at all. Passing `group_id` adds that group's merged demand next to the standing quota it is judged against; a family that several holders admitted still counts once. `departure` is present only when this node itself departed and reports the executions it could not resolve, which are unresolved rather than finished: a departing node never declares a remotely observed execution terminal, and removal is never blocked because those copies or executions exist.",
+    description = r#"Reports the compute demand and reservation snapshots this node has replicated.
+
+**Authentication**: bearer token issued for this realm, with READ on the realm configuration path.
+
+**Behavior**
+- Two different controls are reported side by side and are never summed: logical admitted demand,
+  which is what the standing group quota is decided against, and exact physical reservations, which
+  is capacity a target actually holds for accepted executions.
+- Every publisher stamps its snapshot with its membership and publisher generations plus the time
+  it observed them, so a stale or superseded advertisement is recognizable rather than silently
+  averaged in.
+- Passing `group_id` adds that group's merged demand next to the standing quota it is judged
+  against; a family that several holders admitted still counts once.
+- `departure` is present only when this node itself departed and reports the executions it could
+  not resolve, which are unresolved rather than finished: a departing node never declares a
+  remotely observed execution terminal, and removal is never blocked because those copies or
+  executions exist.
+
+**Limits**
+- All totals are approximate: they merge what this node has replicated, so a partition may overshoot
+  a cap before convergence.
+- `demand_truncated` marks a publisher whose snapshot understates it, either because a group holds
+  more nonterminal families than the snapshot names or because whole groups could not be named at
+  all.
+- `group_id` must be a ULID; any other value is refused with 400."#,
     params(
-        ("group_id" = Option<String>, Query, description = "Merge the demand of one group and report the standing quota it is judged against; a value that is not a ULID is 400")
+        ("group_id" = Option<String>, Query, description = "Merge one group's demand and report the standing quota it is judged against")
     ),
     responses(
         (status = 200, description = "The snapshots this node has replicated, all approximate", body = ComputeSnapshotsResponse, example = json!({
             "approximate": true,
             "operator_draining": false,
-            "nodes": [{
-                "node_id": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
-                "membership_generation": 4,
-                "publisher_generation": 118,
-                "observed_at_ms": 1755500000000u64,
-                "compute_draining": false,
-                "leaving": false,
-                "reserved": {"count": 2, "cpu_cores": 6, "ram_bytes": 12884901888_i64, "disk_bytes": 0},
-                "demand_groups": 1,
-                "demand_truncated": false
-            }],
+            "nodes": [
+                {
+                    "node_id": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
+                    "membership_generation": 4,
+                    "publisher_generation": 118,
+                    "observed_at_ms": 1755500000000u64,
+                    "compute_draining": false,
+                    "leaving": false,
+                    "reserved": {
+                        "count": 2,
+                        "cpu_cores": 6,
+                        "ram_bytes": 12884901888_i64,
+                        "disk_bytes": 0
+                    },
+                    "demand_groups": 1,
+                    "demand_truncated": false
+                }
+            ],
             "group": {
                 "group_id": "01JABCDEF0123456789ABCDEFG",
-                "demand": {"count": 3, "cpu_cores": 10, "ram_bytes": 21474836480_i64, "disk_bytes": 0},
+                "demand": {
+                    "count": 3,
+                    "cpu_cores": 10,
+                    "ram_bytes": 21474836480_i64,
+                    "disk_bytes": 0
+                },
                 "truncated": false,
-                "quota": {"max_jobs": 8, "max_job_walltime_ms": 3600000}
+                "quota": {
+                    "max_jobs": 8,
+                    "max_job_walltime_ms": 3600000
+                }
             }
         })),
         (status = 400, description = "`group_id` is not a ULID", body = ErrorResponse),
@@ -531,14 +652,32 @@ pub async fn get_compute_snapshots(
     path = "/admin/compute/drain",
     tag = "compute",
     summary = "Drain or undrain this node's compute plane",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path. A drained node advertises itself as draining, so no planner selects it for new executions and it declines launch offers, while everything that already holds a receipt keeps running: draining never cancels admitted, queued, preparing or running work, and it never revokes a reservation. The flag is this node's own operator decision and is stored separately from the departure state a placement change causes, so returning to the placement map cannot silently undrain a node an operator drained; undrain it explicitly with `draining` false. A node that is leaving the realm stays draining regardless. The change is republished in this node's advertisement, so other nodes stop planning here as it propagates, and `changed` is false when the node already had that state.",
+    description = r#"Sets whether this node advertises its compute plane as draining.
+
+**Authentication**: bearer token issued for this realm, with WRITE on the realm configuration path.
+
+**Behavior**
+- A drained node advertises itself as draining, so no planner selects it for new executions and it
+  declines launch offers, while everything that already holds a receipt keeps running: draining
+  never cancels admitted, queued, preparing or running work, and it never revokes a reservation.
+- The flag is this node's own operator decision and is stored separately from the departure state a
+  placement change causes, so returning to the placement map cannot silently undrain a node an
+  operator drained; undrain it explicitly with `draining` false.
+- A node that is leaving the realm stays draining regardless.
+- The change is republished in this node's advertisement, so other nodes stop planning here as it
+  propagates, and `changed` is false when the node already had that state."#,
     request_body(
         content = DrainRequest,
         description = "Whether this node's compute plane should be drained",
-        example = json!({"draining": true})
+        example = json!({
+            "draining": true
+        })
     ),
     responses(
-        (status = 200, description = "The drain state now advertised by this node", body = DrainResponse, example = json!({"draining": true, "changed": true})),
+        (status = 200, description = "The drain state now advertised by this node", body = DrainResponse, example = json!({
+            "draining": true,
+            "changed": true
+        })),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller may not administer the realm configuration", body = ErrorResponse),
         (status = 503, description = "The advertisement could not be republished; retryable", body = ErrorResponse)

--- a/api/src/routes/connectors.rs
+++ b/api/src/routes/connectors.rs
@@ -514,8 +514,8 @@ pub async fn get_source_connector(
   a reference can always be resolved with the credentials it was created against.
 
 **Errors**: the 400 body again states only that the request was bad, without the reason. The refusal
-to change referenced credentials is currently reported as an internal error rather than as a
-conflict."#,
+to change referenced credentials is a 409 and stays one until the referencing versions are gone, so
+it is not worth retrying unchanged."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID"),
         ("connector_id" = String, Path, description = "Connector to replace, as a 26-character ULID")
@@ -572,6 +572,11 @@ conflict."#,
         (
             status = 404,
             description = "No connector with that id is registered for this group on this node",
+            body = ErrorResponse
+        ),
+        (
+            status = 409,
+            description = "The credentials are still referenced by a stored object version",
             body = ErrorResponse
         )
     ),
@@ -630,8 +635,8 @@ pub async fn replace_source_connector(
 - The deletion is refused while any stored object version still references the connector's
   credentials, so a referenced connector must be detached before it can be removed.
 
-**Errors**: the refusal to delete a referenced connector is currently reported as an internal error
-rather than as a conflict."#,
+**Errors**: the refusal to delete a referenced connector is a 409 and stays one until the
+referencing versions are gone, so it is not worth retrying unchanged."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID"),
         ("connector_id" = String, Path, description = "Connector to delete, as a 26-character ULID")
@@ -655,6 +660,11 @@ rather than as a conflict."#,
         (
             status = 404,
             description = "No connector with that id is registered for this group on this node",
+            body = ErrorResponse
+        ),
+        (
+            status = 409,
+            description = "The credentials are still referenced by a stored object version",
             body = ErrorResponse
         )
     ),
@@ -1166,6 +1176,9 @@ fn map_replace_connector_error(error: ReplaceSourceConnectorError) -> ServerErro
     match error {
         ReplaceSourceConnectorError::ValidationError(_) => ServerError::BadRequest,
         ReplaceSourceConnectorError::NotFound => ServerError::NotFound,
+        ReplaceSourceConnectorError::ReferencedByObjectVersion => {
+            ServerError::Conflict(error.to_string())
+        }
         _ => ServerError::InternalError(error.to_string()),
     }
 }
@@ -1173,6 +1186,9 @@ fn map_replace_connector_error(error: ReplaceSourceConnectorError) -> ServerErro
 fn map_delete_connector_error(error: DeleteSourceConnectorError) -> ServerError {
     match error {
         DeleteSourceConnectorError::NotFound => ServerError::NotFound,
+        DeleteSourceConnectorError::ReferencedByObjectVersion => {
+            ServerError::Conflict(error.to_string())
+        }
         _ => ServerError::InternalError(error.to_string()),
     }
 }
@@ -1498,6 +1514,19 @@ mod tests {
         assert!(matches!(
             error,
             ServerError::BadGatewayReason(message) if message == "List error: not an index"
+        ));
+    }
+
+    #[test]
+    fn referenced_connector_conflicts() {
+        // A still-referenced credential is a policy refusal, not an internal error.
+        assert!(matches!(
+            map_replace_connector_error(ReplaceSourceConnectorError::ReferencedByObjectVersion),
+            ServerError::Conflict(_)
+        ));
+        assert!(matches!(
+            map_delete_connector_error(DeleteSourceConnectorError::ReferencedByObjectVersion),
+            ServerError::Conflict(_)
         ));
     }
 

--- a/api/src/routes/connectors.rs
+++ b/api/src/routes/connectors.rs
@@ -206,7 +206,33 @@ pub struct ListSourceConnectorsResponse {
     path = "/groups/{group_id}/connectors",
     tag = "connectors",
     summary = "Register a source connector for a group",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's data path; a caller lacking that permission and a caller naming a group that does not exist both receive 403. `secret_config` is write-only: the credentials are stored apart from the connector record and are never returned by any endpoint, so a reader only learns from `has_secret_config` whether any are stored. The accepted keys depend on `kind`: `http` and `webdav` require the public key `endpoint` and also accept `root`, with `username`, `password` or `token` as secrets; `s3` requires `bucket` and `endpoint`, also accepts `region`, `root` and `skip_signature`, and requires the secrets `access_key_id` and `secret_access_key` unless `skip_signature` is `true`, which in turn forbids any secret; `ftp` and `aruna_native` are refused outright. An unknown or empty config key, an endpoint the HTTP client would parse differently than it is written, and a bucket containing a path or authority separator are refused as well. The 400 body states only that the request was bad, without the reason; the connector check operation reports the reason. Nothing is contacted here, so a successful registration is no evidence that the credentials work or that the host is reachable, and an endpoint resolving to a blocked address is only refused when the connector is used. The record is written on the node that serves the request and is not replicated to the realm's other nodes.",
+    description = r#"Registers an external source connector for a group and stores its credentials write-only.
+
+**Authentication**: realm bearer token with WRITE on the group's data path; a caller lacking that
+permission and a caller naming a group that does not exist both receive 403.
+
+**Behavior**
+- `secret_config` is write-only: the credentials are stored apart from the connector record and are
+  never returned by any endpoint, so a reader only learns from `has_secret_config` whether any are
+  stored.
+- Nothing is contacted here, so a successful registration is no evidence that the credentials work
+  or that the host is reachable, and an endpoint resolving to a blocked address is only refused when
+  the connector is used.
+- The record is written on the node that serves the request and is not replicated to the realm's
+  other nodes.
+
+**Limits** (the accepted keys depend on `kind`)
+- `http` and `webdav` require the public key `endpoint` and also accept `root`, with `username`,
+  `password` or `token` as secrets.
+- `s3` requires `bucket` and `endpoint`, also accepts `region`, `root` and `skip_signature`, and
+  requires the secrets `access_key_id` and `secret_access_key` unless `skip_signature` is `true`,
+  which in turn forbids any secret.
+- `ftp` and `aruna_native` are refused outright.
+- An unknown or empty config key, an endpoint the HTTP client would parse differently than it is
+  written, and a bucket containing a path or authority separator are refused as well.
+
+**Errors**: the 400 body states only that the request was bad, without the reason; the connector
+check operation reports the reason."#,
     params(("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID")),
     request_body(
         content = CreateSourceConnectorRequest,
@@ -298,7 +324,18 @@ pub async fn create_source_connector(
     path = "/groups/{group_id}/connectors",
     tag = "connectors",
     summary = "List a group's source connectors",
-    description = "Requires a bearer token issued for this realm and READ on the group's data path; a caller lacking that permission and a caller naming a group that does not exist both receive 403. Returns every connector registered for the group on this node, ordered by connector id and therefore by registration time, in a single response: there is no paging, no cursor and no limit. Credentials are never included; `has_secret_config` is resolved per connector and only states whether any are stored. This is the node's own view, so a connector registered against another node of the realm is not listed here.",
+    description = r#"Returns every source connector the group has registered on this node.
+
+**Authentication**: realm bearer token with READ on the group's data path; a caller lacking that
+permission and a caller naming a group that does not exist both receive 403.
+
+**Behavior**
+- Connectors are ordered by connector id and therefore by registration time, and are returned in a
+  single response: there is no paging, no cursor and no limit.
+- Credentials are never included; `has_secret_config` is resolved per connector and only states
+  whether any are stored.
+- This is the node's own view, so a connector registered against another node of the realm is not
+  listed here."#,
     params(("group_id" = String, Path, description = "Group whose connectors are listed, as a 26-character ULID")),
     responses(
         (
@@ -368,7 +405,17 @@ pub async fn list_source_connectors(
     path = "/groups/{group_id}/connectors/{connector_id}",
     tag = "connectors",
     summary = "Read one source connector",
-    description = "Requires a bearer token issued for this realm and READ on the group's data path. The connector is looked up under the group in the path, so a connector id that belongs to a different group reads as not found rather than as forbidden. Returns the stored name, kind and public configuration; the credentials are never returned and `has_secret_config` is the only thing a reader learns about them. Reads this node's own records, so a connector registered against another node of the realm is not found here.",
+    description = r#"Returns one stored connector with its name, kind and public configuration.
+
+**Authentication**: realm bearer token with READ on the group's data path.
+
+**Behavior**
+- The connector is looked up under the group in the path, so a connector id that belongs to a
+  different group reads as not found rather than as forbidden.
+- The credentials are never returned and `has_secret_config` is the only thing a reader learns about
+  them.
+- Reads this node's own records, so a connector registered against another node of the realm is not
+  found here."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID"),
         ("connector_id" = String, Path, description = "Connector to read, as a 26-character ULID")
@@ -447,7 +494,28 @@ pub async fn get_source_connector(
     path = "/groups/{group_id}/connectors/{connector_id}",
     tag = "connectors",
     summary = "Replace a source connector's settings and credentials",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's data path. This is a full replacement, not a patch: name, kind, public configuration and credentials are all taken from the request, so credentials that are not sent again are deleted, and after a request without `secret_config` the connector has none and `has_secret_config` reads false. The connector id, the owning group, the creation time and the creator are preserved and the update time is refreshed. The same validation rules as registration apply, and the 400 body again states only that the request was bad, without the reason. Changing the credentials is refused while any stored object version still references them, so that a reference can always be resolved with the credentials it was created against; that refusal is currently reported as an internal error rather than as a conflict. Changing only the name or the public configuration is allowed even while such references exist. Nothing is contacted, so a successful replace does not prove that the new credentials work.",
+    description = r#"Replaces a stored connector's name, kind, public configuration and credentials in full.
+
+**Authentication**: realm bearer token with WRITE on the group's data path.
+
+**Behavior**
+- This is a full replacement, not a patch: name, kind, public configuration and credentials are all
+  taken from the request, so credentials that are not sent again are deleted, and after a request
+  without `secret_config` the connector has none and `has_secret_config` reads false.
+- The connector id, the owning group, the creation time and the creator are preserved and the update
+  time is refreshed.
+- Changing only the name or the public configuration is allowed even while stored object versions
+  still reference the credentials.
+- Nothing is contacted, so a successful replace does not prove that the new credentials work.
+
+**Limits**
+- The same validation rules as registration apply.
+- Changing the credentials is refused while any stored object version still references them, so that
+  a reference can always be resolved with the credentials it was created against.
+
+**Errors**: the 400 body again states only that the request was bad, without the reason. The refusal
+to change referenced credentials is currently reported as an internal error rather than as a
+conflict."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID"),
         ("connector_id" = String, Path, description = "Connector to replace, as a 26-character ULID")
@@ -548,7 +616,22 @@ pub async fn replace_source_connector(
     path = "/groups/{group_id}/connectors/{connector_id}",
     tag = "connectors",
     summary = "Delete a source connector",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's data path. Removes the connector record and its stored credentials together; after a 204 nothing on this node can resolve the connector any more, and a staged reference that would have used it fails from then on. The deletion is refused while any stored object version still references the connector's credentials, so a referenced connector must be detached before it can be removed; that refusal is currently reported as an internal error rather than as a conflict. Deleting a connector that is not registered for this group is a 404, not a silent success, so the call is not idempotent once it has succeeded.",
+    description = r#"Removes a source connector record and its stored credentials together.
+
+**Authentication**: realm bearer token with WRITE on the group's data path.
+
+**Behavior**
+- After a 204 nothing on this node can resolve the connector any more, and a staged reference that
+  would have used it fails from then on.
+- Deleting a connector that is not registered for this group is a 404, not a silent success, so the
+  call is not idempotent once it has succeeded.
+
+**Limits**
+- The deletion is refused while any stored object version still references the connector's
+  credentials, so a referenced connector must be detached before it can be removed.
+
+**Errors**: the refusal to delete a referenced connector is currently reported as an internal error
+rather than as a conflict."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID"),
         ("connector_id" = String, Path, description = "Connector to delete, as a 26-character ULID")
@@ -605,7 +688,32 @@ pub async fn delete_source_connector(
     path = "/groups/{group_id}/connectors/check",
     tag = "connectors",
     summary = "Test connector settings without registering them",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's data path, the same permission as registration, because the request carries credentials and makes the node open a connection to the endpoint they name. The body is validated with exactly the registration rules, so a malformed body is rejected with 400 before anything is contacted, and here the 400 carries the validation reason. Otherwise the node opens the source and reports the outcome inside a 200 response: `{\"ok\": true, \"latency_ms\": ...}` when the source answered, `{\"ok\": false, \"error\": ...}` when it did not. A failed check is never an HTTP error status. The `error` text comes from a fixed set, since a kind that cannot be staged at all is already refused with 400 before the probe: `connector configuration is invalid` means the settings cannot be turned into a client and the configuration must be corrected; `connector is unreachable` means the endpoint refused, denied, or its address was blocked by the egress policy, which is worth retrying only if the remote is expected to recover; `connector check is unavailable` means this node cannot run source checks at the moment and the call may be retried as is; `connector check timed out` means the check exceeded its five-second budget and may be retried. An `http` source counts as reachable as soon as the endpoint answers, including with a 404 for the probe path. Nothing is stored: the credentials in the body are used for this request only and are not written anywhere.",
+    description = r#"Probes a candidate connector definition and reports whether the source answered.
+
+**Authentication**: realm bearer token with WRITE on the group's data path, the same permission as
+registration, because the request carries credentials and makes the node open a connection to the
+endpoint they name.
+
+**Behavior**
+- The body is validated with exactly the registration rules, so a malformed body is rejected with
+  400 before anything is contacted, and here the 400 carries the validation reason.
+- Otherwise the node opens the source and reports the outcome inside a 200 response:
+  `{"ok": true, "latency_ms": ...}` when the source answered, `{"ok": false, "error": ...}` when it
+  did not. A failed check is never an HTTP error status.
+- An `http` source counts as reachable as soon as the endpoint answers, including with a 404 for the
+  probe path.
+- Nothing is stored: the credentials in the body are used for this request only and are not written
+  anywhere.
+
+**Errors**: the `error` text comes from a fixed set, since a kind that cannot be staged at all is
+  already refused with 400 before the probe.
+- `connector configuration is invalid`: the settings cannot be turned into a client and the
+  configuration must be corrected.
+- `connector is unreachable`: the endpoint refused, denied, or its address was blocked by the egress
+  policy, which is worth retrying only if the remote is expected to recover.
+- `connector check is unavailable`: this node cannot run source checks at the moment and the call
+  may be retried as is.
+- `connector check timed out`: the check exceeded its five-second budget and may be retried."#,
     params(("group_id" = String, Path, description = "Group whose data permission gates the check, as a 26-character ULID")),
     request_body(
         content = SourceConnectorRequest,
@@ -631,11 +739,17 @@ pub async fn delete_source_connector(
             examples(
                 ("Reachable" = (
                     summary = "The source answered within the budget",
-                    value = json!({"ok": true, "latency_ms": 87})
+                    value = json!({
+                        "ok": true,
+                        "latency_ms": 87
+                    })
                 )),
                 ("Unreachable" = (
                     summary = "The endpoint did not answer or was blocked",
-                    value = json!({"ok": false, "error": "connector is unreachable"})
+                    value = json!({
+                        "ok": false,
+                        "error": "connector is unreachable"
+                    })
                 ))
             )
         ),
@@ -682,7 +796,23 @@ pub async fn check_source_connector(
     path = "/groups/{group_id}/connectors/{connector_id}/check",
     tag = "connectors",
     summary = "Test a registered connector's stored settings",
-    description = "Requires a bearer token issued for this realm and READ on the group's data path. READ is enough here, unlike the check that takes settings in the body, because the caller supplies no credentials: the node resolves the stored record and its stored credentials and probes the source root with them, which tells the caller whether the credentials still work without exposing them. The outcome is reported inside a 200 response exactly as for the inline check: `{\"ok\": true, \"latency_ms\": ...}` or `{\"ok\": false, \"error\": ...}` with the same fixed reason texts and the same five-second budget, so `connector check is unavailable` and `connector check timed out` are retryable while `connector configuration is invalid` and `connector kind is not supported` mean the stored record must be replaced. A stored `ftp` connector resolves but always reports `connector kind is not supported`. Nothing is written and the record is left untouched whatever the outcome.",
+    description = r#"Probes a registered connector with its stored credentials and reports the outcome.
+
+**Authentication**: realm bearer token with READ on the group's data path. READ is enough here,
+unlike the check that takes settings in the body, because the caller supplies no credentials.
+
+**Behavior**
+- The node resolves the stored record and its stored credentials and probes the source root with
+  them, which tells the caller whether the credentials still work without exposing them.
+- The outcome is reported inside a 200 response exactly as for the inline check:
+  `{"ok": true, "latency_ms": ...}` or `{"ok": false, "error": ...}`, with the same fixed reason
+  texts and the same five-second budget.
+- A stored `ftp` connector resolves but always reports `connector kind is not supported`.
+- Nothing is written and the record is left untouched whatever the outcome.
+
+**Errors**: `connector check is unavailable` and `connector check timed out` are retryable, while
+`connector configuration is invalid` and `connector kind is not supported` mean the stored record
+must be replaced."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID"),
         ("connector_id" = String, Path, description = "Connector to probe, as a 26-character ULID")
@@ -695,11 +825,17 @@ pub async fn check_source_connector(
             examples(
                 ("Reachable" = (
                     summary = "The stored credentials still open the source",
-                    value = json!({"ok": true, "latency_ms": 142})
+                    value = json!({
+                        "ok": true,
+                        "latency_ms": 142
+                    })
                 )),
                 ("Unavailable" = (
                     summary = "This node cannot run source checks at the moment",
-                    value = json!({"ok": false, "error": "connector check is unavailable"})
+                    value = json!({
+                        "ok": false,
+                        "error": "connector check is unavailable"
+                    })
                 ))
             )
         ),
@@ -752,7 +888,27 @@ pub async fn check_stored_connector(
     path = "/groups/{group_id}/connectors/{connector_id}/entries",
     tag = "connectors",
     summary = "Browse the entries under a connector path",
-    description = "Requires a bearer token issued for this realm and READ on the group's data path. Lists one level below `path` at the source, using the connector's stored credentials, and never descends into subdirectories: directories are returned as entries of kind `dir` and must be browsed with a follow-up request. `size` and `modified_ms` are omitted for entries whose source reports neither, and `modified_ms` is milliseconds since the Unix epoch. There is no cursor: `truncated` only says that the source held more entries than the limit allowed, and the only way to see more is a larger `limit`, up to the cap, or a narrower `path`. An `http` connector has no listing protocol, so its entries are parsed out of the server's HTML directory index and a server that does not serve one fails with 502. A source error, a blocked address or an unparsable index all read as 502 and carry the source's own message; retry only when the source is expected to recover, since the same 502 also reports a configuration that can never work.",
+    description = r#"Lists one level below a path at the connector's source, using its stored credentials.
+
+**Authentication**: realm bearer token with READ on the group's data path.
+
+**Behavior**
+- The listing never descends into subdirectories: directories are returned as entries of kind `dir`
+  and must be browsed with a follow-up request.
+- `size` and `modified_ms` are omitted for entries whose source reports neither, and `modified_ms`
+  is milliseconds since the Unix epoch.
+- An object source that simply holds nothing below the path answers 200 with an empty list, while a
+  source that reports the path itself as gone is a 404.
+- An `http` connector has no listing protocol, so its entries are parsed out of the server's HTML
+  directory index and a server that does not serve one fails with 502.
+
+**Limits**
+- There is no cursor: `truncated` only says that the source held more entries than the limit
+  allowed, and the only way to see more is a larger `limit`, up to the cap, or a narrower `path`.
+
+**Errors**: a source error, a blocked address or an unparsable index all read as 502 and carry the
+source's own message; retry only when the source is expected to recover, since the same 502 also
+reports a configuration that can never work."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the connector, as a 26-character ULID"),
         ("connector_id" = String, Path, description = "Connector to browse, as a 26-character ULID"),
@@ -803,12 +959,12 @@ pub async fn check_stored_connector(
         ),
         (
             status = 404,
-            description = "No connector with that id is registered for this group on this node, or the source itself reported the path as gone; an object source that simply holds nothing below the path answers 200 with an empty list instead",
+            description = "No connector with that id on this node, or the source reported the path as gone",
             body = ErrorResponse
         ),
         (
             status = 502,
-            description = "The source refused the listing, was blocked by the egress policy, or returned something that is not a directory listing; the message repeats the source's reason and the request may be retried once the source recovers",
+            description = "The source refused the listing, was blocked, or returned no directory listing; the message repeats the source's reason",
             body = ErrorResponse
         )
     ),

--- a/api/src/routes/credentials.rs
+++ b/api/src/routes/credentials.rs
@@ -205,7 +205,23 @@ fn serialize_restrictions(restrictions: &[NormalizedRestriction]) -> Vec<PathRes
     path = "/users/credentials",
     tag = "credentials",
     summary = "List the caller's S3 credentials",
-    description = "Requires a realm bearer token that carries no path restrictions; a delegated token is refused with 403. Self-scoped: the response only ever contains credentials issued to the calling identity, and only those held by the node that serves the request, so a credential issued on another node of the realm is not listed here. Secret access keys are never returned by this operation; every entry carries the access key id, the group the credential is bound to, expiry and revocation timestamps as RFC 3339 UTC with second precision, the id of the issuing node, the effective path restrictions and the derived status active, expired or revoked. The listing is not paginated and covers at most 16 active credentials per user, ordered by access key id.",
+    description = r#"Lists the S3 credentials of the calling identity held by the node serving the request.
+
+**Authentication**: realm bearer token that carries no path restrictions; a delegated token is
+refused with 403.
+
+**Behavior**
+- Self-scoped: the response only ever contains credentials issued to the calling identity.
+- Only credentials held by the serving node are listed, so a credential issued on another node of
+  the realm does not appear here.
+- Secret access keys are never returned by this operation.
+- Every entry carries the access key id, the group the credential is bound to, expiry and
+  revocation timestamps as RFC 3339 UTC with second precision, the id of the issuing node, the
+  effective path restrictions and the derived status `active`, `expired` or `revoked`.
+
+**Limits**
+- The listing is not paginated and covers at most 16 active credentials per user, ordered by access
+  key id."#,
     responses(
         (
             status = 200,
@@ -266,15 +282,40 @@ pub async fn list_s3_credentials(
     path = "/users/credentials",
     tag = "credentials",
     summary = "Create an S3 credential for a group",
-    description = "Requires a realm bearer token and write access to the group's data path. Self-scoped: the credential is always issued to the calling identity, so no caller can mint a credential for another user. A path-restricted (delegated) token may be used; the issued credential inherits the caller's restrictions narrowed to the group data root and can never widen them, and every requested allow scope is authorized against the caller's own grant before it is written. The secret access key is returned once, in this response only: it is stored sealed and is not retrievable afterwards, so a caller that loses it has to create a new credential, and later listings show only the access key id. The credential is stored on the node that served the request and is accepted by that node's S3 endpoint. A user holds at most 16 active credentials; a further request is refused with 409 until one is revoked or expires.",
+    description = r#"Issues an S3 access key and a one-time secret bound to a group, for the calling identity.
+
+**Authentication**: realm bearer token with write access to the group's data path. A
+path-restricted (delegated) token may be used; the issued credential inherits the caller's
+restrictions narrowed to the group data root and can never widen them, and every requested allow
+scope is authorized against the caller's own grant before it is written.
+
+**Behavior**
+- Self-scoped: the credential is always issued to the calling identity, so no caller can mint a
+  credential for another user.
+- The secret access key is returned once, in this response only: it is stored sealed and is not
+  retrievable afterwards, so a caller that loses it has to create a new credential, and later
+  listings show only the access key id.
+- The credential is stored on the node that served the request and is accepted by that node's S3
+  endpoint.
+
+**Limits**
+- The optional lifetime is given in seconds between 60 and 31536000 and defaults to 31536000.
+- A restriction pattern is relative to the group data root or an absolute path inside it, may name
+  an exact path or a subtree with a trailing `/**`, and takes the permission `READ`, `WRITE` or
+  `DENY` case insensitively; at most 50 restrictions are accepted.
+- A user holds at most 16 active credentials; a further request is refused with 409 until one is
+  revoked or expires."#,
     request_body(
         content = CreateS3CredentialsRequest,
-        description = "Group the credential is bound to, an optional lifetime in seconds between 60 and 31536000 that defaults to 31536000, and optional path restrictions. A restriction pattern is relative to the group data root or an absolute path inside it, may name an exact path or a subtree with a trailing /**, and takes the permission READ, WRITE or DENY case insensitively; at most 50 restrictions are accepted.",
+        description = "Group the credential is bound to, an optional lifetime in seconds, and optional path restrictions",
         example = json!({
             "group_id": "01JGRP00123456789ABCDEFGHJ",
             "expires_in_seconds": 86400,
             "path_restrictions": [
-                {"pattern": "shared/**", "permission": "READ"}
+                {
+                    "pattern": "shared/**",
+                    "permission": "READ"
+                }
             ]
         })
     ),
@@ -367,7 +408,19 @@ pub async fn create_s3_credentials(
     path = "/users/credentials/{access_key_id}",
     tag = "credentials",
     summary = "Revoke an S3 credential",
-    description = "Requires a realm bearer token that carries no path restrictions; a delegated token is refused with 403. A caller may always revoke a credential issued to their own identity; revoking another user's credential additionally requires write access on that user's realm administration path, so write access to the group the credential is bound to is deliberately not enough. Only credentials held by the node that serves the request can be revoked here, and an access key unknown to this node is answered with 404. The record is not deleted: it keeps appearing in the caller's listing with a revocation timestamp and the revoked status, and the node stops accepting the key for new S3 requests.",
+    description = r#"Revokes an S3 credential held by the node serving the request.
+
+**Authentication**: realm bearer token that carries no path restrictions; a delegated token is
+refused with 403. A caller may always revoke a credential issued to their own identity; revoking
+another user's credential additionally requires write access on that user's realm administration
+path, so write access to the group the credential is bound to is deliberately not enough.
+
+**Behavior**
+- Only credentials held by the node that serves the request can be revoked here, and an access key
+  unknown to this node is answered with 404.
+- The record is not deleted: it keeps appearing in the caller's listing with a revocation timestamp
+  and the `revoked` status.
+- The node stops accepting the key for new S3 requests."#,
     params(("access_key_id" = String, Path, description = "Access key id of the credential to revoke, a ULID as returned when the credential was created or listed")),
     responses(
         (status = 204, description = "Credential revoked; the response carries no body"),

--- a/api/src/routes/credentials/sessions.rs
+++ b/api/src/routes/credentials/sessions.rs
@@ -66,26 +66,49 @@ pub struct S3SessionResponse {
     post,
     path = "/users/s3-sessions",
     tag = "credentials",
-    summary = "Exchange a bearer token for a short-lived S3 session",
-    description = "Requires a bearer token issued for this realm, explicit membership in the requested group, and WRITE capability under the effective bearer restrictions on that group's node-local data path. The group is always taken from group_id and is never inferred from membership order. The returned access key, signing secret, and session token are accepted only by the issuing node; expiry is the earlier of one hour from issuance and the current bearer expiry. Sessions are stored outside the long-lived credential list and limit.",
+    summary = "Exchange a bearer token for an S3 session",
+    description = r#"Issues a short-lived, node-local S3 session for an explicitly selected group.
+
+**Authentication**: bearer token issued for this realm, explicit membership in the requested group,
+and WRITE capability under the effective bearer restrictions on that group's node-local data path.
+
+**Behavior**
+- The group is always taken from `group_id` and is never inferred from membership order.
+- The returned access key, signing secret and session token are accepted only by the issuing node.
+- Expiry is the earlier of one hour from issuance and the current bearer expiry.
+- Sessions are stored outside the long-lived credential list and limit."#,
     request_body(
         content = CreateS3SessionRequest,
         description = "The explicitly selected group; group_id is required.",
-        example = json!({"group_id": "01JGRP00123456789ABCDEFGHJ"})
+        example = json!({
+            "group_id": "01JGRP00123456789ABCDEFGHJ"
+        })
     ),
     responses(
-        (status = 201, description = "A new node-local temporary S3 session; the secret and token are shown redacted here and are returned in full to the caller", body = S3SessionResponse, example = json!({
-            "access_key_id": "ARUNASESSION0123456789AB",
-            "secret_access_key": "<redacted>",
-            "session_token": "<redacted>",
-            "expires_at": "2026-04-09T12:00:00Z",
-            "group": {"id": "01JGRP00123456789ABCDEFGHJ"},
-            "restrictions": [{"pattern": "/realm/group/*", "permission": "WRITE"}],
-            "issuer_node": {
-                "node_id": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
-                "s3_endpoint": "https://s3.example.org"
-            }
-        })),
+        (
+            status = 201,
+            description = "A new node-local temporary S3 session; the secret and token are redacted here and returned in full to the caller",
+            body = S3SessionResponse,
+            example = json!({
+                "access_key_id": "ARUNASESSION0123456789AB",
+                "secret_access_key": "<redacted>",
+                "session_token": "<redacted>",
+                "expires_at": "2026-04-09T12:00:00Z",
+                "group": {
+                    "id": "01JGRP00123456789ABCDEFGHJ"
+                },
+                "restrictions": [
+                    {
+                        "pattern": "/realm/group/*",
+                        "permission": "WRITE"
+                    }
+                ],
+                "issuer_node": {
+                    "node_id": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
+                    "s3_endpoint": "https://s3.example.org"
+                }
+            })
+        ),
         (status = 400, description = "group_id is not a ULID", body = ErrorResponse),
         (status = 401, description = "The bearer token is absent, invalid, expired, or has no remaining lifetime", body = ErrorResponse),
         (status = 403, description = "The caller is not a group member or lacks effective WRITE capability", body = ErrorResponse),
@@ -132,22 +155,44 @@ pub async fn create_s3_session(
     post,
     path = "/users/s3-sessions/{access_key_id}/refresh",
     tag = "credentials",
-    summary = "Rotate an active S3 session in its refresh window",
+    summary = "Rotate an active S3 session",
+    description = r#"Rotates the secret and session token of an active S3 session inside its refresh window.
+
+**Authentication**: the owning bearer identity must remain a member of the session's group with
+effective WRITE capability.
+
+**Behavior**
+- Refresh is accepted at or after five minutes before expiry, and only when this session has
+  completed an authenticated S3 request since its last issuance.
+- It keeps the access key id, rotates the signing secret and session token in place, and resets
+  activity for the next cycle.
+- The new expiry is capped by the current bearer."#,
     params(("access_key_id" = String, Path, description = "Temporary access key returned by the session exchange")),
-    description = "Requires the owning bearer identity to remain a member with effective WRITE capability. Refresh is accepted at or after five minutes before expiry only when this session has completed an authenticated S3 request since its last issuance. It keeps the access key id, rotates the signing secret and session token in place, resets activity for the next cycle, and caps the new expiry by the current bearer.",
     responses(
-        (status = 200, description = "The same session id with rotated temporary secret and token, shown redacted here", body = S3SessionResponse, example = json!({
-            "access_key_id": "ARUNASESSION0123456789AB",
-            "secret_access_key": "<redacted>",
-            "session_token": "<redacted>",
-            "expires_at": "2026-04-09T12:00:00Z",
-            "group": {"id": "01JGRP00123456789ABCDEFGHJ"},
-            "restrictions": [{"pattern": "/realm/group/*", "permission": "WRITE"}],
-            "issuer_node": {
-                "node_id": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
-                "s3_endpoint": "https://s3.example.org"
-            }
-        })),
+        (
+            status = 200,
+            description = "The same session id with rotated temporary secret and token, redacted here",
+            body = S3SessionResponse,
+            example = json!({
+                "access_key_id": "ARUNASESSION0123456789AB",
+                "secret_access_key": "<redacted>",
+                "session_token": "<redacted>",
+                "expires_at": "2026-04-09T12:00:00Z",
+                "group": {
+                    "id": "01JGRP00123456789ABCDEFGHJ"
+                },
+                "restrictions": [
+                    {
+                        "pattern": "/realm/group/*",
+                        "permission": "WRITE"
+                    }
+                ],
+                "issuer_node": {
+                    "node_id": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
+                    "s3_endpoint": "https://s3.example.org"
+                }
+            })
+        ),
         (status = 401, description = "The bearer token is absent, invalid, expired, or has no remaining lifetime", body = ErrorResponse),
         (status = 403, description = "The caller is no longer a group member or lacks effective WRITE capability", body = ErrorResponse),
         (status = 404, description = "The session is absent, purged, foreign, or belongs to another user", body = ErrorResponse),

--- a/api/src/routes/drs.rs
+++ b/api/src/routes/drs.rs
@@ -228,7 +228,17 @@ enum ResolveOutcome {
     path = "/ga4gh/drs/v1/service-info",
     tag = "drs",
     summary = "Describe this node's GA4GH DRS service",
-    description = "Deliberately public: the GA4GH service-info document is served without authentication and a bearer token changes nothing. Answered from this node alone, with no lookup and no network call, so it is always current for the node that received the request. `id` and `name` are derived from the realm this node serves, `type` reports the GA4GH `org.ga4gh`/`drs` service type with this node's software version, and `organization.url` is the externally visible base URL of the node, taken from the forwarded scheme and host when the request came through a trusted proxy and from the `Host` header otherwise.",
+    description = r#"Serves the GA4GH service-info document for this node.
+
+**Authentication**: none; the route is deliberately public and a bearer token changes nothing.
+
+**Behavior**
+- Answered from this node alone, with no lookup and no network call, so it is always current for
+  the node that received the request.
+- `id` and `name` are derived from the realm this node serves, and `type` reports the GA4GH
+  `org.ga4gh`/`drs` service type with this node's software version.
+- `organization.url` is the externally visible base URL of the node, taken from the forwarded scheme
+  and host when the request came through a trusted proxy and from the `Host` header otherwise."#,
     responses((
         status = 200,
         description = "GA4GH service-info document for this node",
@@ -236,8 +246,15 @@ enum ResolveOutcome {
         example = json!({
             "id": "org.aruna.9xC3nQ2vRk5tYbW0aZ7pLmJ4hS6dF8gT1uV3wX5yZ2c",
             "name": "Aruna Realm 9xC3nQ2vRk5tYbW0aZ7pLmJ4hS6dF8gT1uV3wX5yZ2c",
-            "type": {"group": "org.ga4gh", "artifact": "drs", "version": "3.0.0-alpha.41"},
-            "organization": {"name": "Aruna", "url": "https://node.example.test"},
+            "type": {
+                "group": "org.ga4gh",
+                "artifact": "drs",
+                "version": "3.0.0-alpha.41"
+            },
+            "organization": {
+                "name": "Aruna",
+                "url": "https://node.example.test"
+            },
             "environment": "dev",
             "documentation_url": "https://docs.aruna-engine.org"
         })
@@ -273,9 +290,21 @@ pub async fn get_service_info(
     options,
     path = "/ga4gh/drs/v1/objects/{object_id}",
     tag = "drs",
-    summary = "Report the authentication schemes accepted for a DRS object",
-    description = "Deliberately public and never resolves the object: the identifier is echoed back unparsed, so this operation can neither confirm nor deny that an object exists and answers the same for every caller. `supported_types` is always `[BearerAuth]`; GA4GH passports are not accepted, so `passport_auth_issuers` is always empty. `bearer_auth_issuers` lists the OIDC issuers this node currently trusts, and is empty when no OIDC validator is configured or it cannot be reached. A browser CORS preflight on this path is answered by the CORS layer, when one is configured, and never reaches this operation.",
-    params(("object_id" = String, Path, description = "Aruna data W3ID, content-hash ch ARN, or versioned s3 ARN locator, in the same three forms the object lookup accepts; it is echoed back verbatim and is not validated here")),
+    summary = "Report the authentication schemes for a DRS object",
+    description = r#"Reports the authentication schemes and bearer issuers this node accepts for DRS content.
+
+**Authentication**: none; the route is deliberately public and answers the same for every caller.
+
+**Behavior**
+- The object is never resolved: the identifier is echoed back unparsed, so this operation can
+  neither confirm nor deny that an object exists.
+- `supported_types` is always `[BearerAuth]`; GA4GH passports are not accepted, so
+  `passport_auth_issuers` is always empty.
+- `bearer_auth_issuers` lists the OIDC issuers this node currently trusts, and is empty when no
+  OIDC validator is configured or it cannot be reached.
+- A browser CORS preflight on this path is answered by the CORS layer, when one is configured, and
+  never reaches this operation."#,
+    params(("object_id" = String, Path, description = "Aruna data W3ID, content-hash `ch` ARN, or versioned `s3` ARN locator; echoed back verbatim and not validated here")),
     responses(
         (status = 200, description = "Authentication schemes and bearer issuers this node accepts for DRS content", body = DrsAuthorizationsResponse, example = json!({
             "drs_object_id": "https://w3id.org/aruna/data/000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
@@ -312,8 +341,43 @@ pub async fn get_authorizations(
     path = "/ga4gh/drs/v1/objects/{object_id}",
     tag = "drs",
     summary = "Resolve a DRS object by identifier",
-    description = "Authentication is optional and changes the result: an anonymous caller only resolves objects readable by the public role. A request without a bearer token, or with one this node cannot validate, is treated as anonymous rather than rejected, and READ is then evaluated for the Everyone principal. An identifier naming another realm answers 404 without any lookup. A versioned identifier naming another node of this realm is probed at that node, which alone establishes absence: within one bounded probe budget the answer is its own 404, 403 or the object's metadata, and anything short of an answer is a retryable 503 rather than a 404. Only the owning node serves the bytes, so a routed answer advertises no access method. A caller that presented a token but lacks READ gets 403, while an anonymous caller in the same position gets the same 404 as for a missing object, so existence is never revealed to an unauthenticated caller. A content-hash identifier is resolved against every object on this node carrying that content and the first one the caller may read is returned, so the same digest can resolve differently for different callers. The response carries the requested identifier in `id`, the canonical W3ID in `aliases` when the request used a different form, the stored checksums including the blake3 content digest in a stable order, and, for an object held here, a single `https` access method whose `access_url.url` is a direct download URL on this node; no redirect is issued and no signed or time-limited URL is minted, so the caller must send its own bearer token to that URL. `contents` is always null because bundles are not served.",
-    params(("object_id" = String, Path, description = "Aruna data W3ID, content-hash ch ARN, or versioned s3 ARN locator: `https://w3id.org/aruna/data/{blake3-hex}`, `https://w3id.org/aruna/data/{versioned-s3-arn}`, `arn:aruna:{realm_id}:{node_id}:ch/{blake3-hex}` with 64 lowercase hex characters, or `arn:aruna:{realm_id}:{node_id}:s3/{bucket}/{key}@{version-ulid}` whose key is percent-encoded except for the separating slashes. Identifiers contain slashes, so the whole remainder of the path is taken as the identifier")),
+    description = r#"Resolves one DRS identifier to the object's metadata and access method.
+
+**Authentication**: optional, and it changes the result: an anonymous caller only resolves objects
+readable by the public role. A request without a bearer token, or with one this node cannot
+validate, is treated as anonymous rather than rejected, and READ is then evaluated for the Everyone
+principal.
+
+**Behavior**
+- An identifier naming another realm answers 404 without any lookup.
+- A versioned identifier naming another node of this realm is probed at that node, which alone
+  establishes absence: within one bounded probe budget the answer is its own 404, 403 or the
+  object's metadata.
+- Only the owning node serves the bytes, so a routed answer advertises no access method.
+- A content-hash identifier is resolved against every object on this node carrying that content and
+  the first one the caller may read is returned, so the same digest can resolve differently for
+  different callers.
+- The response carries the requested identifier in `id`, the canonical W3ID in `aliases` when the
+  request used a different form, and the stored checksums including the blake3 content digest in a
+  stable order.
+- For an object held here it carries a single `https` access method whose `access_url.url` is a
+  direct download URL on this node; no redirect is issued and no signed or time-limited URL is
+  minted, so the caller must send its own bearer token to that URL.
+- `contents` is always null because bundles are not served.
+
+**Limits**
+- The identifier is an Aruna data W3ID, a content-hash `ch` ARN or a versioned `s3` ARN:
+  `https://w3id.org/aruna/data/{blake3-hex}`, `https://w3id.org/aruna/data/{versioned-s3-arn}`,
+  `arn:aruna:{realm_id}:{node_id}:ch/{blake3-hex}` with 64 lowercase hex characters, or
+  `arn:aruna:{realm_id}:{node_id}:s3/{bucket}/{key}@{version-ulid}` whose key is percent-encoded
+  except for the separating slashes.
+- Identifiers contain slashes, so the whole remainder of the path is taken as the identifier.
+
+**Errors**: a caller that presented a token but lacks READ gets 403, while an anonymous caller in
+the same position gets the same 404 as for a missing object, so existence is never revealed to an
+unauthenticated caller. A probed owner that answers nothing inside the budget is a retryable 503
+rather than a 404."#,
+    params(("object_id" = String, Path, description = "Aruna data W3ID, content-hash `ch` ARN, or versioned `s3` ARN locator; the whole remainder of the path is taken as the identifier")),
     responses(
         (status = 200, description = "The resolved DRS object, as visible to this caller", body = DrsObjectResponse, example = json!({
             "id": "https://w3id.org/aruna/data/000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
@@ -322,8 +386,14 @@ pub async fn get_authorizations(
             "description": null,
             "size": 10485760,
             "checksums": [
-                {"type": "blake3", "checksum": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"},
-                {"type": "sha256", "checksum": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}
+                {
+                    "type": "blake3",
+                    "checksum": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+                },
+                {
+                    "type": "sha256",
+                    "checksum": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                }
             ],
             "mime_type": "application/octet-stream",
             "aliases": [],
@@ -377,7 +447,33 @@ pub async fn get_object(
     path = "/ga4gh/drs/v1/objects",
     tag = "drs",
     summary = "Resolve several DRS objects in one request",
-    description = "Authentication is optional and changes the result: an anonymous caller only resolves objects readable by the public role. Each identifier is resolved and authorized exactly as the single-object lookup does, so a batch is a convenience and not a transaction. At most 100 identifiers may be named and a longer list is rejected with 400 before anything is resolved. Identifiers owned by other nodes are probed concurrently against one budget for the whole request, so a batch costs no more wall time than a single lookup; an identifier whose owner did not answer inside that budget appears as a per-item 503, never as an absence. The request itself succeeds with 200 whenever the body parses and stays inside the cap: per-identifier failures are reported inside the matching entry as `{status_code, msg}` instead of failing the batch, an unreadable object appears as 403 for a token-bearing caller and as 404 for an anonymous one, and an object that could not be serialized appears as 500. Entries are returned in the order the identifiers were given, one entry per identifier, including duplicates.",
+    description = r#"Resolves a list of DRS identifiers in one request, one entry per identifier.
+
+**Authentication**: optional, and it changes the result: an anonymous caller only resolves objects
+readable by the public role, exactly as in the single-object lookup.
+
+**Behavior**
+- Each identifier is resolved and authorized exactly as the single-object lookup does, so a batch
+  is a convenience and not a transaction.
+- Identifiers owned by other nodes are probed concurrently against one budget for the whole
+  request, so a batch costs no more wall time than a single lookup.
+- The request itself succeeds with 200 whenever the body parses and stays inside the cap:
+  per-identifier failures are reported inside the matching entry as `{status_code, msg}` instead of
+  failing the batch.
+- Entries are returned in the order the identifiers were given, one entry per identifier, including
+  duplicates.
+
+**Limits**
+- At most 100 identifiers may be named, and a longer list is rejected with 400 before anything is
+  resolved.
+
+**Errors**
+- An identifier whose owner did not answer inside the budget appears as a per-item 503, never as an
+  absence.
+- An unreadable object appears as 403 for a token-bearing caller and as 404 for an anonymous one,
+  and an object that could not be serialized appears as 500.
+- A body that is not valid JSON for a list of identifiers is rejected by the body extractor and
+  returned as plain text rather than the declared payload."#,
     request_body(
         content = DrsBulkObjectsRequestBody,
         description = "The DRS identifiers to resolve, in any of the forms the single-object lookup accepts",
@@ -399,7 +495,12 @@ pub async fn get_object(
                         "name": "content-000102030405",
                         "description": null,
                         "size": 10485760,
-                        "checksums": [{"type": "blake3", "checksum": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"}],
+                        "checksums": [
+                            {
+                                "type": "blake3",
+                                "checksum": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+                            }
+                        ],
                         "mime_type": "application/octet-stream",
                         "aliases": [],
                         "access_methods": [
@@ -418,11 +519,14 @@ pub async fn get_object(
                 },
                 {
                     "object_id": "arn:aruna:9xC3nQ2vRk5tYbW0aZ7pLmJ4hS6dF8gT1uV3wX5yZ2c:1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978:s3/reads/run-42/sample.fastq.gz@01JABCDEF0123456789ABCDEFG",
-                    "result": {"status_code": 404, "msg": "DRS object not found"}
+                    "result": {
+                        "status_code": 404,
+                        "msg": "DRS object not found"
+                    }
                 }
             ]
         })),
-        (status = 400, description = "More than 100 identifiers were named, or the request body is not valid JSON for a list of identifiers; the malformed-body rejection comes from the body extractor and is returned as plain text rather than the declared payload", body = DrsErrorPayload)
+        (status = 400, description = "More than 100 identifiers were named, or the request body is not valid JSON for a list of identifiers", body = DrsErrorPayload)
     ),
     security((), ("bearer_auth" = []))
 )]
@@ -511,8 +615,34 @@ fn download_error(error: GetObjectError) -> Response {
     path = "/ga4gh/drs/v1/download",
     tag = "drs",
     summary = "Download the bytes of a DRS object",
-    description = "Authentication is optional and changes the result: an anonymous caller only downloads objects readable by the public role. This is the URL advertised as the object's `https` access method; it streams the bytes itself and never redirects, so a client follows no `Location` and needs no signed URL, only its own bearer token. The identifier is resolved and authorized exactly as the object lookup does, and every denial an anonymous caller could observe is reported as 404 so that existence stays hidden; an authenticated caller without READ gets 403. Only the owning node serves bytes: an identifier that resolves at another node of the realm is answered 501, because this node holds the metadata but not the object. On success the response is 200 with the raw bytes and a `Content-Length` taken from the stored object; no content type is asserted and range requests are not supported. Each transfer takes one node-wide download slot and one per-caller slot, keyed by user for an authenticated caller and by client address for an anonymous one; when a slot cannot be taken the download is refused rather than queued and the caller may retry later. A transfer that stalls for 20 seconds, or that is still running after 30 minutes, is cut mid-body: the 200 has already been sent, so a client must treat a body shorter than `Content-Length` as a failed download and retry.",
-    params(("object_id" = String, Query, description = "Aruna data W3ID, content-hash ch ARN, or versioned s3 ARN locator, in the same three forms the object lookup accepts, given as a single query parameter and URL-encoded because these identifiers contain `:` and `/`")),
+    description = r#"Streams the bytes of a DRS object from the node that owns it.
+
+**Authentication**: optional, and it changes the result: an anonymous caller only downloads objects
+readable by the public role. The identifier is resolved and authorized exactly as the object lookup
+does.
+
+**Behavior**
+- This is the URL advertised as the object's `https` access method; it streams the bytes itself and
+  never redirects, so a client follows no `Location` and needs no signed URL, only its own bearer
+  token.
+- Only the owning node serves bytes: an identifier that resolves at another node of the realm is
+  answered 501, because this node holds the metadata but not the object.
+- On success the response is 200 with the raw bytes and a `Content-Length` taken from the stored
+  object; no content type is asserted and range requests are not supported.
+- Each transfer takes one node-wide download slot and one per-caller slot, keyed by user for an
+  authenticated caller and by client address for an anonymous one; when a slot cannot be taken the
+  download is refused rather than queued and the caller may retry later.
+
+**Limits**
+- `object_id` takes the same three forms the object lookup accepts, given as a single query
+  parameter.
+- A transfer that stalls for 20 seconds, or that is still running after 30 minutes, is cut
+  mid-body: the 200 has already been sent, so a client must treat a body shorter than
+  `Content-Length` as a failed download and retry.
+
+**Errors**: every denial an anonymous caller could observe is reported as 404 so that existence
+stays hidden, while an authenticated caller without READ gets 403."#,
+    params(("object_id" = String, Query, description = "Aruna data W3ID, content-hash `ch` ARN, or versioned `s3` ARN locator, URL-encoded because these identifiers contain `:` and `/`")),
     responses(
         (status = 200, description = "Object bytes, streamed inline with a `Content-Length` header and no content type"),
         (status = 400, description = "The identifier is not one of the accepted forms, or its content hash, key encoding or version is malformed", body = DrsErrorPayload),

--- a/api/src/routes/group_backends.rs
+++ b/api/src/routes/group_backends.rs
@@ -185,7 +185,42 @@ async fn admin_of_group(
     path = "/groups/{group_id}/storage-backends",
     tag = "storage-backends",
     summary = "Register a storage backend for a group",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's administrative path: a backend receives the group's data, so group write rights are deliberately not enough, and a caller who is not a group administrator, as well as a caller naming a group that does not exist, receives 403. `secret_config` is write-only: the credentials are stored apart from the record, are never returned by any endpoint, and no response field reports whether they are set. `kind` is one of `s3`, `gcs`, `azblob`, `azdls` and `b2`, matched case-insensitively; source-only kinds such as WebDAV are not write backends and are refused. Config keys are a closed allowlist per kind, are lowercased before matching and may not be given twice: `s3` requires `endpoint` and `bucket`, also accepts `region`, `root` and `force_path_style`, and requires the secrets `access_key_id` and `secret_access_key`; `gcs` requires `bucket`, also accepts `root` and `endpoint`, and requires the secret `credential`; `azblob` requires `endpoint`, `container` and `account_name` and `azdls` requires `endpoint`, `filesystem` and `account_name`, both accepting `root` and both requiring either `account_key` or `sas_token`; `b2` requires `bucket` and `bucket_id` and the secrets `application_key_id` and `application_key`. An endpoint must be an `https` URL spelled the way the HTTP client parses it, and `root` must be a relative path that stays below itself. Before anything is stored, the node proves the credentials by writing a probe object to the backend and deleting it again, so delete rights are required and not just write rights; if the probe fails, nothing is registered and the failure is reported as 400 with the reason, including when the real cause is the remote store being unreachable rather than the request being wrong. `cleanup` defaults to `retain`, which never reclaims tenant storage. The backend is registered enabled, and its record lives on the node that serves the request rather than being replicated to the realm's other nodes.",
+    description = r#"Registers a write backend on the group's own object storage after proving its credentials.
+
+**Authentication**: bearer token issued for this realm with WRITE on the group's administrative
+path. A backend receives the group's data, so group write rights are deliberately not enough: a
+caller who is not a group administrator, as well as a caller naming a group that does not exist,
+receives 403.
+
+**Behavior**
+- Before anything is stored the node proves the credentials by writing a probe object to the
+  backend and deleting it again, so delete rights are required and not just write rights.
+- A failed probe registers nothing.
+- `secret_config` is write-only: the credentials are stored apart from the record, are never
+  returned by any endpoint, and no response field reports whether they are set.
+- `cleanup` defaults to `retain`, which never reclaims tenant storage.
+- The backend is registered enabled, and its record lives on the node that serves the request
+  rather than being replicated to the realm's other nodes.
+
+**Limits**
+- `kind` is one of `s3`, `gcs`, `azblob`, `azdls` and `b2`, matched case-insensitively;
+  source-only kinds such as WebDAV are not write backends and are refused.
+- Config keys are a closed allowlist per kind, are lowercased before matching and may not be
+  given twice.
+- `s3` requires `endpoint` and `bucket`, also accepts `region`, `root` and `force_path_style`, and
+  requires the secrets `access_key_id` and `secret_access_key`.
+- `gcs` requires `bucket`, also accepts `root` and `endpoint`, and requires the secret
+  `credential`.
+- `azblob` requires `endpoint`, `container` and `account_name`, `azdls` requires `endpoint`,
+  `filesystem` and `account_name`; both accept `root` and both require either `account_key` or
+  `sas_token`.
+- `b2` requires `bucket` and `bucket_id` and the secrets `application_key_id` and
+  `application_key`.
+- An endpoint must be an `https` URL spelled the way the HTTP client parses it, and `root` must be
+  a relative path that stays below itself.
+
+**Errors**: a failed probe is reported as 400 with the reason, including when the real cause is the
+remote store being unreachable rather than the request being wrong."#,
     params(("group_id" = String, Path, description = "Group that will own the backend, as a 26-character ULID")),
     request_body(
         content = CreateGroupBackendRequest,
@@ -203,7 +238,10 @@ async fn admin_of_group(
                 "access_key_id": "EXAMPLE-KEY-ID-PLACEHOLDER",
                 "secret_access_key": "EXAMPLE-SECRET-PLACEHOLDER"
             },
-            "cleanup": {"mode": "reclaim", "after_secs": 86400}
+            "cleanup": {
+                "mode": "reclaim",
+                "after_secs": 86400
+            }
         })
     ),
     responses(
@@ -223,12 +261,15 @@ async fn admin_of_group(
                     "root": "aruna/"
                 },
                 "disabled": false,
-                "cleanup": {"mode": "reclaim", "after_secs": 86400}
+                "cleanup": {
+                    "mode": "reclaim",
+                    "after_secs": 86400
+                }
             })
         ),
         (
             status = 400,
-            description = "The group id is not a ULID, the kind is unknown, the configuration failed validation, the cleanup policy is not `retain` or `reclaim` with a positive `after_secs`, or the probe against the endpoint failed",
+            description = "Invalid group id, unknown kind, rejected configuration or cleanup policy, or a failed endpoint probe",
             body = ErrorResponse
         ),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
@@ -274,7 +315,20 @@ pub async fn create_group_backend(
     path = "/groups/{group_id}/storage-backends",
     tag = "storage-backends",
     summary = "List a group's storage backends",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's administrative path, the same group administrator right that registration takes; a caller without it, and a caller naming a group that does not exist, receives 403. Returns every backend registered for the group on this node, disabled ones included, ordered by backend id and therefore by registration time, in a single response without paging or a cursor. Credentials are never included and no field states whether any are stored. A `disabled` backend still appears and still serves reads of the copies it already holds; only new writes are refused. This is the node's own view: a backend registered against another node of the realm is not listed here.",
+    description = r#"Lists every storage backend the group has registered on this node.
+
+**Authentication**: bearer token issued for this realm with WRITE on the group's administrative
+path, the same group administrator right that registration takes; a caller without it, and a
+caller naming a group that does not exist, receives 403.
+
+**Behavior**
+- Disabled backends are included, ordered by backend id and therefore by registration time, in a
+  single response without paging or a cursor.
+- Credentials are never included and no field states whether any are stored.
+- A `disabled` backend still appears and still serves reads of the copies it already holds; only
+  new writes are refused.
+- This is the node's own view: a backend registered against another node of the realm is not
+  listed here."#,
     params(("group_id" = String, Path, description = "Group whose backends are listed, as a 26-character ULID")),
     responses(
         (
@@ -294,7 +348,9 @@ pub async fn create_group_backend(
                             "root": "aruna/"
                         },
                         "disabled": false,
-                        "cleanup": {"mode": "retain"}
+                        "cleanup": {
+                            "mode": "retain"
+                        }
                     }
                 ]
             })
@@ -330,7 +386,18 @@ pub async fn list_group_backends(
     path = "/groups/{group_id}/storage-backends/{backend_id}",
     tag = "storage-backends",
     summary = "Read one registered storage backend",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's administrative path. The record is fetched by backend id and then checked against the group in the path, so a backend belonging to a different group reads as not found rather than as forbidden. Returns the name, kind, public configuration, the `disabled` flag and the cleanup policy as stored on this node; the credentials are never returned and no field reports whether they are set.",
+    description = r#"Returns one storage backend registration as stored on this node.
+
+**Authentication**: bearer token issued for this realm with WRITE on the group's administrative
+path.
+
+**Behavior**
+- Returns the name, kind, public configuration, the `disabled` flag and the cleanup policy as
+  stored on this node.
+- The credentials are never returned and no field reports whether they are set.
+
+**Errors**: the record is fetched by backend id and then checked against the group in the path, so
+a backend belonging to a different group reads as not found rather than as forbidden."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the backend, as a 26-character ULID"),
         ("backend_id" = String, Path, description = "Backend to read, as a 26-character ULID")
@@ -395,8 +462,31 @@ pub async fn get_group_backend(
     put,
     path = "/groups/{group_id}/storage-backends/{backend_id}",
     tag = "storage-backends",
-    summary = "Replace a storage backend's credentials, name and cleanup policy",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's administrative path. This is a full replacement of the record, so every field must be sent again, including the credentials: they are replaced wholesale and are not carried over from the stored ones. The physical store is immutable, because stored copies record only the path below the backend's root: the kind and the keys that name the store, that is `endpoint`, `bucket`, `container`, `filesystem`, `account_name`, `bucket_id` and `root` as they apply to the kind, must be repeated exactly as registered, otherwise the request is refused with 400 and a new backend has to be registered instead. Everything else may change: the name, the remaining public keys, the credentials and the cleanup policy, which falls back to `retain` when `cleanup` is omitted rather than keeping the stored one. The `disabled` flag is preserved, and a replacement is deliberately allowed while the backend is disabled so a leaked credential can be rotated without opening the backend for writes first. The new credentials are proved with the same write-and-delete probe as registration before the record is updated, and a failed probe leaves the stored record untouched and is reported as 400 even when the cause is the store being unreachable.",
+    summary = "Replace a storage backend registration",
+    description = r#"Replaces a backend record whole, credentials included, after proving the new credentials.
+
+**Authentication**: bearer token issued for this realm with WRITE on the group's administrative
+path.
+
+**Behavior**
+- Every field must be sent again, including the credentials: they are replaced wholesale and are
+  not carried over from the stored ones.
+- The name, the remaining public keys, the credentials and the cleanup policy may change; an
+  omitted `cleanup` falls back to `retain` rather than keeping the stored one.
+- The `disabled` flag is preserved, and a replacement is deliberately allowed while the backend is
+  disabled so a leaked credential can be rotated without opening the backend for writes first.
+- The new credentials are proved with the same write-and-delete probe as registration before the
+  record is updated, and a failed probe leaves the stored record untouched.
+
+**Limits**
+- The physical store is immutable, because stored copies record only the path below the backend's
+  root.
+- The kind and the keys that name the store, that is `endpoint`, `bucket`, `container`,
+  `filesystem`, `account_name`, `bucket_id` and `root` as they apply to the kind, must be repeated
+  exactly as registered; to move the data a new backend has to be registered instead.
+
+**Errors**: a request that would move the backend to another store is refused with 400, as is a
+failed probe, even when the cause is the store being unreachable."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the backend, as a 26-character ULID"),
         ("backend_id" = String, Path, description = "Backend to replace, as a 26-character ULID")
@@ -417,7 +507,9 @@ pub async fn get_group_backend(
                 "access_key_id": "EXAMPLE-ROTATED-KEY-ID-PLACEHOLDER",
                 "secret_access_key": "EXAMPLE-ROTATED-SECRET-PLACEHOLDER"
             },
-            "cleanup": {"mode": "retain"}
+            "cleanup": {
+                "mode": "retain"
+            }
         })
     ),
     responses(
@@ -437,7 +529,9 @@ pub async fn get_group_backend(
                     "root": "aruna/"
                 },
                 "disabled": false,
-                "cleanup": {"mode": "retain"}
+                "cleanup": {
+                    "mode": "retain"
+                }
             })
         ),
         (
@@ -497,7 +591,26 @@ pub async fn replace_group_backend(
     path = "/groups/{group_id}/storage-backends/{backend_id}",
     tag = "storage-backends",
     summary = "Disable a group's storage backend",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's administrative path. Despite the method this deletes neither the data nor the registration: it marks the backend disabled, and that is all a 204 promises. After it, write routing no longer chooses the backend, and a writer that resolved the backend just before the call is fenced by the same record and loses its commit rather than landing bytes afterwards; reads of the copies already on the backend keep working, and the record stays visible in the listing with `disabled` set. Disabling a backend that is already disabled commits nothing and still answers 204, so the call may be repeated. What follows depends on the cleanup policy: under `retain` the copies and the registration stay indefinitely; under `reclaim` unreferenced copies are queued and physically deleted once their grace has passed, and when the backend finally holds nothing and nothing holds it, a background sweep on this node deletes the record together with its credentials, after which the id reads as not found. Until that happens the backend can be enabled again, and its progress can be followed through the reclaim status of the same backend.",
+    description = r#"Marks a group's storage backend disabled for new writes.
+
+**Authentication**: bearer token issued for this realm with WRITE on the group's administrative
+path.
+
+**Behavior**
+- Despite the method this deletes neither the data nor the registration: it marks the backend
+  disabled, and that is all a 204 promises.
+- Write routing no longer chooses the backend, and a writer that resolved it just before the call
+  is fenced by the same record and loses its commit rather than landing bytes afterwards.
+- Reads of the copies already on the backend keep working, and the record stays visible in the
+  listing with `disabled` set.
+- Disabling a backend that is already disabled commits nothing and still answers 204, so the call
+  may be repeated.
+- Under `retain` the copies and the registration stay indefinitely.
+- Under `reclaim` unreferenced copies are queued and physically deleted once their grace has
+  passed; when the backend finally holds nothing and nothing holds it, a background sweep on this
+  node deletes the record together with its credentials, after which the id reads as not found.
+- Until that happens the backend can be enabled again, and its progress can be followed through
+  the reclaim status of the same backend."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the backend, as a 26-character ULID"),
         ("backend_id" = String, Path, description = "Backend to disable, as a 26-character ULID")
@@ -541,7 +654,22 @@ pub async fn delete_group_backend(
     path = "/groups/{group_id}/storage-backends/{backend_id}/enable",
     tag = "storage-backends",
     summary = "Re-enable a disabled storage backend",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's administrative path. Clears the `disabled` flag, so write routing may choose the backend again and the sweep that removes drained backends no longer considers it. Enabling a backend that is already enabled commits nothing and returns the stored record unchanged, so the call may be repeated. Nothing is contacted: unlike registration and replacement this does not probe the endpoint, so a backend whose credentials expired while it was disabled enables successfully and only fails at the next write; replace it to rotate them. A 200 says the flag is cleared on this node, not that any copy already reclaimed under a `reclaim` policy has come back. Once the removal sweep has deleted a drained backend there is nothing left to enable and the id reads as not found.",
+    description = r#"Clears a backend's `disabled` flag so write routing may choose it again.
+
+**Authentication**: bearer token issued for this realm with WRITE on the group's administrative
+path.
+
+**Behavior**
+- The sweep that removes drained backends no longer considers the backend once it is enabled.
+- Enabling a backend that is already enabled commits nothing and returns the stored record
+  unchanged, so the call may be repeated.
+- Nothing is contacted: unlike registration and replacement this does not probe the endpoint, so a
+  backend whose credentials expired while it was disabled enables successfully and only fails at
+  the next write; replace it to rotate them.
+- A 200 says the flag is cleared on this node, not that any copy already reclaimed under a
+  `reclaim` policy has come back.
+- Once the removal sweep has deleted a drained backend there is nothing left to enable and the id
+  reads as not found."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the backend, as a 26-character ULID"),
         ("backend_id" = String, Path, description = "Backend to enable, as a 26-character ULID")
@@ -562,7 +690,9 @@ pub async fn delete_group_backend(
                     "root": "aruna/"
                 },
                 "disabled": false,
-                "cleanup": {"mode": "retain"}
+                "cleanup": {
+                    "mode": "retain"
+                }
             })
         ),
         (
@@ -598,8 +728,31 @@ pub async fn enable_group_backend(
     get,
     path = "/groups/{group_id}/storage-backends/{backend_id}/reclaim-status",
     tag = "storage-backends",
-    summary = "Read how much reclaim work a backend still owes",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's administrative path. The backend must exist and belong to the group before anything is counted, otherwise the answer is 404. The counts are taken from the queues of the node serving the request at the moment of the call and describe that node only: `pending_candidates` is how many copies are waiting for the reclaim sweep to judge them, `queued_cleanups` is how many physical deletes are still owed to this backend, and `oldest_enqueued_at` is when the oldest item in either queue was enqueued, as an RFC 3339 timestamp, absent when both queues are empty for this backend. Both sweeps run on their own timers, so non-zero counts are normal and mean work is pending rather than stuck; reclaim is only blocked when `oldest_enqueued_at` stops moving forward across calls. Candidates are queued whatever the cleanup policy says, so a backend on `retain` can report pending candidates too, and the sweep will drop them without deleting anything. `truncated` reports that a scan hit its cap, at ten thousand candidates or one thousand cleanup rows, and that both counts are then lower bounds. A backend that reports zeroes and holds no data is the one the background sweep is free to remove.",
+    summary = "Read a backend's pending reclaim work",
+    description = r#"Counts the reclaim and cleanup work this node still owes one storage backend.
+
+**Authentication**: bearer token issued for this realm with WRITE on the group's administrative
+path; the backend must exist and belong to the group before anything is counted, otherwise the
+answer is 404.
+
+**Behavior**
+- The counts are taken from the queues of the node serving the request at the moment of the call
+  and describe that node only.
+- `pending_candidates` is how many copies are waiting for the reclaim sweep to judge them and
+  `queued_cleanups` how many physical deletes are still owed to this backend.
+- `oldest_enqueued_at` is when the oldest item in either queue was enqueued, as an RFC 3339
+  timestamp, absent when both queues are empty for this backend.
+- Both sweeps run on their own timers, so non-zero counts are normal and mean work is pending
+  rather than stuck; reclaim is only blocked when `oldest_enqueued_at` stops moving forward across
+  calls.
+- Candidates are queued whatever the cleanup policy says, so a backend on `retain` can report
+  pending candidates too, and the sweep will drop them without deleting anything.
+- A backend that reports zeroes and holds no data is the one the background sweep is free to
+  remove.
+
+**Limits**
+- A scan stops at ten thousand candidates or one thousand cleanup rows; `truncated` then reports
+  that both counts are lower bounds."#,
     params(
         ("group_id" = String, Path, description = "Group that owns the backend, as a 26-character ULID"),
         ("backend_id" = String, Path, description = "Backend whose reclaim queues are counted, as a 26-character ULID")

--- a/api/src/routes/groups.rs
+++ b/api/src/routes/groups.rs
@@ -335,11 +335,24 @@ impl From<(Group, GroupAuthorizationDocument)> for GroupInfoResponse {
     path = "/groups",
     tag = "groups",
     summary = "Create a group in this realm",
-    description = "Requires a bearer token issued for this realm; a token confined to a path subset is refused. Group creation is self-service: any unrestricted realm member may create groups up to the realm's per-user group quota, and a caller holding WRITE on the realm group-admin path is exempt from that cap. The caller becomes the owner and the only member of the new group's admin role, next to the default user and viewer roles. The write commits on this node and replicates to the rest of the realm afterwards, so another node may not list the group immediately.",
+    description = r#"Creates a group in this realm and makes the caller its owner and sole administrator.
+
+**Authentication**: realm bearer token; a token confined to a path subset is refused.
+
+**Behavior**
+- Group creation is self-service: any unrestricted realm member may create groups up to the realm's
+  per-user group quota, and a caller holding WRITE on the realm group-admin path is exempt from that
+  cap.
+- The caller becomes the owner and the only member of the new group's admin role, next to the
+  default user and viewer roles.
+- The write commits on this node and replicates to the rest of the realm afterwards, so another node
+  may not list the group immediately."#,
     request_body(
         content = CreateGroupRequest,
         description = "Display name for the new group. It is stored as given and need not be unique.",
-        example = json!({"name": "Proteomics Lab"})
+        example = json!({
+            "name": "Proteomics Lab"
+        })
     ),
     responses(
         (
@@ -471,7 +484,19 @@ pub async fn create_group(
     path = "/groups",
     tag = "groups",
     summary = "List the groups of this realm",
-    description = "Requires a bearer token issued for this realm: an anonymous caller is rejected and a token from another realm is forbidden. Reads the group directory as replicated to this node, so a group created elsewhere can be missing until it arrives here. Every realm member sees each group's id, realm and display name. `include=roles` additionally returns each group's roles and their permission paths, but the users assigned to a role are only included for groups the caller is a member of; for every other group the `assigned_users` field is omitted and a role that applies to everyone is visible only through its `public` flag.",
+    description = r#"Lists this realm's groups, optionally with their roles and permission paths.
+
+**Authentication**: realm bearer token; an anonymous caller is rejected and a token from another
+realm is forbidden.
+
+**Behavior**
+- Reads the group directory as replicated to this node, so a group created elsewhere can be missing
+  until it arrives here.
+- Every realm member sees each group's id, realm and display name.
+- `include=roles` additionally returns each group's roles and their permission paths, but the users
+  assigned to a role are only included for groups the caller is a member of; for every other group
+  the `assigned_users` field is omitted and a role that applies to everyone is visible only through
+  its `public` flag."#,
     params(
         ("limit" = Option<u32>, Query, description = "Maximum number of groups to return; defaults to 100 and is clamped to the range 1-1000"),
         ("offset" = Option<u32>, Query, description = "Number of groups to skip from the start of the directory; defaults to 0"),
@@ -587,7 +612,17 @@ async fn build_api_groups(
     path = "/groups/{id}",
     tag = "groups",
     summary = "Read one group's directory entry",
-    description = "Requires a bearer token issued for this realm; no group membership is needed, because every realm member may look up any group in the realm. Reads the copy replicated to this node. Members receive the full role list including the users assigned to each role; a non-member receives the same roles and permission paths with the `assigned_users` field omitted, and learns only from the `public` flag that a role applies to everyone. A group whose record or authorization document is not present on this node reads as not found.",
+    description = r#"Returns one group's directory entry together with its roles.
+
+**Authentication**: realm bearer token; no group membership is needed, because every realm member
+may look up any group in the realm.
+
+**Behavior**
+- Reads the copy replicated to this node.
+- Members receive the full role list including the users assigned to each role.
+- A non-member receives the same roles and permission paths with the `assigned_users` field omitted,
+  and learns only from the `public` flag that a role applies to everyone.
+- A group whose record or authorization document is not present on this node reads as not found."#,
     params(("id" = String, Path, description = "Group id as a 26-character ULID")),
     responses(
         (
@@ -684,7 +719,31 @@ fn map_remove_member_error(error: RemoveUserFromGroupError) -> ServerError {
     path = "/groups/{id}/usage",
     tag = "groups",
     summary = "Read a group's storage usage",
-    description = "Requires a bearer token issued for this realm and membership in the group: membership is the only check, so a realm administrator who is not a member is forbidden. The flat counters report what this node stores for the group, while `realm` reports the realm-wide totals aggregated from the usage summaries the realm's nodes publish, which trail recent writes. `dataset_count`, `profile_count` and `process_run_count` are exact lifecycle-live metadata-document counts for this group when this node's metadata subsystem can answer; all three are omitted together when it cannot. Classification reads each live registry record's root-only RO-Crate summary from the metadata graph store: a root whose `@type` contains `http://www.w3.org/ns/dx/prof/Profile` is a Profile; otherwise exact `conformsTo` `https://w3id.org/ro/wfrun/process/0.5` is a Process Run; every other root is a Dataset. Document storage paths never participate. The registry/lifecycle candidate set is bounded by the metadata registry limit and root-summary reads have at most eight in flight, so an over-limit or unreadable set is reported as unavailable rather than partially counted; full crates are never scanned and no result cache is added. `quota` restates the realm quota configuration for this group together with a warning flag evaluated against the group's realm-wide logical bytes; it is omitted when the realm configuration cannot be read, and the document count reported by the realm-wide usage endpoint is never included here.",
+    description = r#"Reports what this node stores for a group next to the realm-wide totals.
+
+**Authentication**: realm bearer token and membership in the group; membership is the only check, so
+a realm administrator who is not a member is forbidden.
+
+**Behavior**
+- The flat counters report what this node stores for the group, while `realm` reports the realm-wide
+  totals aggregated from the usage summaries the realm's nodes publish, which trail recent writes.
+- `dataset_count`, `profile_count` and `process_run_count` are exact lifecycle-live
+  metadata-document counts for this group when this node's metadata subsystem can answer; all three
+  are omitted together when it cannot.
+- Classification reads each live registry record's root-only RO-Crate summary from the metadata
+  graph store: a root whose `@type` contains `http://www.w3.org/ns/dx/prof/Profile` is a Profile;
+  otherwise exact `conformsTo` `https://w3id.org/ro/wfrun/process/0.5` is a Process Run; every other
+  root is a Dataset. Document storage paths never participate.
+- `quota` restates the realm quota configuration for this group together with a warning flag
+  evaluated against the group's realm-wide logical bytes; it is omitted when the realm configuration
+  cannot be read, and the document count reported by the realm-wide usage endpoint is never included
+  here.
+
+**Limits**
+- The registry/lifecycle candidate set is bounded by the metadata registry limit and root-summary
+  reads have at most eight in flight, so an over-limit or unreadable set is reported as unavailable
+  rather than partially counted.
+- Full crates are never scanned and no result cache is added."#,
     params(("id" = String, Path, description = "Group id as a 26-character ULID")),
     responses(
         (
@@ -780,7 +839,18 @@ pub async fn get_group_usage(
     path = "/groups/{id}/members",
     tag = "groups",
     summary = "List the members of a group",
-    description = "Requires a bearer token issued for this realm and membership in the group; the member list is never exposed to outsiders, so a non-member is forbidden. Returns every member in one response, sorted by user id, each with the roles that assign them, sorted by role name. A role that applies to everyone contributes no member here, since the principal standing for everyone is not a user. Display names are resolved from the realm's user directory as a best effort: a member without a resolvable record is returned with a null name instead of failing the listing.",
+    description = r#"Returns every member of a group with the roles that assign them.
+
+**Authentication**: realm bearer token and membership in the group; the member list is never exposed
+to outsiders, so a non-member is forbidden.
+
+**Behavior**
+- Every member is returned in one response, sorted by user id, each with the roles that assign them,
+  sorted by role name.
+- A role that applies to everyone contributes no member here, since the principal standing for
+  everyone is not a user.
+- Display names are resolved from the realm's user directory as a best effort: a member without a
+  resolvable record is returned with a null name instead of failing the listing."#,
     params(("id" = String, Path, description = "Group id as a 26-character ULID")),
     responses(
         (
@@ -888,7 +958,18 @@ async fn resolve_member_names(
     path = "/groups/{id}/members",
     tag = "groups",
     summary = "Add a user to a group",
-    description = "Requires an unrestricted bearer token issued for this realm and WRITE on the group's administrative path for the user being added, so authority can be delegated per member. When `role_ids` is omitted or empty the user is assigned the group's role named user, and the request is rejected when that role is missing or ambiguous. Adding a user who already holds the roles is accepted and changes nothing. The response is the group's complete role list after the change, including the users assigned to each role. The change commits on this node and replicates to the rest of the realm afterwards.",
+    description = r#"Assigns a user one or more roles in a group.
+
+**Authentication**: unrestricted realm bearer token with WRITE on the group's administrative path
+for the user being added, so authority can be delegated per member.
+
+**Behavior**
+- When `role_ids` is omitted or empty the user is assigned the group's role named user, and the
+  request is rejected when that role is missing or ambiguous.
+- Adding a user who already holds the roles is accepted and changes nothing.
+- The response is the group's complete role list after the change, including the users assigned to
+  each role.
+- The change commits on this node and replicates to the rest of the realm afterwards."#,
     request_body(
         content = AddGroupMemberRequest,
         description = "User to add, and optionally the exact roles to assign instead of the default user role.",
@@ -995,8 +1076,20 @@ pub async fn add_group_member(
     delete,
     path = "/groups/{id}/members/{user_id}",
     tag = "groups",
-    summary = "Remove a member from a group or revoke one of their roles",
-    description = "Requires an unrestricted bearer token issued for this realm. Removing yourself needs no group permission; removing anyone else requires WRITE on the group's administrative path for that user. Without `role_id` the user loses every role in the group, with it only that one assignment is revoked and the rest are kept. A group must keep at least one administrator, so the request is refused when it would strip the last one. The change commits on this node and replicates to the rest of the realm afterwards.",
+    summary = "Remove a group member or revoke one role",
+    description = r#"Revokes a user's roles in a group, or only the one named by `role_id`.
+
+**Authentication**: unrestricted realm bearer token. Removing yourself needs no group permission;
+removing anyone else requires WRITE on the group's administrative path for that user.
+
+**Behavior**
+- Without `role_id` the user loses every role in the group, with it only that one assignment is
+  revoked and the rest are kept.
+- The change commits on this node and replicates to the rest of the realm afterwards.
+
+**Limits**
+- A group must keep at least one administrator, so the request is refused when it would strip the
+  last one."#,
     params(
         ("id" = String, Path, description = "Group id as a 26-character ULID"),
         ("user_id" = String, Path, description = "Member to remove, in the realm-qualified user id form `<user ULID>@<realm id>`"),
@@ -1062,7 +1155,18 @@ pub async fn remove_group_member(
     path = "/groups/{id}/leave",
     tag = "groups",
     summary = "Leave a group",
-    description = "Self-scoped: the caller drops every role they hold in the group, and no group permission is required because the token's own subject is the only user affected. Requires an unrestricted bearer token issued for this realm; a token confined to a path subset is refused. A group must keep at least one administrator, so the last one cannot leave and must hand the role over first. Leaving a group the caller does not belong to changes nothing. The change commits on this node and replicates to the rest of the realm afterwards.",
+    description = r#"Drops every role the calling user holds in the group.
+
+**Authentication**: unrestricted realm bearer token; a token confined to a path subset is refused.
+No group permission is required, because the token's own subject is the only user affected.
+
+**Behavior**
+- Leaving a group the caller does not belong to changes nothing.
+- The change commits on this node and replicates to the rest of the realm afterwards.
+
+**Limits**
+- A group must keep at least one administrator, so the last one cannot leave and must hand the role
+  over first."#,
     params(("id" = String, Path, description = "Group id as a 26-character ULID")),
     responses(
         (status = 204, description = "The caller no longer holds any role in the group; no response body is returned"),
@@ -1099,7 +1203,22 @@ pub async fn leave_group(
     path = "/groups/{id}/roles",
     tag = "groups",
     summary = "Create a role in a group",
-    description = "Requires an unrestricted bearer token issued for this realm and WRITE on the group's administrative path. The name is trimmed, must not be empty and must not be admin or user, which are reserved for the built-in roles. Every permission path must lie inside the group's own path, so a group administrator cannot mint authority over anything else, and each is granted as read, write or deny (accepted case-insensitively, reported capitalised). A public role applies to every principal including anonymous callers and may therefore only carry read grants. The role commits on this node and replicates to the rest of the realm afterwards.",
+    description = r#"Creates a role in a group from permission paths confined to that group.
+
+**Authentication**: unrestricted realm bearer token with WRITE on the group's administrative path.
+
+**Behavior**
+- Each permission path is granted as read, write or deny, accepted case-insensitively and reported
+  capitalised.
+- The role commits on this node and replicates to the rest of the realm afterwards.
+
+**Limits**
+- The name is trimmed, must not be empty and must not be admin or user, which are reserved for the
+  built-in roles.
+- Every permission path must lie inside the group's own path, so a group administrator cannot mint
+  authority over anything else.
+- A public role applies to every principal including anonymous callers and may therefore only carry
+  read grants."#,
     request_body(
         content = CreateGroupRoleRequest,
         description = "Role name, the permission paths it grants inside the group, and the users it is assigned to.",
@@ -1227,7 +1346,18 @@ pub async fn create_group_role(
     path = "/groups/{id}/roles/{role_id}",
     tag = "groups",
     summary = "Delete a role from a group",
-    description = "Requires an unrestricted bearer token issued for this realm and WRITE on the group's administrative path. Deleting a role revokes it from every user holding it, which can leave a user with no role in the group at all. The built-in admin role is permanent and cannot be deleted, so a group never loses its administrative path. The change commits on this node and replicates to the rest of the realm afterwards.",
+    description = r#"Deletes a role from a group and revokes it from everyone holding it.
+
+**Authentication**: unrestricted realm bearer token with WRITE on the group's administrative path.
+
+**Behavior**
+- Deleting a role revokes it from every user holding it, which can leave a user with no role in the
+  group at all.
+- The change commits on this node and replicates to the rest of the realm afterwards.
+
+**Limits**
+- The built-in admin role is permanent and cannot be deleted, so a group never loses its
+  administrative path."#,
     params(
         ("id" = String, Path, description = "Group id as a 26-character ULID"),
         ("role_id" = String, Path, description = "Role to delete, as a 26-character ULID")
@@ -1325,7 +1455,20 @@ pub struct DataPathsQuery {
     path = "/groups/{id}/data-paths",
     tag = "groups",
     summary = "Browse the data permission paths of a group",
-    description = "Requires a bearer token issued for this realm and membership in the group, and every page is additionally authorized as a data read: browsing the bucket level needs READ on the group's data root, browsing inside a bucket needs READ on that bucket or on the prefix being listed, so a token confined to a narrower path sees only what it may read. The entries are the permission paths that role grants are written against, folders ending at the delimiter and objects as leaves, and they are scoped to this node, so a prefix belonging to another node is rejected. Bucket names are globally unique: naming a bucket owned by another group returns an empty page instead of an error. Paging is forward-only through an opaque token that must be echoed back unchanged; a response without one is the last page.",
+    description = r#"Returns one page of the data permission paths that a group's role grants are written against.
+
+**Authentication**: realm bearer token and membership in the group, and every page is additionally
+authorized as a data read: browsing the bucket level needs READ on the group's data root, browsing
+inside a bucket needs READ on that bucket or on the prefix being listed, so a token confined to a
+narrower path sees only what it may read.
+
+**Behavior**
+- Entries are folders ending at the delimiter and objects as leaves.
+- They are scoped to this node, so a prefix belonging to another node is rejected.
+- Bucket names are globally unique: naming a bucket owned by another group returns an empty page
+  instead of an error.
+- Paging is forward-only through an opaque token that must be echoed back unchanged; a response
+  without one is the last page."#,
     params(
         ("id" = String, Path, description = "Group id as a 26-character ULID"),
         ("prefix" = Option<String>, Query, description = "Data permission path to browse under; empty or the group data path lists buckets; a bucket path lists that bucket's contents; any other bare segment filters bucket names by that prefix"),

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1398,26 +1398,30 @@ pub async fn mutate_realm_placement(
     Extension(auth): Extension<Option<AuthContext>>,
     request: Result<Json<RealmPlacementMutationRequest>, JsonRejection>,
 ) -> ServerResult<(StatusCode, Json<RealmPlacementConfigResponse>)> {
-    let auth = authorize_realm_config_admin(&state, auth).await?;
+    let auth = require_realm_auth(&state, auth)?;
     let Json(request) =
         request.map_err(|error| ServerError::BadRequestReason(error.body_text()))?;
     let action = request.into_core()?;
     let actor = Actor {
         node_id: state.get_node_id(),
         user_id: auth.user_id,
-        realm_id: auth.realm_id,
+        realm_id: state.get_realm_id(),
     };
     let context = state.get_ctx();
     let document = match action {
-        RealmPlacementAction::Mutation(mutation) => {
-            drive_realm_placement_mutation(MutateRealmPlacementConfig { actor, mutation }, &context)
-                .await
-                .map_err(map_mutate_realm_placement_error)?
-        }
+        RealmPlacementAction::Mutation(mutation) => drive_realm_placement_mutation(
+            MutateRealmPlacementConfig { actor, mutation },
+            Some(auth),
+            &context,
+        )
+        .await
+        .map_err(map_mutate_realm_placement_error)?,
         RealmPlacementAction::Provision {
             strategy_id,
             group_id,
         } => {
+            // Handle allocation carries no authorization of its own.
+            authorize_realm_config_admin(&state, Some(auth)).await?;
             let scope = group_id
                 .map(PlacementScope::Group)
                 .unwrap_or(PlacementScope::Realm(actor.realm_id));
@@ -1561,15 +1565,19 @@ pub async fn set_realm_quota(
     Extension(auth): Extension<Option<AuthContext>>,
     Json(request): Json<RealmQuotaConfig>,
 ) -> ServerResult<(StatusCode, Json<RealmQuotaConfig>)> {
-    let auth = authorize_realm_config_admin(&state, auth).await?;
+    let auth = require_realm_auth(&state, auth)?;
     let quota = request.into_quota_config()?;
     let actor = Actor {
         node_id: state.get_node_id(),
         user_id: auth.user_id,
-        realm_id: auth.realm_id,
+        realm_id: state.get_realm_id(),
     };
     let stored = drive(
-        SetRealmQuotaOperation::new(SetRealmQuotaConfig { actor, quota }),
+        SetRealmQuotaOperation::new(SetRealmQuotaConfig {
+            actor,
+            auth_context: auth,
+            quota,
+        }),
         &state.get_ctx(),
     )
     .await
@@ -1580,6 +1588,9 @@ pub async fn set_realm_quota(
 fn map_set_realm_quota_error(error: SetRealmQuotaError) -> ServerError {
     match error {
         SetRealmQuotaError::RealmConfigNotFound => ServerError::NotFound,
+        SetRealmQuotaError::Unauthorized | SetRealmQuotaError::NotManagementNode => {
+            ServerError::Forbidden
+        }
         SetRealmQuotaError::InvalidQuota { reason } => ServerError::BadRequestReason(reason),
         SetRealmQuotaError::StorageError(StorageError::TransactionConflict) => {
             ServerError::Conflict("concurrent realm quota update conflict; retry".to_string())

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1389,7 +1389,8 @@ response."#,
         (status = 403, description = "Caller is not a realm config admin or this is not a management node", body = crate::error::ErrorResponse),
         (status = 404, description = "This node holds no configuration document for its realm", body = crate::error::ErrorResponse),
         (status = 409, description = "The strategy is still referenced by a binding or override, the placement handle space is exhausted, or another update of the realm configuration won the race; the caller may retry", body = crate::error::ErrorResponse),
-        (status = 500, description = "Unexpected server error", body = crate::error::ErrorResponse)
+        (status = 500, description = "Unexpected server error", body = crate::error::ErrorResponse),
+        (status = 503, description = "Storage cleanup capacity exhausted, retry later", body = crate::error::ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -1469,6 +1470,11 @@ fn map_handle_error(error: HandleAllocationError) -> ServerError {
         HandleAllocationError::Storage(StorageError::TransactionConflict) => {
             ServerError::Conflict("concurrent placement provisioning conflict; retry".to_string())
         }
+        HandleAllocationError::Storage(StorageError::CleanupCapacity) => {
+            ServerError::ServiceUnavailableReason(
+                "storage cleanup capacity exhausted; retry".to_string(),
+            )
+        }
         other => ServerError::InternalError(other.to_string()),
     }
 }
@@ -1495,6 +1501,11 @@ fn map_mutate_realm_placement_error(error: MutateRealmPlacementError) -> ServerE
         }
         MutateRealmPlacementError::StorageError(StorageError::TransactionConflict) => {
             ServerError::Conflict("concurrent realm placement update conflict; retry".to_string())
+        }
+        MutateRealmPlacementError::StorageError(StorageError::CleanupCapacity) => {
+            ServerError::ServiceUnavailableReason(
+                "storage cleanup capacity exhausted; retry".to_string(),
+            )
         }
         other => ServerError::InternalError(other.to_string()),
     }
@@ -1566,7 +1577,8 @@ a management node serves it; an anonymous caller is rejected and every other nod
         (status = 400, description = "A percentage outside its allowed range, a duplicate or malformed override, an id that is not a ULID or user identifier, or a value for max_devices_per_user", body = crate::error::ErrorResponse),
         (status = 403, description = "Caller is not a realm config admin or this is not a management node", body = crate::error::ErrorResponse),
         (status = 404, description = "This node holds no configuration document for its realm", body = crate::error::ErrorResponse),
-        (status = 409, description = "Another update of the realm configuration won the race; the caller may retry with the same body", body = crate::error::ErrorResponse)
+        (status = 409, description = "Another update of the realm configuration won the race; the caller may retry with the same body", body = crate::error::ErrorResponse),
+        (status = 503, description = "Storage cleanup capacity exhausted, retry later", body = crate::error::ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -1612,6 +1624,11 @@ fn map_set_realm_quota_error(error: SetRealmQuotaError) -> ServerError {
         SetRealmQuotaError::InvalidQuota { reason } => ServerError::BadRequestReason(reason),
         SetRealmQuotaError::StorageError(StorageError::TransactionConflict) => {
             ServerError::Conflict("concurrent realm quota update conflict; retry".to_string())
+        }
+        SetRealmQuotaError::StorageError(StorageError::CleanupCapacity) => {
+            ServerError::ServiceUnavailableReason(
+                "storage cleanup capacity exhausted; retry".to_string(),
+            )
         }
         other => ServerError::InternalError(other.to_string()),
     }
@@ -2825,6 +2842,16 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn quota_capacity_unavailable() {
+        // Cleanup capacity is transient, so it must not read as an internal error.
+        let error = map_set_realm_quota_error(SetRealmQuotaError::StorageError(
+            StorageError::CleanupCapacity,
+        ));
+
+        assert!(matches!(error, ServerError::ServiceUnavailableReason(_)));
+    }
+
     async fn setup_management_state() -> (Arc<ServerState>, RealmId, UserId, TempDir) {
         let tempdir = tempdir().unwrap();
         let storage_handle = storage::FjallStorage::open(tempdir.path().to_str().unwrap()).unwrap();
@@ -3377,6 +3404,23 @@ mod tests {
         assert!(matches!(
             map_mutate_realm_placement_error(MutateRealmPlacementError::RealmConfigNotFound),
             ServerError::NotFound
+        ));
+    }
+
+    #[test]
+    fn placement_capacity_unavailable() {
+        // Cleanup capacity is transient on both placement paths.
+        assert!(matches!(
+            map_mutate_realm_placement_error(MutateRealmPlacementError::StorageError(
+                StorageError::CleanupCapacity
+            )),
+            ServerError::ServiceUnavailableReason(_)
+        ));
+        assert!(matches!(
+            map_handle_error(HandleAllocationError::Storage(
+                StorageError::CleanupCapacity
+            )),
+            ServerError::ServiceUnavailableReason(_)
         ));
     }
 

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -2296,8 +2296,9 @@ mod tests {
         InterfaceServicesStatus, InterfaceStatus, NodeCapabilityKind, RealmPlacementBinding,
         RealmPlacementBindingScope, RealmPlacementMutationRequest, RealmPlacementOverride,
         RealmPlacementStrategy, RealmQuotaConfig, RealmUserGroupCapOverride, ServiceStatus,
-        get_info, get_realm_info, get_realm_placement, get_usage, map_mutate_realm_placement_error,
-        map_set_realm_quota_error, mutate_realm_placement, presence_nodes, set_realm_quota,
+        get_info, get_realm_info, get_realm_placement, get_usage, map_handle_error,
+        map_mutate_realm_placement_error, map_set_realm_quota_error, mutate_realm_placement,
+        presence_nodes, set_realm_quota,
     };
     use crate::error::ServerError;
     use crate::openapi::ApiDoc;
@@ -2312,7 +2313,7 @@ mod tests {
         Actor, AuthContext, DocumentClass, Group, NodeCapabilities, PlacementScope, QuotaConfig,
         RealmId,
     };
-    use aruna_operations::allocate_handle::allocate_placement_binding;
+    use aruna_operations::allocate_handle::{HandleAllocationError, allocate_placement_binding};
     use aruna_operations::claim_initial_realm_admin::{
         ClaimInitialRealmAdminInput, ClaimInitialRealmAdminOperation,
     };

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1,4 +1,4 @@
-use crate::auth::{permission_granted, require_realm_auth};
+use crate::auth::{ensure_permission, permission_granted, require_realm_auth};
 use crate::error::{ServerError, ServerResult};
 pub use crate::server_state::PortalStatus;
 use crate::server_state::ServerState;
@@ -7,7 +7,7 @@ use aruna_core::alpn::Alpn;
 use aruna_core::errors::StorageError;
 use aruna_core::structs::{
     Actor, AuthContext, GroupQuotaOverride, Permission, PlacementScope, QuotaConfig,
-    UserGroupCapOverride,
+    UserGroupCapOverride, policy_admin_path,
 };
 use aruna_core::structs::{BackendRef, USAGE_GLOBAL_KEY, UsageCounters};
 use aruna_core::structs::{ConnectionAddressStatus, PeerConnectionStatus, RequestSummaryState};
@@ -1409,13 +1409,23 @@ pub async fn mutate_realm_placement(
     };
     let context = state.get_ctx();
     let document = match action {
-        RealmPlacementAction::Mutation(mutation) => drive_realm_placement_mutation(
-            MutateRealmPlacementConfig { actor, mutation },
-            Some(auth),
-            &context,
-        )
-        .await
-        .map_err(map_mutate_realm_placement_error)?,
+        RealmPlacementAction::Mutation(mutation) => {
+            // Request policies live at this boundary; the operation only checks roles.
+            ensure_permission(
+                &state,
+                &auth,
+                policy_admin_path(actor.realm_id),
+                Permission::WRITE,
+            )
+            .await?;
+            drive_realm_placement_mutation(
+                MutateRealmPlacementConfig { actor, mutation },
+                Some(auth),
+                &context,
+            )
+            .await
+            .map_err(map_mutate_realm_placement_error)?
+        }
         RealmPlacementAction::Provision {
             strategy_id,
             group_id,
@@ -1566,6 +1576,14 @@ pub async fn set_realm_quota(
     Json(request): Json<RealmQuotaConfig>,
 ) -> ServerResult<(StatusCode, Json<RealmQuotaConfig>)> {
     let auth = require_realm_auth(&state, auth)?;
+    // Request policies live at this boundary; the operation only checks roles.
+    ensure_permission(
+        &state,
+        &auth,
+        policy_admin_path(state.get_realm_id()),
+        Permission::WRITE,
+    )
+    .await?;
     let quota = request.into_quota_config()?;
     let actor = Actor {
         node_id: state.get_node_id(),

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -889,8 +889,34 @@ impl From<&RealmNodeKind> for RealmNodeKindInfo {
     get,
     path = "/info/realm",
     tag = "info",
-    summary = "Read the realm's public settings and its node topology",
-    description = "Answers every caller, but answers a realm member with more. Without a usable token of this realm, and that includes a token of another realm or one this node cannot validate, the response is the public part: realm id, description, metadata replication policy, the OIDC providers a client needs to obtain a token, public interface urls, and `public_overview`. That overview contains only three nullable aggregates: `live_datasets` is the realm's lifecycle-live metadata registry count, never caller-filtered or replica-multiplied; `groups` is the realm's stored group count; and `nodes_configured` is the membership count in this node's replicated realm configuration, never DHT presence or health. A null overview value means this node could not answer and is never encoded as zero. No resource titles, group membership, storage/capacity, bucket/object, or node-health detail is implied by these counts. A bearer token of this realm additionally reveals the realm's discovery configuration, its quota policy, the node list and the interface listen addresses, and receives the same public overview. Gated values are absent or empty, never restructured, so one parser handles both. The node list is the realm's configured membership read from this node's replicated realm configuration; `placement` is the node's entry in the placement map and `info` is the last node information document that reached this node, so it may lag or be absent. Liveness is a separate, deliberately conservative signal: presence is resolved through a bounded realm lookup with a four second budget, and if that lookup is stale, times out or fails, only this node counts as present. `present` true and `connection_status` `connected` therefore mean the peer was confirmed live by a fresh lookup just now; `configured` means no fresh confirmation, which is not evidence that the peer is down. Stale presence is candidate data and is never reported as a connection.",
+    summary = "Read the realm's public settings and node topology",
+    description = r#"Answers every caller, but answers a realm member with more.
+
+**Authentication**: optional bearer token; without a usable token of this realm, and that includes a
+token of another realm or one this node cannot validate, the response is the public part only.
+
+**Behavior**
+- The public part is the realm id, description, metadata replication policy, the OIDC providers a
+  client needs to obtain a token, the public interface urls, and `public_overview`.
+- That overview contains only three nullable aggregates: `live_datasets` is the realm's
+  lifecycle-live metadata registry count, never caller-filtered or replica-multiplied; `groups` is
+  the realm's stored group count; and `nodes_configured` is the membership count in this node's
+  replicated realm configuration, never DHT presence or health.
+- A null overview value means this node could not answer and is never encoded as zero. No resource
+  titles, group membership, storage/capacity, bucket/object, or node-health detail is implied by
+  these counts.
+- A bearer token of this realm additionally reveals the realm's discovery configuration, its quota
+  policy, the node list and the interface listen addresses, and receives the same public overview.
+- Gated values are absent or empty, never restructured, so one parser handles both.
+- The node list is the realm's configured membership read from this node's replicated realm
+  configuration; `placement` is the node's entry in the placement map and `info` is the last node
+  information document that reached this node, so it may lag or be absent.
+- Liveness is a separate, deliberately conservative signal: presence is resolved through a bounded
+  realm lookup with a four second budget, and if that lookup is stale, times out or fails, only this
+  node counts as present.
+- `present` true and `connection_status` `connected` therefore mean the peer was confirmed live by a
+  fresh lookup just now; `configured` means no fresh confirmation, which is not evidence that the
+  peer is down. Stale presence is candidate data and is never reported as a connection."#,
     responses(
         (
             status = 200,
@@ -1177,7 +1203,23 @@ async fn info_access(state: &ServerState, auth: Option<&AuthContext>) -> InfoAcc
     path = "/info/realm/placement",
     tag = "info",
     summary = "Read the realm's placement strategies, bindings and overrides",
-    description = "Requires a bearer token of this realm with WRITE on the realm's configuration admin path, and only a management node serves it; every other node answers 403 whatever the caller holds. Returns the placement policy as stored in this node's copy of the realm configuration: the defined strategies with their replica count, distinctness requirement, affinity rules and shard count; the default strategy; the immutable job-family strategy id; the bindings that map a scope, the realm, a group, a document class or a metadata path prefix, to a strategy; and the per-subject overrides that pin or exclude individual nodes. `job_family_strategy_id` names a strategy that cannot be removed or have its shard count reshaped: those mutations fail with `JobFamilyImmutable`; removing a strategy that is still referenced fails with `StrategyReferenced`. This is policy, not a placement result: it says how replicas are chosen, not where any particular document currently sits.",
+    description = r#"Returns the placement policy as stored in this node's copy of the realm configuration.
+
+**Authentication**: realm bearer token with WRITE on the realm's configuration admin path, and only
+a management node serves it; every other node answers 403 whatever the caller holds.
+
+**Behavior**
+- The response carries the defined strategies with their replica count, distinctness requirement,
+  affinity rules and shard count; the default strategy; the immutable job-family strategy id; the
+  bindings that map a scope (the realm, a group, a document class or a metadata path prefix) to a
+  strategy; and the per-subject overrides that pin or exclude individual nodes.
+- This is policy, not a placement result: it says how replicas are chosen, not where any particular
+  document currently sits.
+
+**Limits**
+- `job_family_strategy_id` names a strategy that cannot be removed or have its shard count
+  reshaped: those mutations fail with `JobFamilyImmutable`.
+- Removing a strategy that is still referenced fails with `StrategyReferenced`."#,
     responses(
         (
             status = 200,
@@ -1249,7 +1291,31 @@ pub async fn get_realm_placement(
     path = "/info/realm/placement",
     tag = "info",
     summary = "Apply one change to the realm's placement policy",
-    description = "Requires a bearer token of this realm with WRITE on the realm's configuration admin path, and only a management node serves it; every other node answers 403. The body carries exactly one change, selected by its `mutation` field: define or replace a strategy, remove one, set the default, set or remove a binding for a scope, set or remove a per-subject override, or provision a metadata binding for a strategy. Provisioning is idempotent, an existing binding for the same scope and strategy is returned unchanged instead of allocating a second one. The whole placement policy after the change is returned, so a client never has to re-read to learn the new state. `job_family_strategy_id` identifies the job-family strategy, which cannot be removed or have its shard count reshaped; those mutations fail with `JobFamilyImmutable`. The change is written to the replicated realm configuration, which means it is durable here when the response is sent and reaches the other realm nodes asynchronously; it does not move any data by itself, existing replicas are relocated by later placement work. Removing a strategy that a binding or override still points at fails with `StrategyReferenced` and is refused with 409 rather than leaving a dangling reference, and a concurrent update of the same configuration is also 409, where retrying the request is the expected response.",
+    description = r#"Applies exactly one change to the realm's placement policy and returns the whole policy.
+
+**Authentication**: realm bearer token with WRITE on the realm's configuration admin path, and only
+a management node serves it; every other node answers 403.
+
+**Behavior**
+- The body carries exactly one change, selected by its `mutation` field: define or replace a
+  strategy, remove one, set the default, set or remove a binding for a scope, set or remove a
+  per-subject override, or provision a metadata binding for a strategy.
+- Provisioning is idempotent, an existing binding for the same scope and strategy is returned
+  unchanged instead of allocating a second one.
+- The whole placement policy after the change is returned, so a client never has to re-read to learn
+  the new state.
+- The change is written to the replicated realm configuration, which means it is durable here when
+  the response is sent and reaches the other realm nodes asynchronously; it does not move any data
+  by itself, existing replicas are relocated by later placement work.
+
+**Limits**
+- `job_family_strategy_id` identifies the job-family strategy, which cannot be removed or have its
+  shard count reshaped; those mutations fail with `JobFamilyImmutable`.
+
+**Errors**: removing a strategy that a binding or override still points at fails with
+`StrategyReferenced` and is refused with 409 rather than leaving a dangling reference, and a
+concurrent update of the same configuration is also 409, where retrying the request is the expected
+response."#,
     request_body(
         content = RealmPlacementMutationRequest,
         description = "Exactly one placement change, discriminated by `mutation`. Ids are ULIDs, node ids are hex-encoded, an override `subject` is a hex-encoded key prefix",
@@ -1425,7 +1491,28 @@ fn map_mutate_realm_placement_error(error: MutateRealmPlacementError) -> ServerE
     path = "/info/realm/quota",
     tag = "info",
     summary = "Replace the realm-wide quota policy",
-    description = "Requires a bearer token of this realm with WRITE on the realm's configuration admin path, and only a management node serves it; an anonymous caller is rejected and every other node answers 403. This replaces the stored policy wholesale rather than patching it: overrides absent from the body are dropped, so send the complete intended policy. `default_group_quota_bytes` is the pre-grace allowance per group and null means unlimited; `grace_factor_percent` must be at least 100 and scales that allowance into the hard ceiling a write is refused at; `warn_threshold_percent` must be between 1 and 100 and only decides when a group is reported as warning. Per-group overrides replace both values for one group, and per-user overrides cap how many groups a user may hold. `max_devices_per_user` must be null, since device ownership is not enforced yet and any other value is refused. Quota is evaluated against a group's realm-wide logical bytes, which are aggregated from counters that replicate between nodes, so enforcement follows a policy change as those counters and the realm configuration propagate. The stored policy after the change is echoed back.",
+    description = r#"Replaces the realm-wide quota policy wholesale and echoes back the stored result.
+
+**Authentication**: realm bearer token with WRITE on the realm's configuration admin path, and only
+a management node serves it; an anonymous caller is rejected and every other node answers 403.
+
+**Behavior**
+- This replaces the stored policy rather than patching it: overrides absent from the body are
+  dropped, so send the complete intended policy.
+- `default_group_quota_bytes` is the pre-grace allowance per group and null means unlimited.
+- `grace_factor_percent` scales that allowance into the hard ceiling a write is refused at, while
+  `warn_threshold_percent` only decides when a group is reported as warning.
+- Per-group overrides replace both values for one group, and per-user overrides cap how many groups
+  a user may hold.
+- Quota is evaluated against a group's realm-wide logical bytes, which are aggregated from counters
+  that replicate between nodes, so enforcement follows a policy change as those counters and the
+  realm configuration propagate.
+
+**Limits**
+- `grace_factor_percent` must be at least 100.
+- `warn_threshold_percent` must be between 1 and 100.
+- `max_devices_per_user` must be null, since device ownership is not enforced yet and any other
+  value is refused."#,
     request_body(
         content = RealmQuotaConfig,
         description = "The complete quota policy to store; it replaces the current one, including all override lists",
@@ -1639,7 +1726,22 @@ pub async fn load_realm_usage(
     path = "/info/usage",
     tag = "info",
     summary = "Report this node's and the realm's storage usage",
-    description = "Requires a bearer token of this realm; an anonymous caller gets 401 and a token of another realm 403. No further permission is checked, because the figures are realm-wide totals and not per-caller views. The flat fields are this node's own counters, while `realm` is the total summed from every realm node's replicated usage snapshot, so it is eventually consistent: a node whose snapshot has not arrived or has not refreshed yet is simply not part of the sum, which can make the total lag reality after a burst of writes. `metadata_documents` counts the realm's live metadata documents, excluding lifecycle-deleted ones, and is deliberately unfiltered by what the caller may read; it is omitted, never zeroed, when this node has no metadata subsystem or the count cannot be produced, so an absent field means unknown. `quota` is not reported here, it belongs to the per-group usage view.",
+    description = r#"Reports this node's own storage counters together with the realm-wide totals.
+
+**Authentication**: realm bearer token; an anonymous caller gets 401 and a token of another realm
+403. No further permission is checked, because the figures are realm-wide totals and not per-caller
+views.
+
+**Behavior**
+- The flat fields are this node's own counters, while `realm` is the total summed from every realm
+  node's replicated usage snapshot, so it is eventually consistent: a node whose snapshot has not
+  arrived or has not refreshed yet is simply not part of the sum, which can make the total lag
+  reality after a burst of writes.
+- `metadata_documents` counts the realm's live metadata documents, excluding lifecycle-deleted ones,
+  and is deliberately unfiltered by what the caller may read.
+- It is omitted, never zeroed, when this node has no metadata subsystem or the count cannot be
+  produced, so an absent field means unknown.
+- `quota` is not reported here, it belongs to the per-group usage view."#,
     responses(
         (
             status = 200,
@@ -1834,7 +1936,25 @@ async fn backend_statuses(
     path = "/info",
     tag = "info",
     summary = "Report this node's health, version and service status",
-    description = "The health check of a single node, answered locally and never routed to a peer, so it always returns 200 for a node that is serving requests at all. Every caller is answered, but the amount of detail depends on the token. Anonymous callers, and callers whose token belongs to another realm or cannot be validated here, see only what is needed to health check the node and learn where to authenticate: node status, realm id, api version and the public interface urls. A bearer token of this realm adds the node's own identity and capability kind, its listen addresses, its peer connections and the network service summary. A token with WRITE on the realm's configuration admin path additionally reveals the blob and database services, every registered storage backend with its quota and used bytes, the portal deployment state, operational warnings and the last error of each peer connection. Gated values are absent or empty rather than restructured, so the same parser works at every level. Backend `used_bytes` comes from maintained counters and is absent when they cannot be read, which is not the same as zero.",
+    description = r#"The health check of a single node, answered locally and never routed to a peer.
+
+**Authentication**: optional bearer token; every caller is answered, but the amount of detail
+depends on the token, and a token of another realm or one that cannot be validated here counts as
+anonymous.
+
+**Behavior**
+- The route always returns 200 for a node that is serving requests at all.
+- Anonymous callers see only what is needed to health check the node and learn where to
+  authenticate: node status, realm id, api version and the public interface urls.
+- A bearer token of this realm adds the node's own identity and capability kind, its listen
+  addresses, its peer connections and the network service summary.
+- A token with WRITE on the realm's configuration admin path additionally reveals the blob and
+  database services, every registered storage backend with its quota and used bytes, the portal
+  deployment state, operational warnings and the last error of each peer connection.
+- Gated values are absent or empty rather than restructured, so the same parser works at every
+  level.
+- Backend `used_bytes` comes from maintained counters and is absent when they cannot be read, which
+  is not the same as zero."#,
     responses(
         (
             status = 200,

--- a/api/src/routes/job_audit.rs
+++ b/api/src/routes/job_audit.rs
@@ -228,12 +228,41 @@ fn kind_name(record: &JobFamilyRecord) -> &'static str {
     path = "/jobs/{job_id}/audit",
     tag = "jobs",
     summary = "Page the immutable records of one external job",
-    description = "Requires a realm bearer token; a path-restricted (delegated) token is refused. Reads are self-scoped: only the submitter of the request may audit it, and any other id answers 404, so the surface never confirms that somebody else's job exists. The page is ordered by stable record key, never by arrival, and it exposes every alternative execution and every output that any partition produced, not only the canonical one: at-least-once execution means duplicates are normal and stay auditable forever. `scope=family` pages the request family the alias resolves to; `scope=submission` also pages the idempotency conflicts of the same submission, each record marked with `conflicting_family`. Records are projected, never returned raw: signatures, envelopes and the node identities of publishers, schedulers and executors are omitted. `conflicts` lists records refused under a key another record already held and is reported with the first page only. `partial` means this responder holds more records than one projection reduces, and the answer is this node's local view of a replicated log, so a later page may reveal records an earlier one could not. An output whose owning node's S3 endpoint is not known here carries `endpoint_url: null` instead of withholding the record.",
+    description = r#"Pages the immutable records of one external job, ordered by stable record key.
+
+**Authentication**: realm bearer token; a path-restricted (delegated) token is refused. Reads are
+self-scoped: only the submitter of a request may audit it, and any other id answers 404, so the
+surface never confirms that somebody else's job exists.
+
+**Behavior**
+- The page is ordered by stable record key, never by arrival.
+- `scope=family` pages the request family the alias resolves to; `scope=submission` also pages the
+  idempotency conflicts of the same submission, each record marked with `conflicting_family`.
+- Every alternative execution and every output any partition produced is listed, not only the
+  canonical one: at-least-once execution means duplicates are normal and stay auditable forever.
+- Records are projected, never returned raw: signatures, envelopes and the node identities of
+  publishers, schedulers and executors are omitted.
+- `conflicts` lists records refused under a key another record already held and is reported with
+  the first page only.
+- `partial` means this responder holds more records than one projection reduces, and the answer is
+  this node's local view of a replicated log, so a later page may reveal records an earlier one
+  could not.
+- An output whose owning node's S3 endpoint is not known here carries `endpoint_url: null` instead
+  of withholding the record.
+
+**Limits** (all refused with 400)
+- `limit` is 1 to 64 records per page and defaults to 64.
+- `cursor` must be a `next_cursor` of this log, base64url without padding.
+- `scope` is `family` or `submission`.
+
+**Errors**: an unknown id, an unparseable id and a job submitted by somebody else are the same 404,
+as is a responder that never held the family, so page the node that accepted the submission. A 503
+means the log could not be reduced here and the caller may page again."#,
     params(
-        ("job_id" = String, Path, description = "Job identifier as returned by submission, or any accepted alias of the same request: a 26-character ULID-shaped id. An unparseable id is 404"),
-        ("scope" = Option<String>, Query, description = "`family` (the default) pages the request family only; `submission` also pages other request families of the same submission. Any other value is 400"),
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token from a previous page's `next_cursor`, base64url without padding. Anything that is not a record key of this log is rejected with 400"),
-        ("limit" = Option<usize>, Query, description = "Records per page, 1 to 64; the default is 64 and any other value is rejected with 400")
+        ("job_id" = String, Path, description = "Job id from submission, or any accepted alias of the same request: a 26-character ULID"),
+        ("scope" = Option<String>, Query, description = "`family` (the default) pages this request family only; `submission` also pages other families of the same submission"),
+        ("cursor" = Option<String>, Query, description = "Opaque `next_cursor` from a previous page, base64url without padding"),
+        ("limit" = Option<usize>, Query, description = "Records per page, 1 to 64; the default is 64")
     ),
     responses(
         (
@@ -263,16 +292,18 @@ fn kind_name(record: &JobFamilyRecord) -> &'static str {
                         "conflicting_family": false,
                         "job_id": "01JJRSTVWXYZ0123456789ABCD",
                         "execution_id": "01JJRSEXEC0123456789ABCDEF",
-                        "outputs": [{
-                            "bucket": "ws-01jjrstvwxyz0123456789abcd",
-                            "key": "reports/reads_fastqc.html",
-                            "version_id": "01JJRSVERSION0123456789ABC",
-                            "execution_id": "01JJRSEXEC0123456789ABCDEF",
-                            "container_path": "/outputs/reads_fastqc.html",
-                            "size": 20480,
-                            "digest": "fa2c8cc4f28176bbeed4b736df569a34c79cd3723e9ec42f9674b4d46ac6b8b8",
-                            "endpoint_url": "https://s3.example"
-                        }],
+                        "outputs": [
+                            {
+                                "bucket": "ws-01jjrstvwxyz0123456789abcd",
+                                "key": "reports/reads_fastqc.html",
+                                "version_id": "01JJRSVERSION0123456789ABC",
+                                "execution_id": "01JJRSEXEC0123456789ABCDEF",
+                                "container_path": "/outputs/reads_fastqc.html",
+                                "size": 20480,
+                                "digest": "fa2c8cc4f28176bbeed4b736df569a34c79cd3723e9ec42f9674b4d46ac6b8b8",
+                                "endpoint_url": "https://s3.example"
+                            }
+                        ],
                         "at_ms": 1755500009000u64
                     }
                 ],
@@ -286,7 +317,7 @@ fn kind_name(record: &JobFamilyRecord) -> &'static str {
         (status = 400, description = "Unknown `scope`, a cursor that is not a record key of this log, or a `limit` outside 1..=64", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "The token is path-restricted or belongs to another realm", body = ErrorResponse),
-        (status = 404, description = "No external job with that id is known at this responder, or it was submitted by somebody else; absence and foreign ownership are deliberately indistinguishable, and a responder that never held the family answers the same way, so page the node that accepted the submission", body = ErrorResponse),
+        (status = 404, description = "Unknown, unparseable or foreign job id, or a responder that never held the family", body = ErrorResponse),
         (status = 503, description = "The log could not be reduced here; retryable, the caller may page again", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))

--- a/api/src/routes/jobs.rs
+++ b/api/src/routes/jobs.rs
@@ -1078,8 +1078,9 @@ answers 404 rather than 403, so the surface never confirms that an id exists.
 - Node identities of other nodes are never disclosed; only the responder names itself, and an
   output whose owning node's S3 endpoint is unknown here carries `endpoint_url: null` rather than
   failing the read.
-- The read is answered by the node that owns the job, derived from the id itself: when that is
-  another node the request is forwarded under the caller's own bearer token.
+- A distributed execution job is answered here from the replicated family projection, without
+  routing. Every other kind is answered by the node that owns the job, derived from the id itself:
+  when that is another node the request is forwarded under the caller's own bearer token.
 - `run_crate` appears only for jobs that owe a run crate and reports that side obligation, not the
   job itself.
 

--- a/api/src/routes/jobs.rs
+++ b/api/src/routes/jobs.rs
@@ -721,11 +721,32 @@ fn validate_output_prefixes(prefixes: Vec<String>) -> ServerResult<Vec<String>> 
     path = "/jobs/",
     tag = "jobs",
     summary = "List the caller's jobs on this node",
-    description = "Requires a realm bearer token; a path-restricted (delegated) token is refused even for its own jobs. The page is self-scoped and node-local: it holds only jobs the caller submitted and only jobs this node owns, ordered newest first. Jobs recorded on other nodes are never merged in, so a caller that submitted against another node pages that node's listing instead (submission answers with the `origin_node_url` it was accepted at). A distributed execution job is listed where it was admitted or is running; read one by id for the replicated family view, which any node holding its records can answer. Jobs the system creates for its own bookkeeping are never listed. `limit` defaults to 50 and is capped at 200, `cursor` continues a previous page, and a page without `next_cursor` is the last one.",
+    description = r#"Pages the jobs the caller submitted to this node, newest first.
+
+**Authentication**: realm bearer token; a path-restricted (delegated) token is refused even for
+its own jobs.
+
+**Behavior**
+- The page is self-scoped and node-local: it holds only jobs the caller submitted and only jobs
+  this node owns.
+- Jobs recorded on other nodes are never merged in, so a caller that submitted against another
+  node pages that node's listing instead (submission answers with the `origin_node_url` it was
+  accepted at).
+- A distributed execution job is listed where it was admitted or is running; read one by id for
+  the replicated family view, which any node holding its records can answer.
+- Jobs the system creates for its own bookkeeping are never listed.
+- A page without `next_cursor` is the last one.
+
+**Limits**
+- `limit` defaults to 50 and is capped at 200; `0` is treated as unset.
+- `cursor` is a previous page's `next_cursor`: 24 bytes, base64url without padding, and anything
+  else is rejected with 400.
+- `state` selects one of `queued`, `claimed`, `preparing`, `ready`, `running`, `cancelling`,
+  `indeterminate`, `succeeded`, `failed` or `cancelled`; any other value is rejected with 400."#,
     params(
-        ("limit" = Option<usize>, Query, description = "Maximum jobs in one page. Default 50, clamped to at most 200; 0 is treated as unset"),
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token taken from a previous page's `next_cursor`: 24 bytes, base64url without padding. Anything else is rejected with 400. Absent starts at the newest job"),
-        ("state" = Option<String>, Query, description = "Restrict the page to one job state: `queued`, `claimed`, `preparing`, `ready`, `running`, `cancelling`, `indeterminate`, `succeeded`, `failed` or `cancelled`. Any other value is rejected with 400. Absent returns every state")
+        ("limit" = Option<usize>, Query, description = "Maximum jobs in one page; default 50, at most 200, and 0 is treated as unset"),
+        ("cursor" = Option<String>, Query, description = "Opaque `next_cursor` from a previous page; absent starts at the newest job"),
+        ("state" = Option<String>, Query, description = "Restrict the page to one job state; absent returns every state")
     ),
     responses(
         (
@@ -742,7 +763,11 @@ fn validate_output_prefixes(prefixes: Vec<String>) -> ServerResult<Vec<String>> 
                         "cancel_requested": false,
                         "created_at": "2026-04-09T14:23:11.123+00:00",
                         "updated_at": "2026-04-09T14:24:02.481+00:00",
-                        "progress": {"current": 2, "total": 5, "unit": "phases"},
+                        "progress": {
+                            "current": 2,
+                            "total": 5,
+                            "unit": "phases"
+                        },
                         "workspace_bucket": "ws-01jjrstvwxyz0123456789abcd",
                         "workspace_mode": "kept"
                     }
@@ -794,7 +819,50 @@ pub async fn list_jobs(
     path = "/jobs/",
     tag = "jobs",
     summary = "Submit a container execution job",
-    description = "Requires a realm bearer token with WRITE on the target group's data; a path-restricted (delegated) token is refused. Submission is asynchronous: a 2xx means the request is durably admitted into its replicated submission family and queued, never that it started, finished or produced outputs. The job is not anchored to one node: any node that reduced the family answers for it, and `origin_node_url` is a preferred route rather than an owner. The response carries the opaque `submission_id` of the request itself and the alias this responder currently reduces as canonical; `job_id` stays the caller's stable handle even when a later merge moves the canonical alias. Execution is at-least-once: a partition may admit and run duplicates, whose outputs stay retrievable and auditable while one canonical success supplies the result. `idempotency_key` is scoped to the caller: replaying the same key with the same plan answers 200 with the job that already exists and `created` false, while the same key with a different plan is a 409 conflict. Set `workspace.mode` to `existing` to run in a bucket that already exists, which additionally requires WRITE on that bucket and that it belongs to the same group; omitting `workspace` keeps a per-job workspace bucket. Rejected with 400: an empty image, `cpu_cores` of 0, a `ram_bytes` of 0 or above 2^63-1, more than 512 inputs, more than 1024 outputs, more than 32 output prefixes, an empty `dest_key`, a container path that is not absolute and traversal-free, two inputs sharing a container path, or two outputs sharing a `dest_key` or container path. Two inputs sharing a `dest_key` are not a transport error: `mode` and `collision_policy` decide the staged result, and only `reject` refuses them, as a 409 from the composition. The group's standing quota is decided against a replicated demand view: a view that understates the group is a 409 quota denial like an exceeded cap, carrying the dimension with `observed` reported at the limit, because a cap that cannot be shown to hold is not evidence of room. A replay of an idempotency key this node already claimed is settled before any quota is read and is never quota-refused. A 503 is retryable: the caller may submit again. It means the demand view could not be read, it kept moving under three reads, or three admission transactions in a row lost to a concurrent submission of the same group.",
+    description = r#"Accepts a container execution job for asynchronous execution and returns the id to poll.
+
+**Authentication**: realm bearer token with WRITE on the target group's data; a path-restricted
+(delegated) token is refused. Running in a bucket that already exists additionally requires WRITE
+on that bucket and that it belongs to the same group.
+
+**Behavior**
+- A 2xx means the request is durably admitted into its replicated submission family and queued,
+  never that it started, finished or produced outputs.
+- The job is not anchored to one node: any node that reduced the family answers for it, and
+  `origin_node_url` is a preferred route rather than an owner.
+- The response carries the opaque `submission_id` of the request itself and the alias this
+  responder currently reduces as canonical; `job_id` stays the caller's stable handle even when a
+  later merge moves the canonical alias.
+- Execution is at-least-once: a partition may admit and run duplicates, whose outputs stay
+  retrievable and auditable while one canonical success supplies the result.
+- `idempotency_key` is scoped to the caller: replaying the same key with the same plan answers 200
+  with the job that already exists and `created` false, while the same key with a different plan
+  is a 409 conflict.
+- On a replay `state` reports what the responder currently reduces for that family, so a running
+  or finished request reads `running`, `succeeded`, `failed`, `cancelled` or `indeterminate`
+  rather than `queued`.
+- Set `workspace.mode` to `existing` to run in a bucket that already exists; omitting `workspace`
+  keeps a per-job workspace bucket.
+- The group's standing quota is decided against a replicated demand view. A replay of an
+  idempotency key this node already claimed is settled before any quota is read and is never
+  quota-refused.
+
+**Limits** (all refused with 400)
+- An empty image, a `cpu_cores` of 0, or a `ram_bytes` of 0 or above 2^63-1.
+- More than 512 inputs, more than 1024 outputs, or more than 32 output prefixes.
+- An empty `dest_key`, or a container path that is not absolute and traversal-free.
+- Two inputs sharing a container path, or two outputs sharing a `dest_key` or container path.
+
+**Errors**
+- Two inputs sharing a `dest_key` are not a transport error: `mode` and `collision_policy` decide
+  the staged result, and only `reject` refuses them, as a 409 from the composition.
+- A quota refusal is a 409 carrying the exact scope, dimension and numbers in `quota`; a demand
+  view that understates the group is refused like an exceeded cap, with `observed` reported at the
+  limit, because a cap that cannot be shown to hold is not evidence of room.
+- A 503 is retryable and the caller may submit again with the same idempotency key: no family
+  holder could admit the request, the demand view could not be read or kept moving under three
+  reads, three admission transactions in a row lost to a concurrent submission of the same group,
+  or the id clock is unhealthy."#,
     request_body(
         content = SubmitExecutionRequest,
         description = "Container image, command and the inputs and outputs to stage around it",
@@ -802,19 +870,30 @@ pub async fn list_jobs(
             "group_id": "01JABCDEF0123456789ABCDEFG",
             "image": "registry.example.test/tools/fastqc:0.12.1",
             "command": ["fastqc", "--outdir", "/outputs", "/inputs/reads.fastq"],
-            "env": {"FASTQC_THREADS": "2"},
+            "env": {
+                "FASTQC_THREADS": "2"
+            },
             "cpu_cores": 2,
             "ram_bytes": 4294967296_i64,
             "max_walltime_ms": 3600000,
             "inputs": [
-                {"bucket": "project-data", "key": "raw/reads.fastq", "dest_key": "reads.fastq"}
+                {
+                    "bucket": "project-data",
+                    "key": "raw/reads.fastq",
+                    "dest_key": "reads.fastq"
+                }
             ],
             "outputs": [
-                {"container_path": "/outputs/reads_fastqc.html", "dest_key": "reports/reads_fastqc.html"}
+                {
+                    "container_path": "/outputs/reads_fastqc.html",
+                    "dest_key": "reports/reads_fastqc.html"
+                }
             ],
             "output_prefixes": ["reports/"],
             "idempotency_key": "fastqc-reads-2026-04-09",
-            "workspace": {"mode": "kept"}
+            "workspace": {
+                "mode": "kept"
+            }
         })
     ),
     responses(
@@ -834,7 +913,7 @@ pub async fn list_jobs(
         ),
         (
             status = 200,
-            description = "The idempotency key already names a request with this exact plan; nothing new was admitted, and `state` reports what the responder currently reduces for that family, so a replay of a running or finished request reads `running`, `succeeded`, `failed`, `cancelled` or `indeterminate` rather than `queued`",
+            description = "Replay of an idempotency key naming this exact plan; nothing new was admitted and `state` reports what the responder currently reduces",
             body = SubmitJobResponse,
             example = json!({
                 "job_id": "01JJRSTVWXYZ0123456789ABCD",
@@ -847,10 +926,10 @@ pub async fn list_jobs(
             })
         ),
         (status = 400, description = "Malformed group id, empty image, out-of-range resources, an invalid or duplicated input, output or container path, or a workspace request that names no usable bucket", body = ErrorResponse),
-        (status = 409, description = "The idempotency key is already bound to a request with a different plan, the group's standing compute quota refuses this new admission, the composition conflicts on a staged key, or the active RO-Crate job limit is reached; a quota refusal carries the exact scope, dimension and numbers in `quota`, and a refusal decided on an understated demand view reports `observed` at the limit", body = ErrorResponse),
+        (status = 409, description = "The idempotency key is bound to a different plan, the group's compute quota refuses the admission, the composition conflicts on a staged key, or the active RO-Crate job limit is reached", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "The token is path-restricted, or the caller lacks WRITE on the group or on the named existing workspace bucket", body = ErrorResponse),
-        (status = 503, description = "No family holder could admit the request, the group's demand view could not be read or did not settle, admission lost three transactions in a row to concurrent submissions of the same group, or the id clock is unhealthy; retryable, the caller may submit again with the same idempotency key", body = ErrorResponse)
+        (status = 503, description = "No family holder could admit the request, an unreadable or unsettled demand view, three lost admission transactions, or an unhealthy id clock; retryable", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -976,8 +1055,37 @@ pub async fn submit_job(
     path = "/jobs/{job_id}",
     tag = "jobs",
     summary = "Read one job's status",
-    description = "Requires a realm bearer token; a path-restricted (delegated) token is refused. Reads are self-scoped: only the job's own submitter may read it, and a job belonging to somebody else answers 404 rather than 403, so the surface never confirms that an id exists. A distributed execution job carries a `family` block reduced from the replicated records: it names the request's `submission_id`, the currently canonical alias, the canonical execution and its exact output VersionIds, how many physical executions and duplicate successes are known, the projection `revision` and digest to detect that the view changed, and the responder that answered. `family.partial` means this responder could not reduce every record, and `family.locally_exhausted` is a responder-local diagnostic (outside the projection digest) meaning every known execution ended without success and no retry is armed here; it is not evidence of a permanent failure. Node identities of other nodes are never disclosed; only the responder names itself, and an output whose owning node's S3 endpoint is unknown here carries `endpoint_url: null` rather than failing the read. The one exception is a persistent-id minting job the caller joined, which stays readable while the caller holds WRITE on the document it mints for. The read is answered by the node that owns the job, derived from the id itself: when that is another node the request is forwarded under the caller's own bearer token, so a malformed token is 400 and an owner that cannot be reached is a retryable 503. `state` is a point-in-time value that keeps moving until it reaches `succeeded`, `failed` or `cancelled`. `run_crate` appears only for jobs that owe a run crate and reports that side obligation, not the job itself.",
-    params(("job_id" = String, Path, description = "Job identifier as returned by submission: a 26-character ULID-shaped id. An unparseable id is 404")),
+    description = r#"Returns one job's current status, with the replicated family view for a distributed execution job.
+
+**Authentication**: realm bearer token; a path-restricted (delegated) token is refused. Reads are
+self-scoped: only the job's own submitter may read it, and a job belonging to somebody else
+answers 404 rather than 403, so the surface never confirms that an id exists.
+
+**Behavior**
+- The one exception to self-scoping is a persistent-id minting job the caller joined, which stays
+  readable while the caller holds WRITE on the document it mints for.
+- `state` is a point-in-time value that keeps moving until it reaches `succeeded`, `failed` or
+  `cancelled`.
+- A distributed execution job carries a `family` block reduced from the replicated records: it
+  names the request's `submission_id`, the currently canonical alias, the canonical execution and
+  its exact output VersionIds, how many physical executions and duplicate successes are known, the
+  projection `revision` and digest to detect that the view changed, and the responder that
+  answered.
+- `family.partial` means this responder could not reduce every record.
+- `family.locally_exhausted` is a responder-local diagnostic (outside the projection digest)
+  meaning every known execution ended without success and no retry is armed here; it is not
+  evidence of a permanent failure.
+- Node identities of other nodes are never disclosed; only the responder names itself, and an
+  output whose owning node's S3 endpoint is unknown here carries `endpoint_url: null` rather than
+  failing the read.
+- The read is answered by the node that owns the job, derived from the id itself: when that is
+  another node the request is forwarded under the caller's own bearer token.
+- `run_crate` appears only for jobs that owe a run crate and reports that side obligation, not the
+  job itself.
+
+**Errors**: a bearer token that cannot be forwarded to the owning node is a 400, and an owner that
+cannot be reached is a retryable 503."#,
+    params(("job_id" = String, Path, description = "Job id as returned by submission: a 26-character ULID; an unparseable id is 404")),
     responses(
         (
             status = 200,
@@ -992,7 +1100,11 @@ pub async fn submit_job(
                 "created_at": "2026-04-09T14:23:11.123+00:00",
                 "updated_at": "2026-04-09T14:31:47.902+00:00",
                 "finished_at": "2026-04-09T14:31:47.902+00:00",
-                "progress": {"current": 5, "total": 5, "unit": "phases"},
+                "progress": {
+                    "current": 5,
+                    "total": 5,
+                    "unit": "phases"
+                },
                 "result": {
                     "exit_code": 0,
                     "workspace_bucket": "ws-01jjrstvwxyz0123456789abcd",
@@ -1013,7 +1125,10 @@ pub async fn submit_job(
                 },
                 "workspace_bucket": "ws-01jjrstvwxyz0123456789abcd",
                 "workspace_mode": "kept",
-                "run_crate": {"status": "written", "resource": "https://w3id.org/aruna/01JMETADATA0123456789ABCDE#run/01JJRSTVWXYZ0123456789ABCD"},
+                "run_crate": {
+                    "status": "written",
+                    "resource": "https://w3id.org/aruna/01JMETADATA0123456789ABCDE#run/01JJRSTVWXYZ0123456789ABCD"
+                },
                 "family": {
                     "submission_id": "6b1f8c9d0e2a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4",
                     "request_digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d",
@@ -1025,16 +1140,18 @@ pub async fn submit_job(
                     "canonical_execution_id": "01JJRSEXEC0123456789ABCDEF",
                     "executions": 2,
                     "duplicate_successes": 1,
-                    "outputs": [{
-                        "bucket": "ws-01jjrstvwxyz0123456789abcd",
-                        "key": "reports/reads_fastqc.html",
-                        "version_id": "01JJRSVERSION0123456789ABC",
-                        "execution_id": "01JJRSEXEC0123456789ABCDEF",
-                        "endpoint_url": "https://s3.example",
-                        "container_path": "/outputs/reads_fastqc.html",
-                        "size": 20480,
-                        "digest": "fa2c8cc4f28176bbeed4b736df569a34c79cd3723e9ec42f9674b4d46ac6b8b8"
-                    }],
+                    "outputs": [
+                        {
+                            "bucket": "ws-01jjrstvwxyz0123456789abcd",
+                            "key": "reports/reads_fastqc.html",
+                            "version_id": "01JJRSVERSION0123456789ABC",
+                            "execution_id": "01JJRSEXEC0123456789ABCDEF",
+                            "endpoint_url": "https://s3.example",
+                            "container_path": "/outputs/reads_fastqc.html",
+                            "size": 20480,
+                            "digest": "fa2c8cc4f28176bbeed4b736df569a34c79cd3723e9ec42f9674b4d46ac6b8b8"
+                        }
+                    ],
                     "revision": 7,
                     "projection_digest": "1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f",
                     "eventually_consistent": true,
@@ -1135,11 +1252,32 @@ fn decode_report_row(
     path = "/jobs/{job_id}/report",
     tag = "jobs",
     summary = "Page a finished RO-Crate job's report",
-    description = "Requires a realm bearer token; a path-restricted (delegated) token is refused. Self-scoped like the status read: a job submitted by somebody else answers 404 instead of 403. Only RO-Crate import and export jobs keep a per-entry report; every other kind answers 404. The report exists only once the job is terminal, so while it is still running the answer is 404 carrying a pending marker with the job's current state, and the caller should poll. It is then frozen and immutable, and it disappears again once the job's retention window passes, which is a plain 404. Paging is stable against that frozen snapshot: `report_digest` names it, a cursor carries both the job and that digest, and a cursor from another job or another report is 409 rather than a silently different page. The read is answered by the node that owns the job, forwarded under the caller's own bearer token when this node is not the owner, so an unreachable owner is a retryable 503.",
+    description = r#"Pages the frozen per-entry report of a finished RO-Crate import or export job.
+
+**Authentication**: realm bearer token; a path-restricted (delegated) token is refused.
+Self-scoped like the status read: a job submitted by somebody else answers 404 instead of 403.
+
+**Behavior**
+- Only RO-Crate import and export jobs keep a per-entry report; every other kind answers 404.
+- The report exists only once the job is terminal, so while it is still running the answer is 404
+  carrying a pending marker with the job's current state, and the caller should poll.
+- It is then frozen and immutable, and it disappears again once the job's retention window passes,
+  which is a plain 404.
+- Paging is stable against that frozen snapshot: `report_digest` names it and a cursor carries
+  both the job and that digest.
+- The read is answered by the node that owns the job, forwarded under the caller's own bearer
+  token when this node is not the owner.
+
+**Limits**
+- `limit` defaults to 200 and is capped at 1000; `0` is treated as unset.
+
+**Errors**: a cursor from another job or another report is a 409 rather than a silently different
+page, a malformed cursor or a token that cannot be forwarded is a 400, and an unreachable owner is
+a retryable 503."#,
     params(
-        ("job_id" = String, Path, description = "Job identifier as returned by submission: a 26-character ULID-shaped id. An unparseable id is 404"),
-        ("limit" = Option<usize>, Query, description = "Maximum report rows in one page. Default 200, clamped to at most 1000; 0 is treated as unset"),
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token taken from a previous page's `next_cursor`, bound to this job and to the frozen report it was issued against. Malformed values are 400 and mismatched ones 409. Absent starts at the first row")
+        ("job_id" = String, Path, description = "Job id as returned by submission: a 26-character ULID; an unparseable id is 404"),
+        ("limit" = Option<usize>, Query, description = "Maximum report rows in one page; default 200, at most 1000, and 0 is treated as unset"),
+        ("cursor" = Option<String>, Query, description = "Opaque `next_cursor` from a previous page, bound to this job and its frozen report; absent starts at the first row")
     ),
     responses(
         (
@@ -1173,12 +1311,15 @@ fn decode_report_row(
         (status = 403, description = "The token is path-restricted or belongs to another realm", body = ErrorResponse),
         (
             status = 404,
-            description = "Either the report is not available yet, answered as a pending marker naming the job's current state, or there is no readable report at all: unknown job, a job submitted by somebody else, a kind that keeps no report, or a report whose retention has passed, answered as the standard error body",
+            description = "A pending marker naming the job's current state, or the standard error body: unknown job, a foreign job, a kind that keeps no report, or retention passed",
             body = ReportUnavailableResponse,
             examples(
                 ("Report pending" = (
                     summary = "The job has not reached a terminal state, so no report is frozen yet",
-                    value = json!({"code": "report_pending", "state": "running"})
+                    value = json!({
+                        "code": "report_pending",
+                        "state": "running"
+                    })
                 ))
             )
         ),
@@ -1500,10 +1641,31 @@ async fn artifact_response(
     path = "/jobs/{job_id}/artifacts/rocrate",
     tag = "jobs",
     summary = "Download a finished export job's RO-Crate",
-    description = "Downloads the packaged RO-Crate produced by an export job as a binary `application/zip` body, not JSON. Requires a realm bearer token; a path-restricted (delegated) token is refused. Self-scoped like the status read: a job submitted by somebody else answers 404 instead of 403, and a job kind that produces no crate answers 404 as well. A successful answer always carries `Content-Type: application/zip`, `Content-Length`, `Accept-Ranges: bytes`, an `ETag` that is the artifact's quoted hex BLAKE3 digest, and a `Content-Disposition: attachment` naming the crate file with both an ASCII fallback and a UTF-8 form; a partial answer adds `Content-Range`. While the export job has not finished the crate is not ready and the answer is 404 with the code `artifact_pending` and the job's current state in its details, so the caller should poll the status instead of retrying blindly; once the artifact's retention window passes it is 410 and never comes back. `Range` accepts one byte range only. Downloads are admission-limited, so a saturated node refuses rather than queueing.",
+    description = r#"Downloads the packaged RO-Crate an export job produced as a binary `application/zip` body, not JSON.
+
+**Authentication**: realm bearer token; a path-restricted (delegated) token is refused.
+Self-scoped like the status read: a job submitted by somebody else answers 404 instead of 403, and
+a job kind that produces no crate answers 404 as well.
+
+**Behavior**
+- A successful answer always carries `Content-Type: application/zip`, `Content-Length`,
+  `Accept-Ranges: bytes`, an `ETag` that is the artifact's quoted hex BLAKE3 digest, and a
+  `Content-Disposition: attachment` naming the crate file with both an ASCII fallback and a UTF-8
+  form; a partial answer adds `Content-Range`.
+- While the export job has not finished the crate is not ready and the answer is 404 with the code
+  `artifact_pending` and the job's current state in its details, so the caller should poll the
+  status instead of retrying blindly.
+- Downloads are admission-limited, so a saturated node refuses rather than queueing.
+
+**Limits**
+- `Range` accepts one byte range only.
+
+**Errors**: once the artifact's retention window passes it is a 410 and never comes back, a range
+that is not a single satisfiable one is a 416, and a saturated or unreachable owner is a retryable
+503."#,
     params(
-        ("job_id" = String, Path, description = "Job identifier as returned by submission: a 26-character ULID-shaped id. An unparseable id is 404"),
-        ("Range" = Option<String>, Header, description = "One byte range over the crate: `bytes=<first>-<last>`, `bytes=<first>-` or `bytes=-<suffix length>`. Multiple ranges and unparseable or out-of-bounds values are refused with 416. Absent returns the whole crate")
+        ("job_id" = String, Path, description = "Job id as returned by submission: a 26-character ULID; an unparseable id is 404"),
+        ("Range" = Option<String>, Header, description = "One byte range: `bytes=<first>-<last>`, `bytes=<first>-` or `bytes=-<suffix length>`; absent returns the whole crate")
     ),
     responses(
         (status = 200, description = "The complete RO-Crate as an `application/zip` byte stream, with `Content-Length`, `ETag`, `Accept-Ranges: bytes` and an attachment `Content-Disposition`"),
@@ -1511,7 +1673,7 @@ async fn artifact_response(
         (status = 400, description = "The bearer token cannot be forwarded to the owning node", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "The token is path-restricted or belongs to another realm", body = ErrorResponse),
-        (status = 404, description = "No downloadable crate: unknown job, a job submitted by somebody else, a kind that produces none, or the export has not finished yet, which is coded `artifact_pending` and carries the job's current state", body = ErrorResponse),
+        (status = 404, description = "No downloadable crate: unknown job, a foreign job, a kind that produces none, or an unfinished export, coded `artifact_pending` with the job's state", body = ErrorResponse),
         (status = 410, description = "The crate's retention window has passed and it has been deleted; a retry will not bring it back", body = ErrorResponse),
         (status = 416, description = "The requested range is not a single satisfiable byte range; the answer repeats `Accept-Ranges` and reports the crate size in `Content-Range`", body = ErrorResponse),
         (status = 503, description = "The node owning this job could not be reached, or this node's download capacity is exhausted; retryable, the caller may repeat the download", body = ErrorResponse)
@@ -1533,10 +1695,28 @@ pub async fn get_job_artifact(
     path = "/jobs/{job_id}/artifacts/rocrate",
     tag = "jobs",
     summary = "Probe a finished export job's RO-Crate headers",
-    description = "Answers exactly what the download would answer, with the headers but no body, so a client can learn a crate's size, digest and filename before fetching it. Requires a realm bearer token; a path-restricted (delegated) token is refused. Self-scoped like the status read: a job submitted by somebody else answers 404 instead of 403. The headers describe an `application/zip` crate: `Content-Type`, `Content-Length` for the whole crate or for the requested range, `Accept-Ranges: bytes`, an `ETag` that is the artifact's quoted hex BLAKE3 digest, an attachment `Content-Disposition`, and `Content-Range` when a range was asked for. Readiness behaves as it does for the download: a crate whose export has not finished is 404 coded `artifact_pending` with the job's current state, and one past its retention window is 410. Probing does not consume download capacity.",
+    description = r#"Answers exactly what the download would answer, with the headers but no body.
+
+**Authentication**: realm bearer token; a path-restricted (delegated) token is refused.
+Self-scoped like the status read: a job submitted by somebody else answers 404 instead of 403.
+
+**Behavior**
+- A client can learn a crate's size, digest and filename before fetching it.
+- The headers describe an `application/zip` crate: `Content-Type`, `Content-Length` for the whole
+  crate or for the requested range, `Accept-Ranges: bytes`, an `ETag` that is the artifact's
+  quoted hex BLAKE3 digest, an attachment `Content-Disposition`, and `Content-Range` when a range
+  was asked for.
+- Readiness behaves as it does for the download: a crate whose export has not finished is a 404
+  coded `artifact_pending` with the job's current state, and one past its retention window is a
+  410.
+- Probing does not consume download capacity.
+
+**Limits**
+- `Range` accepts one byte range only; multiple ranges and unparseable or out-of-bounds values are
+  refused with 416."#,
     params(
-        ("job_id" = String, Path, description = "Job identifier as returned by submission: a 26-character ULID-shaped id. An unparseable id is 404"),
-        ("Range" = Option<String>, Header, description = "One byte range over the crate: `bytes=<first>-<last>`, `bytes=<first>-` or `bytes=-<suffix length>`. Multiple ranges and unparseable or out-of-bounds values are refused with 416. Absent describes the whole crate")
+        ("job_id" = String, Path, description = "Job id as returned by submission: a 26-character ULID; an unparseable id is 404"),
+        ("Range" = Option<String>, Header, description = "One byte range: `bytes=<first>-<last>`, `bytes=<first>-` or `bytes=-<suffix length>`; absent describes the whole crate")
     ),
     responses(
         (status = 200, description = "Headers for the complete `application/zip` crate: `Content-Length`, `ETag`, `Accept-Ranges: bytes` and an attachment `Content-Disposition`. No body is sent"),
@@ -1544,7 +1724,7 @@ pub async fn get_job_artifact(
         (status = 400, description = "The bearer token cannot be forwarded to the owning node", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "The token is path-restricted or belongs to another realm", body = ErrorResponse),
-        (status = 404, description = "No crate to describe: unknown job, a job submitted by somebody else, a kind that produces none, or the export has not finished yet, which is coded `artifact_pending` and carries the job's current state", body = ErrorResponse),
+        (status = 404, description = "No crate to describe: unknown job, a foreign job, a kind that produces none, or an unfinished export, coded `artifact_pending` with the job's state", body = ErrorResponse),
         (status = 410, description = "The crate's retention window has passed and it has been deleted; a retry will not bring it back", body = ErrorResponse),
         (status = 416, description = "The requested range is not a single satisfiable byte range; the answer repeats `Accept-Ranges` and reports the crate size in `Content-Range`", body = ErrorResponse),
         (status = 503, description = "The node owning this job could not be reached or is not yet known here; retryable, the caller may repeat the probe", body = ErrorResponse)
@@ -1566,8 +1746,31 @@ pub async fn head_job_artifact(
     path = "/jobs/{job_id}/cancel",
     tag = "jobs",
     summary = "Request cancellation of the caller's job",
-    description = "Requires a realm bearer token; a path-restricted (delegated) token is refused. Self-scoped like the status read: only the submitter may cancel, and a job belonging to somebody else answers 404 rather than 403. Cancellation is asynchronous: 202 means the request was durably recorded on the job, not that work has stopped. A job that never started is settled immediately, while one already running is asked to stop and reaches `cancelled` some time later, and may still finish on its own first, so the caller polls the status to learn the outcome. The call is idempotent: repeating it on a job that is still live keeps answering 202 with `cancel_requested` true, and a job that has already reached a terminal state answers 200 with that state unchanged. Cancelling a distributed execution job publishes an append-only cancellation intent into its replicated family, which every holder observes and which suppresses further launches; it never claims that a partitioned execution stopped. An execution that already holds a receipt may still finish, and that late success stays visible with `cancel_requested` true rather than being erased. Cancellation of any other job stays anchored to the node that owns it: when that node cannot be reached the answer is a retryable 503 and nothing was recorded anywhere else.",
-    params(("job_id" = String, Path, description = "Job identifier as returned by submission: a 26-character ULID-shaped id. An unparseable id is 404")),
+    description = r#"Records a cancellation request on the caller's job; it does not stop the work synchronously.
+
+**Authentication**: realm bearer token; a path-restricted (delegated) token is refused.
+Self-scoped like the status read: only the submitter may cancel, and a job belonging to somebody
+else answers 404 rather than 403.
+
+**Behavior**
+- Cancellation is asynchronous: 202 means the request was durably recorded on the job, not that
+  work has stopped.
+- A job that never started is settled immediately, while one already running is asked to stop and
+  reaches `cancelled` some time later, and may still finish on its own first, so the caller polls
+  the status to learn the outcome.
+- The call is idempotent: repeating it on a job that is still live keeps answering 202 with
+  `cancel_requested` true, and a job that has already reached a terminal state answers 200 with
+  that state unchanged.
+- Cancelling a distributed execution job publishes an append-only cancellation intent into its
+  replicated family, which every holder observes and which suppresses further launches; it never
+  claims that a partitioned execution stopped.
+- An execution that already holds a receipt may still finish, and that late success stays visible
+  with `cancel_requested` true rather than being erased.
+- Cancellation of any other job stays anchored to the node that owns it.
+
+**Errors**: when the owning node cannot be reached the answer is a retryable 503 and nothing was
+recorded anywhere else."#,
+    params(("job_id" = String, Path, description = "Job id as returned by submission: a 26-character ULID; an unparseable id is 404")),
     responses(
         (
             status = 202,
@@ -1581,7 +1784,11 @@ pub async fn head_job_artifact(
                 "cancel_requested": true,
                 "created_at": "2026-04-09T14:23:11.123+00:00",
                 "updated_at": "2026-04-09T14:29:55.004+00:00",
-                "progress": {"current": 3, "total": 5, "unit": "phases"},
+                "progress": {
+                    "current": 3,
+                    "total": 5,
+                    "unit": "phases"
+                },
                 "workspace_bucket": "ws-01jjrstvwxyz0123456789abcd",
                 "workspace_mode": "kept"
             })
@@ -1599,7 +1806,11 @@ pub async fn head_job_artifact(
                 "created_at": "2026-04-09T14:23:11.123+00:00",
                 "updated_at": "2026-04-09T14:31:47.902+00:00",
                 "finished_at": "2026-04-09T14:31:47.902+00:00",
-                "progress": {"current": 5, "total": 5, "unit": "phases"},
+                "progress": {
+                    "current": 5,
+                    "total": 5,
+                    "unit": "phases"
+                },
                 "workspace_bucket": "ws-01jjrstvwxyz0123456789abcd",
                 "workspace_mode": "kept"
             })

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -713,7 +713,23 @@ impl MetadataDocumentListItem {
     path = "/metadata",
     tag = "metadata",
     summary = "Create a metadata document",
-    description = "Requires a realm bearer token. On a server or management node the caller needs WRITE on the group's metadata path and on the new document's permission path; a user-kind node holds no metadata bucket, so it forwards the create to a holder that re-runs the same checks under the caller's own bearer token. The document path is normalized and must not be empty, and the token's realm must match the serving node's realm. A 201 means the create was durably accepted into the event/projection pipeline: the graph may not be materialized, queryable, searchable or present on every replica yet, so a follow-up read can still answer 404 or 503 for a moment. A write that can neither be applied locally nor delivered to a holder is refused rather than accepted.",
+    description = r#"Creates a metadata document from scaffold fields or a submitted RO-Crate.
+
+**Authentication**: realm bearer token whose realm matches the serving node; on a server or
+management node the caller needs WRITE on the group's metadata path and on the new document's
+permission path.
+
+**Behavior**
+- A user-kind node holds no metadata bucket, so it forwards the create to a holder that re-runs
+  the same checks under the caller's own bearer token.
+- A 201 means the create was durably accepted into the event/projection pipeline: the graph may
+  not be materialized, queryable, searchable or present on every replica yet, so a follow-up read
+  can still answer 404 or 503 for a moment.
+- A write that can neither be applied locally nor delivered to a holder is refused rather than
+  accepted.
+
+**Limits**
+- The document path is normalized before use and must not be empty."#,
     request_body(
         content = CreateMetadataRequest,
         description = "Create metadata either from scaffold fields or from a full RO-Crate JSON-LD object. Scaffold creation emits RO-Crate 1.3. The RO-Crate form accepts 1.2 and 1.3 contexts and specification IRIs and preserves the submitted version. Both forms reject unknown fields; the RO-Crate form must be a JSON object and is validated before acceptance.",
@@ -918,7 +934,21 @@ pub async fn create_metadata_document(
     path = "/metadata",
     tag = "metadata",
     summary = "List visible metadata documents across groups",
-    description = "Authentication is optional and changes the result: an authenticated caller sees every document their identity may read, an anonymous caller sees only public documents. Answered from this node's eventually consistent registry view, so a just-accepted create can be missing for a moment and a document whose graph is not materialized yet is listed without its RO-Crate summary. Pagination is offset-based over the filtered, visibility-checked sequence in the requested order; a page is stable only as far as concurrent metadata churn allows.",
+    description = r#"Lists metadata documents from every group the caller may see.
+
+**Authentication**: optional bearer token; an authenticated caller sees every document their
+identity may read, an anonymous caller only public documents.
+
+**Behavior**
+- Answered from this node's eventually consistent registry view, so a just-accepted create can be
+  missing for a moment, and a document whose graph is not materialized yet is listed without its
+  RO-Crate summary.
+- Pagination is offset-based over the filtered, visibility-checked sequence in the requested
+  order; a page is stable only as far as concurrent metadata churn allows.
+- `limit` echoes the page size actually applied after clamping and `offset` the skip that was
+  applied; `total_returned` counts this page.
+- `total_estimate` is only present for browse-sized pages (an effective limit of 24 or more),
+  where it counts the documents visible to the caller across all pages of the same filter."#,
     params(
         ("group_id" = Option<String>, Query, description = "Optional group ULID filter. Restricts the listing to that group; omitted lists every group visible to the caller"),
         ("path_prefix" = Option<String>, Query, description = "Normalized metadata path prefix, for example profiles/. Matches the prefix itself and any path directly below it, never a partial path segment"),
@@ -930,7 +960,7 @@ pub async fn create_metadata_document(
     responses(
         (
             status = 200,
-            description = "Metadata documents visible to the caller. limit echoes the page size actually applied after clamping and offset the skip that was applied, total_returned counts this page, and total_estimate is only present for browse-sized pages (effective limit of 24 or more), where it counts the documents visible to the caller across all pages of the same filter",
+            description = "Metadata documents visible to the caller, with the applied page size, offset and counts",
             body = ListMetadataResponse,
             examples(
                 (
@@ -990,7 +1020,20 @@ pub async fn list_all_metadata_documents(
     path = "/groups/{group_id}/metadata",
     tag = "metadata",
     summary = "List a group's visible metadata documents",
-    description = "Authentication is optional and changes the result: an authenticated caller sees every document of the group their identity may read, an anonymous caller sees only public documents. Answered from this node's eventually consistent registry view, so a just-accepted create can be missing for a moment and a document whose graph is not materialized yet is listed without its RO-Crate summary. Pagination is offset-based over the filtered, visibility-checked sequence in the requested order.",
+    description = r#"Lists the metadata documents of one group that the caller may see.
+
+**Authentication**: optional bearer token; an authenticated caller sees every document of the
+group their identity may read, an anonymous caller only public documents.
+
+**Behavior**
+- Answered from this node's eventually consistent registry view, so a just-accepted create can be
+  missing for a moment, and a document whose graph is not materialized yet is listed without its
+  RO-Crate summary.
+- Pagination is offset-based over the filtered, visibility-checked sequence in the requested
+  order.
+- `limit` echoes the page size actually applied after clamping and `offset` the skip that was
+  applied; `total_returned` counts this page.
+- `total_estimate` is only present for browse-sized pages (an effective limit of 24 or more)."#,
     params(
         ("group_id" = String, Path, description = "Group ULID whose metadata documents are listed"),
         ("path_prefix" = Option<String>, Query, description = "Normalized metadata path prefix, for example profiles/. Matches the prefix itself and any path directly below it, never a partial path segment"),
@@ -1002,7 +1045,7 @@ pub async fn list_all_metadata_documents(
     responses(
         (
             status = 200,
-            description = "Metadata documents of the group that are visible to the caller. limit echoes the page size actually applied after clamping and offset the skip that was applied, total_returned counts this page, and total_estimate is only present for browse-sized pages (effective limit of 24 or more)",
+            description = "Metadata documents of the group visible to the caller, with the applied page size, offset and counts",
             body = ListMetadataResponse,
             examples(
                 (
@@ -1052,7 +1095,20 @@ pub async fn list_metadata_documents(
     path = "/groups/{group_id}/metadata/path",
     tag = "metadata",
     summary = "Resolve a metadata path to its winning document",
-    description = "Returns the deterministic visible winner and authorized conflicts reported consistently by every current replica for one normalized metadata path. An unavailable or divergent current-replica view fails closed. Authentication is optional and changes the result: only claims the caller may read are considered, so an anonymous caller resolves the winner among public documents only, and a path whose only claims are invisible answers 404 rather than disclosing that it is taken. The lookup is answered by the replicas that hold the path's registry shards, with a bounded fan-out and an overall deadline of a few seconds.",
+    description = r#"Resolves one normalized metadata path to its visible winning document.
+
+**Authentication**: optional bearer token; only claims the caller may read are considered, so an
+anonymous caller resolves the winner among public documents only.
+
+**Behavior**
+- Returns the deterministic visible winner and the authorized conflicts reported consistently by
+  every current replica for the path.
+- The lookup is answered by the replicas that hold the path's registry shards, with a bounded
+  fan-out and an overall deadline of a few seconds.
+- A path whose only claims are invisible answers 404 rather than disclosing that it is taken.
+
+**Errors**: an unavailable or divergent current-replica view fails closed with 503 instead of
+answering from a partial view."#,
     params(
         ("group_id" = String, Path, description = "Group ULID that owns the path"),
         ("path" = String, Query, description = "Exact metadata path, normalized before lookup (surrounding slashes trimmed); an empty path is rejected with 400. Prefix matching is not applied")
@@ -1125,9 +1181,58 @@ pub async fn get_metadata_path(
     path = "/metadata/profile-validation/capabilities",
     tag = "metadata",
     summary = "Get backend Profile validation capabilities",
-    description = "Shapes registered as a Profile are compiled and executed by craqle's native SHACL Core Subset v1 engine, server side and authoritative. Supported targets are sh:targetClass, sh:targetNode, sh:targetSubjectsOf, sh:targetObjectsOf, and implicit class targets; a node shape that names no target at all is bound to the crate root, so a Profile can constrain the root entity without knowing its minted IRI. Supported paths are predicate, sh:inversePath, sequence, sh:alternativePath, sh:zeroOrOnePath, sh:zeroOrMorePath, and sh:oneOrMorePath. The supported constraint set is listed in supported_constraints. SHACL-SPARQL, SHACL-JS, SHACL-AF, custom components and targets, recursive shapes, RDF-star terms, and remote owl:imports fail closed with an unsupported_constraint finding that names the construct; the same finding is returned when the registered Turtle cannot be parsed. sh:class is exact rdf:type membership: no RDFS or OWL inference is applied, so a subclass instance does not satisfy a superclass constraint. Shapes may reference crate-local ids relative to the crate root, for example sh:hasValue <#person-1>. Evaluation is bounded: exceeding the result, path-edge, or path-depth budget returns a permanent validation_limit finding with incomplete completeness instead of a partial verdict, while a temporarily unavailable Profile or evaluator returns 503 with Retry-After.",
-    responses((status = 200, description = "Evaluator identity, exact supported constraints, fail-closed policy, and accepted Profile IRI forms", body = ProfileValidationCapabilitiesResponse,
-        example = json!({"evaluator": "craqle-shacl-core/0.2", "supported_constraints": ["sh:targetClass", "sh:property", "sh:path", "sh:minCount", "sh:maxCount", "sh:datatype", "sh:class", "sh:nodeKind", "sh:pattern", "sh:in", "sh:hasValue", "sh:closed"], "unsupported_constraint_policy": "fail_closed", "public_profile_iri_template": "https://w3id.org/aruna/profile/{document_id}"})))
+    description = r#"Reports how this node compiles and evaluates registered Profile shapes.
+
+**Authentication**: none; the route declares no security requirement and answers every caller
+with the same capability report.
+
+**Behavior**
+- Shapes registered as a Profile are compiled and executed by craqle's native SHACL Core Subset
+  v1 engine, server side and authoritative.
+- Supported targets are `sh:targetClass`, `sh:targetNode`, `sh:targetSubjectsOf`,
+  `sh:targetObjectsOf` and implicit class targets; a node shape that names no target at all is
+  bound to the crate root, so a Profile can constrain the root entity without knowing its minted
+  IRI.
+- Supported paths are predicate, `sh:inversePath`, sequence, `sh:alternativePath`,
+  `sh:zeroOrOnePath`, `sh:zeroOrMorePath` and `sh:oneOrMorePath`.
+- The supported constraint set is listed in `supported_constraints`.
+- `sh:class` is exact `rdf:type` membership: no RDFS or OWL inference is applied, so a subclass
+  instance does not satisfy a superclass constraint.
+- Shapes may reference crate-local ids relative to the crate root, for example
+  `sh:hasValue <#person-1>`.
+
+**Limits**
+- SHACL-SPARQL, SHACL-JS, SHACL-AF, custom components and targets, recursive shapes, RDF-star
+  terms and remote `owl:imports` fail closed with an `unsupported_constraint` finding that names
+  the construct; the same finding is returned when the registered Turtle cannot be parsed.
+- Evaluation is bounded: exceeding the result, path-edge or path-depth budget returns a permanent
+  `validation_limit` finding with incomplete completeness instead of a partial verdict.
+
+**Errors**: a temporarily unavailable Profile or evaluator answers 503 with `Retry-After`."#,
+    responses((
+        status = 200,
+        description = "Evaluator identity, exact supported constraints, fail-closed policy, and accepted Profile IRI forms",
+        body = ProfileValidationCapabilitiesResponse,
+        example = json!({
+            "evaluator": "craqle-shacl-core/0.2",
+            "supported_constraints": [
+                "sh:targetClass",
+                "sh:property",
+                "sh:path",
+                "sh:minCount",
+                "sh:maxCount",
+                "sh:datatype",
+                "sh:class",
+                "sh:nodeKind",
+                "sh:pattern",
+                "sh:in",
+                "sh:hasValue",
+                "sh:closed"
+            ],
+            "unsupported_constraint_policy": "fail_closed",
+            "public_profile_iri_template": "https://w3id.org/aruna/profile/{document_id}"
+        })
+    ))
 )]
 pub async fn profile_validation_capabilities()
 -> (StatusCode, Json<ProfileValidationCapabilitiesResponse>) {
@@ -1149,13 +1254,67 @@ pub async fn profile_validation_capabilities()
     post,
     path = "/metadata/profile-validation/preview",
     tag = "metadata",
-    summary = "Preview the Profile verdict for an unsaved RO-Crate draft",
-    description = "Runs the exact verdict POST /metadata and PUT /metadata/{document_id}/rocrate would enforce against a draft, without storing anything. structural_violations carries the RO-Crate structural failures and findings carries the Profile constraint findings; accepted is true only when both would let the write through. The draft is evaluated under its own crate root, so focus nodes and paths are reported in crate-local form with the root as `./`. Requires an authenticated realm caller; no document permission is checked because only the realm-public registered Profile is read.",
+    summary = "Preview the Profile verdict for a draft",
+    description = r#"Runs the Profile and structural verdict for a draft crate without storing it.
+
+**Authentication**: authenticated realm caller; no document permission is checked because only
+the realm-public registered Profile is read.
+
+**Behavior**
+- Applies the exact verdict `POST /metadata` and `PUT /metadata/{document_id}/rocrate` would
+  enforce against the draft, and stores nothing.
+- `structural_violations` carries the RO-Crate structural failures and `findings` the Profile
+  constraint findings; `accepted` is true only when both would let the write through.
+- The draft is evaluated under its own crate root, so focus nodes and paths are reported in
+  crate-local form with the root as `./`."#,
     request_body(content = ProfileValidationPreviewRequest,
-        example = json!({"rocrate": {"@context": "https://w3id.org/ro/crate/1.3/context", "@graph": [{"@id": "ro-crate-metadata.json", "@type": "CreativeWork", "conformsTo": {"@id": "https://w3id.org/ro/crate/1.3"}, "about": {"@id": "./"}}, {"@id": "./", "@type": "Dataset", "name": "Draft dataset", "description": "Validated before it is saved", "datePublished": "2026-08-22", "conformsTo": {"@id": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000"}}]}})),
+        example = json!({
+            "rocrate": {
+                "@context": "https://w3id.org/ro/crate/1.3/context",
+                "@graph": [
+                    {
+                        "@id": "ro-crate-metadata.json",
+                        "@type": "CreativeWork",
+                        "conformsTo": { "@id": "https://w3id.org/ro/crate/1.3" },
+                        "about": { "@id": "./" }
+                    },
+                    {
+                        "@id": "./",
+                        "@type": "Dataset",
+                        "name": "Draft dataset",
+                        "description": "Validated before it is saved",
+                        "datePublished": "2026-08-22",
+                        "conformsTo": {
+                            "@id": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000"
+                        }
+                    }
+                ]
+            }
+        })),
     responses(
         (status = 200, description = "Verdict for the draft, including structural violations and Profile findings", body = ProfileValidationPreviewResponse,
-            example = json!({"accepted": false, "state": "invalid", "profile_id": "01JPROFILE0000000000000000", "profile_iri": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000", "profile_revision": "01JPROFILEREVISION00000000", "evaluator": "craqle-shacl-core/0.2", "findings": [{"code": "constraint_violation", "severity": "violation", "focus_node": "./", "path": "http://schema.org/identifier", "rule": "http://www.w3.org/ns/shacl#minCount", "message": "fewer values are present than the Profile requires", "profile_revision": "01JPROFILEREVISION00000000", "completeness": "complete"}], "completeness": "complete", "structural_violations": []})),
+            example = json!({
+                "accepted": false,
+                "state": "invalid",
+                "profile_id": "01JPROFILE0000000000000000",
+                "profile_iri": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000",
+                "profile_revision": "01JPROFILEREVISION00000000",
+                "evaluator": "craqle-shacl-core/0.2",
+                "findings": [
+                    {
+                        "code": "constraint_violation",
+                        "severity": "violation",
+                        "focus_node": "./",
+                        "path": "http://schema.org/identifier",
+                        "rule": "http://www.w3.org/ns/shacl#minCount",
+                        "message": "fewer values are present than the Profile requires",
+                        "profile_revision": "01JPROFILEREVISION00000000",
+                        "completeness": "complete"
+                    }
+                ],
+                "completeness": "complete",
+                "structural_violations": []
+            })),
         (status = 400, description = "The body is not a parseable RO-Crate JSON-LD document", body = ErrorResponse),
         (status = 401, description = "Authentication is missing or invalid", body = ErrorResponse),
         (status = 503, description = "The Profile or the evaluator is temporarily unavailable", body = ErrorResponse)
@@ -1180,11 +1339,42 @@ pub async fn preview_profile_validation(
     path = "/metadata/{document_id}/profile-validation",
     tag = "metadata",
     summary = "Get revision-bound Profile validation status",
-    description = "Returns the durable validation status written atomically with the accepted metadata revision. The response becomes stale when either the Dataset revision or the exact registered Profile revision changes. Authentication is optional and uses the same document READ rules as metadata retrieval.",
+    description = r#"Returns the durable validation status bound to the accepted revision.
+
+**Authentication**: optional bearer token; the same document READ rules as metadata retrieval
+apply.
+
+**Behavior**
+- The status is written atomically with the accepted metadata revision.
+- It becomes stale when either the Dataset revision or the exact registered Profile revision
+  changes."#,
     params(("document_id" = String, Path, description = "Metadata document id")),
     responses(
         (status = 200, description = "Current, invalid, unprofiled, or stale revision-bound validation status", body = ProfileValidationStatusResponse,
-            example = json!({"document_id": "01JMETADATA0123456789ABCDE", "dataset_revision": "01JREVISION000000000000000", "state": "invalid", "profile_id": "01JPROFILE0000000000000000", "profile_iri": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000", "profile_revision": "01JPROFILEREVISION00000000", "evaluator": "craqle-shacl-core/0.2", "validated_at_ms": 1787000000000_u64, "findings": [{"code": "constraint_violation", "severity": "violation", "focus_node": "./", "path": "http://schema.org/identifier", "rule": "http://www.w3.org/ns/shacl#minCount", "message": "fewer values are present than the Profile requires", "profile_revision": "01JPROFILEREVISION00000000", "completeness": "complete"}], "completeness": "complete", "stale_reason": null})),
+            example = json!({
+                "document_id": "01JMETADATA0123456789ABCDE",
+                "dataset_revision": "01JREVISION000000000000000",
+                "state": "invalid",
+                "profile_id": "01JPROFILE0000000000000000",
+                "profile_iri": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000",
+                "profile_revision": "01JPROFILEREVISION00000000",
+                "evaluator": "craqle-shacl-core/0.2",
+                "validated_at_ms": 1787000000000_u64,
+                "findings": [
+                    {
+                        "code": "constraint_violation",
+                        "severity": "violation",
+                        "focus_node": "./",
+                        "path": "http://schema.org/identifier",
+                        "rule": "http://www.w3.org/ns/shacl#minCount",
+                        "message": "fewer values are present than the Profile requires",
+                        "profile_revision": "01JPROFILEREVISION00000000",
+                        "completeness": "complete"
+                    }
+                ],
+                "completeness": "complete",
+                "stale_reason": null
+            })),
         (status = 400, description = "Document id is not a structured metadata id", body = ErrorResponse),
         (status = 401, description = "A holder rejected the forwarded credential", body = ErrorResponse),
         (status = 403, description = "READ is denied", body = ErrorResponse),
@@ -1216,12 +1406,31 @@ pub async fn get_profile_validation_status(
     post,
     path = "/metadata/{document_id}/profile-validation/revalidate",
     tag = "metadata",
-    summary = "Revalidate a metadata document against its exact current Profile revision",
-    description = "Reconstructs validation from the last accepted raw Dataset revision and the registered Profile's current exact revision, fences the Dataset revision, and durably replaces the status. Requires an authenticated caller allowed to READ the document.",
+    summary = "Revalidate a document against its current Profile",
+    description = r#"Rebuilds the durable validation status from the current Profile revision.
+
+**Authentication**: authenticated realm caller allowed to READ the document.
+
+**Behavior**
+- Reconstructs validation from the last accepted raw Dataset revision and the registered
+  Profile's current exact revision.
+- Fences the Dataset revision and durably replaces the stored status."#,
     params(("document_id" = String, Path, description = "Metadata document id")),
     responses(
         (status = 200, description = "Fresh valid, invalid, or unprofiled status", body = ProfileValidationStatusResponse,
-            example = json!({"document_id": "01JMETADATA0123456789ABCDE", "dataset_revision": "01JREVISION000000000000000", "state": "valid", "profile_id": "01JPROFILE0000000000000000", "profile_iri": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000", "profile_revision": "01JPROFILEREVISION00000000", "evaluator": "craqle-shacl-core/0.2", "validated_at_ms": 1787000000000_u64, "findings": [], "completeness": "complete", "stale_reason": null})),
+            example = json!({
+                "document_id": "01JMETADATA0123456789ABCDE",
+                "dataset_revision": "01JREVISION000000000000000",
+                "state": "valid",
+                "profile_id": "01JPROFILE0000000000000000",
+                "profile_iri": "https://w3id.org/aruna/profile/01JPROFILE0000000000000000",
+                "profile_revision": "01JPROFILEREVISION00000000",
+                "evaluator": "craqle-shacl-core/0.2",
+                "validated_at_ms": 1787000000000_u64,
+                "findings": [],
+                "completeness": "complete",
+                "stale_reason": null
+            })),
         (status = 400, description = "Document id or Profile tag is invalid", body = ErrorResponse),
         (status = 401, description = "Authentication is missing or invalid", body = ErrorResponse),
         (status = 403, description = "READ is denied", body = ErrorResponse),
@@ -1258,7 +1467,18 @@ pub async fn revalidate_profile(
     path = "/metadata/{document_id}",
     tag = "metadata",
     summary = "Get a metadata document summary",
-    description = "Authentication is optional and changes the result: a document that is not public is only returned to a caller whose identity may read it. The read is routed to the document's current holders and answered by the first holder that returns a matching record. Existence is hidden: an unknown document and a document the caller may not read both answer 404, so an anonymous caller is never told 401 or 403 for a private document. A record whose create was only just accepted may still answer 404 until it lands on a holder.",
+    description = r#"Returns the registry summary of one metadata document.
+
+**Authentication**: optional bearer token; a document that is not public is only returned to a
+caller whose identity may read it.
+
+**Behavior**
+- The read is routed to the document's current holders and answered by the first holder that
+  returns a matching record.
+- A record whose create was only just accepted may still answer 404 until it lands on a holder.
+
+**Errors**: existence is hidden, so an unknown document and a document the caller may not read
+both answer 404 and an anonymous caller is never told 401 or 403 for a private document."#,
     params(("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list")),
     responses(
         (
@@ -1315,7 +1535,20 @@ pub async fn get_metadata_document(
     path = "/metadata/{document_id}",
     tag = "metadata",
     summary = "Delete a metadata document",
-    description = "Requires a realm bearer token and WRITE on the document's permission path. When this node holds the document the permission is checked here; otherwise the delete is forwarded to a holder that re-runs the same check under the caller's own bearer token, and the delete itself is applied by the document's persistent-id authority. A 204 means the delete was durably accepted into the event/projection pipeline: the graph tombstone, the removal from listings, search and query results, and the pruning of remote replicas follow asynchronously, so the document can still answer reads for a short window.",
+    description = r#"Deletes a metadata document and tombstones its RO-Crate graph.
+
+**Authentication**: realm bearer token with WRITE on the document's permission path.
+
+**Behavior**
+- When this node holds the document the permission is checked here; otherwise the delete is
+  forwarded to a holder that re-runs the same check under the caller's own bearer token.
+- The delete itself is applied by the document's persistent-id authority.
+- A 204 means the delete was durably accepted into the event/projection pipeline: the graph
+  tombstone, the removal from listings, search and query results, and the pruning of remote
+  replicas follow asynchronously, so the document can still answer reads for a short window.
+
+**Errors**: a 503 carries `Retry-After` and means the delete was not accepted, so the caller may
+retry."#,
     params(("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list")),
     responses(
         (status = 204, description = "Delete durably accepted, with no response body. Tombstoning, listing and query visibility, and replica pruning may still be catching up"),
@@ -1323,7 +1556,7 @@ pub async fn get_metadata_document(
         (status = 401, description = "Missing or invalid bearer token, or a holder rejected the forwarded credential", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or WRITE is denied on the document", body = ErrorResponse),
         (status = 404, description = "No holder knows this document", body = ErrorResponse),
-        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, or no holder accepted the forwarded delete. The response carries Retry-After and the caller may retry, because the delete was not accepted", body = ErrorResponse)
+        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, or no holder accepted the forwarded delete", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -1359,10 +1592,36 @@ pub async fn delete_metadata_document(
     path = "/metadata/{document_id}/rocrate",
     tag = "metadata",
     summary = "Export a metadata document as RO-Crate",
-    description = "Authentication is optional and changes the result: a document that is not public is only exported to a caller whose identity may read it, and an unknown document is indistinguishable from an unreadable one because both answer 404. The export is routed to the document's current holders and answered by the first holder that succeeds. RO-Crate 1.2 and 1.3 documents retain their stored context and specification version in every export view. The projected views (full, summary, page) require the document's graph to be materialized and answer 503 while a recently accepted write is still being projected; the raw view returns the last accepted revision together with its projection state, so it is the view that can be read during that window. An export larger than this node's configured metadata byte limit is refused with 503 rather than truncated.",
+    description = r#"Exports a metadata document as an RO-Crate in the requested view.
+
+**Authentication**: optional bearer token; a document that is not public is only exported to a
+caller whose identity may read it, and an unknown document is indistinguishable from an
+unreadable one because both answer 404.
+
+**Behavior**
+- The export is routed to the document's current holders and answered by the first holder that
+  succeeds.
+- RO-Crate 1.2 and 1.3 documents retain their stored context and specification version in every
+  export view.
+- The projected views (`full`, `summary`, `page`) require the document's graph to be materialized
+  and answer 503 while a recently accepted write is still being projected.
+- The `raw` view returns the last accepted revision together with its winning event id,
+  projection state (`pending`, `materialized` or `failed`) and digests, so it is the view that can
+  be read during that window.
+- The pagination fields of the returned crate are only populated for the `page` view.
+- In the `summary` and `page` views the crate's root identifier is rewritten to a view-specific
+  identifier carrying the requested view and cursor, so a partial crate is not mistaken for the
+  full one.
+
+**Limits**
+- An export larger than this node's configured metadata byte limit is refused with 503 rather
+  than truncated.
+
+**Errors**: a 503 carries `Retry-After`; while a recently accepted write is still being projected
+the caller may retry with `view=raw`."#,
     params(
         ("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list"),
-        ("view" = Option<MetadataRoCrateView>, Query, description = "Export view, default full. full returns the whole projected crate, summary only the root entity, page a window over the root-linked data entities, and raw the last accepted revision with its projection state"),
+        ("view" = Option<MetadataRoCrateView>, Query, description = "Export view, default full: full for the whole projected crate, summary for the root entity, page for a window over root-linked data entities, raw for the last accepted revision"),
         ("limit" = Option<usize>, Query, description = "Maximum number of root-linked data entities for page view. Default 100, clamped to 1..1000. Ignored by the other views"),
         ("offset" = Option<usize>, Query, description = "Offset cursor for page view: number of root-linked data entities to skip. Mutually exclusive with after, and sending both is rejected with 400"),
         ("after" = Option<String>, Query, description = "Entity id cursor for page view: continue after this data entity id, taken from a previous response's next_cursor. Mutually exclusive with offset")
@@ -1370,7 +1629,7 @@ pub async fn delete_metadata_document(
     responses(
         (
             status = 200,
-            description = "RO-Crate export. The projected views return a rocrate object whose pagination fields are only populated for the page view; the raw view instead returns the stored revision plus its winning event id, projection state (pending, materialized or failed) and digests. In the summary and page views the crate's root identifier is rewritten to a view-specific identifier carrying the requested view and cursor, so a partial crate is not mistaken for the full one",
+            description = "RO-Crate export in the requested view: a projected rocrate object, or the stored revision for the raw view",
             body = MetadataRoCrateResponse,
             examples(
                 (
@@ -1475,7 +1734,7 @@ pub async fn delete_metadata_document(
         (status = 401, description = "A holder rejected the forwarded credential as unauthenticated", body = ErrorResponse),
         (status = 403, description = "A holder denied READ for this caller on the document", body = ErrorResponse),
         (status = 404, description = "The document does not exist or is not readable by the caller; the two cases are deliberately indistinguishable", body = ErrorResponse),
-        (status = 503, description = "The graph is not materialized yet for a projected view, the export exceeds this node's metadata byte limit, or no holder answered. The response carries Retry-After and the caller may retry, optionally with view=raw while a write is still being projected", body = ErrorResponse)
+        (status = 503, description = "The graph is not materialized yet for a projected view, the export exceeds this node's metadata byte limit, or no holder answered", body = ErrorResponse)
     ),
     security((), ("bearer_auth" = []))
 )]
@@ -1514,17 +1773,34 @@ pub async fn export_metadata_rocrate(
     path = "/metadata/{document_id}/rocrate/exports",
     tag = "metadata",
     summary = "Submit an RO-Crate export job",
-    description = "Requires a realm bearer token that is not path-restricted: a delegated token whose scope is confined to a path is rejected with 403 even when it would pass the per-document check. The caller needs READ on the document, which is resolved from this node's registry view. A 202 only means the job was durably accepted and is owned by this node; the crate is assembled asynchronously, so the artifact does not exist yet. The artifact preserves whether the source document is RO-Crate 1.2 or 1.3. Poll status_url for progress and fetch artifact_url once the job reports success. Submissions are idempotent per caller when idempotency_key is set: replaying the same key returns the same job with created set to false, while reusing it for a different document is a conflict.",
+    description = r#"Submits an asynchronous job that assembles the document's RO-Crate.
+
+**Authentication**: realm bearer token that is not path-restricted (a delegated token whose scope
+is confined to a path is rejected with 403 even when it would pass the per-document check); the
+caller needs READ on the document, which is resolved from this node's registry view.
+
+**Behavior**
+- A 202 only means the job was durably accepted and is owned by this node; the crate is assembled
+  asynchronously, so the artifact does not exist yet.
+- The artifact preserves whether the source document is RO-Crate 1.2 or 1.3.
+- Poll `status_url` for progress and fetch `artifact_url` once the job reports success. The URLs
+  are absolute and point at the owning node, the only node that can serve the job's status,
+  report and artifact.
+- Submissions are idempotent per caller when `idempotency_key` is set: replaying the same key
+  returns the same job with `created` set to false, while reusing it for a different document is
+  a conflict."#,
     params(("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list")),
     request_body(
         content = SubmitRoCrateExportRequest,
         description = "Optional idempotency key, scoped to the calling user. Rejects unknown fields; an empty object submits a new job unconditionally.",
-        example = json!({"idempotency_key": "export-run-42-2026-04-09"})
+        example = json!({
+            "idempotency_key": "export-run-42-2026-04-09"
+        })
     ),
     responses(
         (
             status = 202,
-            description = "Export job durably accepted and queued on this node; the crate is not built yet. created is false when an existing job was returned for the same idempotency key. The URLs are absolute and point at the owning node, which is the only node that can serve the job's status, report and artifact",
+            description = "Export job durably accepted and queued on this node; created is false when an existing job was returned for the same key",
             body = SubmitRoCrateExportResponse,
             examples(
                 (
@@ -1598,7 +1874,22 @@ pub async fn submit_rocrate_export(
     path = "/metadata/{document_id}/rocrate",
     tag = "metadata",
     summary = "Replace a document's RO-Crate",
-    description = "Requires a realm bearer token and WRITE on the document's permission path. When this node holds the document the permission is checked here and the write is applied locally; otherwise it is forwarded to a holder that re-runs the same check under the caller's own bearer token. The submitted crate replaces the stored one wholesale, so any entity omitted from it is dropped. Omitting public leaves the current visibility unchanged. A 200 means the replacement was durably accepted into the event/projection pipeline, not that it is already materialized, queryable, searchable or present on every replica.",
+    description = r#"Replaces a document's stored RO-Crate with the submitted crate.
+
+**Authentication**: realm bearer token with WRITE on the document's permission path.
+
+**Behavior**
+- When this node holds the document the permission is checked here and the write is applied
+  locally; otherwise it is forwarded to a holder that re-runs the same check under the caller's
+  own bearer token.
+- The submitted crate replaces the stored one wholesale, so any entity omitted from it is
+  dropped.
+- Omitting `public` leaves the current visibility unchanged.
+- A 200 means the replacement was durably accepted into the event/projection pipeline, not that
+  it is already materialized, queryable, searchable or present on every replica.
+
+**Errors**: a 503 carries `Retry-After` and means the write was not accepted, so the caller may
+retry."#,
     params(("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list")),
     request_body(
         content = ReplaceMetadataRoCrateRequest,
@@ -1660,7 +1951,7 @@ pub async fn submit_rocrate_export(
         (status = 401, description = "Missing or invalid bearer token, or a holder rejected the forwarded credential", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or WRITE is denied on the document", body = ErrorResponse),
         (status = 404, description = "No holder knows this document", body = ErrorResponse),
-        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, the revision exceeds the stored-document limit, or no holder accepted the forwarded write. The response carries Retry-After and the caller may retry, because the write was not accepted", body = ErrorResponse)
+        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, the revision exceeds the stored-document limit, or no holder accepted the forwarded write", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -1703,8 +1994,24 @@ pub async fn replace_metadata_rocrate(
     post,
     path = "/metadata/{document_id}/rocrate/data-entities",
     tag = "metadata",
-    summary = "Upsert a data entity in a document's RO-Crate",
-    description = "Requires a realm bearer token and WRITE on the document's permission path. When this node holds the document the permission is checked here and the write is applied locally; otherwise it is forwarded to a holder that re-runs the same check under the caller's own bearer token. The entity is matched by its @id: an existing data entity with that id is replaced, otherwise it is added and linked from the crate's root dataset. The rest of the crate, including its RO-Crate 1.2 or 1.3 version, is left untouched, and the document's visibility is unchanged. A 200 means the upsert was durably accepted into the event/projection pipeline, not that it is already materialized, queryable, searchable or present on every replica.",
+    summary = "Upsert an RO-Crate data entity",
+    description = r#"Adds or replaces one root-linked data entity in a document's RO-Crate.
+
+**Authentication**: realm bearer token with WRITE on the document's permission path.
+
+**Behavior**
+- When this node holds the document the permission is checked here and the write is applied
+  locally; otherwise it is forwarded to a holder that re-runs the same check under the caller's
+  own bearer token.
+- The entity is matched by its `@id`: an existing data entity with that id is replaced, otherwise
+  it is added and linked from the crate's root dataset.
+- The rest of the crate, including its RO-Crate 1.2 or 1.3 version, is left untouched, and the
+  document's visibility is unchanged.
+- A 200 means the upsert was durably accepted into the event/projection pipeline, not that it is
+  already materialized, queryable, searchable or present on every replica.
+
+**Errors**: a 503 carries `Retry-After` and means the write was not accepted, so the caller may
+retry."#,
     params(("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list")),
     request_body(
         content = inline(JsonLdObject),
@@ -1750,11 +2057,11 @@ pub async fn replace_metadata_rocrate(
                 )
             )
         ),
-        (status = 400, description = "Malformed body, a body that is not a single JSON-LD object or that contains @graph, a document id that is not a structured metadata id, or RO-Crate validation violations, which are listed in the error body", body = ErrorResponse),
+        (status = 400, description = "Malformed body, a body that is not a single JSON-LD object or that contains @graph, a document id that is not a structured metadata id, or RO-Crate violations listed in the error body", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token, or a holder rejected the forwarded credential", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or WRITE is denied on the document", body = ErrorResponse),
         (status = 404, description = "No holder knows this document", body = ErrorResponse),
-        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, the revision exceeds the stored-document limit, or no holder accepted the forwarded write. The response carries Retry-After and the caller may retry, because the write was not accepted", body = ErrorResponse)
+        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, the revision exceeds the stored-document limit, or no holder accepted the forwarded write", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -1797,8 +2104,25 @@ pub async fn add_metadata_data_entity(
     post,
     path = "/metadata/{document_id}/rocrate/contextual-entities",
     tag = "metadata",
-    summary = "Upsert a contextual entity in a document's RO-Crate",
-    description = "Requires a realm bearer token and WRITE on the document's permission path. When this node holds the document the permission is checked here and the write is applied locally; otherwise it is forwarded to a holder that re-runs the same check under the caller's own bearer token. The entity is matched by its @id: an existing contextual entity with that id is replaced, otherwise it is added. Contextual entities describe people, organizations, licenses and the like and are not linked from the root dataset as parts. The surrounding crate retains its RO-Crate 1.2 or 1.3 version. A 200 means the upsert was durably accepted into the event/projection pipeline, not that it is already materialized, queryable, searchable or present on every replica.",
+    summary = "Upsert an RO-Crate contextual entity",
+    description = r#"Adds or replaces one contextual entity in a document's RO-Crate.
+
+**Authentication**: realm bearer token with WRITE on the document's permission path.
+
+**Behavior**
+- When this node holds the document the permission is checked here and the write is applied
+  locally; otherwise it is forwarded to a holder that re-runs the same check under the caller's
+  own bearer token.
+- The entity is matched by its `@id`: an existing contextual entity with that id is replaced,
+  otherwise it is added.
+- Contextual entities describe people, organizations, licenses and the like and are not linked
+  from the root dataset as parts.
+- The surrounding crate retains its RO-Crate 1.2 or 1.3 version.
+- A 200 means the upsert was durably accepted into the event/projection pipeline, not that it is
+  already materialized, queryable, searchable or present on every replica.
+
+**Errors**: a 503 carries `Retry-After` and means the write was not accepted, so the caller may
+retry."#,
     params(("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list")),
     request_body(
         content = inline(JsonLdObject),
@@ -1840,11 +2164,11 @@ pub async fn add_metadata_data_entity(
                 )
             )
         ),
-        (status = 400, description = "Malformed body, a body that is not a single JSON-LD object or that contains @graph, a document id that is not a structured metadata id, or RO-Crate validation violations, which are listed in the error body", body = ErrorResponse),
+        (status = 400, description = "Malformed body, a body that is not a single JSON-LD object or that contains @graph, a document id that is not a structured metadata id, or RO-Crate violations listed in the error body", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token, or a holder rejected the forwarded credential", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or WRITE is denied on the document", body = ErrorResponse),
         (status = 404, description = "No holder knows this document", body = ErrorResponse),
-        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, the revision exceeds the stored-document limit, or no holder accepted the forwarded write. The response carries Retry-After and the caller may retry, because the write was not accepted", body = ErrorResponse)
+        (status = 503, description = "Realm placement view unreadable, the document has no usable holder, the revision exceeds the stored-document limit, or no holder accepted the forwarded write", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -1888,7 +2212,29 @@ pub async fn add_metadata_contextual_entity(
     path = "/metadata/{document_id}/sparql/query",
     tag = "metadata",
     summary = "Run a SPARQL query against one metadata document",
-    description = "Authentication is optional and changes the result: the document is only queried for a caller whose identity may read it, and an unknown document is indistinguishable from an unreadable one because both answer 404. Only SELECT and ASK are accepted, the query text is limited to 64 KiB, a LIMIT above 10000 rows is rejected, and SERVICE clauses are refused. In distributed mode the document's replicas are tried one after another until one returns a complete result, so a successful answer is never a merge of partial replies; nodes_failed only counts replicas that were tried and failed before a success. The queried graph reflects the last materialized revision, so a write that was only just accepted may not be visible yet.",
+    description = r#"Runs a SPARQL query against the graph of one metadata document.
+
+**Authentication**: optional bearer token; the document is only queried for a caller whose
+identity may read it, and an unknown document is indistinguishable from an unreadable one because
+both answer 404.
+
+**Behavior**
+- In distributed mode the document's replicas are tried one after another until one returns a
+  complete result, so a successful answer is never a merge of partial replies.
+- `nodes_failed` only counts replicas that were tried and failed before a success, and
+  `nodes_queried` counts the replica attempts made.
+- The queried graph reflects the last materialized revision, so a write that was only just
+  accepted may not be visible yet.
+- `kind` is `Solutions` with one object per row (variable name to lexical value, unbound
+  variables omitted) for a `SELECT`, or `Boolean` for an `ASK`.
+- `complete` is false when a selected partition is missing, and `failed_partitions` names the node
+  ids that failed, plus `partition-discovery` when the realm view itself was unavailable.
+
+**Limits** (all refused with 400)
+- Only `SELECT` and `ASK` are accepted.
+- The query text is limited to 64 KiB.
+- A `LIMIT` above 10000 rows is rejected.
+- `SERVICE` clauses are refused."#,
     params(("document_id" = String, Path, description = "Metadata document id, a structured document ULID as returned by create or list")),
     request_body(
         content = SparqlQueryRequest,
@@ -1916,7 +2262,7 @@ pub async fn add_metadata_contextual_entity(
     responses(
         (
             status = 200,
-            description = "SPARQL query result. kind is Solutions with one object per row (variable name to lexical value, unbound variables omitted) for SELECT, or Boolean for ASK. nodes_queried counts the replica attempts made, complete is false when a selected partition is missing, and failed_partitions names the node ids that failed, plus partition-discovery when the realm view itself was unavailable",
+            description = "SPARQL query result for the document, with the replica attempt counters and completeness flags",
             body = MetadataQueryResponse,
             examples(
                 (
@@ -1995,7 +2341,30 @@ pub async fn query_metadata_document(
     path = "/metadata/sparql/query",
     tag = "metadata",
     summary = "Run a SPARQL query across visible metadata",
-    description = "Authentication is optional and changes the result: the queried graph union only contains metadata the caller may read, so an anonymous request sees the public documents alone. Only SELECT and ASK are accepted, the query text is limited to 64 KiB, a LIMIT above 10000 rows is rejected, and SERVICE clauses are refused. Distributed mode fans out to at most 32 realm node partitions, at most 8 of them concurrently, under an overall deadline of a few seconds; partitions beyond that cap, partitions that fail, and a failed realm node discovery all count towards nodes_failed and make complete false. With allow_partial=false any missing partition turns into 503 instead of a partial answer. Results may be served from a short-lived cache keyed to the caller's credential, so a just-accepted write can be missing for a moment.",
+    description = r#"Runs a SPARQL query over the metadata graph union the caller may read.
+
+**Authentication**: optional bearer token; the queried graph union only contains metadata the
+caller may read, so an anonymous request sees the public documents alone.
+
+**Behavior**
+- Distributed mode fans out to at most 32 realm node partitions, at most 8 of them concurrently,
+  under an overall deadline of a few seconds.
+- Partitions beyond that cap, partitions that fail, and a failed realm node discovery all count
+  towards `nodes_failed` and make `complete` false; `failed_partitions` is then non-empty and the
+  rows are a partial view of the realm.
+- With `allow_partial=false` any missing partition turns into 503 instead of a partial answer.
+- Results may be served from a short-lived cache keyed to the caller's credential, so a
+  just-accepted write can be missing for a moment.
+- `kind` is `Solutions` with one object per row (variable name to lexical value, unbound
+  variables omitted) for a `SELECT`, or `Boolean` for an `ASK`.
+
+**Limits** (all refused with 400)
+- Only `SELECT` and `ASK` are accepted.
+- The query text is limited to 64 KiB.
+- A `LIMIT` above 10000 rows is rejected.
+- `SERVICE` clauses are refused.
+- A distributed query must be union-safe: only an `ASK` or a `SELECT DISTINCT` over a single
+  pattern, without `OFFSET`, can be merged across partitions."#,
     request_body(
         content = SparqlQueryRequest,
         description = "Run a SPARQL `SELECT` or `ASK` query across all visible metadata. `mode=local` evaluates the current node's authorized graph union. `mode=distributed` accepts only union-safe `ASK` or `SELECT DISTINCT` single-pattern queries and merges partition sets. Distributed mode is best-effort by default; set `allow_partial=false` to fail if any partition is unavailable.",
@@ -2022,7 +2391,7 @@ pub async fn query_metadata_document(
     responses(
         (
             status = 200,
-            description = "SPARQL query result. kind is Solutions with one object per row (variable name to lexical value, unbound variables omitted) for SELECT, or Boolean for ASK. complete is false and failed_partitions is non-empty when some partition did not answer, in which case the rows are a partial view of the realm",
+            description = "SPARQL query result over the visible graph union, with the partition counters and completeness flags",
             body = MetadataQueryResponse,
             examples(
                 (
@@ -2060,7 +2429,7 @@ pub async fn query_metadata_document(
                 )
             )
         ),
-        (status = 400, description = "Malformed body, a query that is not SELECT or ASK, a query over the size or row limits, a SERVICE clause, or a distributed query that is not union-safe (only ASK or SELECT DISTINCT over a single pattern, without OFFSET, can be merged across partitions)", body = ErrorResponse),
+        (status = 400, description = "Malformed body, a query that is not SELECT or ASK, a query over the size or row limits, a SERVICE clause, or a distributed query that is not union-safe", body = ErrorResponse),
         (status = 501, description = "Unsupported query mode. Not reachable through this route today: both local and distributed are supported", body = ErrorResponse)
     ),
     security((), ("bearer_auth" = []))
@@ -2099,19 +2468,43 @@ pub async fn query_all_metadata(
     path = "/metadata/search",
     tag = "metadata",
     summary = "Search visible metadata documents",
-    description = "Authentication is optional and changes the result: hits are restricted to metadata the caller may read, so an anonymous request returns fewer documents. Either q or conforms_to must be given. Distributed searches fan out to at most 32 realm node partitions, at most 8 of them concurrently, under an overall deadline of a few seconds; nodes_failed counts the partitions that failed, timed out or were dropped by that cap, and any non-zero value means the page is a partial view of the realm. Pagination is cursor-based and stops at a server-side depth of 1000 hits per node, which is reported as truncated. Hits come from each node's own index, so a document whose write was only just accepted may not be findable yet.",
+    description = r#"Searches the metadata documents the caller may read, by text or Profile.
+
+**Authentication**: optional bearer token; hits are restricted to metadata the caller may read,
+so an anonymous request returns fewer documents.
+
+**Behavior**
+- Distributed searches fan out to at most 32 realm node partitions, at most 8 of them
+  concurrently, under an overall deadline of a few seconds.
+- `nodes_failed` counts the partitions that failed, timed out or were dropped by that cap, and
+  any non-zero value means the page is a partial view of the realm.
+- Pagination is cursor-based and stops at a server-side depth of 1000 hits per node, which is
+  reported as `truncated`; `next_cursor` is null once the results are exhausted.
+- Hits come from each node's own index, so a document whose write was only just accepted may not
+  be findable yet.
+- `conforms_to` matches the RO-Crate 1.2 and 1.3 specification IRIs and the RO-Crate community
+  profiles under `https://w3id.org/ro/wfrun/` and
+  `https://w3id.org/workflowhub/workflow-ro-crate/` exactly, without treating them as registered
+  Profiles.
+- A registered Profile uses only `https://w3id.org/aruna/profile/{id}`; other absolute IRIs are
+  matched exactly, never as a prefix.
+
+**Limits**
+- Either `q` or `conforms_to` must be given; a request with neither is rejected with 400.
+- A cursor is bound to the original query, so replaying it with a changed query returns 400.
+- Hits are ordered by descending score and the page size is silently clamped to at most 100."#,
     params(
-        ("q" = Option<String>, Query, description = "Free-text search query, matched against indexed literals. Optional when conforms_to is set; a request with neither is rejected with 400"),
-        ("conforms_to" = Option<String>, Query, description = "RO-Crate conformsTo specification or Profile IRI. The 1.2 and 1.3 specification IRIs and the RO-Crate community profiles under https://w3id.org/ro/wfrun/ and https://w3id.org/workflowhub/workflow-ro-crate/ match exactly and are not treated as registered Profiles. A registered Profile uses only https://w3id.org/aruna/profile/{id}; other absolute IRIs are matched exactly, never as a prefix"),
+        ("q" = Option<String>, Query, description = "Free-text search query, matched against indexed literals. Optional when conforms_to is set"),
+        ("conforms_to" = Option<String>, Query, description = "RO-Crate conformsTo specification or Profile IRI, matched exactly and never as a prefix"),
         ("group_id" = Option<String>, Query, description = "Restrict hits to a single group ULID"),
-        ("limit" = Option<usize>, Query, description = "Page size (default 25, silently clamped to a maximum of 100). Hits are ordered by descending score"),
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token from a previous response's next_cursor. Bound to the original query; replaying it with a changed query returns 400. Paging is best-effort: results may shift under concurrent metadata churn or node failures"),
+        ("limit" = Option<usize>, Query, description = "Page size (default 25, silently clamped to a maximum of 100)"),
+        ("cursor" = Option<String>, Query, description = "Opaque continuation token from a previous response's next_cursor. Paging is best-effort: results may shift under concurrent metadata churn or node failures"),
         ("mode" = Option<MetadataQueryMode>, Query, description = "Search mode: local or distributed. Distributed mode is best-effort and may return partial results if realm node discovery or remote requests fail")
     ),
     responses(
         (
             status = 200,
-            description = "Metadata search hits the caller may read, ordered by descending score. next_cursor is null once the results are exhausted, truncated is true when paging stopped at the server-side depth cap, and a non-zero nodes_failed means this page is partial",
+            description = "Metadata search hits the caller may read, ordered by descending score, with the paging and partition flags",
             body = MetadataSearchResponse,
             examples(
                 (
@@ -2211,7 +2604,22 @@ pub async fn search_metadata(
     path = "/metadata/references",
     tag = "metadata",
     summary = "List documents referencing an IRI",
-    description = "Requires a realm bearer token; there is no anonymous access to this route, and each candidate document is additionally filtered by the caller's READ permission, so an unreadable referencing document is simply omitted. The scan is answered from the local node's reference index only, without realm fan-out, so references held solely by other nodes are missing and a just-accepted write may not be indexed yet. Results are capped at limit and there is no continuation: next_cursor is always absent in this version.",
+    description = r#"Lists the visible metadata documents that reference an IRI.
+
+**Authentication**: realm bearer token; there is no anonymous access to this route, and each
+candidate document is additionally filtered by the caller's READ permission, so an unreadable
+referencing document is simply omitted.
+
+**Behavior**
+- The scan is answered from the local node's reference index only, without realm fan-out, so
+  references held solely by other nodes are missing and a just-accepted write may not be indexed
+  yet.
+- When the scan is empty and `iri` is a known graph IRI, or when `resolve` is set, the matching
+  document's summary is returned as a single predicate-less entry.
+
+**Limits**
+- Results are capped at `limit` and there is no continuation: `next_cursor` is always absent in
+  this version."#,
     params(
         ("iri" = String, Query, description = "Referenced object IRI to find backlinks for, such as a document graph IRI or any IRI appearing as a triple object. Must be a valid absolute IRI"),
         ("predicate" = Option<String>, Query, description = "Optional exact predicate IRI filter, such as http://schema.org/conformsTo. Must be a valid absolute IRI and is matched exactly"),
@@ -2221,7 +2629,7 @@ pub async fn search_metadata(
     responses(
         (
             status = 200,
-            description = "Documents referencing the IRI the caller may read. When the scan is empty and iri is a known graph IRI, or when resolve is set, the matching document's summary is returned as a single predicate-less entry. Local-node-only in v1: only references indexed on the answering node are returned",
+            description = "Documents referencing the IRI that the caller may read, as indexed on the answering node",
             body = MetadataReferencesResponse,
             examples(
                 (
@@ -2318,12 +2726,85 @@ fn map_reference_entry(entry: MetadataReferenceEntry) -> MetadataReferenceItem {
     path = "/metadata/references/preflight",
     tag = "metadata",
     summary = "Preflight destructive content operations against metadata backlinks",
-    description = "Maps a bounded exact content-W3ID set or an authorized bucket/prefix inventory to canonical content identities, then queries canonical and known legacy location IRIs. Local mode reports realm coverage incomplete. Distributed mode fans out to realm nodes and reports per-node index freshness, failed partitions, and stable cursor pagination. With allow_partial=false, any failed, stale, or otherwise incomplete partition returns 503 rather than silently downgrading the request. Restricted referencing documents are represented only by hidden_references_exist; their count and identity are never returned.",
+    description = r#"Reports the metadata backlinks a destructive content operation would break.
+
+**Authentication**: realm bearer token for the serving realm with WRITE on the targeted bucket
+and prefix.
+
+**Behavior**
+- Maps a bounded exact content-W3ID set or an authorized bucket/prefix inventory to canonical
+  content identities, then queries canonical and known legacy location IRIs.
+- Local mode reports realm coverage incomplete.
+- Distributed mode fans out to realm nodes and reports per-node index freshness, failed
+  partitions, and stable cursor pagination.
+- Restricted referencing documents are represented only by `hidden_references_exist`; their count
+  and identity are never returned.
+
+**Errors**: with `allow_partial=false`, any failed, stale, or otherwise incomplete partition
+returns 503 rather than silently downgrading the request."#,
     request_body(content = MetadataReferencePreflightBody,
-        example = json!({"target": {"kind": "bucket_prefix", "bucket": "results", "prefix": "run-42/", "operation": "latest_version_tombstone"}, "allow_partial": true, "limit": 50})),
+        example = json!({
+            "target": {
+                "kind": "bucket_prefix",
+                "bucket": "results",
+                "prefix": "run-42/",
+                "operation": "latest_version_tombstone"
+            },
+            "allow_partial": true,
+            "limit": 50
+        })),
     responses(
         (status = 200, description = "Reference warnings, location impact, pagination, and explicit coverage metadata", body = MetadataReferencePreflightResponse,
-            example = json!({"targets": [{"content_w3id": "https://w3id.org/aruna/data/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "targeted_versions": [{"node_id": "node-a", "bucket": "results", "key": "run-42/output.csv", "version_id": "01JVERSION0000000000000000"}], "visible_references": [{"document_id": "01JMETADATA0123456789ABCDE", "title": "Run 42 results"}], "hidden_references_exist": false, "would_remove_last_resolvable_aruna_location": true, "location_impact_complete": true}], "next_cursor": null, "truncated": false, "nodes_queried": 3, "nodes_failed": 0, "complete": true, "failed_partitions": [], "coverage": {"queried_scope": "realm", "queried_forms": ["content_w3id", "aruna_s3_url"], "excluded_forms": [{"form": "literal_content_url", "reason": "plain string contentUrl values are structurally invisible"}], "node_freshness": [{"node_id": "node-a", "index_state": "fresh", "oldest_status_updated_at_ms": 1787000000000_u64}], "target_resolution_complete": true, "path_style_endpoint_coverage_complete": true, "realm_coverage_complete": true}})),
+            example = json!({
+                "targets": [
+                    {
+                        "content_w3id": "https://w3id.org/aruna/data/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                        "targeted_versions": [
+                            {
+                                "node_id": "node-a",
+                                "bucket": "results",
+                                "key": "run-42/output.csv",
+                                "version_id": "01JVERSION0000000000000000"
+                            }
+                        ],
+                        "visible_references": [
+                            {
+                                "document_id": "01JMETADATA0123456789ABCDE",
+                                "title": "Run 42 results"
+                            }
+                        ],
+                        "hidden_references_exist": false,
+                        "would_remove_last_resolvable_aruna_location": true,
+                        "location_impact_complete": true
+                    }
+                ],
+                "next_cursor": null,
+                "truncated": false,
+                "nodes_queried": 3,
+                "nodes_failed": 0,
+                "complete": true,
+                "failed_partitions": [],
+                "coverage": {
+                    "queried_scope": "realm",
+                    "queried_forms": ["content_w3id", "aruna_s3_url"],
+                    "excluded_forms": [
+                        {
+                            "form": "literal_content_url",
+                            "reason": "plain string contentUrl values are structurally invisible"
+                        }
+                    ],
+                    "node_freshness": [
+                        {
+                            "node_id": "node-a",
+                            "index_state": "current",
+                            "oldest_status_updated_at_ms": 1787000000000_u64
+                        }
+                    ],
+                    "target_resolution_complete": true,
+                    "path_style_endpoint_coverage_complete": true,
+                    "realm_coverage_complete": true
+                }
+            })),
         (status = 400, description = "Malformed or oversized target set, unsupported content identity, or invalid cursor", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "Wrong realm or insufficient WRITE permission for the bucket/prefix", body = ErrorResponse),

--- a/api/src/routes/metadata.rs
+++ b/api/src/routes/metadata.rs
@@ -1206,9 +1206,7 @@ with the same capability report.
   terms and remote `owl:imports` fail closed with an `unsupported_constraint` finding that names
   the construct; the same finding is returned when the registered Turtle cannot be parsed.
 - Evaluation is bounded: exceeding the result, path-edge or path-depth budget returns a permanent
-  `validation_limit` finding with incomplete completeness instead of a partial verdict.
-
-**Errors**: a temporarily unavailable Profile or evaluator answers 503 with `Retry-After`."#,
+  `validation_limit` finding with incomplete completeness instead of a partial verdict."#,
     responses((
         status = 200,
         description = "Evaluator identity, exact supported constraints, fail-closed policy, and accepted Profile IRI forms",
@@ -1230,7 +1228,7 @@ with the same capability report.
                 "sh:closed"
             ],
             "unsupported_constraint_policy": "fail_closed",
-            "public_profile_iri_template": "https://w3id.org/aruna/profile/{document_id}"
+            "public_profile_iri_template": "https://w3id.org/aruna/profile/{id}"
         })
     ))
 )]
@@ -1317,7 +1315,7 @@ the realm-public registered Profile is read.
             })),
         (status = 400, description = "The body is not a parseable RO-Crate JSON-LD document", body = ErrorResponse),
         (status = 401, description = "Authentication is missing or invalid", body = ErrorResponse),
-        (status = 503, description = "The Profile or the evaluator is temporarily unavailable", body = ErrorResponse)
+        (status = 503, description = "The Profile or the evaluator is temporarily unavailable; the response carries Retry-After", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -2728,8 +2726,9 @@ fn map_reference_entry(entry: MetadataReferenceEntry) -> MetadataReferenceItem {
     summary = "Preflight destructive content operations against metadata backlinks",
     description = r#"Reports the metadata backlinks a destructive content operation would break.
 
-**Authentication**: realm bearer token for the serving realm with WRITE on the targeted bucket
-and prefix.
+**Authentication**: realm bearer token for the serving realm. A `bucket_prefix` target additionally
+requires WRITE on the bucket, on the prefix when one is given, and on every key the prefix resolves
+to; a `content_w3ids` target names content identities directly and checks no storage permission.
 
 **Behavior**
 - Maps a bounded exact content-W3ID set or an authorized bucket/prefix inventory to canonical

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -477,7 +477,24 @@ async fn canonicalize_watch_path(
     path = "/notifications",
     tag = "notifications",
     summary = "List the caller's notification inbox",
-    description = "Requires a realm bearer token. The inbox is self-scoped: it always belongs to the calling user and there is no way to read another user's inbox, so no further permission is checked. A token carrying path restrictions is rejected with 403 because a user-scoped surface cannot honour a delegated token's confinement. The request is served by the node that holds the caller's inbox, either locally or proxied to that holder over the realm network, so results are as consistent as that single holder. Notifications are returned newest first by creation time. Resource-watch notifications are re-authorized while the page is assembled and dropped when the caller may no longer read the resource; suppressed rows do not consume the page. A response without `next_cursor` is the last page.",
+    description = r#"Lists the calling user's notification inbox, newest first.
+
+**Authentication**: realm bearer token; the inbox is self-scoped to the calling user, so no further
+permission is checked, and a token carrying path restrictions is rejected with 403 because a
+user-scoped surface cannot honor a delegated token's confinement.
+
+**Behavior**
+- The inbox always belongs to the calling user and there is no way to read another user's inbox.
+- The request is served by the node that holds the caller's inbox, either locally or proxied to
+  that holder over the realm network, so results are as consistent as that single holder.
+- Notifications are returned newest first by creation time.
+- Resource-watch notifications are re-authorized while the page is assembled and dropped when the
+  caller may no longer read the resource; suppressed rows do not consume the page.
+- A response without `next_cursor` is the last page.
+
+**Limits**
+- `limit` defaults to 50 and is capped at 200; a limit of 0 is raised to 1.
+- `cursor` must be an unpadded base64url encoding of exactly 24 bytes; anything else is a 400."#,
     params(
         ("limit" = Option<usize>, Query, description = "Max notifications to return, default 50, capped at 200; a limit of 0 is raised to 1"),
         ("cursor" = Option<String>, Query, description = "Opaque pagination cursor: pass the `next_cursor` of the previous page, an unpadded base64url encoding of 24 bytes; omit it to start at the newest notification")
@@ -563,13 +580,27 @@ pub async fn list_notifications(
     path = "/notifications/unread",
     tag = "notifications",
     summary = "Count the caller's unread notifications",
-    description = "Requires a realm bearer token; the count is self-scoped to the calling user and a path-restricted token is rejected with 403. The count is produced by the node holding the caller's inbox, locally or proxied to that holder. It is a badge value, not an exact total: counting stops at 100 and stops after scanning 2000 inbox rows, and `capped` is true in either case, meaning `at least count unread`. Resource-watch notifications the caller may no longer read are excluded.",
+    description = r#"Returns the unread badge value for the calling user's inbox.
+
+**Authentication**: realm bearer token; the count is self-scoped to the calling user and a
+path-restricted token is rejected with 403.
+
+**Behavior**
+- The count is produced by the node holding the caller's inbox, locally or proxied to that holder.
+- Resource-watch notifications the caller may no longer read are excluded.
+
+**Limits**
+- It is a badge value, not an exact total: counting stops at 100 and stops after scanning 2000 inbox
+  rows, and `capped` is true in either case, meaning `at least count unread`."#,
     responses(
         (
             status = 200,
             description = "Unread badge value for the caller",
             body = UnreadCountApiResponse,
-            example = json!({"count": 7, "capped": false})
+            example = json!({
+                "count": 7,
+                "capped": false
+            })
         ),
         (status = 401, description = "Missing, malformed or expired bearer token", body = ErrorResponse),
         (status = 403, description = "Token belongs to another realm or carries path restrictions", body = ErrorResponse),
@@ -904,9 +935,33 @@ fn state_event(state: NotificationStreamStateResponse) -> Event {
     path = "/notifications/stream",
     tag = "notifications",
     summary = "Stream the caller's notification state",
-    description = "Requires a realm bearer token; the stream is self-scoped to the calling user and a path-restricted token is rejected with 403. The response is a `text/event-stream` that stays open until the client disconnects or the node shuts down; it is not a JSON document and carries no notification payloads, only a small state frame the client uses as a trigger to refetch the inbox. When this node holds the caller's inbox the stream reacts to local delivery wakes within about 200ms of coalescing; otherwise it polls the holder every 5s and emits only on change. A local stream re-resolves the holder after 60s of silence and degrades to polling if the inbox moved to another node, so a client never has to reconnect for that. Transient fetch failures are skipped rather than ending the stream.",
+    description = r#"Streams a small state frame the client uses as a trigger to refetch the inbox.
+
+**Authentication**: realm bearer token; the stream is self-scoped to the calling user and a
+path-restricted token is rejected with 403.
+
+**Behavior**
+- The response is a `text/event-stream` that stays open until the client disconnects or the node
+  shuts down; it is not a JSON document and carries no notification payloads.
+- Every application frame is `event: state` followed by one `data:` line holding JSON
+  `{"epoch": <string>, "revision": <u64>, "unread": {"count": <u32>, "capped": <bool>}}` and a
+  blank line; frames carry no `id:` field, so `Last-Event-ID` is not honored.
+- The current state is sent on connect, after a dashboard revision or unread-state change, and
+  about every 20s without advancing the revision; that periodic frame doubles as the keep-alive,
+  and an SSE comment line is sent instead whenever 20s pass with no frame, so proxies do not cut an
+  idle stream.
+- The epoch changes when the retained counter is reset, which tells a client its cached revision is
+  meaningless.
+- When this node holds the caller's inbox the stream reacts to local delivery wakes within about
+  200ms of coalescing; otherwise it polls the holder every 5s and emits only on change.
+- A local stream re-resolves the holder after 60s of silence and degrades to polling if the inbox
+  moved to another node, so a client never has to reconnect for that.
+- Transient fetch failures are skipped rather than ending the stream.
+- A client resumes by simply reconnecting: the first frame of the new stream is the full current
+  state, and any state missed while disconnected is recovered by refetching the inbox, never
+  replayed on the stream."#,
     responses(
-        (status = 200, description = r#"Server-sent state stream, media type `text/event-stream`. Every application frame is `event: state` followed by one `data:` line holding JSON `{"epoch": <string>, "revision": <u64>, "unread": {"count": <u32>, "capped": <bool>}}` and a blank line; frames carry no `id:` field, so `Last-Event-ID` is not honoured. The current state is sent on connect, after a dashboard revision or unread-state change, and about every 20s without advancing the revision; that periodic frame doubles as the keep-alive, and an SSE comment line is sent instead whenever 20s pass with no frame, so proxies do not cut an idle stream. The epoch changes when the retained counter is reset, which tells a client its cached revision is meaningless. A client resumes by simply reconnecting: the first frame of the new stream is the full current state, and any state missed while disconnected is recovered by refetching the inbox, never replayed on the stream. The stream ends on client disconnect or node shutdown."#, body = NotificationStreamStateResponse, content_type = "text/event-stream"),
+        (status = 200, description = "Server-sent state stream, media type `text/event-stream`; it ends on client disconnect or node shutdown", body = NotificationStreamStateResponse, content_type = "text/event-stream"),
         (status = 401, description = "Missing, malformed or expired bearer token", body = ErrorResponse),
         (status = 403, description = "Token belongs to another realm or carries path restrictions", body = ErrorResponse),
         (status = 503, description = "No inbox holder is available, this node has no realm network handle, or the dashboard change feed is not running; the caller may retry", body = ErrorResponse)
@@ -962,18 +1017,38 @@ pub async fn stream_notifications(
     path = "/notifications/read",
     tag = "notifications",
     summary = "Mark the caller's notifications as read",
-    description = "Requires a realm bearer token; only the calling user's own inbox is affected and a path-restricted token is rejected with 403. The update is applied on the node holding the caller's inbox, locally or proxied to that holder. Both selectors may be combined: `ids` marks those notifications, `up_to_ms` marks every notification created at or before that epoch-millisecond timestamp. Unknown ids are ignored and already-read notifications are left untouched, so the returned count is the number of notifications this call actually flipped to read and repeating a call is safe. A body with no ids and no `up_to_ms` marks nothing and returns 0.",
+    description = r#"Marks the calling user's notifications as read, by id, by age, or both.
+
+**Authentication**: realm bearer token; only the calling user's own inbox is affected and a
+path-restricted token is rejected with 403.
+
+**Behavior**
+- The update is applied on the node holding the caller's inbox, locally or proxied to that holder.
+- Both selectors may be combined: `ids` marks those notifications, `up_to_ms` marks every
+  notification created at or before that epoch-millisecond timestamp.
+- Unknown ids are ignored and already-read notifications are left untouched, so the returned count
+  is the number of notifications this call actually flipped to read and repeating a call is safe.
+- A body with no ids and no `up_to_ms` marks nothing and returns 0.
+
+**Limits**
+- At most 512 ids, and duplicates are collapsed; more ids, or an id that is not a ULID, is refused
+  with 400."#,
     request_body(
         content = MarkReadApiRequest,
         description = "Notifications to mark read, by id, by age, or both; at most 512 ids, duplicates are collapsed",
-        example = json!({"ids": ["01JABCDEF0123456789ABCDEFG"], "up_to_ms": 1775744591123_i64})
+        example = json!({
+            "ids": ["01JABCDEF0123456789ABCDEFG"],
+            "up_to_ms": 1775744591123_i64
+        })
     ),
     responses(
         (
             status = 200,
             description = "Number of notifications flipped from unread to read by this call",
             body = MarkReadApiResponse,
-            example = json!({"marked": 3})
+            example = json!({
+                "marked": 3
+            })
         ),
         (status = 400, description = "An id is not a ULID, or more than 512 ids were supplied", body = ErrorResponse),
         (status = 401, description = "Missing, malformed or expired bearer token", body = ErrorResponse),
@@ -1016,7 +1091,20 @@ pub async fn mark_read(
     path = "/notifications/watches",
     tag = "notifications",
     summary = "List the caller's notification watches",
-    description = "Requires a realm bearer token; watches are per-user, so this returns only the calling user's own subscriptions and a path-restricted token is rejected with 403. The list is read from the node holding the caller's inbox, locally or proxied to that holder. It is complete and unpaginated because a user may hold at most 50 watches. Entries are returned as stored, in watch-id order, with the canonical path prefix that was recorded at creation; authorization is re-evaluated when an event is delivered, so a listed watch may stop producing notifications after a permission change without disappearing here.",
+    description = r#"Lists every watch subscription owned by the calling user.
+
+**Authentication**: realm bearer token; watches are per-user, so this returns only the calling
+user's own subscriptions and a path-restricted token is rejected with 403.
+
+**Behavior**
+- The list is read from the node holding the caller's inbox, locally or proxied to that holder.
+- Entries are returned as stored, in watch-id order, with the canonical path prefix that was
+  recorded at creation.
+- Authorization is re-evaluated when an event is delivered, so a listed watch may stop producing
+  notifications after a permission change without disappearing here.
+
+**Limits**
+- The list is complete and unpaginated, because a user may hold at most 50 watches."#,
     responses(
         (
             status = 200,
@@ -1059,7 +1147,33 @@ pub async fn list_watches(
     path = "/notifications/watches",
     tag = "notifications",
     summary = "Create a notification watch for the caller",
-    description = "Create an authorized watch subscription using a canonical resource prefix. Data events use `s3/{group_id}/{node_id}/{bucket}/{key-prefix}` and require READ on that exact node's blob bucket permission path. For a bucket on this node, the supplied group is canonicalized to the bucket-owning group and the response exposes that canonical prefix. Metadata events use `meta/{group_id}/{normalized_document_path-prefix}` and require READ on the group's metadata permission path. The slash after the bucket or metadata group is required, no leading slash is allowed, and metadata/data event kinds cannot be combined because their canonical namespaces differ. Requires a realm bearer token and creates the watch for the calling user only; a path-restricted token is rejected with 403. READ is evaluated against the caller's current grants at creation time, and a caller that cannot read the prefix always gets 403, never a 404 that would separate an unreadable resource from a missing one. The prefix must be non-empty and at most 1024 bytes and at least one event name must be given; a user may hold at most 50 watches, beyond which creation answers 409. The subscription is stored on the node holding the caller's inbox, locally or proxied to that holder; 201 means it is durably recorded there, while replication to the other holders and publication of the watch interest are scheduled afterwards, so the first matching events may occur before delivery starts. Every delivery is re-authorized, so revoking the caller's READ silently stops notifications without deleting the watch.",
+    description = r#"Creates an authorized watch subscription over a canonical resource prefix.
+
+**Authentication**: realm bearer token; a path-restricted token is rejected with 403. Data events
+require READ on that exact node's blob bucket permission path and metadata events READ on the
+group's metadata permission path, evaluated against the caller's current grants at creation time.
+
+**Behavior**
+- The watch is created for the calling user only.
+- Data events use `s3/{group_id}/{node_id}/{bucket}/{key-prefix}`; for a bucket on this node the
+  supplied group is canonicalized to the bucket-owning group and the response exposes that
+  canonical prefix.
+- Metadata events use `meta/{group_id}/{normalized_document_path-prefix}`.
+- The subscription is stored on the node holding the caller's inbox, locally or proxied to that
+  holder; 201 means it is durably recorded there, while replication to the other holders and
+  publication of the watch interest are scheduled afterwards, so the first matching events may
+  occur before delivery starts.
+- Every delivery is re-authorized, so revoking the caller's READ silently stops notifications
+  without deleting the watch.
+
+**Limits**
+- The slash after the bucket or metadata group is required and no leading slash is allowed.
+- Metadata and data event kinds cannot be combined, because their canonical namespaces differ.
+- The prefix must be non-empty and at most 1024 bytes, and at least one event name must be given.
+- A user may hold at most 50 watches, beyond which creation answers 409.
+
+**Errors**: a caller that cannot read the prefix always gets 403, never a 404 that would separate
+an unreadable resource from a missing one."#,
     request_body(
         content = CreateWatchRequest,
         description = "Canonical resource prefix plus the event names to subscribe to; valid names are `metadata_created`, `data_uploaded`, `sync_completed` and `sync_failed`",
@@ -1143,7 +1257,18 @@ pub async fn create_watch(
     path = "/notifications/watches/{id}",
     tag = "notifications",
     summary = "Delete one of the caller's notification watches",
-    description = "Requires a realm bearer token; watches are per-user and the id is resolved inside the caller's own set, so another user's watch can never be deleted and no further permission is checked. A path-restricted token is rejected with 403. The delete is applied on the node holding the caller's inbox, locally or proxied to that holder, and is idempotent: an id the caller does not own, including one already deleted, also answers 204. The 204 means the subscription is durably removed on that holder; removing the watch interest from the other holders is replicated afterwards, so a small number of already-matched events may still arrive.",
+    description = r#"Deletes one watch subscription owned by the calling user.
+
+**Authentication**: realm bearer token; watches are per-user and the id is resolved inside the
+caller's own set, so another user's watch can never be deleted and no further permission is checked.
+A path-restricted token is rejected with 403.
+
+**Behavior**
+- The delete is applied on the node holding the caller's inbox, locally or proxied to that holder.
+- It is idempotent: an id the caller does not own, including one already deleted, also answers 204.
+- The 204 means the subscription is durably removed on that holder; removing the watch interest
+  from the other holders is replicated afterwards, so a small number of already-matched events may
+  still arrive."#,
     params(("id" = String, Path, description = "ULID of a watch subscription owned by the caller, as returned when the watch was created or listed")),
     responses(
         (status = 204, description = "Watch subscription deleted, or it did not exist; no response body"),

--- a/api/src/routes/oai.rs
+++ b/api/src/routes/oai.rs
@@ -106,7 +106,21 @@ fn protocol(code: &'static str, message: impl Into<String>) -> OaiFault {
     path = "/oai",
     tag = "oai",
     summary = "Answer an OAI-PMH request from query arguments",
-    description = "Public OAI-PMH 2.0 provider for this realm's metadata registry. Authentication is neither required nor accepted: only documents an anonymous caller may read are enumerated, and every candidate is re-checked before it is rendered. Supported verbs are Identify, ListMetadataFormats, ListSets, ListIdentifiers, ListRecords and GetRecord; oai_dc is the only disseminated format and the repository has no set hierarchy. Protocol failures (badVerb, badArgument, cannotDisseminateFormat, idDoesNotExist, noRecordsMatch, noSetHierarchy, badResumptionToken) are returned as an error element inside a 200 text/xml envelope, not as HTTP error codes. Lists are paged at 100 records and continue through resumptionToken, which must then be the only argument; the last response of a token sequence carries an empty resumptionToken element.",
+    description = r#"Public OAI-PMH 2.0 provider for this realm's metadata registry, driven by query arguments.
+
+**Authentication**: none; authentication is neither required nor accepted, only documents an
+anonymous caller may read are enumerated, and every candidate is re-checked before it is rendered.
+
+**Behavior**
+- Supported verbs are `Identify`, `ListMetadataFormats`, `ListSets`, `ListIdentifiers`,
+  `ListRecords` and `GetRecord`.
+- `oai_dc` is the only disseminated format and the repository has no set hierarchy.
+- Lists are paged at 100 records and continue through `resumptionToken`, which must then be the
+  only argument; the last response of a token sequence carries an empty `resumptionToken` element.
+
+**Errors**: protocol failures (`badVerb`, `badArgument`, `cannotDisseminateFormat`,
+`idDoesNotExist`, `noRecordsMatch`, `noSetHierarchy`, `badResumptionToken`) are returned as an
+error element inside a 200 `text/xml` envelope, not as HTTP error codes."#,
     params(
         ("verb" = Option<String>, Query, description = "OAI-PMH verb: Identify, ListMetadataFormats, ListSets, ListIdentifiers, ListRecords or GetRecord. A missing or unknown verb answers badVerb."),
         ("metadataPrefix" = Option<String>, Query, description = "Requested metadata format, required by ListIdentifiers, ListRecords and GetRecord unless a resumptionToken is used. Only oai_dc is supported; anything else answers cannotDisseminateFormat."),
@@ -145,7 +159,18 @@ async fn handle_oai(
     path = "/oai",
     tag = "oai",
     summary = "Answer an OAI-PMH request from a url-encoded form",
-    description = "The POST form of the same public OAI-PMH provider: arguments arrive as an application/x-www-form-urlencoded body instead of a query string, and are validated by the identical verb matrix. Authentication is neither required nor accepted, only anonymously readable documents are enumerated, and protocol failures are returned inside a 200 text/xml envelope. A body sent with any other content type answers a badArgument envelope, and a repeated argument answers badArgument rather than being silently collapsed.",
+    description = r#"The POST form of the same public OAI-PMH provider, taking arguments as a url-encoded body.
+
+**Authentication**: none; authentication is neither required nor accepted and only anonymously
+readable documents are enumerated.
+
+**Behavior**
+- Arguments arrive as an `application/x-www-form-urlencoded` body instead of a query string, and
+  are validated by the identical verb matrix.
+
+**Errors**: protocol failures are returned inside a 200 `text/xml` envelope. A body sent with any
+other content type answers a `badArgument` envelope, and a repeated argument answers `badArgument`
+rather than being silently collapsed."#,
     request_body(
         content = String,
         content_type = "application/x-www-form-urlencoded",

--- a/api/src/routes/onboarding.rs
+++ b/api/src/routes/onboarding.rs
@@ -185,7 +185,25 @@ async fn prune_stale_onboarding_secrets(state: &Arc<ServerState>) -> ServerResul
     path = "/admin/onboarding/secrets",
     tag = "onboarding",
     summary = "Mint a node enrollment secret",
-    description = "Requires a bearer token of this realm with WRITE on the realm's onboarding admin path, and only a management node serves it; any other node answers 403. The response carries the enrollment secret exactly once: the node stores only its hash, so a secret that is lost cannot be recovered and must be revoked and minted again. Treat the value like a credential, hand it to exactly one joining node, and expect it to be single-use. `mode` fixes what the joiner may become and is one of `Management`, `Server` or `Local`; a Management secret later lets the joiner receive the realm private key wrapped to its transport key, so it is the most sensitive of the three. `expires_in_seconds` defaults to 3600 and is clamped to 60..=86400, and `expires_at` is the resulting absolute expiry in Unix seconds. Every expired secret that is not already mid-enrollment is discarded before the new one is created.",
+    description = r#"Mints a single-use enrollment secret that a joining node redeems to enter the realm.
+
+**Authentication**: bearer token of this realm with WRITE on the realm's onboarding admin path;
+only a management node serves it and any other node answers 403.
+
+**Behavior**
+- The response carries the enrollment secret exactly once: the node stores only its hash, so a
+  secret that is lost cannot be recovered and must be revoked and minted again.
+- Treat the value like a credential, hand it to exactly one joining node, and expect it to be
+  single-use.
+- `mode` fixes what the joiner may become and is one of `Management`, `Server` or `Local`; a
+  `Management` secret later lets the joiner receive the realm private key wrapped to its transport
+  key, so it is the most sensitive of the three.
+- Every expired secret that is not already mid-enrollment is discarded before the new one is
+  created.
+
+**Limits**
+- `expires_in_seconds` defaults to 3600 and is clamped to 60..=86400; `expires_at` is the resulting
+  absolute expiry in Unix seconds."#,
     request_body(
         content = CreateOnboardingSecretRequestDoc,
         description = "Seed URL the joiner calls back, the mode it is enrolled as, and an optional lifetime",
@@ -270,7 +288,19 @@ pub async fn create_onboarding_secret(
     path = "/admin/onboarding/secrets",
     tag = "onboarding",
     summary = "List outstanding node enrollment secrets",
-    description = "Requires a bearer token of this realm with WRITE on the realm's onboarding admin path, and only a management node serves it; any other node answers 403. Returns bookkeeping only: the enrollment id, the mode, the absolute expiry in Unix seconds and, once a joiner has claimed the secret, the node id it was claimed by. The secret value itself is never returned here, because only its hash was kept when it was minted. Expired secrets that are not mid-enrollment are discarded before the list is built, so the list holds live and in-flight enrollments; entries are ordered by expiry, soonest first. The list is this management node's local state, not a realm-wide fan-out.",
+    description = r#"Lists this management node's live and in-flight enrollment secrets as bookkeeping only.
+
+**Authentication**: bearer token of this realm with WRITE on the realm's onboarding admin path;
+only a management node serves it and any other node answers 403.
+
+**Behavior**
+- Each entry carries the enrollment id, the mode, the absolute expiry in Unix seconds and, once a
+  joiner has claimed the secret, the node id it was claimed by.
+- The secret value itself is never returned here, because only its hash was kept when it was
+  minted.
+- Expired secrets that are not mid-enrollment are discarded before the list is built, so the list
+  holds live and in-flight enrollments; entries are ordered by expiry, soonest first.
+- The list is this management node's local state, not a realm-wide fan-out."#,
     responses(
         (
             status = 200,
@@ -325,7 +355,19 @@ pub async fn list_onboarding_secrets(
     path = "/admin/onboarding/secrets/{id}",
     tag = "onboarding",
     summary = "Revoke a pending node enrollment secret",
-    description = "Requires a bearer token of this realm with WRITE on the realm's onboarding admin path, and only a management node serves it; any other node answers 403. Deletes the enrollment record on this node, which makes the secret unredeemable from here on. This is the remedy for a secret that leaked or was never used, and it is the only remedy, since the secret value itself was never stored. Revocation does not undo an enrollment that already completed: a node that finished bootstrapping stays a member of the realm and has to be removed through the realm configuration instead. A secret that is already gone, expired and pruned or revoked by an earlier call, answers 404.",
+    description = r#"Deletes the enrollment record on this node, making the secret unredeemable from here on.
+
+**Authentication**: bearer token of this realm with WRITE on the realm's onboarding admin path;
+only a management node serves it and any other node answers 403.
+
+**Behavior**
+- This is the remedy for a secret that leaked or was never used, and it is the only remedy, since
+  the secret value itself was never stored.
+- Revocation does not undo an enrollment that already completed: a node that finished bootstrapping
+  stays a member of the realm and has to be removed through the realm configuration instead.
+
+**Errors**: a secret that is already gone, expired and pruned or revoked by an earlier call,
+answers 404."#,
     params(("id" = String, Path, description = "Enrollment id of the secret, the ULID reported when it was minted and by the list endpoint")),
     responses(
         (status = 204, description = "Secret deleted and no longer redeemable; no response body"),
@@ -358,7 +400,30 @@ pub async fn revoke_onboarding_secret(
     path = "/onboarding/bootstrap",
     tag = "onboarding",
     summary = "Redeem an enrollment secret and join the realm",
-    description = "Deliberately unauthenticated: a joining node has no realm token yet. The enrollment secret plus a signature by the joiner's own node key are the credentials, so an unknown, expired, already claimed or unmatched secret and any signature that does not verify are refused with 401, without saying which of the two failed. Only a management node serves this; any other node answers 403. The secret is single-use and is consumed when enrollment finalizes, which also adds the joiner to the realm configuration; a rejected attempt leaves the secret usable so an operator does not have to mint a new one after a typo. What must be sent depends on the mode the secret was minted for: a Server secret additionally requires `issuer_public_key` and a matching `issuer_proof` and returns a delegation signature; a Management secret requires `transport_public_key` and returns the realm private key encrypted to it, along with the nonce and the ephemeral public key needed to open it; a Local secret needs neither. The response always carries the realm id, the temporary endpoint to dial and a one-time sync ticket the joiner uses to fetch the realm's core documents. `node_location`, `node_weight` and `node_labels` seed the joiner's placement entry and are optional. Everything returned here is one-time joining material and must never be logged or reused.",
+    description = r#"Redeems an enrollment secret and returns the one-time material a joiner needs to enter the realm.
+
+**Authentication**: none; deliberately unauthenticated, because a joining node has no realm token
+yet. The enrollment secret plus a signature by the joiner's own node key are the credentials, and
+only a management node serves this route.
+
+**Behavior**
+- The secret is single-use and is consumed when enrollment finalizes, which also adds the joiner to
+  the realm configuration; a rejected attempt leaves the secret usable so an operator does not have
+  to mint a new one after a typo.
+- What must be sent depends on the mode the secret was minted for: a `Server` secret additionally
+  requires `issuer_public_key` and a matching `issuer_proof` and returns a delegation signature; a
+  `Management` secret requires `transport_public_key` and returns the realm private key encrypted
+  to it, along with the nonce and the ephemeral public key needed to open it; a `Local` secret
+  needs neither.
+- The response always carries the realm id, the temporary endpoint to dial and a one-time sync
+  ticket the joiner uses to fetch the realm's core documents.
+- `node_location`, `node_weight` and `node_labels` seed the joiner's placement entry and are
+  optional.
+- Everything returned here is one-time joining material and must never be logged or reused.
+
+**Errors**: an unknown, expired, already claimed or unmatched secret and a signature that does not
+verify are both refused with 401, without saying which of the two failed. A node that does not
+serve enrollment answers 403."#,
     request_body(
         content = BootstrapOnboardingRequestDoc,
         description = "The enrollment secret, the joiner's node id, its proof of possession of the node key, and any mode-specific key material",
@@ -370,7 +435,9 @@ pub async fn revoke_onboarding_secret(
             "issuer_proof": "<issuer-proof-signature>",
             "node_location": "dc-a",
             "node_weight": 100,
-            "node_labels": {"zone": "dc-a"}
+            "node_labels": {
+                "zone": "dc-a"
+            }
         })
     ),
     responses(
@@ -384,8 +451,12 @@ pub async fn revoke_onboarding_secret(
                 "temporary_bootstrap_endpoint": {
                     "id": "2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a",
                     "addrs": [
-                        {"Ip": "192.0.2.10:4433"},
-                        {"Relay": "https://relay.example.test/"}
+                        {
+                            "Ip": "192.0.2.10:4433"
+                        },
+                        {
+                            "Relay": "https://relay.example.test/"
+                        }
                     ]
                 },
                 "wrapped_realm_private_key": null,

--- a/api/src/routes/pid.rs
+++ b/api/src/routes/pid.rs
@@ -414,9 +414,10 @@ fn validated_withdrawal_reason(request: &WithdrawPersistentIdRequest) -> ServerR
 - Normal document deletion instead stores `tombstoned`.
 - The transition is terminal and idempotent.
 
-**Limits**
-- The JSON body must name provider `w3id`, confirm the exact stored PID value and carry a non-empty
-  reason."#,
+**Limits** (all refused with 400)
+- `provider` must be `w3id`; no other provider is accepted.
+- `confirm_pid` must equal the stored PID value exactly.
+- `reason` is trimmed first and must then be 1 to 1024 bytes long and free of control characters."#,
     params(("document_id" = String, Path, description = "Document ULID whose PID is withdrawn, for example 01JMETADATA0123456789ABCDE")),
     request_body(
         content = WithdrawPersistentIdRequest,

--- a/api/src/routes/pid.rs
+++ b/api/src/routes/pid.rs
@@ -57,17 +57,32 @@ fn rocrate_location(document_id: Ulid) -> String {
     path = "/pid/{document_id}",
     tag = "pid",
     summary = "Resolve a w3id persistent identifier",
-    description = "Public landing route for the ordinary identity https://w3id.org/aruna/{document_id}; a Profile's mapping uses /profile/{document_id}, so this ordinary path returns 404 for a Profile and never acts as a duplicate PID. No bearer token is required or read. An active public identifier answers 302 to the document's RO-Crate read route, which applies its own authorization. A terminal tombstone answers 410. Unknown, malformed, private, requested, processing and failed identifiers answer 404. When the single PID authority is unreachable the answer is 503 rather than a false 404.",
+    description = r#"Public landing route for the ordinary identity `https://w3id.org/aruna/{document_id}`.
+
+**Authentication**: none; public route, no bearer token is required or read.
+
+**Behavior**
+- A Profile's mapping uses `/profile/{document_id}`, so this ordinary path returns 404 for a Profile
+  and never acts as a duplicate PID.
+- An active public identifier answers 302 to the document's RO-Crate read route, which applies its
+  own authorization.
+- A terminal tombstone answers 410.
+- Unknown, malformed, private, `requested`, `processing` and `failed` identifiers answer 404.
+
+**Errors**: when the single PID authority is unreachable the answer is 503 rather than a false 404."#,
     params(("document_id" = String, Path, description = "Document ULID carried by the w3id PID, for example 01JMETADATA0123456789ABCDE")),
     responses(
-        (status = 302, description = "Registered identifier; the Location header points at /api/v1/metadata/{document_id}/rocrate and the body is empty"),
+        (status = 302, description = "Registered identifier; the Location header points at the RO-Crate read route and the body is empty"),
         (status = 404, description = "No identifier is registered for this document, or the identifier is malformed; the body is empty"),
         (
             status = 410,
             description = "The identifier was withdrawn and stays withdrawn",
             body = Object,
             content_type = "application/json",
-            example = json!({"pid": "https://w3id.org/aruna/01JMETADATA0123456789ABCDE", "status": "withdrawn"})
+            example = json!({
+                "pid": "https://w3id.org/aruna/01JMETADATA0123456789ABCDE",
+                "status": "withdrawn"
+            })
         ),
         (status = 503, description = "The PID authority is unreachable; retry the same request later")
     ),
@@ -96,7 +111,15 @@ async fn resolve_pid(
     path = "/profile/{document_id}",
     tag = "pid",
     summary = "Resolve a Profile w3id persistent identifier",
-    description = "Public landing route for the Profile identity https://w3id.org/aruna/profile/{document_id}. It resolves only when that exact value is the document's stored automatic primary PID; ordinary Datasets return 404 here. Response privacy, 302/410 lifecycle behavior and 503 authority handling are identical to GET /pid/{document_id}.",
+    description = r#"Public landing route for the Profile identity `https://w3id.org/aruna/profile/{document_id}`.
+
+**Authentication**: none; public route.
+
+**Behavior**
+- Resolves only when that exact value is the document's stored automatic primary PID; ordinary
+  Datasets return 404 here.
+- Response privacy, 302 and 410 lifecycle behavior and 503 authority handling are identical to
+  `GET /pid/{document_id}`."#,
     params(("document_id" = String, Path, description = "Profile document ULID")),
     responses(
         (status = 302, description = "Active public Profile identifier"),
@@ -277,21 +300,39 @@ async fn require_status_visibility(
     path = "/metadata/{document_id}/pids",
     tag = "pid",
     summary = "List a document's typed persistent identifiers",
-    description = "Returns the one stored automatic w3id record as a typed list while storage remains keyed 1:1 by document. Stored mapping state is authoritative for requested, processing, active, failed, admin-withdrawn and tombstoned, including its job reference and failure/retry data; job-read failure is never interpreted as unminted. A missing or unavailable authority mapping is unknown. Public records may be read anonymously; a private record returns 404 anonymously and requires READ on its frozen document permission path when authenticated.",
+    description = r#"Returns the one stored automatic w3id record for a document as a typed list.
+
+**Authentication**: optional bearer token; public records may be read anonymously, while a private
+record returns 404 anonymously and requires READ on its frozen document permission path when
+authenticated.
+
+**Behavior**
+- Storage remains keyed 1:1 by document, so the list carries the single automatic w3id record.
+- Stored mapping state is authoritative for `requested`, `processing`, `active`, `failed`,
+  `admin-withdrawn` and `tombstoned`, including its job reference and failure/retry data.
+- A job-read failure is never interpreted as unminted.
+- A missing or unavailable authority mapping is reported as `unknown`."#,
     params(("document_id" = String, Path, description = "Metadata document ULID")),
     responses(
-        (status = 200, description = "Typed list containing the automatic w3id status", body = [PersistentIdView], example = json!([{
-            "kind": "conceptual",
-            "provider": "w3id",
-            "value": "https://w3id.org/aruna/01JMETADATA0123456789ABCDE",
-            "state": "active",
-            "document_id": "01JMETADATA0123456789ABCDE",
-            "job_id": "01JABCDEF0123456789ABCDEFG",
-            "failure": null,
-            "requested_at_ms": 1755500000000u64,
-            "minted_at_ms": 1755500001000u64,
-            "withdrawn_at_ms": null
-        }])),
+        (
+            status = 200,
+            description = "Typed list containing the automatic w3id status",
+            body = [PersistentIdView],
+            example = json!([
+                {
+                    "kind": "conceptual",
+                    "provider": "w3id",
+                    "value": "https://w3id.org/aruna/01JMETADATA0123456789ABCDE",
+                    "state": "active",
+                    "document_id": "01JMETADATA0123456789ABCDE",
+                    "job_id": "01JABCDEF0123456789ABCDEFG",
+                    "failure": null,
+                    "requested_at_ms": 1755500000000u64,
+                    "minted_at_ms": 1755500001000u64,
+                    "withdrawn_at_ms": null
+                }
+            ])
+        ),
         (status = 400, description = "Malformed document id", body = ErrorResponse),
         (status = 403, description = "Authenticated caller lacks READ", body = ErrorResponse),
         (status = 404, description = "Unknown document or anonymous private status", body = ErrorResponse)
@@ -362,7 +403,20 @@ fn validated_withdrawal_reason(request: &WithdrawPersistentIdRequest) -> ServerR
     path = "/pid/{document_id}",
     tag = "pid",
     summary = "Withdraw a document's w3id persistent identifier",
-    description = "Exceptional administration route. It requires an unrestricted realm bearer token and WRITE on /{realm}/admin/pids/{document_id}; document WRITE alone is deliberately insufficient. The JSON body must name provider w3id, confirm the exact stored PID value and contain a non-empty reason. The authority stores admin-withdrawn, actor and reason and writes a WithdrawPersistentId metadata audit row in the same transaction. Normal document deletion instead stores tombstoned. The transition is terminal and idempotent.",
+    description = r#"Exceptional administration route that terminally withdraws a document's w3id identifier.
+
+**Authentication**: unrestricted realm bearer token with WRITE on
+`/{realm}/admin/pids/{document_id}`; document WRITE alone is deliberately insufficient.
+
+**Behavior**
+- The authority stores `admin-withdrawn`, the actor and the reason, and writes a
+  `WithdrawPersistentId` metadata audit row in the same transaction.
+- Normal document deletion instead stores `tombstoned`.
+- The transition is terminal and idempotent.
+
+**Limits**
+- The JSON body must name provider `w3id`, confirm the exact stored PID value and carry a non-empty
+  reason."#,
     params(("document_id" = String, Path, description = "Document ULID whose PID is withdrawn, for example 01JMETADATA0123456789ABCDE")),
     request_body(
         content = WithdrawPersistentIdRequest,

--- a/api/src/routes/placement.rs
+++ b/api/src/routes/placement.rs
@@ -589,17 +589,37 @@ async fn bucket_info(
     path = "/admin/placement-policies",
     tag = "placement",
     summary = "Publish an immutable placement policy",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path; the check runs inside the operation, so a caller without it is refused before anything is written. The definition is immutable: publishing the same id with the same selectors returns the stored document unchanged, while the same id with different selectors is refused with 409 and never replaces the stored rule. Omitting `policy_id` mints one. The document is committed on a holder of the bucket its id resolves to; when this node holds none, the publication is forwarded to a current holder under the caller's own token, and that holder re-runs the same admin check, so a relay never becomes the author. A 503 means no holder could be reached or this node cannot sign, and nothing was published. The response carries the publisher, the authorizing user and the definition digest that every later reference must name.",
+    description = r#"Publishes an immutable placement policy definition and returns the document holders serve.
+
+**Authentication**: realm bearer token with WRITE on the realm configuration path; the check runs
+inside the operation, so a caller without it is refused before anything is written.
+
+**Behavior**
+- The definition is immutable: publishing the same id with the same selectors returns the stored
+  document unchanged.
+- Omitting `policy_id` mints one.
+- The document is committed on a holder of the bucket its id resolves to; when this node holds none,
+  the publication is forwarded to a current holder under the caller's own token, and that holder
+  re-runs the same admin check, so a relay never becomes the author.
+- The response carries the publisher, the authorizing user and the definition digest that every
+  later reference must name.
+
+**Errors**: the same id with different selectors is refused with 409 and never replaces the stored
+rule. A 503 means no holder could be reached or this node cannot sign, and nothing was published."#,
     request_body(content = CreatePolicyRequest, example = json!({
         "name": "eu-residency",
-        "allowed": [{ "location": "eu-west" }]
+        "allowed": [
+            { "location": "eu-west" }
+        ]
     })),
     responses(
         (status = 200, description = "The published document, or the identical one that already existed", body = PolicyResponse, example = json!({
             "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
             "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d",
             "name": "eu-residency",
-            "allowed": [{ "location": "eu-west" }],
+            "allowed": [
+                { "location": "eu-west" }
+            ],
             "publisher": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
             "created_by": "01K2ZK4Q0X3D5M6P7R8S9T0V2A@0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0",
             "created_at_ms": 1755500000000u64
@@ -656,7 +676,20 @@ pub async fn create_placement_policy(
     path = "/admin/placement-policies/{policy_id}",
     tag = "placement",
     summary = "Read one placement policy by reference",
-    description = "Requires a bearer token issued for this realm. Both the id and the `digest` of the definition are needed, because an id alone could be answered with other bytes; a digest that does not match what the holders serve is reported as 404 rather than returning a substituted rule. The document is read from this node when it holds a replica and otherwise fetched from the holders the policy id resolves to, and it is only returned after its original publication verified against this node's replicated realm view, so a relay cannot present itself as the author. A 503 means no holder answered or the publication could not be verified here; it never means the rule denies anything.",
+    description = r#"Returns one authenticated placement policy document named by its id and definition digest.
+
+**Authentication**: realm bearer token.
+
+**Behavior**
+- Both the id and the `digest` of the definition are needed, because an id alone could be answered
+  with other bytes.
+- The document is read from this node when it holds a replica and otherwise fetched from the holders
+  the policy id resolves to, and it is only returned after its original publication verified against
+  this node's replicated realm view, so a relay cannot present itself as the author.
+
+**Errors**: a digest that does not match what the holders serve is reported as 404 rather than
+returning a substituted rule. A 503 means no holder answered or the publication could not be
+verified here; it never means the rule denies anything."#,
     params(
         ("policy_id" = String, Path, description = "ULID of the policy"),
         ("digest" = String, Query, description = "Lowercase hex of the 32-byte definition digest")
@@ -666,7 +699,9 @@ pub async fn create_placement_policy(
             "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
             "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d",
             "name": "eu-residency",
-            "allowed": [{ "location": "eu-west" }],
+            "allowed": [
+                { "location": "eu-west" }
+            ],
             "publisher": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
             "created_by": "01K2ZK4Q0X3D5M6P7R8S9T0V2A@0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0",
             "created_at_ms": 1755500000000u64
@@ -709,19 +744,33 @@ pub async fn get_placement_policy(
     path = "/admin/placement-policies",
     tag = "placement",
     summary = "List the placement policies this responder holds",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path, checked inside the operation. Policy documents replicate only to the holders their id resolves to, so a page names what this node stores rather than a realm-wide catalog, and `complete` means this node's own bounded iterator was exhausted in the pass. Policies are ordered by ascending policy id; `next_cursor` continues after the last one returned.",
+    description = r#"Returns one bounded page of the placement policy documents this node holds.
+
+**Authentication**: realm bearer token with READ on the realm configuration path, checked inside the
+operation.
+
+**Behavior**
+- Policy documents replicate only to the holders their id resolves to, so a page names what this
+  node stores rather than a realm-wide catalog.
+- `complete` means this node's own bounded iterator was exhausted in the pass.
+- Policies are ordered by ascending policy id; `next_cursor` continues after the last one
+  returned."#,
     params(PolicyListQuery),
     responses(
         (status = 200, description = "One bounded page of policies this node holds", body = PolicyListResponse, example = json!({
-            "policies": [{
-                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d",
-                "name": "eu-residency",
-                "allowed": [{ "location": "eu-west" }],
-                "publisher": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
-                "created_by": "01K2ZK4Q0X3D5M6P7R8S9T0V2A@0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0",
-                "created_at_ms": 1755500000000u64
-            }],
+            "policies": [
+                {
+                    "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                    "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d",
+                    "name": "eu-residency",
+                    "allowed": [
+                        { "location": "eu-west" }
+                    ],
+                    "publisher": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
+                    "created_by": "01K2ZK4Q0X3D5M6P7R8S9T0V2A@0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0",
+                    "created_at_ms": 1755500000000u64
+                }
+            ],
             "next_cursor": "0197d0b41c1e3d5a6b7c8d9e0f1a2b3c",
             "complete": false
         })),
@@ -772,15 +821,27 @@ pub struct PolicyRefQuery {
     path = "/buckets/{bucket}/placement",
     tag = "placement",
     summary = "Read a bucket's default placement policies",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path, because the default names policy ids. This is a node-local read of the replicated bucket record: a default written on another node can be missing until it arrives here. The `generation` is the counter every default change advances, and it is what a bulk run seals and what a compare-and-set update must present. A bucket that has never been given a default returns an empty list at its current generation.",
+    description = r#"Returns the placement policy refs a bucket applies by default, with their generation.
+
+**Authentication**: realm bearer token with READ on the realm configuration path, because the
+default names policy ids.
+
+**Behavior**
+- This is a node-local read of the replicated bucket record: a default written on another node can
+  be missing until it arrives here.
+- The `generation` is the counter every default change advances, and it is what a bulk run seals and
+  what a compare-and-set update must present.
+- A bucket that has never been given a default returns an empty list at its current generation."#,
     params(("bucket" = String, Path, description = "Bucket name as used by the S3 surface")),
     responses(
         (status = 200, description = "The default ref set and the generation it was written at", body = BucketPlacementResponse, example = json!({
             "bucket": "datasets",
-            "policies": [{
-                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-            }],
+            "policies": [
+                {
+                    "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                    "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+                }
+            ],
             "generation": 3
         })),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
@@ -820,25 +881,47 @@ pub async fn get_bucket_placement(
     path = "/buckets/{bucket}/placement",
     tag = "placement",
     summary = "Replace a bucket's default placement policies",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path, checked inside the operation. The submitted list replaces the whole default set; an empty list clears it. Every ref is resolved and authenticated through the ordinary policy read before it can become a default, so a ref no holder can supply is refused with 503 and the stored default is untouched. A real change advances `placement_policy_generation` exactly once inside the same transaction; submitting the set that is already stored commits nothing and returns the current generation, so a replay cannot supersede a bulk run that sealed the same refs. Sending `expected_generation` makes the change a compare-and-set that is refused with 409 when another writer moved the default first. The default governs versions minted after it: stored versions keep their own refs until a successor is minted for them.",
+    description = r#"Replaces the placement policy refs a bucket applies by default to newly minted versions.
+
+**Authentication**: realm bearer token with WRITE on the realm configuration path, checked inside
+the operation.
+
+**Behavior**
+- The submitted list replaces the whole default set; an empty list clears it.
+- Every ref is resolved and authenticated through the ordinary policy read before it can become a
+  default, so a ref no holder can supply leaves the stored default untouched.
+- A real change advances `placement_policy_generation` exactly once inside the same transaction;
+  submitting the set that is already stored commits nothing and returns the current generation, so a
+  replay cannot supersede a bulk run that sealed the same refs.
+- Sending `expected_generation` makes the change a compare-and-set.
+- The default governs versions minted after it: stored versions keep their own refs until a
+  successor is minted for them.
+
+**Errors**: a compare-and-set that another writer moved first, and an exhausted counter, are 409. A
+ref no holder can authenticate is 503 and nothing was changed. A placement rule refusal is a 400
+reported with a fixed reason that never names a policy, a ref or a node."#,
     params(("bucket" = String, Path, description = "Bucket name as used by the S3 surface")),
     request_body(content = BucketPlacementRequest, example = json!({
-        "policies": [{
-            "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-            "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-        }],
+        "policies": [
+            {
+                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+            }
+        ],
         "expected_generation": 3
     })),
     responses(
         (status = 200, description = "The default set as stored, with the generation it now carries", body = BucketPlacementResponse, example = json!({
             "bucket": "datasets",
-            "policies": [{
-                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-            }],
+            "policies": [
+                {
+                    "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                    "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+                }
+            ],
             "generation": 4
         })),
-        (status = 400, description = "A ref could not be parsed, the set is not a valid ref set, or a placement rule refuses it; a rule refusal is reported with a fixed reason that never names a policy, a ref or a node", body = ErrorResponse),
+        (status = 400, description = "A ref could not be parsed, the set is not a valid ref set, or a placement rule refuses it", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller may not administer the realm configuration", body = ErrorResponse),
         (status = 404, description = "No bucket of that name is known to this node", body = ErrorResponse),
@@ -883,34 +966,63 @@ pub async fn put_bucket_placement(
     path = "/buckets/{bucket}/placement/objects",
     tag = "placement",
     summary = "Attach an exact policy set to one object",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path, checked inside the operation. This is an exact replacement, not a union: the successor carries exactly the submitted refs, so an explicit mutation may tighten or relax. Nothing stored is rewritten; a new version is minted that carries the new refs and the predecessor's bytes, and the predecessor keeps its own refs. The mutation advances the head only while it still is exactly `expected_version_id` at `expected_generation` and the bucket is still the same record, so a concurrent write is reported as 409 and the caller replans from the new head. Repeating the same `mutation_id` with the same parameters returns the version the first attempt assigned, which is what makes a lost response safe; the same id with different parameters is a 409. A materialized object needs a verified local copy of its bytes on a destination the new refs admit: without one the response is `blocked` with a reason and nothing was written, and the ordinary movement path has to stage and register compliant bytes first. A reference-only head mints a successor and registers no copy.",
+    description = r#"Mints a successor version of one object that carries exactly the submitted placement refs.
+
+**Authentication**: realm bearer token with WRITE on the realm configuration path, checked inside
+the operation.
+
+**Behavior**
+- This is an exact replacement, not a union: the successor carries exactly the submitted refs, so an
+  explicit mutation may tighten or relax.
+- Nothing stored is rewritten; a new version is minted that carries the new refs and the
+  predecessor's bytes, and the predecessor keeps its own refs.
+- The mutation advances the head only while it still is exactly `expected_version_id` at
+  `expected_generation` and the bucket is still the same record, so a concurrent write is reported
+  as 409 and the caller replans from the new head.
+- Repeating the same `mutation_id` with the same parameters returns the version the first attempt
+  assigned, which is what makes a lost response safe; the same id with other parameters is a 409.
+- A materialized object needs a verified local copy of its bytes on a destination the new refs
+  admit: without one the response is `blocked` with a reason and nothing was written, and the
+  ordinary movement path has to stage and register compliant bytes first.
+- A reference-only head mints a successor and registers no copy.
+
+**Errors**
+- A 400 covers an unparsable id, version id or ref, and a placement rule that refuses the
+  destination, which is reported with a fixed reason that never names a policy, a ref or a node.
+- A 503 means a referenced policy could not be authenticated, this node advertises no placement
+  subject or is not admitting governed data, or its subject moved during the mutation; nothing was
+  written and the caller may retry."#,
     params(("bucket" = String, Path, description = "Bucket name as used by the S3 surface")),
     request_body(content = ObjectPlacementRequest, example = json!({
         "key": "raw/sample.fastq",
         "mutation_id": "01K2ZK4Q0X3D5M6P7R8S9T0V4C",
         "expected_version_id": "01K2ZK4Q0X3D5M6P7R8S9T0V3B",
         "expected_generation": 7,
-        "policies": [{
-            "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-            "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-        }]
+        "policies": [
+            {
+                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+            }
+        ]
     })),
     responses(
         (status = 200, description = "The minted, replayed or blocked outcome", body = ObjectPlacementResponse, example = json!({
             "outcome": "minted",
             "version_id": "01K2ZK4Q0X3D5M6P7R8S9T0V5D",
             "materialized": true,
-            "policies": [{
-                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-            }]
+            "policies": [
+                {
+                    "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                    "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+                }
+            ]
         })),
-        (status = 400, description = "An id, version id or ref could not be parsed, or a placement rule refuses the destination; a rule refusal is reported with a fixed reason that never names a policy, a ref or a node", body = ErrorResponse),
+        (status = 400, description = "An id, version id or ref could not be parsed, or a placement rule refuses the destination", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller may not administer the realm configuration", body = ErrorResponse),
         (status = 404, description = "No such bucket, or the expected head version no longer exists", body = ErrorResponse),
         (status = 409, description = "The head moved, the bucket changed, the mutation id was reused with other parameters, or the assigned version id is taken", body = ErrorResponse),
-        (status = 503, description = "A referenced policy could not be authenticated, this node advertises no placement subject or is not admitting governed data, or its subject moved during the mutation; nothing was written and the caller may retry", body = ErrorResponse)
+        (status = 503, description = "A referenced policy, this node's placement subject or its admission state made the mutation impossible; nothing was written", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -994,8 +1106,29 @@ fn mutation_response(outcome: SuccessorOutcome) -> ObjectPlacementResponse {
     post,
     path = "/buckets/{bucket}/placement/runs",
     tag = "placement",
-    summary = "Apply the bucket default to this responder's current heads",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path, checked inside the operation. The first call under an `operation_id` seals the run against the bucket's exact identity, generation and default ref set; repeating that id resumes the sealed run, and every later pass is bound to what was sealed. The application is additive: each object's successor carries the union of the refs its head already had and the sealed target, so applying a default never removes a constraint. Exact replacement is a separate surface. One pass walks a bounded page of this responder's own heads and returns a `cursor` to continue with; heads that already carry the target and delete markers are counted as covered. An object whose bytes cannot be reused, whose destination the refs deny, or whose policy cannot be authenticated is retained as a durable blocked gap and retried by a later pass rather than being reported as done. A head that moved is replanned instead of advanced. When the bucket default changes the run is marked superseded and stops, so one run never mixes two policies. `complete` means this node's bounded iterator was exhausted, never that another partition converged.",
+    summary = "Apply the bucket default to local heads",
+    description = r#"Runs one resumable pass that applies the bucket's default refs to this responder's current heads.
+
+**Authentication**: realm bearer token with WRITE on the realm configuration path, checked inside
+the operation.
+
+**Behavior**
+- The first call under an `operation_id` seals the run against the bucket's exact identity,
+  generation and default ref set; repeating that id resumes the sealed run, and every later pass is
+  bound to what was sealed.
+- The application is additive: each object's successor carries the union of the refs its head
+  already had and the sealed target, so applying a default never removes a constraint. Exact
+  replacement is a separate surface.
+- One pass walks a bounded page of this responder's own heads and returns a `cursor` to continue
+  with; heads that already carry the target and delete markers are counted as covered.
+- An object whose bytes cannot be reused, whose destination the refs deny, or whose policy cannot be
+  authenticated is retained as a durable blocked gap and retried by a later pass rather than being
+  reported as done.
+- A head that moved is replanned instead of advanced.
+- When the bucket default changes the run is marked superseded and stops, so one run never mixes two
+  policies.
+- `complete` means this node's bounded iterator was exhausted, never that another partition
+  converged."#,
     params(("bucket" = String, Path, description = "Bucket name as used by the S3 surface")),
     request_body(content = BulkRunRequest, example = json!({
         "operation_id": "01K2ZK4Q0X3D5M6P7R8S9T0V6E",
@@ -1006,15 +1139,22 @@ fn mutation_response(outcome: SuccessorOutcome) -> ObjectPlacementResponse {
             "operation_id": "01K2ZK4Q0X3D5M6P7R8S9T0V6E",
             "status": "active",
             "generation": 3,
-            "target_policies": [{
-                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-            }],
+            "target_policies": [
+                {
+                    "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                    "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+                }
+            ],
             "observed": 64,
             "covered": 58,
             "minted": 4,
             "replanned": 1,
-            "blocked": [{ "key": "raw/sample.fastq", "reason": "source_unavailable" }],
+            "blocked": [
+                {
+                    "key": "raw/sample.fastq",
+                    "reason": "source_unavailable"
+                }
+            ],
             "cursor": "6b0d",
             "complete": false
         })),
@@ -1085,7 +1225,22 @@ const SCAN_DEFAULT_LIMIT: usize = 128;
     path = "/buckets/{bucket}/placement/coverage",
     tag = "placement",
     summary = "Report responder-local coverage of the bucket default",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path, checked inside the operation. The report names the exact default ref set and generation it compared against and reports only what this responder stores: `complete` means its own bounded iterator was exhausted, not that another partition or a concurrent write was observed, and the `limits` list states that explicitly. Attachment gaps and local copy state are separate answers: an object can carry every ref and still have no serveable copy here, so zero gaps never implies that every registered copy is compliant. Scope `current` walks current heads; scope `historical` reports versions that are no longer the head and lack the default, which is diagnostic only, because minting successors never rewrites their immutable refs. Reference-only heads are included and labelled rather than omitted.",
+    description = r#"Reports how far this responder's own stored objects carry the bucket's default placement refs.
+
+**Authentication**: realm bearer token with READ on the realm configuration path, checked inside the
+operation.
+
+**Behavior**
+- The report names the exact default ref set and generation it compared against and reports only
+  what this responder stores: `complete` means its own bounded iterator was exhausted, not that
+  another partition or a concurrent write was observed, and the `limits` list states that
+  explicitly.
+- Attachment gaps and local copy state are separate answers: an object can carry every ref and still
+  have no serveable copy here, so zero gaps never implies that every registered copy is compliant.
+- Scope `current` walks current heads; scope `historical` reports versions that are no longer the
+  head and lack the default, which is diagnostic only, because minting successors never rewrites
+  their immutable refs.
+- Reference-only heads are included and labelled rather than omitted."#,
     params(
         ("bucket" = String, Path, description = "Bucket name as used by the S3 surface"),
         CoverageQuery
@@ -1095,24 +1250,31 @@ const SCAN_DEFAULT_LIMIT: usize = 128;
             "bucket": "datasets",
             "scope": "current",
             "generation": 3,
-            "target_policies": [{
-                "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-                "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-            }],
+            "target_policies": [
+                {
+                    "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                    "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+                }
+            ],
             "observed": 64,
             "deleted": 2,
-            "gaps": [{
-                "key": "raw/sample.fastq",
-                "version_id": "01K2ZK4Q0X3D5M6P7R8S9T0V3B",
-                "attachment": "missing",
-                "copy": "registered"
-            }],
+            "gaps": [
+                {
+                    "key": "raw/sample.fastq",
+                    "version_id": "01K2ZK4Q0X3D5M6P7R8S9T0V3B",
+                    "attachment": "missing",
+                    "copy": "registered"
+                }
+            ],
             "registered": 60,
             "quarantined": 1,
             "absent": 1,
             "reference_only": 2,
             "complete": true,
-            "limits": ["responder_local", "historical_excluded"]
+            "limits": [
+                "responder_local",
+                "historical_excluded"
+            ]
         })),
         (status = 400, description = "The scope, cursor or limit could not be parsed", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
@@ -1215,7 +1377,22 @@ fn coverage_response(
     path = "/admin/placement-diagnostics",
     tag = "placement",
     summary = "Inspect local policy enforcement, violations and cache coverage",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path, checked inside the operation. Everything reported is an observation of this node's own rows: the placement subject it advertises, whether serving is currently blocked or draining, and a bounded page of its registered copies. A copy that is quarantined or was last seen on a departed node is listed as a violation with the refs it was registered under; a serveable registration is counted but never listed, and it is not by itself a compliance claim. Cache figures are diagnostics only and never policy truth: an evicted entry only costs a refetch, and a negative entry is an availability hint that expires. `complete` refers to this node's bounded copy iterator, and `cache_truncated` says the cache scan hit its own bound.",
+    description = r#"Reports this node's own placement subject, its policy violations and its policy cache figures.
+
+**Authentication**: realm bearer token with READ on the realm configuration path, checked inside the
+operation.
+
+**Behavior**
+- Everything reported is an observation of this node's own rows: the placement subject it
+  advertises, whether serving is currently blocked or draining, and a bounded page of its registered
+  copies.
+- A copy that is quarantined or was last seen on a departed node is listed as a violation with the
+  refs it was registered under; a serveable registration is counted but never listed, and it is not
+  by itself a compliance claim.
+- Cache figures are diagnostics only and never policy truth: an evicted entry only costs a refetch,
+  and a negative entry is an availability hint that expires.
+- `complete` refers to this node's bounded copy iterator, and `cache_truncated` says the cache scan
+  hit its own bound."#,
     params(DiagnosticsQuery),
     responses(
         (status = 200, description = "The responder-local enforcement, violation and cache page", body = DiagnosticsResponse, example = json!({
@@ -1227,16 +1404,20 @@ fn coverage_response(
             "registered": 126,
             "quarantined": 2,
             "unresolved_departed": 0,
-            "violations": [{
-                "bucket": "datasets",
-                "key": "raw/sample.fastq",
-                "version_id": "01K2ZK4Q0X3D5M6P7R8S9T0V3B",
-                "state": "quarantined",
-                "policies": [{
-                    "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
-                    "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
-                }]
-            }],
+            "violations": [
+                {
+                    "bucket": "datasets",
+                    "key": "raw/sample.fastq",
+                    "version_id": "01K2ZK4Q0X3D5M6P7R8S9T0V3B",
+                    "state": "quarantined",
+                    "policies": [
+                        {
+                            "policy_id": "01K2ZK4Q0X3D5M6P7R8S9T0V1W",
+                            "digest": "9d3b0c1a2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+                        }
+                    ]
+                }
+            ],
             "cache_entries": 12,
             "cache_verified": 11,
             "cache_unavailable": 1,
@@ -1340,7 +1521,29 @@ pub struct QuarantineResolveResponse {
     path = "/admin/placement-quarantine",
     tag = "placement",
     summary = "Resolve the quarantined copies that block governed admission",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path, checked inside the operation. A subject transition, a rejoin or a failed revalidation leaves non-compliant copies quarantined, and while any of them remains this node serves no governed data and admits no new governed work, including new execution targets. This route is how an operator ends that state. List the quarantined copies with `GET /admin/placement-diagnostics` first: each violation names the exact bucket, key and version to act on. `action` of `revalidate` re-evaluates every local registration against the subject this node advertises now, restoring the ones that comply again; `action` of `release` additionally drops every local registration of the one named version first, which makes that version locally unavailable rather than serveable and never deletes data on another node. A release needs `bucket`, `key` and `version_id`; sending them with `revalidate` is refused so an accidental release is impossible. The block ends only when the walk finds nothing quarantined, which the response reports as `cleared`; a still-quarantined copy leaves the node draining, which is the safe state, not an error.",
+    description = r#"Revalidates or releases the quarantined copies that keep this node from admitting governed data.
+
+**Authentication**: realm bearer token with WRITE on the realm configuration path, checked inside
+the operation.
+
+**Behavior**
+- A subject transition, a rejoin or a failed revalidation leaves non-compliant copies quarantined,
+  and while any of them remains this node serves no governed data and admits no new governed work,
+  including new execution targets. This route is how an operator ends that state.
+- List the quarantined copies with `GET /admin/placement-diagnostics` first: each violation names
+  the exact bucket, key and version to act on.
+- `action` of `revalidate` re-evaluates every local registration against the subject this node
+  advertises now, restoring the ones that comply again.
+- `action` of `release` additionally drops every local registration of the one named version first,
+  which makes that version locally unavailable rather than serveable and never deletes data on
+  another node.
+- The block ends only when the walk finds nothing quarantined, which the response reports as
+  `cleared`; a still-quarantined copy leaves the node draining, which is the safe state, not an
+  error.
+
+**Limits** (all refused with 400)
+- A release needs `bucket`, `key` and `version_id`.
+- Sending them with `revalidate` is refused, so an accidental release is impossible."#,
     request_body(
         content = QuarantineResolveRequest,
         description = "The decision plus, for a release, the exact version it applies to",

--- a/api/src/routes/policies.rs
+++ b/api/src/routes/policies.rs
@@ -316,16 +316,6 @@ async fn group_policies(
     }
 }
 
-async fn require_config_admin(state: &ServerState, auth: &AuthContext) -> ServerResult<()> {
-    ensure_permission(
-        state,
-        auth,
-        format!("/{}/admin/config", state.get_realm_id()),
-        Permission::WRITE,
-    )
-    .await
-}
-
 async fn require_group_admin(
     state: &ServerState,
     auth: &AuthContext,
@@ -484,7 +474,6 @@ pub async fn set_realm_policies(
     Json(request): Json<SetPoliciesRequest>,
 ) -> ServerResult<(StatusCode, Json<PoliciesResponse>)> {
     let auth = require_realm_auth(&state, auth)?;
-    require_config_admin(&state, &auth).await?;
 
     let policies = request
         .policies
@@ -503,8 +492,9 @@ pub async fn set_realm_policies(
             actor: Actor {
                 node_id: state.get_node_id(),
                 user_id: auth.user_id,
-                realm_id: auth.realm_id,
+                realm_id: state.get_realm_id(),
             },
+            auth_context: auth,
             policies,
             expected_hash,
         }),
@@ -513,6 +503,7 @@ pub async fn set_realm_policies(
     .await
     .map_err(|error| match error {
         SetRealmPoliciesError::InvalidPolicies { reason } => ServerError::BadRequestMessage(reason),
+        SetRealmPoliciesError::Unauthorized => ServerError::Forbidden,
         SetRealmPoliciesError::StaleHash => {
             ServerError::Conflict("stored realm policy set changed".to_string())
         }
@@ -649,7 +640,6 @@ pub async fn set_group_policies(
 ) -> ServerResult<(StatusCode, Json<PoliciesResponse>)> {
     let auth = require_realm_auth(&state, auth)?;
     let group_id = parse_group_id(&group_id)?;
-    require_group_admin(&state, &auth, group_id).await?;
 
     let policies = request
         .policies
@@ -668,8 +658,9 @@ pub async fn set_group_policies(
             actor: Actor {
                 node_id: state.get_node_id(),
                 user_id: auth.user_id,
-                realm_id: auth.realm_id,
+                realm_id: state.get_realm_id(),
             },
+            auth_context: auth,
             group_id,
             policies,
             expected_hash,
@@ -679,6 +670,7 @@ pub async fn set_group_policies(
     .await
     .map_err(|error| match error {
         SetGroupPoliciesError::InvalidPolicies { reason } => ServerError::BadRequestMessage(reason),
+        SetGroupPoliciesError::Unauthorized => ServerError::Forbidden,
         SetGroupPoliciesError::GroupAuthDocNotFound => ServerError::NotFound,
         SetGroupPoliciesError::StaleHash => {
             ServerError::Conflict("stored group policy set changed".to_string())

--- a/api/src/routes/policies.rs
+++ b/api/src/routes/policies.rs
@@ -411,7 +411,8 @@ pub async fn get_realm_policies(
     summary = "Replace the realm's request policy set",
     description = r#"Replaces the realm's request policy set wholesale with the submitted list.
 
-**Authentication**: realm bearer token with WRITE on the realm configuration path.
+**Authentication**: realm bearer token with WRITE on the realm configuration path, and only a
+management node serves it; every other node answers 403.
 
 **Behavior**
 - Policies missing from the request are removed, an entry without a `policy_id` is given a fresh
@@ -463,7 +464,7 @@ pub async fn get_realm_policies(
         ),
         (status = 400, description = "Unknown policy kind, malformed policy or hash, or a set that breaks the size or compile limits", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
-        (status = 403, description = "Token belongs to another realm, or the caller may not write the realm configuration", body = ErrorResponse),
+        (status = 403, description = "Token belongs to another realm, the caller may not write the realm configuration, or this is not a management node", body = ErrorResponse),
         (status = 409, description = "The stored set no longer matches expected_hash and nothing was written; re-read the set and retry", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
@@ -503,7 +504,9 @@ pub async fn set_realm_policies(
     .await
     .map_err(|error| match error {
         SetRealmPoliciesError::InvalidPolicies { reason } => ServerError::BadRequestMessage(reason),
-        SetRealmPoliciesError::Unauthorized => ServerError::Forbidden,
+        SetRealmPoliciesError::Unauthorized | SetRealmPoliciesError::NotManagementNode => {
+            ServerError::Forbidden
+        }
         SetRealmPoliciesError::StaleHash => {
             ServerError::Conflict("stored realm policy set changed".to_string())
         }

--- a/api/src/routes/policies.rs
+++ b/api/src/routes/policies.rs
@@ -369,7 +369,18 @@ async fn require_group_read(
     path = "/policies/realm",
     tag = "policies",
     summary = "Read the realm's request policy set",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path. Returns the stored realm-scoped policies in the order enforcement evaluates them, together with `set_hash`, the 64-character hexadecimal content address of the set that a later write can pass as `expected_hash`. Policies only ever narrow access: a deny policy rejects a request its expression matches and a require policy rejects one it does not match, and neither can grant anything the caller's roles do not already allow. A realm whose configuration has not been written or replicated to this node reads as an empty set rather than a missing resource.",
+    description = r#"Returns the stored realm-scoped request policies in the order enforcement evaluates them.
+
+**Authentication**: realm bearer token with READ on the realm configuration path.
+
+**Behavior**
+- `set_hash` is the 64-character hexadecimal content address of the set, which a later write can
+  pass as `expected_hash`.
+- Policies only ever narrow access: a deny policy rejects a request its expression matches and a
+  require policy rejects one it does not match, and neither can grant anything the caller's roles do
+  not already allow.
+- A realm whose configuration has not been written or replicated to this node reads as an empty set
+  rather than a missing resource."#,
     responses(
         (
             status = 200,
@@ -408,7 +419,23 @@ pub async fn get_realm_policies(
     path = "/policies/realm",
     tag = "policies",
     summary = "Replace the realm's request policy set",
-    description = "Requires a bearer token issued for this realm and WRITE on the realm configuration path. The set is replaced wholesale: policies missing from the request are removed, an entry without a `policy_id` is given a fresh one, and the stored order is the evaluation order. The set is checked before it is stored, so at most 64 policies per scope, at most 4096 bytes per expression or guard, and every expression and guard must compile; a failure names the offending policy and stores nothing. When `expected_hash` is sent it is compared inside the write transaction, and a set changed in the meantime is rejected without writing, so re-read the set and reapply. The new set takes effect on this node as soon as it commits and reaches the rest of the realm afterwards as a single last-writer-wins value, so other nodes keep enforcing their previous set until it arrives, and concurrent writes on two nodes resolve to one of them rather than merging.",
+    description = r#"Replaces the realm's request policy set wholesale with the submitted list.
+
+**Authentication**: realm bearer token with WRITE on the realm configuration path.
+
+**Behavior**
+- Policies missing from the request are removed, an entry without a `policy_id` is given a fresh
+  one, and the stored order is the evaluation order.
+- When `expected_hash` is sent it is compared inside the write transaction, and a set changed in the
+  meantime is rejected without writing, so re-read the set and reapply.
+- The new set takes effect on this node as soon as it commits and reaches the rest of the realm
+  afterwards as a single last-writer-wins value, so other nodes keep enforcing their previous set
+  until it arrives, and concurrent writes on two nodes resolve to one of them rather than merging.
+
+**Limits** (checked before storing; a failure names the offending policy and stores nothing)
+- At most 64 policies per scope.
+- At most 4096 bytes per expression or guard.
+- Every expression and guard must compile."#,
     request_body(
         content = SetPoliciesRequest,
         description = "The complete realm policy set, optionally guarded by the hash of the set it is expected to replace.",
@@ -503,7 +530,16 @@ pub async fn set_realm_policies(
     path = "/policies/group/{group_id}",
     tag = "policies",
     summary = "Read a group's request policy set",
-    description = "Requires a bearer token issued for this realm and READ on the group's administrative configuration path, which the group's built-in member and admin roles both grant. Returns the group-scoped policies in evaluation order with `set_hash`, the 64-character hexadecimal content address to pass as `expected_hash` on a write. Group policies are evaluated after the realm ones and, like them, can only narrow access. A group that carries no policies, and one whose authorization document has not replicated to this node, both read as an empty set.",
+    description = r#"Returns the group-scoped request policies in the order enforcement evaluates them.
+
+**Authentication**: realm bearer token with READ on the group's administrative configuration path,
+which the group's built-in member and admin roles both grant.
+
+**Behavior**
+- `set_hash` is the 64-character hexadecimal content address to pass as `expected_hash` on a write.
+- Group policies are evaluated after the realm ones and, like them, can only narrow access.
+- A group that carries no policies, and one whose authorization document has not replicated to this
+  node, both read as an empty set."#,
     params(("group_id" = String, Path, description = "Group id as a 26-character ULID")),
     responses(
         (
@@ -545,7 +581,24 @@ pub async fn get_group_policies(
     path = "/policies/group/{group_id}",
     tag = "policies",
     summary = "Replace a group's request policy set",
-    description = "Requires a bearer token issued for this realm and WRITE on the group's configuration path. The set is replaced wholesale: policies missing from the request are removed, an entry without a `policy_id` is given a fresh one, and the stored order is the evaluation order. The same limits apply as to the realm set, at most 64 policies and at most 4096 bytes per expression or guard, and every expression and guard must compile before anything is stored. When `expected_hash` is sent it is compared inside the write transaction and a set changed in the meantime is rejected without writing. The set takes effect on this node as soon as it commits and rides the group's authorization document to the rest of the realm afterwards as a single last-writer-wins value. Because policies only deny, a group set can restrict the group's own members further but can never widen what their roles grant.",
+    description = r#"Replaces a group's request policy set wholesale with the submitted list.
+
+**Authentication**: realm bearer token with WRITE on the group's configuration path.
+
+**Behavior**
+- Policies missing from the request are removed, an entry without a `policy_id` is given a fresh
+  one, and the stored order is the evaluation order.
+- When `expected_hash` is sent it is compared inside the write transaction and a set changed in the
+  meantime is rejected without writing.
+- The set takes effect on this node as soon as it commits and rides the group's authorization
+  document to the rest of the realm afterwards as a single last-writer-wins value.
+- Because policies only deny, a group set can restrict the group's own members further but can never
+  widen what their roles grant.
+
+**Limits** (the same as for the realm set, all checked before anything is stored)
+- At most 64 policies.
+- At most 4096 bytes per expression or guard.
+- Every expression and guard must compile."#,
     params(("group_id" = String, Path, description = "Group id as a 26-character ULID")),
     request_body(
         content = SetPoliciesRequest,
@@ -640,8 +693,19 @@ pub async fn set_group_policies(
     get,
     path = "/policies/effective",
     tag = "policies",
-    summary = "List the policies that would be evaluated for a scope",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path; naming a group additionally requires READ on that group's configuration path. Returns the realm policies first and the group policies after them, in exactly the order enforcement walks them, each entry labelled with the scope it came from so an inherited rule is distinguishable from a group-local one. Evaluation stops at the first policy that denies, so a later entry in this list only applies while every earlier one passes. The merged view is derived, not stored: it carries no content address, and changes are made through the per-scope endpoints.",
+    summary = "List the effective policies for a scope",
+    description = r#"Returns the realm policies followed by the group policies, in the order enforcement walks them.
+
+**Authentication**: realm bearer token with READ on the realm configuration path; naming a group
+additionally requires READ on that group's configuration path.
+
+**Behavior**
+- Each entry is labelled with the scope it came from, so an inherited rule is distinguishable from a
+  group-local one.
+- Evaluation stops at the first policy that denies, so a later entry in this list only applies while
+  every earlier one passes.
+- The merged view is derived, not stored: it carries no content address, and changes are made
+  through the per-scope endpoints."#,
     params(("group_id" = Option<String>, Query, description = "Group id as a 26-character ULID whose policies are appended after the realm ones; omit it to list realm policies only")),
     responses(
         (
@@ -711,7 +775,19 @@ pub async fn effective_policies(
     path = "/policies/validate",
     tag = "policies",
     summary = "Compile-check a candidate policy expression",
-    description = "Requires a bearer token issued for this realm and READ on the realm configuration path, because the endpoint compiles caller-supplied expressions; it is restricted to policy authors for that reason. Nothing is stored and no request is evaluated: the guard and expression are only parsed, and the report names the request variables they reference plus any variable or function outside the set enforcement provides. Unknown names are informational and do not by themselves make the candidate invalid, since a helper may be registered elsewhere; `valid` turns false only when a source fails to compile or exceeds 4096 bytes, and each reason is listed in `errors`.",
+    description = r#"Parses a candidate policy guard and expression and reports whether they compile.
+
+**Authentication**: realm bearer token with READ on the realm configuration path, because the
+endpoint compiles caller-supplied expressions; it is restricted to policy authors for that reason.
+
+**Behavior**
+- Nothing is stored and no request is evaluated: the guard and expression are only parsed.
+- The report names the request variables they reference plus any variable or function outside the
+  set enforcement provides.
+- Unknown names are informational and do not by themselves make the candidate invalid, since a
+  helper may be registered elsewhere.
+- `valid` turns false only when a source fails to compile or exceeds 4096 bytes, and each reason is
+  listed in `errors`."#,
     request_body(
         content = ValidatePolicyRequest,
         description = "The candidate expression, its kind, and an optional applicability guard.",
@@ -729,7 +805,11 @@ pub async fn effective_policies(
             example = json!({
                 "valid": true,
                 "errors": [],
-                "referenced_variables": ["operation", "path", "permission"],
+                "referenced_variables": [
+                    "operation",
+                    "path",
+                    "permission"
+                ],
                 "unknown_variables": [],
                 "unknown_functions": []
             })
@@ -770,7 +850,24 @@ pub async fn validate_policy(
     path = "/policies/dry-run",
     tag = "policies",
     summary = "Evaluate policies against a hypothetical request",
-    description = "Requires a bearer token issued for this realm; sending a `group_id` requires WRITE on that group's configuration path, and otherwise READ on the realm configuration path is required, with the stored scopes each additionally checked as if they were read directly. The call never changes anything: no policy is stored, and no real request is authorized or denied by it. Either ad hoc `candidate_policies` are evaluated, size- and compile-checked first, or, when none are given, the stored set named by `scope`. Within a scope the policies run in stored order, disabled ones are skipped, a guard that is false skips its policy, a deny matches when its expression is true and a require matches when it is not, and the first match ends evaluation; an expression that errors or does not return a boolean also denies, so a broken policy fails closed. The response reports whether the request would be denied, which scope and policy decided it, and a trace of every policy considered up to that point.",
+    description = r#"Evaluates policies against a hypothetical request and reports the decision they would reach.
+
+**Authentication**: realm bearer token; sending a `group_id` requires WRITE on that group's
+configuration path, and otherwise READ on the realm configuration path is required, with the stored
+scopes each additionally checked as if they were read directly.
+
+**Behavior**
+- The call never changes anything: no policy is stored, and no real request is authorized or denied
+  by it.
+- Either ad hoc `candidate_policies` are evaluated, size- and compile-checked first, or, when none
+  are given, the stored set named by `scope`.
+- Within a scope the policies run in stored order, disabled ones are skipped, a guard that is false
+  skips its policy, a deny matches when its expression is true and a require matches when it is not,
+  and the first match ends evaluation.
+- An expression that errors or does not return a boolean also denies, so a broken policy fails
+  closed.
+- The response reports whether the request would be denied, which scope and policy decided it, and a
+  trace of every policy considered up to that point."#,
     request_body(
         content = DryRunRequest,
         description = "The request attributes to evaluate, plus either candidate policies to try or the stored scope to evaluate.",

--- a/api/src/routes/policies.rs
+++ b/api/src/routes/policies.rs
@@ -475,6 +475,14 @@ pub async fn set_realm_policies(
     Json(request): Json<SetPoliciesRequest>,
 ) -> ServerResult<(StatusCode, Json<PoliciesResponse>)> {
     let auth = require_realm_auth(&state, auth)?;
+    // Request policies live at this boundary; the operation only checks roles.
+    ensure_permission(
+        &state,
+        &auth,
+        format!("/{}/admin/config", state.get_realm_id()),
+        Permission::WRITE,
+    )
+    .await?;
 
     let policies = request
         .policies
@@ -643,6 +651,8 @@ pub async fn set_group_policies(
 ) -> ServerResult<(StatusCode, Json<PoliciesResponse>)> {
     let auth = require_realm_auth(&state, auth)?;
     let group_id = parse_group_id(&group_id)?;
+    // Request policies live at this boundary; the operation only checks roles.
+    require_group_admin(&state, &auth, group_id).await?;
 
     let policies = request
         .policies
@@ -1369,6 +1379,15 @@ mod tests {
             &anonymous,
             format!("/{realm}/admin/config"),
             Permission::WRITE,
+        )
+        .await;
+        assert!(matches!(denied, Err(ServerError::Forbidden)));
+
+        // The config route itself must honour the deny, not only the RBAC check.
+        let denied = set_realm_policies(
+            State(fx.state.clone()),
+            Extension(Some(fx.admin.clone())),
+            Json(body("true")),
         )
         .await;
         assert!(matches!(denied, Err(ServerError::Forbidden)));

--- a/api/src/routes/policies.rs
+++ b/api/src/routes/policies.rs
@@ -1,6 +1,7 @@
 use crate::auth::{ensure_permission, parse_group_id, require_realm_auth};
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
+use aruna_core::errors::StorageError;
 use aruna_core::request_policy::{
     CompiledPolicySet, PolicyDecision, PolicyFunctions, PolicyKind, PolicyRequest,
     PolicyTraceEntry, RequestPolicy, analyze_policy_source, policy_set_hash, validate_policy_set,
@@ -465,7 +466,9 @@ management node serves it; every other node answers 403.
         (status = 400, description = "Unknown policy kind, malformed policy or hash, or a set that breaks the size or compile limits", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "Token belongs to another realm, the caller may not write the realm configuration, or this is not a management node", body = ErrorResponse),
-        (status = 409, description = "The stored set no longer matches expected_hash and nothing was written; re-read the set and retry", body = ErrorResponse)
+        (status = 404, description = "This node holds no configuration document for its realm", body = ErrorResponse),
+        (status = 409, description = "The stored set no longer matches expected_hash and nothing was written; re-read the set and retry", body = ErrorResponse),
+        (status = 503, description = "Storage cleanup capacity exhausted, retry later", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -515,8 +518,14 @@ pub async fn set_realm_policies(
         SetRealmPoliciesError::Unauthorized | SetRealmPoliciesError::NotManagementNode => {
             ServerError::Forbidden
         }
+        SetRealmPoliciesError::RealmConfigNotFound => ServerError::NotFound,
         SetRealmPoliciesError::StaleHash => {
             ServerError::Conflict("stored realm policy set changed".to_string())
+        }
+        SetRealmPoliciesError::StorageError(StorageError::CleanupCapacity) => {
+            ServerError::ServiceUnavailableReason(
+                "storage cleanup capacity exhausted; retry".to_string(),
+            )
         }
         other => ServerError::InternalError(other.to_string()),
     })?;
@@ -639,7 +648,9 @@ pub async fn get_group_policies(
         (status = 400, description = "Malformed group id, unknown policy kind, malformed hash, or a set that breaks the size or compile limits", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "Token belongs to another realm, or the caller may not write this group's configuration", body = ErrorResponse),
-        (status = 409, description = "The stored set no longer matches expected_hash and nothing was written; re-read the set and retry", body = ErrorResponse)
+        (status = 404, description = "This node holds no authorization document for the group", body = ErrorResponse),
+        (status = 409, description = "The stored set no longer matches expected_hash and nothing was written; re-read the set and retry", body = ErrorResponse),
+        (status = 503, description = "Storage cleanup capacity exhausted, retry later", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -687,6 +698,11 @@ pub async fn set_group_policies(
         SetGroupPoliciesError::GroupAuthDocNotFound => ServerError::NotFound,
         SetGroupPoliciesError::StaleHash => {
             ServerError::Conflict("stored group policy set changed".to_string())
+        }
+        SetGroupPoliciesError::StorageError(StorageError::CleanupCapacity) => {
+            ServerError::ServiceUnavailableReason(
+                "storage cleanup capacity exhausted; retry".to_string(),
+            )
         }
         other => ServerError::InternalError(other.to_string()),
     })?;

--- a/api/src/routes/rocrate_import.rs
+++ b/api/src/routes/rocrate_import.rs
@@ -123,7 +123,34 @@ pub struct SubmitImportResponse {
     path = "/metadata/rocrate/uploads",
     tag = "rocrate-import",
     summary = "Upload an RO-Crate archive for a later import",
-    description = "Requires a bearer token issued by this realm; a token from another realm and a path-restricted delegated token are both refused with 403. The body is the archive itself, streamed as application/zip or application/vnd.eln+zip, with media-type parameters such as a version allowed after a semicolon; any other Content-Type is rejected with 400 before the body is read. Bytes are hashed and spooled while they arrive, so the whole archive never has to fit in memory, and the upload is private to the caller: only the same user can later reference it, and only on this node, whose base URL is returned as owner_node_url. Uploading only stores the archive; nothing is unpacked, validated or imported until the import endpoint is called with the returned upload_id, and the upload is single-use so a second import of the same upload_id is refused. The upload expires at expires_at, one day after creation by default, after which it is swept and an import naming it fails. The size cap is the node's configured direct-upload limit, 8 GiB by default: a Content-Length above it is refused with 413 before any body byte is read, and without a Content-Length the stream is read until the cap is passed and then refused with 413 as well, with the partial spool discarded either way. A body that delivers nothing for 30 seconds, or a transfer still running after 30 minutes, is aborted and its partial spool discarded as well, but as a failed transfer rather than a 413. The node also bounds concurrent uploads and answers 503 with a Retry-After header when its upload capacity is exhausted or blob storage is unavailable, which the caller may retry.",
+    description = r#"Stores an RO-Crate archive privately on this node so a later import can claim it.
+
+**Authentication**: bearer token issued by this realm; a token from another realm and a
+path-restricted delegated token are both refused with 403.
+
+**Behavior**
+- Bytes are hashed and spooled while they arrive, so the whole archive never has to fit in memory.
+- The upload is private to the caller: only the same user can later reference it, and only on this
+  node, whose base URL is returned as `owner_node_url`.
+- Uploading only stores the archive; nothing is unpacked, validated or imported until the import
+  endpoint is called with the returned `upload_id`.
+- The upload is single-use, so a second import of the same `upload_id` is refused.
+- The upload expires at `expires_at`, one day after creation by default, after which it is swept
+  and an import naming it fails.
+
+**Limits**
+- The body is the archive itself, streamed as `application/zip` or `application/vnd.eln+zip`, with
+  media-type parameters such as a version allowed after a semicolon; any other `Content-Type` is
+  rejected with 400 before the body is read.
+- The size cap is the node's configured direct-upload limit, 8 GiB by default: a `Content-Length`
+  above it is refused with 413 before any body byte is read, and without a `Content-Length` the
+  stream is read until the cap is passed and then refused with 413 as well, with the partial spool
+  discarded either way.
+- A body that delivers nothing for 30 seconds, or a transfer still running after 30 minutes, is
+  aborted and its partial spool discarded as well, but as a failed transfer rather than a 413.
+
+**Errors**: the node bounds concurrent uploads and answers 503 with a `Retry-After` header when its
+upload capacity is exhausted or blob storage is unavailable, which the caller may retry."#,
     request_body(
         content(
             (String = "application/zip"),
@@ -222,13 +249,53 @@ pub async fn upload_rocrate(
     path = "/metadata/rocrate/imports",
     tag = "rocrate-import",
     summary = "Submit an RO-Crate import job",
-    description = "Requires a bearer token issued by this realm; a token from another realm and a path-restricted delegated token are both refused with 403. RO-Crate 1.2 and 1.3 contexts and specification IRIs are accepted, structurally validated, and retained in the published metadata and later exports. The caller is checked against all three parts of the plan before the job is taken: the source must be readable, which for an upload means it is the caller's own, unclaimed, unexpired and within the import-source cap and for an object or connector source means READ on it, the target bucket needs WRITE, and the metadata document path needs WRITE in its group. The 202 means the plan passed those checks and the job was durably recorded, nothing more: no archive has been unpacked, no object written and no metadata document published yet. Progress is followed at status_url and the per-entry outcome at report_url, both on owner_node_url, which is the node that owns the job. Send idempotency_key to make retries safe: a repeat with the same key and the same plan replays the original job and returns created false, while the same key with a different plan is refused with 409, as is exceeding the per-user active-job cap of 4. An upload source is single-use, so a second import of an upload already claimed by another job is refused with 409 too. A connector source whose staging backend cannot be reached answers 502, which the caller may retry. A 503 carries a Retry-After header and means the node could not place the job right now, which the caller may retry unchanged.",
+    description = r#"Accepts an RO-Crate import plan and durably records it as a job on this node.
+
+**Authentication**: bearer token issued by this realm; a token from another realm and a
+path-restricted delegated token are both refused with 403. The plan is authorized in all three
+parts before the job is taken: READ on the source, WRITE on the target bucket, and WRITE on the
+metadata document path in its group.
+
+**Behavior**
+- For an upload source, readable means the upload is the caller's own, unclaimed, unexpired and
+  within the import-source cap; an object or connector source needs READ on it.
+- RO-Crate 1.2 and 1.3 contexts and specification IRIs are accepted, structurally validated, and
+  retained in the published metadata and later exports.
+- The 202 means the plan passed those checks and the job was durably recorded, nothing more: no
+  archive has been unpacked, no object written and no metadata document published yet.
+- Progress is followed at `status_url` and the per-entry outcome at `report_url`, both on
+  `owner_node_url`, which is the node that owns the job.
+- Send `idempotency_key` to make retries safe: a repeat with the same key and the same plan replays
+  the original job and returns `created` false.
+
+**Limits**
+- An upload source is single-use, so a second import of an upload already claimed by another job is
+  refused.
+- A caller holds at most 4 active import jobs.
+- Bucket, prefix and metadata paths must be non-empty and within the configured key size, and a
+  prefix or connector path may not contain dot segments, backslashes or control characters.
+
+**Errors**
+- The same `idempotency_key` bound to a different plan, an upload already claimed by another job,
+  and a reached active-job cap are each a 409.
+- The group's standing compute quota refusing this admission is a 409 as well, carrying the exact
+  scope, dimension and numbers in `quota`.
+- A connector source whose staging backend cannot be reached answers 502, which the caller may
+  retry.
+- A 503 carries a `Retry-After` header and means the node could not place the job right now, which
+  the caller may retry unchanged."#,
     request_body(
         content = SubmitImportRequest,
         description = "The import plan: where the archive comes from, which bucket and prefix its payload lands in, and which metadata document the crate is published as",
         example = json!({
-            "source": {"kind": "upload", "upload_id": "01JABCDEF0123456789ABCDEFG"},
-            "target": {"bucket": "lab-raw", "prefix": "imports/rna-seq"},
+            "source": {
+                "kind": "upload",
+                "upload_id": "01JABCDEF0123456789ABCDEFG"
+            },
+            "target": {
+                "bucket": "lab-raw",
+                "prefix": "imports/rna-seq"
+            },
             "metadata": {
                 "group_id": "01JGROUP0123456789ABCDEFGH",
                 "path": "datasets/rna-seq",
@@ -250,11 +317,11 @@ pub async fn upload_rocrate(
                 "report_url": "https://node.example.test/api/v1/jobs/01JJOB0123456789ABCDEFGHIJ/report"
             })
         ),
-        (status = 400, description = "Malformed ids, an empty or oversized bucket, prefix or metadata path, a prefix or connector path containing dot segments, backslashes or control characters, or a source that expired or exceeds the import-source cap", body = ErrorResponse),
+        (status = 400, description = "Malformed ids, an empty or oversized bucket, prefix or metadata path, an unsafe path segment, or an expired or oversized source", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "Token belongs to another realm, is a path-restricted delegated token, names another user's upload, or lacks READ on the source or WRITE on the target bucket or metadata path", body = ErrorResponse),
         (status = 404, description = "The upload, source object or version, connector source, or target bucket does not exist", body = ErrorResponse),
-        (status = 409, description = "The idempotency key is already bound to a different plan, the upload is already claimed by another job, the caller's active-job cap is reached, or the group's standing compute quota refuses this admission; a quota refusal carries the exact scope, dimension and numbers in `quota`", body = ErrorResponse),
+        (status = 409, description = "Idempotency key bound to a different plan, an already claimed upload, a reached active-job cap, or a standing compute quota refusal", body = ErrorResponse),
         (status = 503, description = "The job could not be placed right now; the response carries Retry-After and the caller may retry the unchanged request", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))

--- a/api/src/routes/search.rs
+++ b/api/src/routes/search.rs
@@ -325,7 +325,27 @@ fn parse_search_types(types: Option<&str>) -> ServerResult<SearchTypes> {
     path = "/search/buckets",
     tag = "search",
     summary = "Search buckets across the realm",
-    description = "Requires a bearer token issued by this realm; a token from another realm is refused with 403. The query is trimmed and must keep at least 2 characters, otherwise the request is rejected with 400. The search fans out over the realm's serving nodes, at most 32 nodes per request and under one shared deadline of about 12 seconds, and every node applies its own authorization and deny policies to its own buckets, so a bucket the caller may not read never appears. Answers are merged and cut to the page size; there is no continuation token, so a broader result set is reached by narrowing the query rather than by paging. A node that fails, is omitted by the node cap or times out does not fail the request: the answer is partial and says so through nodes_queried, nodes_failed and failed_nodes, which names the nodes that did not answer and carries the entry partition-discovery when node discovery itself failed. A partial answer means matching buckets may be missing rather than absent, and the caller may repeat the request.",
+    description = r#"Searches bucket names across the realm's serving nodes and merges the authorized matches.
+
+**Authentication**: bearer token issued by this realm; a token from another realm is refused with
+403. Every node applies its own authorization and deny policies to its own buckets, so a bucket the
+caller may not read never appears.
+
+**Behavior**
+- The search fans out over the realm's serving nodes under one shared deadline of about 12 seconds.
+- Answers are merged and cut to the page size; there is no continuation token, so a broader result
+  set is reached by narrowing the query rather than by paging.
+- A node that fails, is omitted by the node cap or times out does not fail the request: the answer
+  is partial and says so through `nodes_queried`, `nodes_failed` and `failed_nodes`, which names
+  the nodes that did not answer and carries the entry `partition-discovery` when node discovery
+  itself failed.
+- A partial answer means matching buckets may be missing rather than absent, and the caller may
+  repeat the request.
+
+**Limits**
+- The query is trimmed and must keep at least 2 characters, otherwise the request is rejected with
+  400.
+- At most 32 nodes are queried per request."#,
     params(
         ("q" = String, Query, description = "Case-insensitive bucket-name substring; trimmed, minimum 2 characters, no wildcards"),
         ("limit" = Option<usize>, Query, description = "Maximum number of merged hits (default 10, clamped to 1..=50)")
@@ -336,17 +356,21 @@ fn parse_search_types(types: Option<&str>) -> ServerResult<SearchTypes> {
             description = "Authorized federated bucket matches, possibly partial when nodes_failed is non-zero",
             body = BucketsSection,
             example = json!({
-                "hits": [{
-                    "arn": "arn:aruna:cmVhbG0tZXhhbXBsZS0wMTIzNDU2Nzg5YWJjZGVmZ2g:1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978:s3/lab-raw",
-                    "bucket": "lab-raw",
-                    "node_id": "1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978",
-                    "group_id": "01JABCDEF0123456789ABCDEFG",
-                    "group_name": "Lab A",
-                    "created_at": "2026-04-09T14:23:11.123+00:00"
-                }],
+                "hits": [
+                    {
+                        "arn": "arn:aruna:cmVhbG0tZXhhbXBsZS0wMTIzNDU2Nzg5YWJjZGVmZ2g:1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978:s3/lab-raw",
+                        "bucket": "lab-raw",
+                        "node_id": "1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978",
+                        "group_id": "01JABCDEF0123456789ABCDEFG",
+                        "group_name": "Lab A",
+                        "created_at": "2026-04-09T14:23:11.123+00:00"
+                    }
+                ],
                 "nodes_queried": 3,
                 "nodes_failed": 1,
-                "failed_nodes": ["2a3b4c5d6e7f89900a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789"]
+                "failed_nodes": [
+                    "2a3b4c5d6e7f89900a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789"
+                ]
             })
         ),
         (status = 400, description = "Query shorter than 2 characters or otherwise malformed", body = ErrorResponse),
@@ -390,8 +414,21 @@ pub async fn bucket_search(
     get,
     path = "/search/objects",
     tag = "search",
-    summary = "Search current object heads locally or across the realm",
-    description = "Requires a bearer token issued by this realm. Keys are matched case-sensitively by substring or prefix, optionally inside one exact bucket. Every current live head is checked against group READ, token path restrictions, and request policies before it can be returned; delete markers and historical versions are excluded, and no total is exposed. local searches this node, distributed_best_effort returns reachable node pages with explicit failed coverage, and distributed_strict returns 503 rather than a partial page. The opaque cursor is bound to the query, bucket, match type, and mode; it composes per-node keyset positions and an as-of watermark so newly created versions do not enter a cursor chain. Coverage names the live-head source, observation times, failed partitions, completeness, and truncation.",
+    summary = "Search current object heads",
+    description = r#"Searches current live object heads by key, on this node or across the realm.
+
+**Authentication**: bearer token issued by this realm. Every current live head is checked against
+group READ, token path restrictions and request policies before it can be returned.
+
+**Behavior**
+- Keys are matched case-sensitively by substring or prefix, optionally inside one exact bucket.
+- Delete markers and historical versions are excluded, and no total is exposed.
+- `local` searches this node, `distributed_best_effort` returns reachable node pages with explicit
+  failed coverage, and `distributed_strict` returns 503 rather than a partial page.
+- The opaque cursor is bound to the query, bucket, match type and mode; it composes per-node keyset
+  positions and an as-of watermark so newly created versions do not enter a cursor chain.
+- `coverage` names the live-head source, observation times, failed partitions, completeness and
+  truncation."#,
     params(
         ("q" = String, Query, description = "Case-sensitive key substring or prefix; trimmed, minimum 2 characters"),
         ("bucket" = Option<String>, Query, description = "Optional exact bucket name"),
@@ -401,8 +438,53 @@ pub async fn bucket_search(
         ("cursor" = Option<String>, Query, description = "Opaque continuation token from the same query, bucket, match type, and mode")
     ),
     responses(
-        (status = 200, description = "Authorized live object heads with explicit coverage", body = ObjectSearchResponse,
-            example = json!({"hits": [{"kind": "object", "mode": "distributed_best_effort", "issuer_node_id": "node-a", "group_id": "01JGROUP000000000000000000", "bucket": "results", "key": "run-42/output.csv", "content_w3id": "https://w3id.org/aruna/data/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "checksum": {"algorithm": "blake3", "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}, "size": 4096, "updated_at": "2026-08-22T12:00:00Z"}], "next_cursor": null, "coverage": {"scope": "realm", "mode": "distributed_best_effort", "index_freshness": {"source": "inventory", "as_of": "2026-08-22T12:00:00Z", "oldest_observed_at": "2026-08-22T11:59:00Z"}, "nodes_queried": 3, "nodes_failed": 0, "failed_partitions": [], "omitted_partitions": 0, "complete": true, "truncated": false, "partitions": [{"node_id": "node-a", "observed_at": "2026-08-22T12:00:00Z", "truncated": false}]}})),
+        (
+            status = 200,
+            description = "Authorized live object heads with explicit coverage",
+            body = ObjectSearchResponse,
+            example = json!({
+                "hits": [
+                    {
+                        "kind": "object",
+                        "mode": "distributed_best_effort",
+                        "issuer_node_id": "node-a",
+                        "group_id": "01JGROUP000000000000000000",
+                        "bucket": "results",
+                        "key": "run-42/output.csv",
+                        "content_w3id": "https://w3id.org/aruna/data/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                        "checksum": {
+                            "algorithm": "blake3",
+                            "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        },
+                        "size": 4096,
+                        "updated_at": "2026-08-22T12:00:00Z"
+                    }
+                ],
+                "next_cursor": null,
+                "coverage": {
+                    "scope": "realm",
+                    "mode": "distributed_best_effort",
+                    "index_freshness": {
+                        "source": "inventory",
+                        "as_of": "2026-08-22T12:00:00Z",
+                        "oldest_observed_at": "2026-08-22T11:59:00Z"
+                    },
+                    "nodes_queried": 3,
+                    "nodes_failed": 0,
+                    "failed_partitions": [],
+                    "omitted_partitions": 0,
+                    "complete": true,
+                    "truncated": false,
+                    "partitions": [
+                        {
+                            "node_id": "node-a",
+                            "observed_at": "2026-08-22T12:00:00Z",
+                            "truncated": false
+                        }
+                    ]
+                }
+            })
+        ),
         (status = 400, description = "Malformed query or cursor", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "Token belongs to another realm", body = ErrorResponse),
@@ -547,13 +629,38 @@ fn format_system_time(time: std::time::SystemTime) -> String {
     get,
     path = "/search",
     tag = "search",
-    summary = "Search documents, buckets, groups and users in one request",
-    description = "Requires a bearer token issued by this realm; a token from another realm is refused with 403. The four sections are searched concurrently and each one is authorized on its own terms: documents and buckets fan out over the realm's serving nodes, at most 32 nodes under one shared deadline of about 12 seconds, and each node filters its own results; groups are matched locally and then filtered per hit against READ on the group's data, so a caller who may not read a group never learns it exists; the user directory is an admin-scoped read, and a caller without it simply gets no users section instead of an error. A section that was not requested is omitted from the response. Answers can be partial: for documents and buckets, nodes_queried and nodes_failed count the fan-out and a non-zero nodes_failed (a node that failed, timed out or was dropped by the node cap) means hits may be missing rather than absent; documents also set truncated when paging stopped at the server-side depth cap, and groups set truncated when the per-hit visibility scan hit its round cap with matches still pending. A partial answer is still 200 and the caller may repeat the request. Paging is per section and only for a single-type request: pass the section's next_cursor back as cursor. A missing next_cursor means that section is exhausted; a cursor sent with more than one type, or with types=buckets, which has no continuation token, is rejected with 400.",
+    summary = "Search documents, buckets, groups and users",
+    description = r#"Searches documents, buckets, groups and users concurrently and returns one sectioned answer.
+
+**Authentication**: bearer token issued by this realm; a token from another realm is refused with
+403. Each section is authorized on its own terms: every node filters its own document and bucket
+results, group hits are filtered per hit against READ on the group's data so a caller who may not
+read a group never learns it exists, and the user directory is an admin-scoped read.
+
+**Behavior**
+- Documents and buckets fan out over the realm's serving nodes, at most 32 nodes under one shared
+  deadline of about 12 seconds; groups are matched locally.
+- A caller without the admin-scoped directory read simply gets no `users` section instead of an
+  error, and a section that was not requested is omitted from the response.
+- Answers can be partial: for documents and buckets, `nodes_queried` and `nodes_failed` count the
+  fan-out and a non-zero `nodes_failed` (a node that failed, timed out or was dropped by the node
+  cap) means hits may be missing rather than absent.
+- Documents also set `truncated` when paging stopped at the server-side depth cap, and groups set
+  `truncated` when the per-hit visibility scan hit its round cap with matches still pending.
+- A partial answer is still 200 and the caller may repeat the request.
+- Paging is per section and only for a single-type request: pass the section's `next_cursor` back
+  as `cursor`, and a missing `next_cursor` means that section is exhausted.
+- A document cursor is a signed token bound to the exact query and filters, a group cursor is the
+  last returned group id as a ULID, and a user cursor is the last returned user id in its
+  `ulid@realm` form.
+
+**Errors**: a malformed or unsupported cursor is rejected with 400, as is a cursor sent with more
+than one type or with `types=buckets`, which has no continuation token."#,
     params(
         ("q" = String, Query, description = "Search query; trimmed, minimum 2 characters, matched as a substring for buckets, groups and users and as a full-text query for documents"),
         ("types" = Option<String>, Query, description = "Comma-separated subset of documents,buckets,groups,users. Defaults to all four; empty entries are ignored and an unknown type returns 400"),
         ("limit" = Option<usize>, Query, description = "Per-section page size (default 10, clamped to 1..=100, and additionally capped at 50 for the buckets section)"),
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token from the same section's next_cursor. Only accepted when exactly one type is requested; for documents it is a signed token bound to the exact query and filters, for groups the last returned group id as a ULID and for users the last returned user id in its ulid@realm form, and a malformed or unsupported cursor returns 400"),
+        ("cursor" = Option<String>, Query, description = "Opaque continuation token from the same section's next_cursor; only accepted when exactly one type is requested"),
         ("group_id" = Option<String>, Query, description = "Documents-only: restrict metadata hits to a single group id, given as a ULID; a malformed id returns 400"),
         ("conforms_to" = Option<String>, Query, description = "Documents-only: exact RO-Crate conformsTo specification or Profile IRI, such as the https://w3id.org/ro/crate/1.3 specification or an https://w3id.org/aruna/profile/{id} Profile"),
         ("mode" = Option<MetadataQueryMode>, Query, description = "Documents-only: local restricts the document search to this node, distributed fans out over the realm; defaults to distributed")
@@ -561,47 +668,58 @@ fn format_system_time(time: std::time::SystemTime) -> String {
     responses(
         (
             status = 200,
-            description = "Sectioned search results; a section is omitted when it was not requested and the users section is also omitted when the caller may not read the user directory, and a section is authoritative only when its failure counters are zero",
+            description = "Sectioned search results; a section is omitted when it was not requested and is authoritative only when its failure counters are zero",
             body = SearchResponse,
             example = json!({
                 "documents": {
-                    "hits": [{
-                        "document_id": "01JMETADATA0123456789ABCDE",
-                        "group_id": "01JABCDEF0123456789ABCDEFG",
-                        "document_path": "datasets/rna-seq",
-                        "graph_iri": "https://node.example.test/api/v1/metadata/01JMETADATA0123456789ABCDE",
-                        "subject_iri": "https://node.example.test/api/v1/metadata/01JMETADATA0123456789ABCDE#root",
-                        "score": 4.5,
-                        "title": "RNA-seq reference run",
-                        "snippet": "reference run of the RNA-seq pipeline"
-                    }],
-                    "next_cursor": "eyJ3IjoiMDFKTUVUQURBVEEwMTIzNDU2Nzg5QUJDREUifQ",
+                    "hits": [
+                        {
+                            "document_id": "01JMETADATA0123456789ABCDE",
+                            "group_id": "01JABCDEF0123456789ABCDEFG",
+                            "document_path": "datasets/rna-seq",
+                            "graph_iri": "https://node.example.test/api/v1/metadata/01JMETADATA0123456789ABCDE",
+                            "subject_iri": "https://node.example.test/api/v1/metadata/01JMETADATA0123456789ABCDE#root",
+                            "score": 4.5,
+                            "title": "RNA-seq reference run",
+                            "snippet": "reference run of the RNA-seq pipeline"
+                        }
+                    ],
+                    "next_cursor": "<opaque-documents-cursor>",
                     "nodes_queried": 3,
                     "nodes_failed": 0,
                     "truncated": false
                 },
                 "buckets": {
-                    "hits": [{
-                        "arn": "arn:aruna:cmVhbG0tZXhhbXBsZS0wMTIzNDU2Nzg5YWJjZGVmZ2g:1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978:s3/lab-raw",
-                        "bucket": "lab-raw",
-                        "node_id": "1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978",
-                        "group_id": "01JABCDEF0123456789ABCDEFG",
-                        "group_name": "Lab A",
-                        "created_at": "2026-04-09T14:23:11.123+00:00"
-                    }],
+                    "hits": [
+                        {
+                            "arn": "arn:aruna:cmVhbG0tZXhhbXBsZS0wMTIzNDU2Nzg5YWJjZGVmZ2g:1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978:s3/lab-raw",
+                            "bucket": "lab-raw",
+                            "node_id": "1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978",
+                            "group_id": "01JABCDEF0123456789ABCDEFG",
+                            "group_name": "Lab A",
+                            "created_at": "2026-04-09T14:23:11.123+00:00"
+                        }
+                    ],
                     "nodes_queried": 3,
                     "nodes_failed": 0,
                     "failed_nodes": []
                 },
                 "groups": {
-                    "hits": [{"group_id": "01JABCDEF0123456789ABCDEFG", "display_name": "Lab A"}],
+                    "hits": [
+                        {
+                            "group_id": "01JABCDEF0123456789ABCDEFG",
+                            "display_name": "Lab A"
+                        }
+                    ],
                     "truncated": false
                 },
                 "users": {
-                    "hits": [{
-                        "user_id": "01JUSER0123456789ABCDEFGHI@cmVhbG0tZXhhbXBsZS0wMTIzNDU2Nzg5YWJjZGVmZ2g",
-                        "name": "example-user"
-                    }]
+                    "hits": [
+                        {
+                            "user_id": "01JUSER0123456789ABCDEFGHI@cmVhbG0tZXhhbXBsZS0wMTIzNDU2Nzg5YWJjZGVmZ2g",
+                            "name": "example-user"
+                        }
+                    ]
                 }
             })
         ),

--- a/api/src/routes/search.rs
+++ b/api/src/routes/search.rs
@@ -447,7 +447,7 @@ group READ, token path restrictions and request policies before it can be return
                     {
                         "kind": "object",
                         "mode": "distributed_best_effort",
-                        "issuer_node_id": "node-a",
+                        "issuer_node_id": "1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978",
                         "group_id": "01JGROUP000000000000000000",
                         "bucket": "results",
                         "key": "run-42/output.csv",
@@ -465,7 +465,7 @@ group READ, token path restrictions and request policies before it can be return
                     "scope": "realm",
                     "mode": "distributed_best_effort",
                     "index_freshness": {
-                        "source": "inventory",
+                        "source": "live_heads",
                         "as_of": "2026-08-22T12:00:00Z",
                         "oldest_observed_at": "2026-08-22T11:59:00Z"
                     },
@@ -477,7 +477,7 @@ group READ, token path restrictions and request policies before it can be return
                     "truncated": false,
                     "partitions": [
                         {
-                            "node_id": "node-a",
+                            "node_id": "1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978",
                             "observed_at": "2026-08-22T12:00:00Z",
                             "truncated": false
                         }
@@ -684,7 +684,7 @@ than one type or with `types=buckets`, which has no continuation token."#,
                             "snippet": "reference run of the RNA-seq pipeline"
                         }
                     ],
-                    "next_cursor": "<opaque-documents-cursor>",
+                    "next_cursor": "eyJ3IjoiMDFKTUVUQURBVEEwMTIzNDU2Nzg5QUJDREUifQ",
                     "nodes_queried": 3,
                     "nodes_failed": 0,
                     "truncated": false

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -402,6 +402,7 @@ them.
         ),
         (status = 400, description = "The group or connector id does not parse, `node_id` names another node, a prefix is not a confined relative path, or the batch would exceed 1000 objects", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
+        (status = 403, description = "The token belongs to another realm, or prefixes were given and the caller has no READ on the group's data path", body = ErrorResponse),
         (status = 501, description = "The `sync` strategy is declared but not implemented", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
@@ -576,6 +577,7 @@ unavailable job placement binding or an unhealthy structured id clock is a 503 c
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller lacks READ on a source path or WRITE on a target key", body = ErrorResponse),
         (status = 404, description = "The bucket is unknown to this node or belongs to another group, or a connector or source path does not exist", body = ErrorResponse),
+        (status = 501, description = "The `sync` strategy is declared but not implemented", body = ErrorResponse),
         (status = 503, description = "Job placement or the structured id clock is unavailable; retry the same body", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -4,6 +4,7 @@ use crate::auth::{
 };
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::routes::connectors::ApiSourceConnectorKind;
+use crate::routes::jobs::map_submit_error;
 use crate::server_state::ServerState;
 use aruna_core::NodeId;
 use aruna_core::errors::{SourceConnectorResolutionError, StagingSourceError};
@@ -540,7 +541,11 @@ WRITE on each target key or target prefix. Nothing is authorized later while the
 - At least one item or prefix is required.
 - Source paths must be relative and confined, and target keys must not be blank.
 - `node_id`, when given, must be this node, because the job runs where it was submitted.
-- The `sync` strategy is not implemented."#,
+- The `sync` strategy is not implemented.
+
+**Errors**: a refusal from job admission keeps its own status instead of collapsing into a 500. An
+unavailable job placement binding or an unhealthy structured id clock is a 503 carrying
+`Retry-After`, so the identical body may be resubmitted; a storage failure stays a 500."#,
     request_body(
         content = StageBatchRequest,
         description = "One connector and target bucket for the job, plus the `items` and `prefixes` it should stage; at least one of the two must be non-empty. `node_id` defaults to this node.",
@@ -570,7 +575,8 @@ WRITE on each target key or target prefix. Nothing is authorized later while the
         (status = 400, description = "The group or connector id does not parse, `node_id` names another node, a source path or prefix is not confined, a target key is blank, or neither items nor prefixes were given", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller lacks READ on a source path or WRITE on a target key", body = ErrorResponse),
-        (status = 404, description = "The bucket is unknown to this node or belongs to another group, or a connector or source path does not exist", body = ErrorResponse)
+        (status = 404, description = "The bucket is unknown to this node or belongs to another group, or a connector or source path does not exist", body = ErrorResponse),
+        (status = 503, description = "Job placement or the structured id clock is unavailable; retry the same body", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -676,7 +682,7 @@ pub async fn submit_staging(
         state.rocrate_limits().artifact_retention_ms,
     )
     .await
-    .map_err(|error| ServerError::InternalError(error.to_string()))?;
+    .map_err(map_submit_error)?;
 
     Ok((
         StatusCode::ACCEPTED,
@@ -1842,6 +1848,24 @@ mod tests {
             .await
             .is_some(),
             "durable obligation should remain repairable when staging queue kick fails"
+        );
+    }
+
+    #[test]
+    fn staging_submit_classifies() {
+        // Job admission refusals must keep their status instead of collapsing into 500.
+        use aruna_operations::jobs::submit::SubmitJobError;
+
+        assert_eq!(
+            map_submit_error(SubmitJobError::PlacementUnavailable(
+                "no binding".to_string()
+            ))
+            .status_code(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            map_submit_error(SubmitJobError::InvalidWorkspace("bad".to_string())).status_code(),
+            StatusCode::BAD_REQUEST
         );
     }
 

--- a/api/src/routes/staging.rs
+++ b/api/src/routes/staging.rs
@@ -51,7 +51,10 @@ use utoipa_axum::routes;
 
 #[derive(OpenApi)]
 #[openapi(
-    tags((name = "staging", description = "Blob staging"))
+    tags((
+        name = "staging",
+        description = "Staging source objects into buckets, inline or as background jobs"
+    ))
 )]
 pub struct StagingApiDoc;
 
@@ -246,7 +249,30 @@ pub struct StagingJobListResponse {
     path = "/staging/",
     tag = "staging",
     summary = "Stage a single source object into a bucket",
-    description = "Requires a bearer token issued for this realm. The body is chosen by its `strategy` field. `snapshot` reads the object from the source connector and commits its bytes to this node's storage before answering, so it is as slow as the transfer; `reference` records the object as a pointer to its source and copies nothing, so the bytes are fetched on demand at read time; `sync` is accepted by the schema but not implemented and always fails. The caller needs WRITE on the target bucket key and READ on the connector's source path, and both are checked against the concrete path, not a prefix alone. The bucket must exist on this node and belong to the given group; a bucket owned by a different group is reported as not found rather than forbidden. Source paths must be relative and confined, so a leading slash or any `.` or `..` segment is rejected. A snapshot is also charged against the realm's quota ceiling for the group and is refused with 403 when it would exceed it. A 201 means the new object version is committed here and immediately readable through S3; propagating that version to any sync target is queued afterwards and is neither awaited nor reported by this response.",
+    description = r#"Stages one source object into a bucket, either by copying its bytes now or by recording a pointer.
+
+**Authentication**: realm bearer token; the caller needs WRITE on the target bucket key and READ on
+the connector's source path, and both are checked against the concrete path, not a prefix alone.
+
+**Behavior**
+- The body is chosen by its `strategy` field.
+- `snapshot` reads the object from the source connector and commits its bytes to this node's storage
+  before answering, so it is as slow as the transfer.
+- `reference` records the object as a pointer to its source and copies nothing, so the bytes are
+  fetched on demand at read time.
+- `sync` is accepted by the schema but not implemented and always fails.
+- A 201 means the new object version is committed here and immediately readable through S3;
+  propagating that version to any sync target is queued afterwards and is neither awaited nor
+  reported by this response.
+
+**Limits**
+- The bucket must exist on this node and belong to the given group.
+- Source paths must be relative and confined, so a leading slash or any `.` or `..` segment is
+  rejected with 400.
+- A snapshot is charged against the realm's quota ceiling for the group.
+
+**Errors**: a bucket owned by a different group is reported as not found rather than forbidden, and
+a snapshot that would exceed the group's quota ceiling is a 403."#,
     request_body(
         content = StageBlobRequest,
         description = "The staging strategy and the source and target it applies to. All five target fields are required, and `strategy` selects between copying the bytes now and recording a reference.",
@@ -303,7 +329,33 @@ pub async fn stage_blob(
     path = "/staging/batch",
     tag = "staging",
     summary = "Stage many source objects in one blocking request",
-    description = "Requires a bearer token issued for this realm. Every object is staged inside this request, one after another, so the call blocks for the whole transfer and a large batch is better submitted as a job instead. The outcome is per item and best effort: a 200 only means the batch ran, and each entry in `results` carries its own `ok` or `error` status, so a caller must inspect them rather than trust the status code. Objects can be named directly in `items` and expanded from `prefixes`, which lists the connector recursively and takes files only; using prefixes additionally requires READ on the group's data path, while individual items are authorized exactly as the single-object endpoint authorizes them. Named and expanded objects together may not exceed 1000, and a prefix that would expand past that limit fails the entire request rather than truncating. `node_id` is optional and, when given, must be this node: staging always runs where the request lands. The `sync` strategy is not implemented and fails the whole request. Error text on a result is deliberately coarse for server-side and upstream failures, which appear only as `Internal server error` and `Bad gateway`. A prefix that cannot be listed contributes one error entry naming that prefix instead of its objects. Items that succeeded are committed here and their propagation to sync targets is queued afterwards.",
+    description = r#"Stages many source objects inside one request, reporting the outcome of each separately.
+
+**Authentication**: realm bearer token; using prefixes additionally requires READ on the group's
+data path, while individual items are authorized exactly as the single-object endpoint authorizes
+them.
+
+**Behavior**
+- Every object is staged inside this request, one after another, so the call blocks for the whole
+  transfer and a large batch is better submitted as a job instead.
+- The outcome is per item and best effort: a 200 only means the batch ran, and each entry in
+  `results` carries its own `ok` or `error` status, so a caller must inspect them rather than trust
+  the status code.
+- Objects can be named directly in `items` and expanded from `prefixes`, which lists the connector
+  recursively and takes files only.
+- A prefix that cannot be listed contributes one error entry naming that prefix instead of its
+  objects.
+- Error text on a result is deliberately coarse for server-side and upstream failures, which appear
+  only as `Internal server error` and `Bad gateway`.
+- Items that succeeded are committed here and their propagation to sync targets is queued
+  afterwards.
+
+**Limits**
+- Named and expanded objects together may not exceed 1000, and a prefix that would expand past that
+  limit fails the entire request rather than truncating.
+- `node_id` is optional and, when given, must be this node: staging always runs where the request
+  lands.
+- The `sync` strategy is not implemented and fails the whole request."#,
     request_body(
         content = StageBatchRequest,
         description = "One connector and target bucket for the whole batch, plus explicit `items`, `prefixes` to expand, or both; leaving both out runs an empty batch. `node_id` defaults to this node.",
@@ -313,22 +365,37 @@ pub async fn stage_blob(
             "bucket": "research-raw",
             "strategy": "reference",
             "items": [
-                {"source_path": "refseq/2026/a.fna.gz", "target_key": "genomes/2026/a.fna.gz"}
+                {
+                    "source_path": "refseq/2026/a.fna.gz",
+                    "target_key": "genomes/2026/a.fna.gz"
+                }
             ],
             "prefixes": [
-                {"source_prefix": "refseq/2026/batch-7", "target_prefix": "genomes/2026/batch-7"}
+                {
+                    "source_prefix": "refseq/2026/batch-7",
+                    "target_prefix": "genomes/2026/batch-7"
+                }
             ]
         })
     ),
     responses(
         (
             status = 200,
-            description = "One result per staged object plus one per prefix that could not be expanded, in that order; individual failures are reported here rather than as a status code",
+            description = "One result per staged object plus one per prefix that could not be expanded, in that order",
             body = StageBatchResponse,
             example = json!({
                 "results": [
-                    {"source_path": "refseq/2026/a.fna.gz", "target_key": "genomes/2026/a.fna.gz", "status": "ok"},
-                    {"source_path": "refseq/2026/batch-7/b.fna.gz", "target_key": "genomes/2026/batch-7/b.fna.gz", "status": "error", "error": "Not found"}
+                    {
+                        "source_path": "refseq/2026/a.fna.gz",
+                        "target_key": "genomes/2026/a.fna.gz",
+                        "status": "ok"
+                    },
+                    {
+                        "source_path": "refseq/2026/batch-7/b.fna.gz",
+                        "target_key": "genomes/2026/batch-7/b.fna.gz",
+                        "status": "error",
+                        "error": "Not found"
+                    }
                 ]
             })
         ),
@@ -450,8 +517,30 @@ pub async fn stage_batch(
     post,
     path = "/staging/jobs",
     tag = "staging",
-    summary = "Submit a staging job to run in the background",
-    description = "Requires a bearer token issued for this realm. Takes the same body as the blocking batch endpoint but returns as soon as the work is recorded: a 202 means the job is durable and queued on this node, and no object has been read, copied or referenced yet. Every named item and every prefix is authorized before the job is accepted, so acceptance already implies READ on each connector source path or prefix and WRITE on each target key or target prefix; nothing is authorized later while the job runs. The bucket must exist on this node and belong to the given group, otherwise the request is not found, and at least one item or prefix is required. Source paths must be relative and confined, target keys must not be blank, and `node_id`, when given, must be this node, because the job runs where it was submitted. The `sync` strategy is not implemented. Unlike the blocking endpoint there is no cap on the number of items, and no request-side prefix expansion happens: prefixes are stored and walked by the job. There is no idempotency key, so every call creates a new job, `created` is always true, and resubmitting the same body stages the same objects a second time. Progress and completion are observed by reading the job by its id.",
+    summary = "Submit a background staging job",
+    description = r#"Records a staging batch as a durable job on this node and returns before any object is read.
+
+**Authentication**: realm bearer token; every named item and every prefix is authorized before the
+job is accepted, so acceptance already implies READ on each connector source path or prefix and
+WRITE on each target key or target prefix. Nothing is authorized later while the job runs.
+
+**Behavior**
+- Takes the same body as the blocking batch endpoint but returns as soon as the work is recorded: a
+  202 means the job is durable and queued on this node, and no object has been read, copied or
+  referenced yet.
+- Unlike the blocking endpoint there is no cap on the number of items, and no request-side prefix
+  expansion happens: prefixes are stored and walked by the job.
+- There is no idempotency key, so every call creates a new job, `created` is always true, and
+  resubmitting the same body stages the same objects a second time.
+- Progress and completion are observed by reading the job by its id.
+
+**Limits**
+- The bucket must exist on this node and belong to the given group, otherwise the request is not
+  found.
+- At least one item or prefix is required.
+- Source paths must be relative and confined, and target keys must not be blank.
+- `node_id`, when given, must be this node, because the job runs where it was submitted.
+- The `sync` strategy is not implemented."#,
     request_body(
         content = StageBatchRequest,
         description = "One connector and target bucket for the job, plus the `items` and `prefixes` it should stage; at least one of the two must be non-empty. `node_id` defaults to this node.",
@@ -461,7 +550,10 @@ pub async fn stage_batch(
             "bucket": "research-raw",
             "strategy": "snapshot",
             "prefixes": [
-                {"source_prefix": "refseq/2026", "target_prefix": "genomes/2026"}
+                {
+                    "source_prefix": "refseq/2026",
+                    "target_prefix": "genomes/2026"
+                }
             ]
         })
     ),
@@ -470,7 +562,10 @@ pub async fn stage_batch(
             status = 202,
             description = "The job is durably queued on this node; `created` is always true because staging jobs are never deduplicated",
             body = SubmitStagingJobResponse,
-            example = json!({"job_id": "01JJOB0123456789ABCDEFGHJ", "created": true})
+            example = json!({
+                "job_id": "01JJOB0123456789ABCDEFGHJ",
+                "created": true
+            })
         ),
         (status = 400, description = "The group or connector id does not parse, `node_id` names another node, a source path or prefix is not confined, a target key is blank, or neither items nor prefixes were given", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
@@ -596,8 +691,19 @@ pub async fn submit_staging(
     get,
     path = "/staging/jobs",
     tag = "staging",
-    summary = "List the staging jobs you submitted to this node",
-    description = "Requires a bearer token issued for this realm. Lists only the calling user's own staging jobs that are owned by this node, so a job submitted to another node is not visible here and must be listed there; other users' jobs and non-staging jobs never appear. A path-restricted token sees only the jobs submitted under exactly the same restrictions. Jobs come back oldest first by submission time. Each entry carries the job's own progress and per-object errors as last checkpointed by the runner, so a running job's counts trail the work slightly and a job that has not started yet reports the queued phase with zero progress.",
+    summary = "List your staging jobs on this node",
+    description = r#"Returns one page of the calling user's own staging jobs that this node owns, oldest first.
+
+**Authentication**: realm bearer token; a path-restricted token sees only the jobs submitted under
+exactly the same restrictions.
+
+**Behavior**
+- A job submitted to another node is not visible here and must be listed there; other users' jobs
+  and non-staging jobs never appear.
+- Jobs come back oldest first by submission time.
+- Each entry carries the job's own progress and per-object errors as last checkpointed by the
+  runner, so a running job's counts trail the work slightly and a job that has not started yet
+  reports the queued phase with zero progress."#,
     params(
         ("limit" = Option<usize>, Query, description = "Page size; defaults to 50 when absent or zero and is capped at 200"),
         ("cursor" = Option<String>, Query, description = "Opaque cursor returned as `next_cursor` by the previous page, passed back unchanged. Omit for the first page; a cursor that does not decode is rejected")
@@ -676,7 +782,24 @@ pub async fn list_staging_jobs(
     path = "/staging/jobs/{job_id}",
     tag = "staging",
     summary = "Read one staging job and its progress",
-    description = "Requires a bearer token issued for this realm. The job is always answered by the node that owns it: a request that lands anywhere else is forwarded to that owner with the caller's own token, so the same id can be read from any node in the realm and the answer is the owner's current record rather than a replica. Only the owner decides that a job does not exist, and a job created by another user, a non-staging job, and a job whose restrictions do not match the presenting token are all reported as not found rather than forbidden. `state` collapses the lifecycle into queued, running, done or failed, while `phase` names the stage the runner last checkpointed, so a job can read as running long before any bytes move. `progress` and `errors` come from that same checkpoint, so they trail the work slightly; per-object failures are listed in `errors` while the job as a whole may still succeed, and `finished_at` is set only once the job has stopped.",
+    description = r#"Returns one staging job as the node that owns it currently records it, with its progress.
+
+**Authentication**: realm bearer token, which is forwarded unchanged when the job belongs to another
+node.
+
+**Behavior**
+- The job is always answered by the node that owns it: a request that lands anywhere else is
+  forwarded to that owner with the caller's own token, so the same id can be read from any node in
+  the realm and the answer is the owner's current record rather than a replica.
+- `state` collapses the lifecycle into queued, running, done or failed, while `phase` names the
+  stage the runner last checkpointed, so a job can read as running long before any bytes move.
+- `progress` and `errors` come from that same checkpoint, so they trail the work slightly;
+  per-object failures are listed in `errors` while the job as a whole may still succeed, and
+  `finished_at` is set only once the job has stopped.
+
+**Errors**: only the owner decides that a job does not exist, and a job created by another user, a
+non-staging job, and a job whose restrictions do not match the presenting token are all reported as
+not found rather than forbidden."#,
     params(("job_id" = String, Path, description = "Staging job id as a 26-character ULID, as returned when the job was submitted")),
     responses(
         (
@@ -747,7 +870,23 @@ pub async fn get_staging_job(
     path = "/staging/references",
     tag = "staging",
     summary = "List a bucket's objects with their source bindings",
-    description = "Requires a bearer token issued for this realm and READ on the bucket; the bucket's owning group is resolved first, so a bucket unknown to this node is not found and the permission check always runs against the group that owns it. This is a node-local listing of the bucket as this node currently sees it, so objects written elsewhere appear once they have replicated here. Every live object is returned, materialized and referenced alike, which is what lets a caller total a bucket in one pass: `referenced` false means the bytes are stored here and `size` is the stored blob size, while `referenced` true means the object is still only a pointer, `size` is the length its source reported, and `kind` with `source_path` describe where it points, `connector_id` for an external source connector or `origin_node_id` for another Aruna node. Those four fields are omitted entirely for a materialized object. Objects are listed in key order and pagination is by opaque cursor.",
+    description = r#"Lists a bucket's live objects in key order, saying for each whether it is stored here or referenced.
+
+**Authentication**: realm bearer token with READ on the bucket; the bucket's owning group is
+resolved first, so a bucket unknown to this node is not found and the permission check always runs
+against the group that owns it.
+
+**Behavior**
+- This is a node-local listing of the bucket as this node currently sees it, so objects written
+  elsewhere appear once they have replicated here.
+- Every live object is returned, materialized and referenced alike, which is what lets a caller
+  total a bucket in one pass.
+- `referenced` false means the bytes are stored here and `size` is the stored blob size.
+- `referenced` true means the object is still only a pointer, `size` is the length its source
+  reported, and `kind` with `source_path` describe where it points, `connector_id` for an external
+  source connector or `origin_node_id` for another Aruna node.
+- Those four fields are omitted entirely for a materialized object.
+- Objects are listed in key order and pagination is by opaque cursor."#,
     params(
         ("bucket" = String, Query, description = "Bucket to list, as used by the S3 surface; required"),
         ("prefix" = Option<String>, Query, description = "Return only objects whose key starts with this prefix; an empty value is treated as no prefix"),
@@ -761,7 +900,11 @@ pub async fn get_staging_job(
             body = ReferenceListResponse,
             example = json!({
                 "entries": [
-                    {"key": "genomes/2026/a.fna.gz", "size": 1048576, "referenced": false},
+                    {
+                        "key": "genomes/2026/a.fna.gz",
+                        "size": 1048576,
+                        "referenced": false
+                    },
                     {
                         "key": "genomes/2026/b.fna.gz",
                         "size": 2097152,

--- a/api/src/routes/storage_deletion.rs
+++ b/api/src/routes/storage_deletion.rs
@@ -173,43 +173,73 @@ pub struct SubmitPurgeResponse {
     post,
     path = "/storage/deletion-preflight",
     tag = "storage deletion",
-    summary = "Report what a permanent deletion of one scope would destroy",
-    description = "Requires a bearer token issued for this realm and READ on the selected scope; the reported `permissions.purge` says separately whether the same caller could actually run the purge. Nothing is deleted or reserved here. The inventory is one bounded page of this node's own rows: `counts.complete` false means every number counts that page rather than the scope, and `truncation` carries the markers a following request resumes from. Sync relationships that a bucket delete would act on are listed with the ones that block it. `reference_coverage` never implies that the scope is unreferenced: it reports how much of the backlink question this node could answer at all.",
+    summary = "Preview what a permanent deletion would destroy",
+    description = r#"Reports the bounded inventory and consequences of permanently deleting one storage scope.
+
+**Authentication**: bearer token issued for this realm and READ on the selected scope; the reported
+`permissions.purge` says separately whether the same caller could actually run the purge.
+
+**Behavior**
+- Nothing is deleted or reserved here.
+- The inventory is one bounded page of this node's own rows: `counts.complete` false means every
+  number counts that page rather than the scope, and `truncation` carries the markers a following
+  request resumes from.
+- Sync relationships that a bucket delete would act on are listed with the ones that block it.
+- `reference_coverage` never implies that the scope is unreferenced: it reports how much of the
+  backlink question this node could answer at all."#,
     request_body(
         content = DeletionPreflightRequest,
         description = "The scope to inspect plus optional page bound and resume markers",
         example = json!({
-            "scope": {"kind": "prefix", "bucket": "datasets", "prefix": "raw/"},
+            "scope": {
+                "kind": "prefix",
+                "bucket": "datasets",
+                "prefix": "raw/"
+            },
             "limit": 1000
         })
     ),
     responses(
-        (status = 200, description = "Bounded, scope-aware deletion inventory and consequences", body = DeletionPreflightResponse, example = json!({
-            "scope": {"kind": "prefix", "bucket": "datasets", "prefix": "raw/"},
-            "counts": {
-                "current_heads": 42,
-                "noncurrent_versions": 7,
-                "delete_markers": 1,
-                "open_multipart_uploads": 0,
-                "complete": true
-            },
-            "sync_relationships_apply_to_bucket_delete": false,
-            "sync_relationships": [],
-            "permissions": {"read": true, "purge": false},
-            "truncation": {
-                "truncated": false,
-                "versions_truncated": false,
-                "multipart_uploads_truncated": false
-            },
-            "reference_coverage": {
-                "complete": false,
-                "hidden_references_exist": null,
-                "queried_nodes": 1,
-                "failed_nodes": 0,
-                "index_freshness": "local",
-                "excluded": ["remote_nodes"]
-            }
-        })),
+        (
+            status = 200,
+            description = "Bounded, scope-aware deletion inventory and consequences",
+            body = DeletionPreflightResponse,
+            example = json!({
+                "scope": {
+                    "kind": "prefix",
+                    "bucket": "datasets",
+                    "prefix": "raw/"
+                },
+                "counts": {
+                    "current_heads": 42,
+                    "noncurrent_versions": 7,
+                    "delete_markers": 1,
+                    "open_multipart_uploads": 0,
+                    "complete": true
+                },
+                "sync_relationships_apply_to_bucket_delete": false,
+                "sync_relationships": [],
+                "permissions": {
+                    "read": true,
+                    "purge": false
+                },
+                "truncation": {
+                    "truncated": false,
+                    "versions_truncated": false,
+                    "multipart_uploads_truncated": false
+                },
+                "reference_coverage": {
+                    "complete": false,
+                    "hidden_references_exist": null,
+                    "queried_nodes": 1,
+                    "failed_nodes": 0,
+                    "index_freshness": "local",
+                    "excluded": [
+                        "remote_nodes"
+                    ]
+                }
+            })
+        ),
         (status = 400, description = "Invalid scope, marker, or limit", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "The caller cannot read the selected scope", body = ErrorResponse),
@@ -353,26 +383,52 @@ pub async fn deletion_preflight(
     path = "/storage/purge-jobs",
     tag = "storage deletion",
     summary = "Submit a permanent purge of one storage scope",
-    description = "Requires a bearer token issued for this realm and WRITE on the selected scope. The purge runs as a job: a 201 means it was durably queued, never that anything was deleted yet, so poll the returned `status_url`. Deletion is permanent and no version survives it, which is why the preflight surface exists to report the consequences first. An `idempotency_key` makes a retried submission return the retained job with a 200 instead of queuing a second purge; the same key naming a different scope is a 409.",
+    description = r#"Queues a permanent purge of one storage scope as a job.
+
+**Authentication**: bearer token issued for this realm and WRITE on the selected scope.
+
+**Behavior**
+- The purge runs as a job: a 201 means it was durably queued, never that anything was deleted yet,
+  so poll the returned `status_url`.
+- Deletion is permanent and no version survives it, which is why the preflight surface exists to
+  report the consequences first.
+- An `idempotency_key` makes a retried submission return the retained job with a 200 instead of
+  queuing a second purge.
+
+**Errors**: an `idempotency_key` that names a different scope than the retained job is a 409."#,
     request_body(
         content = SubmitPurgeRequest,
         description = "The scope to purge plus an optional idempotency key",
         example = json!({
-            "scope": {"kind": "prefix", "bucket": "datasets", "prefix": "raw/"},
+            "scope": {
+                "kind": "prefix",
+                "bucket": "datasets",
+                "prefix": "raw/"
+            },
             "idempotency_key": "purge-raw-2026-04-09-001"
         })
     ),
     responses(
-        (status = 201, description = "Purge job created", body = SubmitPurgeResponse, example = json!({
-            "job_id": "01JABCDEF0123456789ABCDEFG",
-            "created": true,
-            "status_url": "/api/v1/jobs/01JABCDEF0123456789ABCDEFG"
-        })),
-        (status = 200, description = "Idempotent replay returned the retained job", body = SubmitPurgeResponse, example = json!({
-            "job_id": "01JABCDEF0123456789ABCDEFG",
-            "created": false,
-            "status_url": "/api/v1/jobs/01JABCDEF0123456789ABCDEFG"
-        })),
+        (
+            status = 201,
+            description = "Purge job created",
+            body = SubmitPurgeResponse,
+            example = json!({
+                "job_id": "01JABCDEF0123456789ABCDEFG",
+                "created": true,
+                "status_url": "/api/v1/jobs/01JABCDEF0123456789ABCDEFG"
+            })
+        ),
+        (
+            status = 200,
+            description = "Idempotent replay returned the retained job",
+            body = SubmitPurgeResponse,
+            example = json!({
+                "job_id": "01JABCDEF0123456789ABCDEFG",
+                "created": false,
+                "status_url": "/api/v1/jobs/01JABCDEF0123456789ABCDEFG"
+            })
+        ),
         (status = 400, description = "Invalid scope or idempotency key", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
         (status = 403, description = "The caller cannot purge the selected scope", body = ErrorResponse),

--- a/api/src/routes/storage_routing.rs
+++ b/api/src/routes/storage_routing.rs
@@ -217,20 +217,42 @@ pub(crate) async fn ensure_group_admin(
     path = "/buckets/{bucket}/storage-routing",
     tag = "storage-routing",
     summary = "Read a bucket's write routing rules",
-    description = "Requires a bearer token issued for this realm and WRITE on the owning group's admin path: routing decides where a group's bytes physically land, so the write rights that suffice for objects are not enough. The bucket's owning group is resolved first, so a bucket unknown to this node is not found and the admin check always runs against the group that owns it. This is a node-local read of the replicated bucket record: rules written on another node can be missing until they arrive here, and a bucket that has never been given rules returns an empty list. The `warnings` list is advisory only and is recomputed per request from the storage classes this node offers to tenants plus the backends the group itself registered, so the same stored rules can warn here and not on another node.",
+    description = r#"Returns the write routing rules stored for a bucket on this node, in the order they were submitted.
+
+**Authentication**: realm bearer token with WRITE on the owning group's admin path. Routing decides
+where a group's bytes physically land, so the write rights that suffice for objects are not enough.
+
+**Behavior**
+- The bucket's owning group is resolved first, so a bucket unknown to this node is not found and the
+  admin check always runs against the group that owns it.
+- This is a node-local read of the replicated bucket record: rules written on another node can be
+  missing until they arrive here, and a bucket that never had rules returns an empty list.
+- `warnings` is advisory only and is recomputed per request from the storage classes this node
+  offers to tenants plus the backends the group itself registered, so the same stored rules can
+  warn here and not on another node."#,
     params(("bucket" = String, Path, description = "Bucket name as used by the S3 surface, without a leading slash")),
     responses(
         (
             status = 200,
-            description = "The rules stored for this bucket, in the order they were submitted, plus advisory warnings for targets this node cannot serve",
+            description = "The stored rules in submission order, plus advisory warnings for targets this node cannot serve",
             body = BucketRoutingResponse,
             example = json!({
                 "bucket": "research-raw",
                 "rules": [
-                    {"key_prefix": "archive/", "exact": false, "target": {"class": "cold"}},
-                    {"key_prefix": "", "exact": false, "target": {"backend_id": "01JBACKEND0123456789ABCDE"}}
+                    {
+                        "key_prefix": "archive/",
+                        "exact": false,
+                        "target": { "class": "cold" }
+                    },
+                    {
+                        "key_prefix": "",
+                        "exact": false,
+                        "target": { "backend_id": "01JBACKEND0123456789ABCDE" }
+                    }
                 ],
-                "warnings": ["storage class `cold` is not offered to tenants by this node"]
+                "warnings": [
+                    "storage class `cold` is not offered to tenants by this node"
+                ]
             })
         ),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
@@ -274,33 +296,69 @@ pub async fn get_bucket_routing(
     path = "/buckets/{bucket}/storage-routing",
     tag = "storage-routing",
     summary = "Replace a bucket's write routing rules",
-    description = "Requires a bearer token issued for this realm and WRITE on the owning group's admin path. The submitted list replaces the bucket's whole rule set; sending an empty list clears it. Each rule target must set exactly one of `backend_id` or `class`: a `backend_id` must be the ULID of a backend the group itself registered, so tenant rules can never name an operator's node backend, and a `class` must be a valid storage-class name. Two rules may not share the same `key_prefix` and `exact` combination. At write time the most specific rule wins, in this order: an exact-key rule, then the longest matching `key_prefix` rule (an empty prefix is the bucket default), then the group default, then the operator's own node rules, then the node's default backend. This only steers data written after the change; objects already stored are never moved. Rules are stored even when this node cannot serve their target, because the bucket record replicates to nodes that may offer it, and the unserved targets come back in `warnings`.",
+    description = r#"Replaces the whole write routing rule set of a bucket with the submitted list.
+
+**Authentication**: realm bearer token with WRITE on the owning group's admin path.
+
+**Behavior**
+- The submitted list replaces the bucket's whole rule set; sending an empty list clears it.
+- At write time the most specific rule wins, in this order: an exact-key rule, then the longest
+  matching `key_prefix` rule (an empty prefix is the bucket default), then the group default, then
+  the operator's own node rules, then the node's default backend.
+- This only steers data written after the change; objects already stored are never moved.
+- Rules are stored even when this node cannot serve their target, because the bucket record
+  replicates to nodes that may offer it, and the unserved targets come back in `warnings`.
+
+**Limits** (all refused with 400)
+- Each rule target sets exactly one of `backend_id` or `class`.
+- A `backend_id` must be the ULID of a backend the group itself registered, so tenant rules can
+  never name an operator's node backend.
+- A `class` must be a valid storage-class name.
+- Two rules may not share the same `key_prefix` and `exact` combination."#,
     params(("bucket" = String, Path, description = "Bucket name as used by the S3 surface, without a leading slash")),
     request_body(
         content = BucketRoutingRequest,
         description = "The complete rule set for this bucket. `key_prefix` defaults to the empty string (the bucket default) and `exact` defaults to false (prefix match).",
         example = json!({
             "rules": [
-                {"key_prefix": "archive/", "exact": false, "target": {"class": "cold"}},
-                {"key_prefix": "index/manifest.json", "exact": true, "target": {"backend_id": "01JBACKEND0123456789ABCDE"}}
+                {
+                    "key_prefix": "archive/",
+                    "exact": false,
+                    "target": { "class": "cold" }
+                },
+                {
+                    "key_prefix": "index/manifest.json",
+                    "exact": true,
+                    "target": { "backend_id": "01JBACKEND0123456789ABCDE" }
+                }
             ]
         })
     ),
     responses(
         (
             status = 200,
-            description = "The rule set as stored, echoed back with advisory warnings for targets this node cannot serve",
+            description = "The rule set as stored, with advisory warnings for targets this node cannot serve",
             body = BucketRoutingResponse,
             example = json!({
                 "bucket": "research-raw",
                 "rules": [
-                    {"key_prefix": "archive/", "exact": false, "target": {"class": "cold"}},
-                    {"key_prefix": "index/manifest.json", "exact": true, "target": {"backend_id": "01JBACKEND0123456789ABCDE"}}
+                    {
+                        "key_prefix": "archive/",
+                        "exact": false,
+                        "target": { "class": "cold" }
+                    },
+                    {
+                        "key_prefix": "index/manifest.json",
+                        "exact": true,
+                        "target": { "backend_id": "01JBACKEND0123456789ABCDE" }
+                    }
                 ],
-                "warnings": ["storage class `cold` is not offered to tenants by this node"]
+                "warnings": [
+                    "storage class `cold` is not offered to tenants by this node"
+                ]
             })
         ),
-        (status = 400, description = "A target sets neither or both of `backend_id` and `class`, names a backend the group does not own, uses an invalid storage-class name, or two rules share the same prefix and match mode", body = ErrorResponse),
+        (status = 400, description = "A rule target is invalid, names a backend the group does not own, or duplicates another rule's prefix and match mode", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller lacks WRITE on the group admin path", body = ErrorResponse),
         (status = 404, description = "No bucket of that name is known to this node, or it no longer belongs to the authorized group", body = ErrorResponse)
@@ -346,16 +404,29 @@ pub async fn put_bucket_routing(
     path = "/groups/{group_id}/storage-routing",
     tag = "storage-routing",
     summary = "Read a group's default write target",
-    description = "Requires a bearer token issued for this realm and WRITE on that group's admin path. The group default applies to every bucket of the group and is consulted only after the bucket's own rules: an exact-key rule and then the longest matching key prefix on the bucket take precedence over it, and it in turn takes precedence over the operator's node rules and the node's default backend. This is a node-local read of the replicated group routing record; a group that has never set a default returns `default_target` omitted. The `warnings` list is advisory only and is recomputed per request against the classes this node offers to tenants and the backends the group registered, so it can differ between nodes for the same stored default.",
+    description = r#"Returns the default write target this node holds for a group, or none when the group never set one.
+
+**Authentication**: realm bearer token with WRITE on that group's admin path.
+
+**Behavior**
+- The group default applies to every bucket of the group and is consulted only after the bucket's
+  own rules: an exact-key rule and then the longest matching key prefix on the bucket take
+  precedence over it, and it in turn takes precedence over the operator's node rules and the node's
+  default backend.
+- This is a node-local read of the replicated group routing record; a group that has never set a
+  default returns `default_target` omitted.
+- `warnings` is advisory only and is recomputed per request against the classes this node offers to
+  tenants and the backends the group registered, so it can differ between nodes for the same stored
+  default."#,
     params(("group_id" = String, Path, description = "Group id as a 26-character ULID")),
     responses(
         (
             status = 200,
-            description = "The group's default target, omitted when none is set, plus advisory warnings when this node cannot serve it",
+            description = "The group's default target, omitted when none is set, plus advisory warnings",
             body = GroupRoutingResponse,
             example = json!({
                 "group_id": "01JABCDEF0123456789ABCDEFG",
-                "default_target": {"class": "warm"},
+                "default_target": { "class": "warm" },
                 "warnings": []
             })
         ),
@@ -395,25 +466,48 @@ pub async fn get_group_routing(
     path = "/groups/{group_id}/storage-routing",
     tag = "storage-routing",
     summary = "Set or clear a group's default write target",
-    description = "Requires a bearer token issued for this realm and WRITE on that group's admin path. The submitted value replaces the group's default outright, and omitting `default_target` or sending it as null clears it, which returns the group to the operator's node rules and the node default. The target must set exactly one of `backend_id` or `class`: a `backend_id` must be the ULID of a backend the group itself registered, so a tenant can never bind an operator's node backend, and a `class` must be a valid storage-class name. The default is scoped to the whole group and is weaker than any matching rule on an individual bucket. It only steers data written after the change; objects already stored are never moved. The record is stored even when this node cannot serve the target, because it replicates to nodes that may, and the unserved target comes back in `warnings`. Each write records the caller and the time as the last decider.",
+    description = r#"Replaces the group's default write target, or clears it when no target is submitted.
+
+**Authentication**: realm bearer token with WRITE on that group's admin path.
+
+**Behavior**
+- The submitted value replaces the group's default outright, and omitting `default_target` or
+  sending it as null clears it, which returns the group to the operator's node rules and the node
+  default.
+- The default is scoped to the whole group and is weaker than any matching rule on an individual
+  bucket.
+- It only steers data written after the change; objects already stored are never moved.
+- The record is stored even when this node cannot serve the target, because it replicates to nodes
+  that may, and the unserved target comes back in `warnings`.
+- Each write records the caller and the time as the last decider.
+
+**Limits** (all refused with 400)
+- The target sets exactly one of `backend_id` or `class`.
+- A `backend_id` must be the ULID of a backend the group itself registered, so a tenant can never
+  bind an operator's node backend.
+- A `class` must be a valid storage-class name."#,
     params(("group_id" = String, Path, description = "Group id as a 26-character ULID")),
     request_body(
         content = GroupRoutingRequest,
         description = "The new default target, or an empty object to clear the group default.",
-        example = json!({"default_target": {"class": "warm"}})
+        example = json!({
+            "default_target": { "class": "warm" }
+        })
     ),
     responses(
         (
             status = 200,
-            description = "The default as stored, omitted when the request cleared it, plus advisory warnings when this node cannot serve it",
+            description = "The default as stored, omitted when the request cleared it, plus advisory warnings",
             body = GroupRoutingResponse,
             example = json!({
                 "group_id": "01JABCDEF0123456789ABCDEFG",
-                "default_target": {"class": "warm"},
-                "warnings": ["storage class `warm` is not offered to tenants by this node"]
+                "default_target": { "class": "warm" },
+                "warnings": [
+                    "storage class `warm` is not offered to tenants by this node"
+                ]
             })
         ),
-        (status = 400, description = "The path segment is not a valid group ULID, or the target sets neither or both of `backend_id` and `class`, names a backend the group does not own, or uses an invalid storage-class name", body = ErrorResponse),
+        (status = 400, description = "The path segment is not a valid group ULID, or the target is invalid or names a backend the group does not own", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
         (status = 403, description = "The token belongs to another realm, or the caller lacks WRITE on the group admin path", body = ErrorResponse)
     ),

--- a/api/src/routes/sync.rs
+++ b/api/src/routes/sync.rs
@@ -226,12 +226,38 @@ pub struct SyncListParams {
     path = "/data/sync-relationships",
     tag = "sync",
     summary = "Create a bucket sync relationship",
-    description = "Requires a bearer token issued for this realm; a token confined to a path subset is refused outright, because this surface cannot honour that confinement. The source always lives on this node and needs READ on the source bucket; the target node additionally checks WRITE on the target bucket before it accepts its half of the relationship, so a caller without write rights there is forbidden. Source and target must differ, bucket names must be non-empty and free of `/`, workspace buckets are refused, and a prefix, when given, must be a confined relative path. A 201 means the relationship record is durable here and its mirror is durable on the target node; no data has been copied yet. For `once` and `reference` mode an initial backfill run is queued as part of creation, and `continuous` instead replicates versions as they are written. Completion is observed by polling the relationship, whose `pending_jobs`, `last_synced_at` and counters advance as replication drains. `reference` mode forces `preserve` reference handling regardless of what the body asks for. An enabled relationship with the same source, target and mode already existing is a conflict. A target node that cannot be reached fails the whole creation with 502 and the caller may retry; a partially created mirror is repaired in the background.",
+    description = r#"Creates a bucket sync relationship from this node to a bucket on a target node.
+
+**Authentication**: realm bearer token; a token confined to a path subset is refused outright,
+because this surface cannot honor that confinement. The source always lives on this node and needs
+READ on the source bucket; the target node additionally checks WRITE on the target bucket before it
+accepts its half of the relationship, so a caller without write rights there is forbidden.
+
+**Behavior**
+- A 201 means the relationship record is durable here and its mirror is durable on the target node;
+  no data has been copied yet.
+- For `once` and `reference` mode an initial backfill run is queued as part of creation, and
+  `continuous` instead replicates versions as they are written.
+- `reference` mode forces `preserve` reference handling regardless of what the body asks for.
+- Completion is observed by polling the relationship, whose `pending_jobs`, `last_synced_at` and
+  counters advance as replication drains.
+
+**Limits** (all refused with 400)
+- Source and target must differ.
+- Bucket names must be non-empty and free of `/`, and workspace buckets are refused.
+- A prefix, when given, must be a confined relative path.
+
+**Errors**: an already existing enabled relationship with the same source, target and mode is a
+409. A target node that cannot be reached fails the whole creation with 502 and the caller may
+retry; a partially created mirror is repaired in the background."#,
     request_body(
         content = CreateSyncRequest,
         description = "Source endpoint on this node, target endpoint on the receiving node, and the sync mode. `reference_handling` defaults to `materialize` and `replicate_deletes` to false.",
         example = json!({
-            "source": {"bucket": "research-raw", "prefix": "2026/"},
+            "source": {
+                "bucket": "research-raw",
+                "prefix": "2026/"
+            },
             "target": {
                 "node_id": "2a3b4c5d6e7f80910a1b2c3d4e5f60710a1b2c3d4e5f60710a1b2c3d4e5f6071",
                 "bucket": "research-mirror",
@@ -257,7 +283,14 @@ pub struct SyncListParams {
                 "created_by": "01JUSER01ABCDEFGHJKMNPQRST@AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
                 "created_at": "2026-04-09T14:23:11.123+00:00",
                 "state": "enabled",
-                "status": {"counters": {"versions_synced": 0, "bytes_synced": 0, "failures": 0, "consecutive_failures": 0}}
+                "status": {
+                    "counters": {
+                        "versions_synced": 0,
+                        "bytes_synced": 0,
+                        "failures": 0,
+                        "consecutive_failures": 0
+                    }
+                }
             })
         ),
         (status = 400, description = "The endpoints are identical, a bucket name is empty or contains `/`, the bucket is a workspace bucket, the prefix is not a confined relative path, or the target node id does not parse", body = ErrorResponse),
@@ -409,10 +442,27 @@ pub async fn create_sync(
     path = "/data/sync-relationships",
     tag = "sync",
     summary = "List the sync relationships held on this node",
-    description = "Requires a bearer token issued for this realm; a token confined to a path subset is refused. Only relationships created by the calling user are returned, so this is not a realm-wide view and another user's relationships are never listed. `outgoing` holds relationships whose source bucket lives on this node, `incoming` holds the mirror records this node keeps as a replication target; a relationship therefore appears in `outgoing` on one node and in `incoming` on the other. Detached serving stubs, left behind when a reference relationship is deleted, are hidden. The read is node-local and unpaginated: every matching record is returned in one response, and no ordering is guaranteed.",
+    description = r#"Lists the caller's own sync relationships held on this node, split by direction.
+
+**Authentication**: realm bearer token; a token confined to a path subset is refused.
+
+**Behavior**
+- Only relationships created by the calling user are returned, so this is not a realm-wide view and
+  another user's relationships are never listed.
+- `outgoing` holds relationships whose source bucket lives on this node, `incoming` holds the mirror
+  records this node keeps as a replication target; a relationship therefore appears in `outgoing` on
+  one node and in `incoming` on the other.
+- The `prefix` filter matches an overlap in either direction, so `2026/` matches both `2026/runs/`
+  and `2026`, and a relationship covering a whole bucket always matches.
+- Detached serving stubs, left behind when a reference relationship is deleted, are hidden.
+
+**Limits**
+- The read is node-local and unpaginated: every matching record is returned in one response, and no
+  ordering is guaranteed.
+- A `bucket` or `prefix` filter that is present but empty is refused with 400."#,
     params(
-        ("bucket" = Option<String>, Query, description = "Keep only relationships whose endpoint for the listed direction uses this bucket; the source bucket for outgoing, the target bucket for incoming. Omit for all buckets; an empty value is rejected"),
-        ("prefix" = Option<String>, Query, description = "Keep only relationships whose endpoint prefix overlaps this one, in either direction, so `2026/` matches both `2026/runs/` and `2026`. A relationship covering a whole bucket always matches. Omit for no prefix filter; an empty value is rejected"),
+        ("bucket" = Option<String>, Query, description = "Keep only relationships whose endpoint for the listed direction uses this bucket: source for outgoing, target for incoming. Omit for all buckets"),
+        ("prefix" = Option<String>, Query, description = "Keep only relationships whose endpoint prefix overlaps this one, in either direction. Omit for no prefix filter"),
         ("direction" = Option<String>, Query, description = "Which lists to populate: `out` for source-side relationships, `in` for mirrors held here, `both` for either. Defaults to `both`; the list that is not requested comes back empty")
     ),
     responses(
@@ -434,7 +484,12 @@ pub async fn create_sync(
                         "state": "enabled",
                         "status": {
                             "last_synced_at": "2026-04-09T15:02:44.907+00:00",
-                            "counters": {"versions_synced": 128, "bytes_synced": 4294967296_i64, "failures": 0, "consecutive_failures": 0}
+                            "counters": {
+                                "versions_synced": 128,
+                                "bytes_synced": 4294967296_i64,
+                                "failures": 0,
+                                "consecutive_failures": 0
+                            }
                         }
                     }
                 ],
@@ -507,7 +562,21 @@ pub async fn list_sync(
     path = "/data/sync-relationships/{id}",
     tag = "sync",
     summary = "Read one sync relationship and its progress",
-    description = "Requires a bearer token issued for this realm; a token confined to a path subset is refused. Only the user who created the relationship may read it, and a relationship created by somebody else is refused rather than hidden. The lookup checks this node's source-side records first and then its mirror records, so the same id can be inspected from either end on the node that holds it; a node holding neither reports it as not found, as does a detached serving stub left behind by a deleted reference relationship. `pending_jobs` and `oldest_lag_ms` come from this node's own replication queue: `pending_jobs` counts the replication jobs still queued for this relationship and `oldest_lag_ms` is the age in milliseconds of the oldest of them, omitted once the queue holds none. `pending_jobs` reaching zero with no `last_error` is how a caller sees an accepted run finish; the counters advance only as replication reports back, so they lag the objects already written.",
+    description = r#"Reads one sync relationship with this node's replication progress for it.
+
+**Authentication**: realm bearer token; a token confined to a path subset is refused, and only the
+user who created the relationship may read it, so a relationship created by somebody else is
+refused rather than hidden.
+
+**Behavior**
+- The lookup checks this node's source-side records first and then its mirror records, so the same
+  id can be inspected from either end on the node that holds it; a node holding neither reports it
+  as not found, as does a detached serving stub left behind by a deleted reference relationship.
+- `pending_jobs` and `oldest_lag_ms` come from this node's own replication queue: `pending_jobs`
+  counts the replication jobs still queued for this relationship and `oldest_lag_ms` is the age in
+  milliseconds of the oldest of them, omitted once the queue holds none.
+- `pending_jobs` reaching zero with no `last_error` is how a caller sees an accepted run finish; the
+  counters advance only as replication reports back, so they lag the objects already written."#,
     params(("id" = String, Path, description = "Relationship id as a 26-character ULID, as returned when the relationship was created")),
     responses(
         (
@@ -527,7 +596,12 @@ pub async fn list_sync(
                     "state": "enabled",
                     "status": {
                         "last_synced_at": "2026-04-09T15:02:44.907+00:00",
-                        "counters": {"versions_synced": 128, "bytes_synced": 4294967296_i64, "failures": 0, "consecutive_failures": 0}
+                        "counters": {
+                            "versions_synced": 128,
+                            "bytes_synced": 4294967296_i64,
+                            "failures": 0,
+                            "consecutive_failures": 0
+                        }
                     }
                 },
                 "pending_jobs": 1,
@@ -569,12 +643,33 @@ pub async fn get_sync(
     path = "/data/sync-relationships/{id}",
     tag = "sync",
     summary = "Change how a relationship handles referenced objects",
-    description = "Requires a bearer token issued for this realm; a token confined to a path subset is refused. Only the creator may change a relationship, and READ on the source bucket is checked as well. Only the source side can be changed: a mirror this node merely holds as a target reads as not found, so the call must go to the node that owns the source bucket. Reference handling is the only mutable field; the mode, endpoints and delete behaviour are fixed at creation. A relationship in `reference` mode only accepts `preserve`. Submitting the value the relationship already has returns it unchanged and touches nothing. Otherwise the target node's mirror is updated first and the local record second, so an unreachable target fails the whole change with 502, leaves the stored value as it was, and the caller may retry once the target is back. The new handling applies to versions replicated after the change; objects already copied or already left as references are not rewritten, and a relationship that has ever used `preserve` keeps serving the references it handed out even after switching to `materialize`.",
+    description = r#"Changes how an existing sync relationship handles referenced objects.
+
+**Authentication**: realm bearer token; a token confined to a path subset is refused. Only the
+creator may change a relationship, and READ on the source bucket is checked as well.
+
+**Behavior**
+- Only the source side can be changed: a mirror this node merely holds as a target reads as not
+  found, so the call must go to the node that owns the source bucket.
+- Submitting the value the relationship already has returns it unchanged and touches nothing.
+- Otherwise the target node's mirror is updated first and the local record second, so an
+  unreachable target fails the whole change with 502, leaves the stored value as it was, and the
+  caller may retry once the target is back.
+- The new handling applies to versions replicated after the change; objects already copied or
+  already left as references are not rewritten, and a relationship that has ever used `preserve`
+  keeps serving the references it handed out even after switching to `materialize`.
+
+**Limits**
+- Reference handling is the only mutable field; the mode, endpoints and delete behavior are fixed
+  at creation.
+- A relationship in `reference` mode accepts only `preserve`; anything else is refused with 400."#,
     params(("id" = String, Path, description = "Relationship id as a 26-character ULID; must name a relationship whose source bucket is on this node")),
     request_body(
         content = UpdateSyncRequest,
         description = "The new reference handling: `materialize` copies referenced source bytes, `preserve` replicates the reference itself, `skip` leaves referenced objects out of the sync.",
-        example = json!({"reference_handling": "preserve"})
+        example = json!({
+            "reference_handling": "preserve"
+        })
     ),
     responses(
         (
@@ -591,7 +686,14 @@ pub async fn get_sync(
                 "created_by": "01JUSER01ABCDEFGHJKMNPQRST@AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
                 "created_at": "2026-04-09T14:23:11.123+00:00",
                 "state": "enabled",
-                "status": {"counters": {"versions_synced": 128, "bytes_synced": 4294967296_i64, "failures": 0, "consecutive_failures": 0}}
+                "status": {
+                    "counters": {
+                        "versions_synced": 128,
+                        "bytes_synced": 4294967296_i64,
+                        "failures": 0,
+                        "consecutive_failures": 0
+                    }
+                }
             })
         ),
         (status = 400, description = "The path segment is not a valid relationship ULID, or the relationship is in reference mode and the request asked for anything other than preserve", body = ErrorResponse),
@@ -674,14 +776,35 @@ pub async fn update_sync(
     path = "/data/sync-relationships/{id}/run",
     tag = "sync",
     summary = "Trigger a backfill run of an existing relationship",
-    description = "Requires a bearer token issued for this realm; a token confined to a path subset is refused. Only the creator may run a relationship, and READ on the source bucket is checked as well. Only the source node can run it: a mirror this node merely holds as a target reads as not found. A relationship left in the failed state is returned to enabled first, with its last error and consecutive-failure count cleared, so a run is also how a stalled relationship is resumed. The 202 means one backfill job covering the relationship's whole scope, the source bucket or its prefix, is durably queued on this node; nothing has been copied and no object has been compared yet. The call is idempotent per relationship: the queued job is keyed by the relationship and its scope, so triggering a run while one is already in flight does not start a second pass, it re-arms the drain over the same job. `queued` reports how many scope jobs were enqueued and is 1 on every success, not a count of objects. Progress and completion are observed by polling the relationship, whose `pending_jobs` returns to zero when the run has drained.",
+    description = r#"Queues one backfill run over the whole scope of an existing relationship.
+
+**Authentication**: realm bearer token; a token confined to a path subset is refused. Only the
+creator may run a relationship, and READ on the source bucket is checked as well.
+
+**Behavior**
+- Only the source node can run it: a mirror this node merely holds as a target reads as not found.
+- A relationship left in the failed state is returned to enabled first, with its last error and
+  consecutive-failure count cleared, so a run is also how a stalled relationship is resumed.
+- The 202 means one backfill job covering the relationship's whole scope, the source bucket or its
+  prefix, is durably queued on this node; nothing has been copied and no object has been compared
+  yet.
+- The call is idempotent per relationship: the queued job is keyed by the relationship and its
+  scope, so triggering a run while one is already in flight does not start a second pass, it
+  re-arms the drain over the same job.
+- `queued` reports how many scope jobs were enqueued and is 1 on every success, not a count of
+  objects.
+- Progress and completion are observed by polling the relationship, whose `pending_jobs` returns to
+  zero when the run has drained."#,
     params(("id" = String, Path, description = "Relationship id as a 26-character ULID; must name a relationship whose source bucket is on this node")),
     responses(
         (
             status = 202,
             description = "A backfill job for the relationship is durably queued; the copy itself happens afterwards",
             body = SyncRunResponse,
-            example = json!({"relationship_id": "01JSYNC0123456789ABCDEFGHJ", "queued": 1})
+            example = json!({
+                "relationship_id": "01JSYNC0123456789ABCDEFGHJ",
+                "queued": 1
+            })
         ),
         (status = 400, description = "The path segment is not a valid relationship ULID, or the stored relationship has no usable source bucket", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented", body = ErrorResponse),
@@ -730,7 +853,21 @@ pub async fn run_sync(
     path = "/data/sync-relationships/{id}",
     tag = "sync",
     summary = "Delete a sync relationship",
-    description = "Requires a bearer token issued for this realm; a token confined to a path subset is refused. Only the creator may delete a relationship, and WRITE is checked on whichever bucket this node holds for it: the source bucket for a source-side relationship, the target bucket for a mirror. Either end may be deleted from the node that holds it. Objects already synchronized are never removed, on either side; only the relationship goes away, and continuous replication simply stops. Deleting a source-side `reference` relationship leaves a detached serving stub behind so that data the target still holds as references stays readable; the stub is invisible to this API, so reading or deleting the same id afterwards is not found. Other modes are removed outright. The peer is asked to drop its half as part of the call, and a peer that cannot be reached does not fail the delete: the removal is retried in the background until the mirror is gone.",
+    description = r#"Deletes one end of a sync relationship from the node that holds it.
+
+**Authentication**: realm bearer token; a token confined to a path subset is refused. Only the
+creator may delete a relationship, and WRITE is checked on whichever bucket this node holds for it:
+the source bucket for a source-side relationship, the target bucket for a mirror.
+
+**Behavior**
+- Either end may be deleted from the node that holds it.
+- Objects already synchronized are never removed, on either side; only the relationship goes away,
+  and continuous replication simply stops.
+- Deleting a source-side `reference` relationship leaves a detached serving stub behind so that data
+  the target still holds as references stays readable; the stub is invisible to this API, so reading
+  or deleting the same id afterwards is not found. Other modes are removed outright.
+- The peer is asked to drop its half as part of the call, and a peer that cannot be reached does not
+  fail the delete: the removal is retried in the background until the mirror is gone."#,
     params(("id" = String, Path, description = "Relationship id as a 26-character ULID, from either end of the relationship")),
     responses(
         (status = 204, description = "The relationship is removed on this node and the peer's mirror is being dropped; the response has no body and synchronized objects are retained on both sides"),

--- a/api/src/routes/sync_quarantine.rs
+++ b/api/src/routes/sync_quarantine.rs
@@ -181,10 +181,28 @@ fn event_summary(event: &DocumentSyncEvent) -> String {
     path = "/admin/sync-quarantine",
     tag = "sync-quarantine",
     summary = "List rejected sync events held on this node",
-    description = "Realm-admin evidence console over the replicated sync events this node refused. Requires a realm bearer token with WRITE on the realm's sync-quarantine admin path, because a retained row carries the whole rejected document; a path-restricted (delegated) token is refused outright. The listing is node-local and never fanned out: each node keeps the events its own replication path rejected, so an operator asks the node that saw them. Rows are ordered by their transport identity, publisher then delivery order, not by rejection time. Retention is manual: a row stays until an operator acknowledges it and prunes it, and `usage` reports how much of the node's fixed quarantine budget is consumed, so an operator can see a node approaching the point where new rejections can no longer be retained. `limit` defaults to 50 and is clamped to 1..=200, and a page without `next_cursor` is the last one.",
+    description = r#"Realm-admin evidence console over the replicated sync events this node refused.
+
+**Authentication**: realm bearer token with WRITE on the realm's sync-quarantine admin path,
+because a retained row carries the whole rejected document; a path-restricted (delegated) token is
+refused outright.
+
+**Behavior**
+- The listing is node-local and never fanned out: each node keeps the events its own replication
+  path rejected, so an operator asks the node that saw them.
+- Rows are ordered by their transport identity, publisher then delivery order, not by rejection
+  time.
+- Retention is manual: a row stays until an operator acknowledges it and prunes it.
+- `usage` reports how much of the node's fixed quarantine budget is consumed, so an operator can
+  see a node approaching the point where new rejections can no longer be retained.
+- A page without `next_cursor` is the last one.
+
+**Limits**
+- `limit` defaults to 50 and is clamped to 1..=200.
+- A `cursor` or `topic` that is not valid hex is refused with 400."#,
     params(
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token taken from a previous page's `next_cursor`, hex encoded. Non-hex values are rejected with 400. Absent starts at the first row"),
-        ("topic" = Option<String>, Query, description = "Hex-encoded sync topic, 64 characters, restricting the page to the evidence that arrived on it; a shorter even-length hex string matches as a leading prefix. Non-hex values are rejected with 400. Absent lists every topic"),
+        ("cursor" = Option<String>, Query, description = "Opaque continuation token from a previous page's `next_cursor`, hex encoded. Absent starts at the first row"),
+        ("topic" = Option<String>, Query, description = "Hex-encoded sync topic, 64 characters; a shorter even-length hex string matches as a leading prefix. Absent lists every topic"),
         ("limit" = Option<usize>, Query, description = "Maximum rows in one page. Default 50, clamped to 1..=200")
     ),
     responses(
@@ -210,7 +228,12 @@ fn event_summary(event: &DocumentSyncEvent) -> String {
                     }
                 ],
                 "next_cursor": "a5d03b267c5480c60614edcfc08d83615fd0d6ce38048282ba9a85e8d9d61b64d8d15044cac756439413aaa60e3fa5cf7e7c500a6433f9512c1700b7f7fc0a950000000000000007",
-                "usage": {"records": 3, "bytes": 2048, "max_records": 4096, "max_bytes": 67108864}
+                "usage": {
+                    "records": 3,
+                    "bytes": 2048,
+                    "max_records": 4096,
+                    "max_bytes": 67108864
+                }
             })
         ),
         (status = 400, description = "The cursor or topic filter is not valid hex", body = ErrorResponse),
@@ -244,8 +267,23 @@ pub async fn list_quarantine(
     path = "/admin/sync-quarantine/{record_id}",
     tag = "sync-quarantine",
     summary = "Inspect one rejected sync event",
-    description = "Reads a single retained row together with a summary of the envelope it carried, for an operator deciding why a replicated event was refused. Requires a realm bearer token with WRITE on the realm's sync-quarantine admin path, because the row carries the whole rejected document; a path-restricted (delegated) token is refused. Evidence is node-local, so only the node that rejected the event can answer for it and an id retained elsewhere is 404 here. A payload that never decoded into a sync event is still kept, byte for byte, as evidence: such a row has no decoded `event` and no `event_id`, `family`, `target` or `origin_node_id`. Inspecting changes nothing: the event stays rejected and the row stays unacknowledged.",
-    params(("record_id" = String, Path, description = "Hex row id exactly as the listing reported it in `id`, the row's transport identity of topic, publisher and sequence. Non-hex values are rejected with 400")),
+    description = r#"Reads one retained row and a summary of the envelope it carried.
+
+**Authentication**: realm bearer token with WRITE on the realm's sync-quarantine admin path,
+because the row carries the whole rejected document; a path-restricted (delegated) token is
+refused.
+
+**Behavior**
+- The row is the evidence an operator uses to decide why a replicated event was refused.
+- Evidence is node-local, so only the node that rejected the event can answer for it and an id
+  retained elsewhere is 404 here.
+- A payload that never decoded into a sync event is still kept, byte for byte, as evidence: such a
+  row has no decoded `event` and no `event_id`, `family`, `target` or `origin_node_id`.
+- Inspecting changes nothing: the event stays rejected and the row stays unacknowledged.
+
+**Limits**
+- A `record_id` that is not valid hex is refused with 400."#,
+    params(("record_id" = String, Path, description = "Hex row id exactly as the listing reported it in `id`: the row's transport identity of topic, publisher and sequence")),
     responses(
         (
             status = 200,
@@ -302,8 +340,22 @@ pub async fn inspect_quarantine(
     path = "/admin/sync-quarantine/{record_id}/acknowledge",
     tag = "sync-quarantine",
     summary = "Acknowledge one piece of quarantine evidence",
-    description = "Marks a retained row as seen by an operator, which is the only thing that makes it prunable. This is bookkeeping, not recovery: the rejected event is not replayed, re-applied or accepted, nothing is sent back to the publisher, and the document it carried stays exactly as it was. Requires a realm bearer token with WRITE on the realm's sync-quarantine admin path; a path-restricted (delegated) token is refused. Evidence is node-local, so the acknowledgement applies to this node's copy only and an id retained elsewhere is 404 here. The call is idempotent: acknowledging an already acknowledged row rewrites nothing and answers with the same row.",
-    params(("record_id" = String, Path, description = "Hex row id exactly as the listing reported it in `id`, the row's transport identity of topic, publisher and sequence. Non-hex values are rejected with 400")),
+    description = r#"Marks a retained row as seen by an operator, the only thing that makes it prunable.
+
+**Authentication**: realm bearer token with WRITE on the realm's sync-quarantine admin path; a
+path-restricted (delegated) token is refused.
+
+**Behavior**
+- This is bookkeeping, not recovery: the rejected event is not replayed, re-applied or accepted,
+  nothing is sent back to the publisher, and the document it carried stays exactly as it was.
+- Evidence is node-local, so the acknowledgement applies to this node's copy only and an id
+  retained elsewhere is 404 here.
+- The call is idempotent: acknowledging an already acknowledged row rewrites nothing and answers
+  with the same row.
+
+**Limits**
+- A `record_id` that is not valid hex is refused with 400."#,
+    params(("record_id" = String, Path, description = "Hex row id exactly as the listing reported it in `id`: the row's transport identity of topic, publisher and sequence")),
     responses(
         (
             status = 200,
@@ -351,10 +403,28 @@ pub async fn acknowledge_quarantine(
     path = "/admin/sync-quarantine",
     tag = "sync-quarantine",
     summary = "Prune acknowledged quarantine evidence",
-    description = "Runs one bounded sweep over this node's retained evidence and deletes the acknowledged rows it scanned. Requires a realm bearer token with WRITE on the realm's sync-quarantine admin path; a path-restricted (delegated) token is refused. Only acknowledged rows are removed, so unreviewed evidence is never lost to a sweep, and deletion is permanent: the rejected events are gone from this node and are not replayed by removing them. One call is a page, not the whole store: `scanned` reports how many rows the pass looked at and `pruned` how many it deleted, and the caller repeats the call with the returned `next_cursor` until none comes back. Pruning is how a node reclaims its fixed quarantine budget, and a node whose budget is full stops accepting further replicated events on the affected topics until it has room again, so `usage` in the answer is the signal to keep sweeping.",
+    description = r#"Runs one bounded sweep over this node's evidence and deletes the acknowledged rows it scanned.
+
+**Authentication**: realm bearer token with WRITE on the realm's sync-quarantine admin path; a
+path-restricted (delegated) token is refused.
+
+**Behavior**
+- Only acknowledged rows are removed, so unreviewed evidence is never lost to a sweep, and deletion
+  is permanent: the rejected events are gone from this node and are not replayed by removing them.
+- One call is a page, not the whole store: `scanned` reports how many rows the pass looked at and
+  `pruned` how many it deleted, and the caller repeats the call with the returned `next_cursor`
+  until none comes back.
+- Pruning is how a node reclaims its fixed quarantine budget, and a node whose budget is full stops
+  accepting further replicated events on the affected topics until it has room again, so `usage` in
+  the answer is the signal to keep sweeping.
+
+**Limits**
+- `limit` bounds the rows examined in one pass, not the rows deleted. Default 50, clamped to
+  1..=200.
+- A `cursor` or `topic` that is not valid hex is refused with 400."#,
     params(
-        ("cursor" = Option<String>, Query, description = "Opaque continuation token taken from a previous pass's `next_cursor`, hex encoded. Non-hex values are rejected with 400. Absent starts at the first row"),
-        ("topic" = Option<String>, Query, description = "Hex-encoded sync topic, 64 characters, restricting the sweep to the evidence that arrived on it; a shorter even-length hex string matches as a leading prefix. Non-hex values are rejected with 400. Absent sweeps every topic"),
+        ("cursor" = Option<String>, Query, description = "Opaque continuation token from a previous pass's `next_cursor`, hex encoded. Absent starts at the first row"),
+        ("topic" = Option<String>, Query, description = "Hex-encoded sync topic, 64 characters; a shorter even-length hex string matches as a leading prefix. Absent sweeps every topic"),
         ("limit" = Option<usize>, Query, description = "Maximum rows examined in one pass, of which only the acknowledged ones are deleted. Default 50, clamped to 1..=200")
     ),
     responses(
@@ -366,7 +436,12 @@ pub async fn acknowledge_quarantine(
                 "pruned": 1,
                 "scanned": 50,
                 "next_cursor": "a5d03b267c5480c60614edcfc08d83615fd0d6ce38048282ba9a85e8d9d61b64d8d15044cac756439413aaa60e3fa5cf7e7c500a6433f9512c1700b7f7fc0a950000000000000007",
-                "usage": {"records": 2, "bytes": 1536, "max_records": 4096, "max_bytes": 67108864}
+                "usage": {
+                    "records": 2,
+                    "bytes": 1536,
+                    "max_records": 4096,
+                    "max_bytes": 67108864
+                }
             })
         ),
         (status = 400, description = "The cursor or topic filter is not valid hex", body = ErrorResponse),

--- a/api/src/routes/tes.rs
+++ b/api/src/routes/tes.rs
@@ -457,7 +457,17 @@ fn parse_tag_filters(raw_query: Option<&str>) -> Vec<(String, String)> {
     path = "/ga4gh/tes/v1/service-info",
     tag = "tes",
     summary = "Describe this GA4GH TES endpoint",
-    description = "Deliberately public: no credential is required and every caller sees the same document. It names the TES version spoken, the realm this endpoint serves, the running server version, and the deviations from full TES conformance a client must plan for: exactly one executor per task, and PAUSED is never entered. The organization url is the externally visible base url of the node that answered, taken from the forwarded headers only when the request arrived through a trusted proxy and from the Host header otherwise.",
+    description = r#"Describes this TES endpoint, the realm it serves and its conformance deviations.
+
+**Authentication**: none; the route is deliberately public and every caller sees the same document.
+
+**Behavior**
+- Names the TES version spoken, the realm this endpoint serves, the running server version, and the
+  deviations from full TES conformance a client must plan for: exactly one executor per task, and
+  `PAUSED` is never entered.
+- The organization url is the externally visible base url of the node that answered, taken from the
+  forwarded headers only when the request arrived through a trusted proxy and from the `Host` header
+  otherwise."#,
     responses((
         status = 200,
         description = "Description of this TES endpoint and its conformance deviations",
@@ -465,9 +475,16 @@ fn parse_tag_filters(raw_query: Option<&str>) -> Vec<(String, String)> {
         example = json!({
             "id": "org.aruna.AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
             "name": "Aruna Realm AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
-            "type": {"group": "org.ga4gh", "artifact": "tes", "version": "1.1.0"},
+            "type": {
+                "group": "org.ga4gh",
+                "artifact": "tes",
+                "version": "1.1.0"
+            },
             "description": "Aruna TES facade over the internal execution job model.",
-            "organization": {"name": "Aruna", "url": "https://node.example.test"},
+            "organization": {
+                "name": "Aruna",
+                "url": "https://node.example.test"
+            },
             "documentation_url": "https://docs.aruna-engine.org",
             "environment": "dev",
             "version": "3.0.0-alpha.41",
@@ -511,32 +528,88 @@ pub async fn service_info(
     path = "/ga4gh/tes/v1/tasks",
     tag = "tes",
     summary = "Create a TES task",
-    description = "Accepts a task for asynchronous execution. Authenticate either with a realm bearer token or with HTTP Basic using an access key and secret issued by this node; a path restricted credential is rejected. Every task runs inside one group: with basic authentication the group of the credential is used and an `aruna-engine.org/group` tag naming a different group is refused, while with a bearer token that tag is required. The caller needs WRITE permission on the target group. A 200 means only that the task was durably accepted and queued, never that it started or finished: poll the returned id, whose state runs QUEUED, INITIALIZING, RUNNING and then to COMPLETE, EXECUTOR_ERROR, SYSTEM_ERROR or CANCELED, reports CANCELING while a cancellation is in flight and UNKNOWN when the outcome cannot be determined; PAUSED and PREEMPTED are never emitted. Facade limits, all answered with 400: exactly one executor whose `command` is the full argv; `id`, `state`, `logs` and `creation_time` are read only, as are the derived tags `aruna-engine.org/job-id`, `aruna-engine.org/logical-state`, `aruna-engine.org/executor-kind` and `aruna-engine.org/estimated-transfer-bytes`, which a task naming any of them is refused for with the error code `reserved_tag`; input and output urls must be s3://bucket/key; container paths must be absolute and canonical and may not overlap between inputs and outputs; at most 512 inputs and 1024 outputs, the same bound the immutable output record carries; directory entries, inline input content, wildcards in an input path, volumes, executor stdin/stdout/stderr redirection and resource zones are unsupported. An output path carrying POSIX wildcards additionally requires `path_prefix`, the literal ancestor stripped from each match before it is appended to the destination url. An `aruna-engine.org/idempotency-key` tag deduplicates submissions per caller, and reusing a key already bound to a different task is a 409 carrying that task id. Admission refusals carry the same status semantics as the native submit surface: a quota or composition refusal is a 409, an unusable input or workspace a 400, a refused routed authority a 403, and the retryable 503 is reserved for an unreachable family holder, a demand view that could not be read or did not settle, admission losing three transactions in a row to concurrent submissions of the same group, and an unhealthy id clock. A standing quota decided on an understated demand view is a 409 like an exceeded cap, and a replay of a known idempotency key is settled before any quota is read and is never quota-refused.",
+    description = r#"Accepts a task for asynchronous execution and returns the id to poll.
+
+**Authentication**: realm bearer token, or HTTP Basic with an access key and secret issued by
+this node; a path-restricted credential is rejected. Basic authentication uses the credential's
+group and refuses an `aruna-engine.org/group` tag naming a different group; a bearer token requires
+that tag. The caller needs WRITE on the target group.
+
+**Behavior**
+- 200 means the task was durably accepted and queued, never that it started or finished.
+- State runs `QUEUED`, `INITIALIZING`, `RUNNING`, then `COMPLETE`, `EXECUTOR_ERROR`,
+  `SYSTEM_ERROR` or `CANCELED`; `CANCELING` shows while a cancellation is in flight and `UNKNOWN`
+  when the outcome cannot be determined. `PAUSED` and `PREEMPTED` are never emitted.
+- An `aruna-engine.org/idempotency-key` tag deduplicates submissions per caller; reusing a key
+  bound to a different task is a 409 carrying that task id. A replay is settled before any quota
+  is read and is never quota-refused.
+
+**Limits** (all refused with 400)
+- Exactly one executor whose `command` is the full argv.
+- `id`, `state`, `logs` and `creation_time` are read only, as are the derived tags
+  `aruna-engine.org/job-id`, `aruna-engine.org/logical-state`, `aruna-engine.org/executor-kind`
+  and `aruna-engine.org/estimated-transfer-bytes`; naming one is refused with error code
+  `reserved_tag`.
+- Input and output urls must be `s3://bucket/key`; container paths must be absolute, canonical and
+  may not overlap between inputs and outputs; at most 512 inputs and 1024 outputs, the same bound
+  the immutable output record carries.
+- An output path with POSIX wildcards additionally requires `path_prefix`, the literal ancestor
+  stripped from each match before it is appended to the destination url.
+- Unsupported: directory entries, inline input content, wildcards in an input path, volumes,
+  executor stdin/stdout/stderr redirection and resource zones.
+
+**Errors**
+- Admission refusals carry the same status semantics as the native submit surface: a quota or
+  composition refusal is a 409, an unusable input or workspace a 400, a refused routed authority a
+  403.
+- 503 is reserved for an unreachable family holder, a demand view that could not be read or did not
+  settle, admission losing three transactions in a row to concurrent submissions of the same group,
+  and an unhealthy id clock.
+- A standing quota decided on an understated demand view is a 409 like an exceeded cap."#,
     request_body(
         content = TesTask,
         description = "Task definition: one executor, s3:// inputs and outputs, and optional resources and tags",
         example = json!({
             "name": "align-reads",
             "description": "align one fastq against the reference",
-            "executors": [{
-                "image": "ghcr.io/example/aligner:1.4.0",
-                "command": ["/usr/bin/align", "--in", "/data/input.fastq", "--out", "/data/out/aligned.bam"],
-                "workdir": "/data",
-                "env": {"THREADS": "4"}
-            }],
-            "inputs": [{
-                "name": "reads",
-                "url": "s3://example-bucket/reads/input.fastq",
-                "path": "/data/input.fastq",
-                "type": "FILE"
-            }],
-            "outputs": [{
-                "name": "aligned",
-                "url": "s3://example-bucket/results/aligned.bam",
-                "path": "/data/out/aligned.bam",
-                "type": "FILE"
-            }],
-            "resources": {"cpu_cores": 4, "ram_gb": 8.0, "disk_gb": 20.0, "preemptible": false},
+            "executors": [
+                {
+                    "image": "ghcr.io/example/aligner:1.4.0",
+                    "command": [
+                        "/usr/bin/align",
+                        "--in",
+                        "/data/input.fastq",
+                        "--out",
+                        "/data/out/aligned.bam"
+                    ],
+                    "workdir": "/data",
+                    "env": {
+                        "THREADS": "4"
+                    }
+                }
+            ],
+            "inputs": [
+                {
+                    "name": "reads",
+                    "url": "s3://example-bucket/reads/input.fastq",
+                    "path": "/data/input.fastq",
+                    "type": "FILE"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "aligned",
+                    "url": "s3://example-bucket/results/aligned.bam",
+                    "path": "/data/out/aligned.bam",
+                    "type": "FILE"
+                }
+            ],
+            "resources": {
+                "cpu_cores": 4,
+                "ram_gb": 8.0,
+                "disk_gb": 20.0,
+                "preemptible": false
+            },
             "tags": {
                 "aruna-engine.org/group": "01JABCDEF0123456789ABCDEFG",
                 "aruna-engine.org/idempotency-key": "align-reads-2026-04-09-001"
@@ -548,13 +621,15 @@ pub async fn service_info(
             status = 200,
             description = "Task durably accepted and queued; the body carries the id to poll and cancel with",
             body = TesCreateTaskResponse,
-            example = json!({"id": "01JABCDEF0123456789ABCDEFG"})
+            example = json!({
+                "id": "01JABCDEF0123456789ABCDEFG"
+            })
         ),
-        (status = 400, description = "Malformed task, a TES feature this facade does not support, an input that is not a readable object, more outputs than a task may declare, or a tag claiming a derived read-only key, which carries the error code `reserved_tag`", body = TesErrorPayload),
+        (status = 400, description = "Malformed task, an unsupported TES feature, an input that is not a readable object, more outputs than a task may declare, or a reserved tag", body = TesErrorPayload),
         (status = 401, description = "Missing or invalid bearer token or basic credential", body = TesErrorPayload),
         (status = 403, description = "No WRITE permission on the target group, a group tag contradicting the credential, a path restricted credential, or a routed authority refusing the submission", body = TesErrorPayload),
         (status = 409, description = "The idempotency key tag is already bound to a different task, the group's standing compute quota refuses this admission, or the composition conflicts on a staged key", body = TesErrorPayload),
-        (status = 503, description = "No family holder could admit the task, the group's demand view could not be read or did not settle, admission lost three transactions in a row to concurrent submissions, or the id clock is unhealthy; retryable, the caller may create the task again with the same idempotency key", body = TesErrorPayload)
+        (status = 503, description = "Retryable admission failure; the caller may create the task again with the same idempotency key", body = TesErrorPayload)
     ),
     security(("bearer_auth" = []), ("basic_auth" = []))
 )]
@@ -629,10 +704,42 @@ pub async fn create_task(
     path = "/ga4gh/tes/v1/tasks/{id}",
     tag = "tes",
     summary = "Get a single TES task",
-    description = "Returns one task of the calling user. Authenticate with a realm bearer token or with HTTP Basic using an access key and secret issued by this node; a path restricted credential is rejected. Tasks are self scoped: a task created by another user, a task outside the group of the basic credential, an id that is not a task of this facade and an id that does not parse are all answered with 404 rather than 403, so the existence of a task is never disclosed. A distributed execution task is reduced from its replicated records by whichever node answers, so it carries the same logical view as the native REST status; any other task is read from the node that owns it and only that node answers absence, and when it cannot be reached the call fails with a retryable 503 instead of reporting the task as missing. The state reported is the polling contract of task creation: QUEUED, INITIALIZING, RUNNING, then COMPLETE, EXECUTOR_ERROR, SYSTEM_ERROR or CANCELED, with CANCELING while a cancellation is in flight and UNKNOWN when the outcome cannot be determined; UNKNOWN is also what a distributed task reports while no execution has succeeded, because realm-wide failure can never be inferred from silence. Output URLs in the task log name the exact `versionId` the canonical execution wrote, which is not necessarily the object's current version: a duplicate execution admitted during a partition, or any later write, may have made another version current. Executor logs, including the exit code, appear only once the task is terminal.",
+    description = r#"Returns one task of the calling user, projected to the requested view.
+
+**Authentication**: realm bearer token, or HTTP Basic with an access key and secret issued by this
+node; a path-restricted credential is rejected.
+
+**Behavior**
+- Tasks are self scoped: a task created by another user, a task outside the group of the basic
+  credential, an id that is not a task of this facade and an id that does not parse are all answered
+  with 404 rather than 403, so the existence of a task is never disclosed.
+- A distributed execution task is reduced from its replicated records by whichever node answers, so
+  it carries the same logical view as the native REST status; any other task is read from the node
+  that owns it and only that node answers absence.
+- The state reported is the polling contract of task creation: `QUEUED`, `INITIALIZING`, `RUNNING`,
+  then `COMPLETE`, `EXECUTOR_ERROR`, `SYSTEM_ERROR` or `CANCELED`, with `CANCELING` while a
+  cancellation is in flight and `UNKNOWN` when the outcome cannot be determined.
+- `UNKNOWN` is also what a distributed task reports while no execution has succeeded, because
+  realm-wide failure can never be inferred from silence.
+- `view` selects the projection: `MINIMAL` (the default) returns only `id` and `state`, `BASIC` adds
+  the task definition, tags, timing and captured output files, and `FULL` adds executor stdout and
+  stderr and the system logs.
+- `BASIC` and `FULL` also carry the derived read-only tags `aruna-engine.org/job-id` always,
+  `aruna-engine.org/logical-state` once a family is known, and `aruna-engine.org/executor-kind` plus
+  `aruna-engine.org/estimated-transfer-bytes` once this responder sealed a placement.
+- Output urls in the task log name the exact `versionId` the canonical execution wrote, which is not
+  necessarily the object's current version: a duplicate execution admitted during a partition, or
+  any later write, may have made another version current.
+- Executor logs, including the exit code, appear only once the task is terminal.
+
+**Limits**
+- `view` must be `MINIMAL`, `BASIC` or `FULL`; any other value is a 400.
+
+**Errors**: when the node owning the task cannot be reached the call fails with a retryable 503
+instead of reporting the task as missing."#,
     params(
-        ("id" = String, Path, description = "TES task id (the JobId): the 26 character ULID returned by task creation; an id that does not parse is answered with 404 like an unknown task"),
-        ("view" = Option<String>, Query, description = "MINIMAL | BASIC | FULL projection: MINIMAL (the default) returns only `id` and `state`, BASIC adds the task definition, tags, timing and captured output files, FULL adds executor stdout and stderr and the system logs; any other value is a 400. BASIC and FULL also carry the derived read-only tags `aruna-engine.org/job-id` always, `aruna-engine.org/logical-state` once a family is known, and `aruna-engine.org/executor-kind` plus `aruna-engine.org/estimated-transfer-bytes` once this responder sealed a placement")
+        ("id" = String, Path, description = "TES task id (the JobId): the 26 character ULID returned by task creation"),
+        ("view" = Option<String>, Query, description = "Projection to apply: `MINIMAL` (the default), `BASIC` or `FULL`")
     ),
     responses(
         (
@@ -643,25 +750,44 @@ pub async fn create_task(
                 "id": "01JABCDEF0123456789ABCDEFG",
                 "state": "COMPLETE",
                 "name": "align-reads",
-                "inputs": [{
-                    "name": "reads",
-                    "url": "s3://example-bucket/reads/input.fastq",
-                    "path": "/data/input.fastq",
-                    "type": "FILE"
-                }],
-                "outputs": [{
-                    "name": "aligned",
-                    "url": "s3://example-bucket/results/aligned.bam",
-                    "path": "/data/out/aligned.bam",
-                    "type": "FILE"
-                }],
-                "resources": {"cpu_cores": 4, "ram_gb": 8.0, "disk_gb": 20.0, "preemptible": false},
-                "executors": [{
-                    "image": "ghcr.io/example/aligner:1.4.0",
-                    "command": ["/usr/bin/align", "--in", "/data/input.fastq", "--out", "/data/out/aligned.bam"],
-                    "workdir": "/data",
-                    "env": {"THREADS": "4"}
-                }],
+                "inputs": [
+                    {
+                        "name": "reads",
+                        "url": "s3://example-bucket/reads/input.fastq",
+                        "path": "/data/input.fastq",
+                        "type": "FILE"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "name": "aligned",
+                        "url": "s3://example-bucket/results/aligned.bam",
+                        "path": "/data/out/aligned.bam",
+                        "type": "FILE"
+                    }
+                ],
+                "resources": {
+                    "cpu_cores": 4,
+                    "ram_gb": 8.0,
+                    "disk_gb": 20.0,
+                    "preemptible": false
+                },
+                "executors": [
+                    {
+                        "image": "ghcr.io/example/aligner:1.4.0",
+                        "command": [
+                            "/usr/bin/align",
+                            "--in",
+                            "/data/input.fastq",
+                            "--out",
+                            "/data/out/aligned.bam"
+                        ],
+                        "workdir": "/data",
+                        "env": {
+                            "THREADS": "4"
+                        }
+                    }
+                ],
                 "tags": {
                     "aruna-engine.org/group": "01JABCDEF0123456789ABCDEFG",
                     "aruna-engine.org/job-id": "01JABCDEF0123456789ABCDEFG",
@@ -669,21 +795,27 @@ pub async fn create_task(
                     "aruna-engine.org/executor-kind": "docker",
                     "aruna-engine.org/estimated-transfer-bytes": "4096"
                 },
-                "logs": [{
-                    "logs": [{
+                "logs": [
+                    {
+                        "logs": [
+                            {
+                                "start_time": "2026-04-09T14:23:11.123+00:00",
+                                "end_time": "2026-04-09T14:25:02.900+00:00",
+                                "stdout": "aligned 1200 reads",
+                                "exit_code": 0
+                            }
+                        ],
                         "start_time": "2026-04-09T14:23:11.123+00:00",
                         "end_time": "2026-04-09T14:25:02.900+00:00",
-                        "stdout": "aligned 1200 reads",
-                        "exit_code": 0
-                    }],
-                    "start_time": "2026-04-09T14:23:11.123+00:00",
-                    "end_time": "2026-04-09T14:25:02.900+00:00",
-                    "outputs": [{
-                        "url": "s3://example-bucket/results/aligned.bam",
-                        "path": "/data/out/aligned.bam",
-                        "size_bytes": "20480"
-                    }]
-                }],
+                        "outputs": [
+                            {
+                                "url": "s3://example-bucket/results/aligned.bam",
+                                "path": "/data/out/aligned.bam",
+                                "size_bytes": "20480"
+                            }
+                        ]
+                    }
+                ],
                 "creation_time": "2026-04-09T14:23:10.010+00:00"
             })
         ),
@@ -803,12 +935,39 @@ async fn list_derived(
     path = "/ga4gh/tes/v1/tasks",
     tag = "tes",
     summary = "List the caller's TES tasks",
-    description = "Lists the tasks the calling user created, newest first. Authenticate with a realm bearer token or with HTTP Basic using an access key and secret issued by this node; a path restricted credential is rejected. The listing is keyed by the caller: another user's tasks are never returned, and a basic credential additionally sees only tasks of that credential's group. Only tasks owned by the node that answers are listed, so tasks submitted through another node of the realm are omitted rather than fetched from it. Paging is cursor based and forward only: read `next_page_token` from a page and send it back as `page_token`, and treat its absence as the end of the listing. State, name and tag filters are applied before a page is filled, so a short page means the listing is exhausted, not that everything was filtered away.",
+    description = r#"Lists the tasks the calling user created, newest first.
+
+**Authentication**: realm bearer token, or HTTP Basic with an access key and secret issued by this
+node; a path-restricted credential is rejected.
+
+**Behavior**
+- The listing is keyed by the caller: another user's tasks are never returned, and a basic
+  credential additionally sees only tasks of that credential's group.
+- Only tasks owned by the node that answers are listed, so tasks submitted through another node of
+  the realm are omitted rather than fetched from it.
+- Paging is cursor based and forward only: read `next_page_token` from a page and send it back as
+  `page_token`, and treat its absence as the end of the listing.
+- State, name and tag filters are applied before a page is filled, so a short page means the
+  listing is exhausted, not that everything was filtered away.
+- `view` projects every task in the page: `MINIMAL` (the default) returns only `id` and `state`,
+  `BASIC` adds the task definition, tags, timing and captured output files, and `FULL` adds executor
+  stdout and stderr and the system logs.
+- `BASIC` and `FULL` also carry the derived read-only tags `aruna-engine.org/job-id`,
+  `aruna-engine.org/logical-state`, `aruna-engine.org/executor-kind` and
+  `aruna-engine.org/estimated-transfer-bytes` wherever this responder knows them.
+- `tag_value` pairs by position with `tag_key`, and an empty or missing value matches any value of
+  that key.
+
+**Limits**
+- `page_size` defaults to 256, is capped at 512, and 0 is treated as unset.
+- An empty `name_prefix` is ignored.
+- An invalid `view`, an unknown `state` name, or a `page_token` that is not a token of this listing
+  is refused with 400."#,
     params(
-        ("view" = Option<String>, Query, description = "MINIMAL | BASIC | FULL projection applied to every task in the page: MINIMAL (the default) returns only `id` and `state`, BASIC adds the task definition, tags, timing and captured output files, FULL adds executor stdout and stderr and the system logs; any other value is a 400. BASIC and FULL also carry the derived read-only tags `aruna-engine.org/job-id`, `aruna-engine.org/logical-state`, `aruna-engine.org/executor-kind` and `aruna-engine.org/estimated-transfer-bytes` wherever this responder knows them"),
+        ("view" = Option<String>, Query, description = "Projection applied to every task in the page: `MINIMAL` (the default), `BASIC` or `FULL`"),
         ("page_size" = Option<usize>, Query, description = "Max tasks per page: default 256, capped at 512, and 0 is treated as unset"),
-        ("page_token" = Option<String>, Query, description = "Opaque page token: the `next_page_token` of the previous page; omit it to start at the newest task, and anything that is not a token of this listing is a 400"),
-        ("state" = Option<String>, Query, description = "TES task state to filter by, for example QUEUED, RUNNING or COMPLETE; an unknown state name is a 400"),
+        ("page_token" = Option<String>, Query, description = "Opaque page token: the `next_page_token` of the previous page; omit it to start at the newest task"),
+        ("state" = Option<String>, Query, description = "TES task state to filter by, for example `QUEUED`, `RUNNING` or `COMPLETE`"),
         ("name_prefix" = Option<String>, Query, description = "Task name prefix; only tasks whose name starts with it are returned, and an empty value is ignored"),
         ("tag_key" = Vec<String>, Query, description = "Repeated tag keys; a task matches only when it carries every key given"),
         ("tag_value" = Vec<String>, Query, description = "Repeated tag values, paired by position with `tag_key`; an empty or missing value matches any value of that key")
@@ -820,8 +979,14 @@ async fn list_derived(
             body = TesListTasksResponse,
             example = json!({
                 "tasks": [
-                    {"id": "01JABCDEF0123456789ABCDEFG", "state": "RUNNING"},
-                    {"id": "01JMETADATA0123456789ABCDE", "state": "COMPLETE"}
+                    {
+                        "id": "01JABCDEF0123456789ABCDEFG",
+                        "state": "RUNNING"
+                    },
+                    {
+                        "id": "01JMETADATA0123456789ABCDE",
+                        "state": "COMPLETE"
+                    }
                 ],
                 "next_page_token": "ZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7"
             })
@@ -909,8 +1074,27 @@ pub async fn list_tasks(
     path = "/ga4gh/tes/v1/tasks/{id}:cancel",
     tag = "tes",
     summary = "Cancel a TES task",
-    description = "Requests cancellation of a task the calling user created. TES addresses this as a POST whose final path segment is the task id followed by the literal `:cancel` action suffix, and a POST that omits the suffix is a 400. Authenticate with a realm bearer token or with HTTP Basic using an access key and secret issued by this node; a path restricted credential is rejected. Cancellation is self scoped exactly like reads: another user's task, a task outside the group of the basic credential and an id that does not parse are all answered with 404 rather than 403. The request is carried out on the node that owns the task, and when that node is unreachable the call fails with a retryable 503. A 200 records only that cancellation was requested, or that the task had already reached a terminal state; the executor may still be winding down, so poll the task until it reports CANCELED.",
-    params(("id" = String, Path, description = "TES task id (the JobId) followed by the `:cancel` action suffix, for example `01JABCDEF0123456789ABCDEFG:cancel`; the id itself is the 26 character ULID returned by task creation")),
+    description = r#"Requests cancellation of a task the calling user created.
+
+**Authentication**: realm bearer token, or HTTP Basic with an access key and secret issued by this
+node; a path-restricted credential is rejected.
+
+**Behavior**
+- TES addresses this as a POST whose final path segment is the task id followed by the literal
+  `:cancel` action suffix.
+- Cancellation is self scoped exactly like reads: another user's task, a task outside the group of
+  the basic credential and an id that does not parse are all answered with 404 rather than 403.
+- The request is carried out on the node that owns the task.
+- A 200 records only that cancellation was requested, or that the task had already reached a
+  terminal state; the executor may still be winding down, so poll the task until it reports
+  `CANCELED`.
+
+**Limits**
+- A POST that omits the `:cancel` suffix is refused with 400.
+
+**Errors**: when the node owning the task is unreachable the cancellation was not delivered and the
+call fails with a retryable 503."#,
+    params(("id" = String, Path, description = "TES task id (the JobId) followed by the `:cancel` suffix, for example `01JABCDEF0123456789ABCDEFG:cancel`")),
     responses(
         (
             status = 200,

--- a/api/src/routes/tokens.rs
+++ b/api/src/routes/tokens.rs
@@ -42,11 +42,30 @@ pub struct RevokeTokenRequest {
     path = "/users/tokens/revoke",
     tag = "tokens",
     summary = "Revoke a bearer token of this realm",
-    description = "Requires a bearer token of this realm. The token in the body must itself be a well-formed, signed bearer token of this realm whose remaining lifetime still fits the retained revocation window; anything else is 400, including a token of another realm. A caller may always retire its own token, but a path-restricted (delegated) token may only revoke the very token it presented; revoking any other user's token requires WRITE on that user's realm admin path. On a user-kind node the revocation is forwarded to a ranked management or server peer under the caller's own token, and 503 is returned when no eligible peer accepts it. Otherwise the revocation is recorded in the replicated realm configuration: it takes effect on this node before the response and reaches the other realm nodes asynchronously with that configuration, so a 204 is not proof that every node already refuses the token. Revoking the same token again is accepted and returns 204 again.",
+    description = r#"Records a bearer token of this realm in the replicated revocation set.
+
+**Authentication**: bearer token of this realm. A caller may always retire its own token, but a
+path-restricted (delegated) token may only revoke the very token it presented; revoking any other
+user's token requires WRITE on that user's realm admin path.
+
+**Behavior**
+- On a user-kind node the revocation is forwarded to a ranked management or server peer under the
+  caller's own token, and 503 is returned when no eligible peer accepts it.
+- Otherwise the revocation is recorded in the replicated realm configuration: it takes effect on
+  this node before the response and reaches the other realm nodes asynchronously with that
+  configuration, so a 204 is not proof that every node already refuses the token.
+- Revoking the same token again is accepted and returns 204 again.
+
+**Limits**
+- The token in the body must itself be a well-formed, signed bearer token of this realm whose
+  remaining lifetime still fits the retained revocation window; anything else is refused with 400,
+  including a token of another realm."#,
     request_body(
         content = RevokeTokenRequest,
         description = "The bearer token to revoke, as issued, not its hash",
-        example = json!({"token": "<aruna-access-token-to-revoke>"})
+        example = json!({
+            "token": "<aruna-access-token-to-revoke>"
+        })
     ),
     responses(
         (status = 204, description = "Revocation recorded, or already recorded by an earlier call; no response body"),

--- a/api/src/routes/tokens.rs
+++ b/api/src/routes/tokens.rs
@@ -44,13 +44,15 @@ pub struct RevokeTokenRequest {
     summary = "Revoke a bearer token of this realm",
     description = r#"Records a bearer token of this realm in the replicated revocation set.
 
-**Authentication**: bearer token of this realm. A caller may always retire its own token, but a
-path-restricted (delegated) token may only revoke the very token it presented; revoking any other
-user's token requires WRITE on that user's realm admin path.
+**Authentication**: bearer token of this realm. Retiring one's own token is self-service, except
+that a path-restricted (delegated) token is self-service only for the very token it presented. Every
+other revocation, another user's token included, needs WRITE on the token owner's
+`/{realm_id}/admin/u/{user_id}` path, so a delegated token holding that permission may still revoke.
 
 **Behavior**
 - On a user-kind node the revocation is forwarded to a ranked management or server peer under the
-  caller's own token, and 503 is returned when no eligible peer accepts it.
+  caller's own token, which is where the permission is then checked, and 503 is returned when no
+  eligible peer accepts it.
 - Otherwise the revocation is recorded in the replicated realm configuration: it takes effect on
   this node before the response and reaches the other realm nodes asynchronously with that
   configuration, so a 204 is not proof that every node already refuses the token.

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -509,8 +509,28 @@ async fn register_admin(
     post,
     path = "/users/register",
     tag = "users",
-    summary = "Register the calling OIDC identity as a realm user",
-    description = "Requires an OIDC bearer token from a configured issuer, not an Aruna access token. It serves two callers: a user registering themselves, and an operator bootstrapping the first realm administrator. Any holder of a valid OIDC token registers themselves by leaving the onboarding secret out; that path is get or create, so a subject that already has a user gets the existing user back unchanged, still with 201. Sending an onboarding secret takes the administrator path: the secret must have been issued for this realm with the initial administrator purpose, it is consumed single use, and the registered user then claims the initial realm administrator role. A secret issued for any other purpose is refused with 403, and one that is unknown, expired, already claimed or issued for another realm is refused with 401. The registered identity is always the subject of the presented token, never a user id chosen by the caller, and the display name comes from the token. The user document is written on the node that serves the request and replicates to the other realm nodes asynchronously, so it may not be visible elsewhere immediately. No access token is returned here: exchange the same OIDC token at GET /users/token.",
+    summary = "Register the calling OIDC identity",
+    description = r#"Registers the subject of the presented OIDC token as a user of this realm.
+
+**Authentication**: an OIDC bearer token from a configured issuer, not an Aruna access token. Any
+holder of a valid one registers themselves; an onboarding secret in the body additionally claims
+the initial realm administrator role.
+
+**Behavior**
+- Two callers are served: a user registering themselves, and an operator bootstrapping the first
+  realm administrator.
+- Leaving the onboarding secret out is get or create, so a subject that already has a user gets
+  the existing user back unchanged, still with 201.
+- An onboarding secret must have been issued for this realm with the initial administrator
+  purpose, it is consumed single use, and the registered user then claims that role.
+- The registered identity is always the subject of the presented token, never a user id chosen by
+  the caller, and the display name comes from the token.
+- The user document is written on the node that serves the request and replicates to the other
+  realm nodes asynchronously, so it may not be visible elsewhere immediately.
+- No access token is returned here: exchange the same OIDC token at `GET /users/token`.
+
+**Errors**: an onboarding secret issued for another purpose is refused with 403, while one that is
+unknown, expired, already claimed or issued for another realm is refused with 401."#,
     request_body(
         content = RegisterUserRequest,
         description = "Optional onboarding secret. Omit it, or send null, for ordinary self service registration; send the secret handed out by the node operator only to claim the initial realm administrator.",
@@ -518,13 +538,17 @@ async fn register_admin(
             (
                 "SelfService" = (
                     summary = "Register the OIDC subject with no special role",
-                    value = json!({"onboarding_secret": null})
+                    value = json!({
+                        "onboarding_secret": null
+                    })
                 )
             ),
             (
                 "InitialAdministrator" = (
                     summary = "Consume an onboarding secret and claim the realm administrator role",
-                    value = json!({"onboarding_secret": "<onboarding-secret-issued-by-the-node-operator>"})
+                    value = json!({
+                        "onboarding_secret": "<onboarding-secret-issued-by-the-node-operator>"
+                    })
                 )
             )
         )
@@ -597,13 +621,28 @@ async fn register_user(
     path = "/users/token",
     tag = "users",
     summary = "Issue an access token for the calling identity",
-    description = "Self-scoped: the token is always minted for the caller's own identity and can never be requested on behalf of somebody else. Two kinds of bearer token are accepted. An Aruna access token without path restrictions refreshes itself, while a path-restricted (delegated) token is refused with 403, as is a token whose subject is an alias rather than the canonical user of that OIDC subject. An OIDC token from a configured issuer is accepted once its subject has been registered at POST /users/register. The issued token is a realm bearer credential valid for 24 hours, it is returned only in this response and is not retrievable afterwards, so a lost token has to be reissued here.",
+    description = r#"Mints a realm access token for the calling identity.
+
+**Authentication**: an Aruna access token without path restrictions, which refreshes itself, or an
+OIDC token from a configured issuer whose subject has been registered at `POST /users/register`.
+Self-scoped: the token is always minted for the caller's own identity and can never be requested
+on behalf of somebody else.
+
+**Behavior**
+- The issued token is a realm bearer credential valid for 24 hours.
+- It is returned only in this response and is not retrievable afterwards, so a lost token has to
+  be reissued here.
+
+**Errors**: a path-restricted (delegated) token is refused with 403, as is a token whose subject is
+an alias rather than the canonical user of that OIDC subject."#,
     responses(
         (
             status = 200,
             description = "A freshly issued access token for the caller, valid for 24 hours and shown only here",
             body = GetTokenResponse,
-            example = json!({"token": "<aruna-access-token>"})
+            example = json!({
+                "token": "<aruna-access-token>"
+            })
         ),
         (status = 400, description = "Not produced by this operation; a request that cannot be authenticated is answered with 401 or 403 instead", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented, the OIDC token failed validation, or this node knows no user for the presented identity", body = ErrorResponse),
@@ -651,7 +690,23 @@ async fn get_token(
     path = "/users/info",
     tag = "users",
     summary = "Get the calling user's profile, roles and preferences",
-    description = "Self-scoped: it always describes the caller and takes no user id. Requires a realm bearer token that carries no path restrictions; a delegated token, or a token issued by another realm, is refused with 403. The response combines the caller's user document, the realm roles whose assignment list contains the caller, one entry for every group known to this node whose roles list the caller, and the UI preferences derived from the caller's ui.theme, ui.preferred_profile_path and ui.favourite_metadata_ids attributes, where the favourites attribute is a comma separated list. Group membership is collected from the groups this node holds, so a group that has not replicated here yet is missing. 404 means this node holds no user document for the caller, which can happen while a registration made on another node is still replicating.",
+    description = r#"Describes the calling user: profile, realm roles, group memberships and UI preferences.
+
+**Authentication**: realm bearer token that carries no path restrictions; a delegated token, or a
+token issued by another realm, is refused with 403. Self-scoped: it always describes the caller
+and takes no user id.
+
+**Behavior**
+- The response combines the caller's user document, the realm roles whose assignment list contains
+  the caller, and one entry for every group known to this node whose roles list the caller.
+- The preferences are derived from the caller's `ui.theme`, `ui.preferred_profile_path` and
+  `ui.favourite_metadata_ids` attributes, where the favourites attribute is a comma separated
+  list.
+- Group membership is collected from the groups this node holds, so a group that has not
+  replicated here yet is missing.
+
+**Errors**: 404 means this node holds no user document for the caller, which can happen while a
+registration made on another node is still replicating."#,
     responses(
         (
             status = 200,
@@ -724,13 +779,36 @@ async fn get_user_info(
     path = "/users/info",
     tag = "users",
     summary = "Update the calling user's profile",
-    description = "Self-scoped: it always writes the caller's own user document and takes no user id. Requires a realm bearer token that carries no path restrictions; a delegated token, or a token issued by another realm, is refused with 403. Fields left out change nothing. The name is trimmed and must be 1 to 256 characters. An attribute key is ASCII letters, digits, dot, underscore, hyphen or colon of at most 128 bytes, a value is at most 4096 bytes and carries no control characters, and a user holds at most 128 attributes. Removals are applied before sets, so a key named in both ends up set to the new value. UI preferences are ordinary attributes: ui.theme, ui.preferred_profile_path and ui.favourite_metadata_ids as a comma separated list. The write is durable on the node that answers and replicates to the other realm nodes asynchronously. The response is the caller's refreshed profile in the same shape as GET /users/info.",
+    description = r#"Updates the calling user's display name and attributes and returns the refreshed profile.
+
+**Authentication**: realm bearer token that carries no path restrictions; a delegated token, or a
+token issued by another realm, is refused with 403. Self-scoped: it always writes the caller's own
+user document and takes no user id.
+
+**Behavior**
+- Fields left out change nothing.
+- Removals are applied before sets, so a key named in both ends up set to the new value.
+- UI preferences are ordinary attributes: `ui.theme`, `ui.preferred_profile_path` and
+  `ui.favourite_metadata_ids` as a comma separated list.
+- The write is durable on the node that answers and replicates to the other realm nodes
+  asynchronously.
+- The response is the caller's refreshed profile in the same shape as `GET /users/info`.
+
+**Limits**
+- The name is trimmed and must be 1 to 256 characters.
+- An attribute key is ASCII letters, digits, dot, underscore, hyphen or colon of at most 128
+  bytes.
+- An attribute value is at most 4096 bytes and carries no control characters.
+- A user holds at most 128 attributes."#,
     request_body(
         content = PatchUserInfoRequest,
         description = "Optional new display name, attributes to set and attribute keys to remove. Send only what changes.",
         example = json!({
             "name": "Alice Example",
-            "set_attributes": {"ui.theme": "dark", "orcid": "0000-0002-1825-0097"},
+            "set_attributes": {
+                "ui.theme": "dark",
+                "orcid": "0000-0002-1825-0097"
+            },
             "remove_attributes": ["ui.preferred_profile_path"]
         })
     ),
@@ -837,10 +915,24 @@ async fn patch_user_info(
     path = "/users",
     tag = "users",
     summary = "List the users of this realm",
-    description = "Requires a realm bearer token and read access on the realm's user administration path, so an ordinary member is refused with 403; the realm request policies are evaluated as well and may deny a read that the role grant alone would allow. Only users of this realm are listed, in user id order, from the replica held by the node that serves the request, so a user registered on another node appears once replication has caught up. Every entry is the full user document including its attributes. Pagination is cursor based: limit defaults to 100 and is clamped into 1 to 1000, next_start_after repeats the last returned user id, and its absence means the end of the listing was reached.",
+    description = r#"Pages this realm's user documents in user id order.
+
+**Authentication**: realm bearer token with READ on the realm's user administration path, so an
+ordinary member is refused with 403; the realm request policies are evaluated as well and may deny
+a read that the role grant alone would allow.
+
+**Behavior**
+- Only users of this realm are listed, from the replica held by the node that serves the request,
+  so a user registered on another node appears once replication has caught up.
+- Every entry is the full user document including its attributes.
+- Pagination is cursor based: `next_start_after` repeats the last returned user id, and its
+  absence means the end of the listing was reached.
+
+**Limits**
+- `limit` defaults to 100 and is clamped into 1 to 1000."#,
     params(
         ("limit" = Option<usize>, Query, description = "Page size; defaults to 100 and is clamped into 1 to 1000"),
-        ("start_after" = Option<String>, Query, description = "Exclusive cursor: the user id returned as next_start_after by the previous page; omit it to start at the first user")
+        ("start_after" = Option<String>, Query, description = "Exclusive cursor: the `next_start_after` of the previous page; omit it to start at the first user")
     ),
     responses(
         (
@@ -853,7 +945,10 @@ async fn patch_user_info(
                         "user_id": "01JABCDEF0123456789ABCDEFG@YXJ1bmEtZXhhbXBsZS1yZWFsbS0wMDAwMDAwMDAwMDA",
                         "name": "Alice Example",
                         "subject_ids": ["YXJ1bmEtZXhhbXBsZS1vaWRjLXN1YmplY3QtMDAwMDA"],
-                        "attributes": {"email": "user@example.test", "orcid": "0000-0002-1825-0097"}
+                        "attributes": {
+                            "email": "user@example.test",
+                            "orcid": "0000-0002-1825-0097"
+                        }
                     }
                 ],
                 "next_start_after": "01JB2C3D4E5F6G7H8J9KABCDEF@YXJ1bmEtZXhhbXBsZS1yZWFsbS0wMDAwMDAwMDAwMDA"
@@ -921,11 +1016,27 @@ async fn list_users(
     path = "/users/search",
     tag = "users",
     summary = "Search this realm's users by name or email",
-    description = "Requires a realm bearer token and read access on the realm's user administration path, the same grant as the full listing, so an ordinary member is refused with 403. The query is trimmed and matched case insensitively as a substring of the display name and of the email attribute, over the users of this realm held by the node that serves the request; a user registered elsewhere is found once replication has caught up. A result carries only the user id and the display name, never attributes. Pagination is cursor based: limit defaults to 20 and is clamped into 1 to 20, next_start_after repeats the last returned user id, and its absence means the scan reached the end of the realm's users rather than that no further match exists on a later page.",
+    description = r#"Pages this realm's users whose display name or email attribute contains the query.
+
+**Authentication**: realm bearer token with READ on the realm's user administration path, the same
+grant as the full listing, so an ordinary member is refused with 403.
+
+**Behavior**
+- The query is trimmed and matched case insensitively as a substring of the display name and of
+  the email attribute, over the users of this realm held by the node that serves the request; a
+  user registered elsewhere is found once replication has caught up.
+- A result carries only the user id and the display name, never attributes.
+- Pagination is cursor based: `next_start_after` repeats the last returned user id, and its
+  absence means the scan reached the end of the realm's users rather than that no further match
+  exists on a later page.
+
+**Limits**
+- `q` must hold at least 2 characters after trimming.
+- `limit` defaults to 20 and is clamped into 1 to 20."#,
     params(
-        ("q" = String, Query, description = "Substring matched case insensitively against the user name and the email attribute; at least 2 characters after trimming"),
+        ("q" = String, Query, description = "Substring matched case insensitively against the user name and the email attribute; at least 2 characters"),
         ("limit" = Option<usize>, Query, description = "Page size; defaults to 20 and is clamped into 1 to 20"),
-        ("start_after" = Option<String>, Query, description = "Exclusive cursor: the user id returned as next_start_after by the previous page; omit it to start at the first user")
+        ("start_after" = Option<String>, Query, description = "Exclusive cursor: the `next_start_after` of the previous page; omit it to start at the first user")
     ),
     responses(
         (
@@ -1010,7 +1121,21 @@ async fn search_users(
     path = "/users/resolve",
     tag = "users",
     summary = "Resolve user ids to directory entries",
-    description = "Requires a realm bearer token and read access on the realm's user administration path, so an ordinary member is refused with 403. Batch lookup of at most 100 user ids per request against the replica held by the node that serves the request. Duplicate ids collapse and ids unknown to this node are dropped silently, so the result may be shorter than the request and carries no positional mapping; match the entries by user id. Only the directory safe attributes orcid, affiliation and department are exposed, while email and every other attribute are withheld here. The response body is a JSON array, not an object.",
+    description = r#"Resolves a batch of user ids to directory entries held by this node.
+
+**Authentication**: realm bearer token with READ on the realm's user administration path, so an
+ordinary member is refused with 403.
+
+**Behavior**
+- The lookup runs against the replica held by the node that serves the request.
+- Duplicate ids collapse and ids unknown to this node are dropped silently, so the result may be
+  shorter than the request and carries no positional mapping; match the entries by user id.
+- Only the directory safe attributes `orcid`, `affiliation` and `department` are exposed, while
+  `email` and every other attribute are withheld here.
+- The response body is a JSON array, not an object.
+
+**Limits**
+- At most 100 user ids per request."#,
     request_body(
         content = ResolveUsersRequest,
         description = "Up to 100 user ids, each in the form ulid@realm-id. Duplicates are collapsed and unknown ids are omitted from the result.",
@@ -1030,7 +1155,10 @@ async fn search_users(
                 {
                     "user_id": "01JABCDEF0123456789ABCDEFG@YXJ1bmEtZXhhbXBsZS1yZWFsbS0wMDAwMDAwMDAwMDA",
                     "name": "Alice Example",
-                    "attributes": {"orcid": "0000-0002-1825-0097", "affiliation": "Example University"}
+                    "attributes": {
+                        "orcid": "0000-0002-1825-0097",
+                        "affiliation": "Example University"
+                    }
                 }
             ])
         ),
@@ -1094,7 +1222,21 @@ async fn resolve_users(
     path = "/users/{id}",
     tag = "users",
     summary = "Get a user of this realm by id",
-    description = "Requires a realm bearer token and read access on the administration path of that specific user, so a caller without the grant is refused with 403 whether or not the user exists and existence stays hidden; the realm request policies are evaluated as well and may deny a read the role grant would allow. The reply is served from the replica held by the node that receives the request, so a user registered on another node appears once replication has caught up, and 404 is only reachable for a caller that may read that user. The response is the full user document including its attributes. A token issued by another trusted realm is answered with 501, because forwarding a read to the owning realm is not implemented.",
+    description = r#"Returns one user document of this realm as held by the responding node.
+
+**Authentication**: realm bearer token with READ on the administration path of that specific user,
+so a caller without the grant is refused with 403 whether or not the user exists and existence
+stays hidden; the realm request policies are evaluated as well and may deny a read the role grant
+would allow.
+
+**Behavior**
+- The reply is served from the replica held by the node that receives the request, so a user
+  registered on another node appears once replication has caught up.
+- The response is the full user document including its attributes.
+
+**Errors**: 404 is only reachable for a caller that may read that user. A token issued by another
+trusted realm is answered with 501, because forwarding a read to the owning realm is not
+implemented."#,
     params(("id" = String, Path, description = "User id in the form ulid@realm-id, as returned by the listing and search operations")),
     responses(
         (
@@ -1105,7 +1247,10 @@ async fn resolve_users(
                 "user_id": "01JABCDEF0123456789ABCDEFG@YXJ1bmEtZXhhbXBsZS1yZWFsbS0wMDAwMDAwMDAwMDA",
                 "name": "Alice Example",
                 "subject_ids": ["YXJ1bmEtZXhhbXBsZS1vaWRjLXN1YmplY3QtMDAwMDA"],
-                "attributes": {"email": "user@example.test", "orcid": "0000-0002-1825-0097"}
+                "attributes": {
+                    "email": "user@example.test",
+                    "orcid": "0000-0002-1825-0097"
+                }
             })
         ),
         (status = 400, description = "Declared for malformed input; in practice an id that is not a user id is refused by the authorization check with 403 instead", body = ErrorResponse),
@@ -1157,14 +1302,36 @@ async fn get_user(
     path = "/users/{id}",
     tag = "users",
     summary = "Update a user of this realm by id",
-    description = "Requires a realm bearer token; a token issued by another realm is refused with 403. Updating the caller's own user needs no further grant but refuses a path-restricted (delegated) token with 403. Updating anybody else requires write access on that user's administration path and additionally passes the realm request policies, which may deny the write even when the role grant allows it. Validation matches the self service profile update: the name is trimmed and must be 1 to 256 characters, an attribute key is ASCII letters, digits, dot, underscore, hyphen or colon of at most 128 bytes, a value is at most 4096 bytes without control characters, and a user holds at most 128 attributes. Removals are applied before sets, so a key named in both ends up set, and fields left out change nothing. The write is durable on the node that answers and replicates to the other realm nodes asynchronously. The response is the updated user document.",
+    description = r#"Updates one user's display name and attributes and returns the updated document.
+
+**Authentication**: realm bearer token; a token issued by another realm is refused with 403.
+Updating the caller's own user needs no further grant but refuses a path-restricted (delegated)
+token with 403. Updating anybody else requires WRITE on that user's administration path and
+additionally passes the realm request policies, which may deny the write even when the role grant
+allows it.
+
+**Behavior**
+- Fields left out change nothing.
+- Removals are applied before sets, so a key named in both ends up set.
+- The write is durable on the node that answers and replicates to the other realm nodes
+  asynchronously.
+- The response is the updated user document.
+
+**Limits** (validation matches the self service profile update)
+- The name is trimmed and must be 1 to 256 characters.
+- An attribute key is ASCII letters, digits, dot, underscore, hyphen or colon of at most 128
+  bytes.
+- An attribute value is at most 4096 bytes and carries no control characters.
+- A user holds at most 128 attributes."#,
     params(("id" = String, Path, description = "User id in the form ulid@realm-id of the user to update; the caller's own id for a self service update")),
     request_body(
         content = UpdateUserRequest,
         description = "Optional new display name, attributes to set and attribute keys to remove. Send only what changes.",
         example = json!({
             "name": "Alice Example",
-            "set_attributes": {"affiliation": "Example University"},
+            "set_attributes": {
+                "affiliation": "Example University"
+            },
             "remove_attributes": ["department"]
         })
     ),
@@ -1177,7 +1344,10 @@ async fn get_user(
                 "user_id": "01JABCDEF0123456789ABCDEFG@YXJ1bmEtZXhhbXBsZS1yZWFsbS0wMDAwMDAwMDAwMDA",
                 "name": "Alice Example",
                 "subject_ids": ["YXJ1bmEtZXhhbXBsZS1vaWRjLXN1YmplY3QtMDAwMDA"],
-                "attributes": {"email": "user@example.test", "affiliation": "Example University"}
+                "attributes": {
+                    "email": "user@example.test",
+                    "affiliation": "Example University"
+                }
             })
         ),
         (status = 400, description = "The id is not a user id, the name is empty or longer than 256 characters, or an attribute key or value is rejected", body = ErrorResponse),

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -1256,7 +1256,8 @@ implemented."#,
         (status = 400, description = "Declared for malformed input; in practice an id that is not a user id is refused by the authorization check with 403 instead", body = ErrorResponse),
         (status = 401, description = "No bearer token was presented, or the presented token failed validation", body = ErrorResponse),
         (status = 403, description = "The caller has no read access on that user's administration path; the same answer is given whether or not the user exists", body = ErrorResponse),
-        (status = 404, description = "This node holds no user with that id, and the caller is allowed to know that", body = ErrorResponse)
+        (status = 404, description = "This node holds no user with that id, and the caller is allowed to know that", body = ErrorResponse),
+        (status = 501, description = "The token was issued by another trusted realm; forwarding the read to the owning realm is not implemented", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -2,6 +2,7 @@ use super::s3_server::S3OpLabel;
 use super::util::{get_s3_operation_permission, is_anonymous_object_read_operation};
 use crate::rate_limit::{LocalKey, LocalLease, LocalPermit};
 use aruna_core::credential_seal::{CredentialSealKey, SealedS3Secret};
+use aruna_core::errors::StorageError;
 use aruna_core::structs::{
     AuthContext, BucketInfo, Permission, RealmId, S3Session, UserAccess,
     blob_bucket_permission_path, blob_group_permission_path, blob_object_permission_path,
@@ -199,10 +200,16 @@ impl S3Access for AuthProvider {
 }
 
 /// Maps an authorization failure to an S3 error, keeping RBAC and policy denials
-/// indistinguishable and control-plane failures fail-closed.
+/// indistinguishable and control-plane failures fail-closed. Exhausted
+/// transaction-cleanup capacity is retryable, so it stays a `SlowDown`.
 pub(super) fn map_authorize_error(error: AuthorizeError) -> s3s::S3Error {
     match error {
-        AuthorizeError::CheckFailed(_) => s3_error!(InternalError, "Failed to check permissions"),
+        AuthorizeError::Storage(StorageError::CleanupCapacity) => {
+            s3_error!(SlowDown, "Reduce your request rate")
+        }
+        AuthorizeError::CheckFailed(_) | AuthorizeError::Storage(_) => {
+            s3_error!(InternalError, "Failed to check permissions")
+        }
         _ => s3_error!(AccessDenied, "Permission denied"),
     }
 }

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -308,6 +308,7 @@ impl ArunaS3Service {
             Err(AuthorizeError::CheckFailed(message)) => {
                 Err(s3_error!(InternalError, "{}", message))
             }
+            Err(error @ AuthorizeError::Storage(_)) => Err(map_authorize_error(error)),
             Err(_) => Ok(false),
         }
     }

--- a/api/tests/api_route_authorization_guard.rs
+++ b/api/tests/api_route_authorization_guard.rs
@@ -18,6 +18,11 @@ const BOUNDARY: &[&str] = &[
 /// is still authorized. A new route must gain a check or a reviewed entry here.
 const ALLOWLIST: &[(&str, &str, &str)] = &[
     (
+        "compute.rs",
+        "put_compute_config",
+        "realm-config WRITE checked inside SetRealmComputeOperation",
+    ),
+    (
         "credentials.rs",
         "list_s3_credentials",
         "self-scoped: only credentials whose identity is the caller",

--- a/api/tests/api_route_authorization_guard.rs
+++ b/api/tests/api_route_authorization_guard.rs
@@ -274,6 +274,16 @@ const ALLOWLIST: &[(&str, &str, &str)] = &[
         "realm-admin WRITE checked inside ResolveQuarantineOperation",
     ),
     (
+        "policies.rs",
+        "set_group_policies",
+        "group-config WRITE checked inside SetGroupPoliciesOperation",
+    ),
+    (
+        "policies.rs",
+        "set_realm_policies",
+        "realm-config WRITE checked inside SetRealmPoliciesOperation",
+    ),
+    (
         "rocrate_import.rs",
         "upload_rocrate",
         "self-scoped: spools a hidden blob owned by the caller",

--- a/api/tests/api_route_authorization_guard.rs
+++ b/api/tests/api_route_authorization_guard.rs
@@ -68,6 +68,12 @@ const ALLOWLIST: &[(&str, &str, &str)] = &[
         "realm-wide counters intentionally open to every realm member",
     ),
     (
+        "info.rs",
+        "set_realm_quota",
+        "realm-config WRITE and the management-node guard checked inside \
+         SetRealmQuotaOperation",
+    ),
+    (
         "job_audit.rs",
         "get_job_audit",
         "self-scoped: family_report and family_audit answer NotFound unless the \

--- a/api/tests/api_route_authorization_guard.rs
+++ b/api/tests/api_route_authorization_guard.rs
@@ -18,11 +18,6 @@ const BOUNDARY: &[&str] = &[
 /// is still authorized. A new route must gain a check or a reviewed entry here.
 const ALLOWLIST: &[(&str, &str, &str)] = &[
     (
-        "compute.rs",
-        "put_compute_config",
-        "realm-config WRITE checked inside SetRealmComputeOperation",
-    ),
-    (
         "credentials.rs",
         "list_s3_credentials",
         "self-scoped: only credentials whose identity is the caller",
@@ -71,12 +66,6 @@ const ALLOWLIST: &[(&str, &str, &str)] = &[
         "info.rs",
         "get_usage",
         "realm-wide counters intentionally open to every realm member",
-    ),
-    (
-        "info.rs",
-        "set_realm_quota",
-        "realm-config WRITE and the management-node guard checked inside \
-         SetRealmQuotaOperation",
     ),
     (
         "job_audit.rs",
@@ -272,16 +261,6 @@ const ALLOWLIST: &[(&str, &str, &str)] = &[
         "placement.rs",
         "resolve_placement_quarantine",
         "realm-admin WRITE checked inside ResolveQuarantineOperation",
-    ),
-    (
-        "policies.rs",
-        "set_group_policies",
-        "group-config WRITE checked inside SetGroupPoliciesOperation",
-    ),
-    (
-        "policies.rs",
-        "set_realm_policies",
-        "realm-config WRITE checked inside SetRealmPoliciesOperation",
     ),
     (
         "rocrate_import.rs",

--- a/aruna-doctor/src/error.rs
+++ b/aruna-doctor/src/error.rs
@@ -73,10 +73,6 @@ pub enum CliError {
     },
     #[error("OIDC provider '{0}' is not configured")]
     OidcProviderNotFound(String),
-    #[error("OIDC flow requires both --oidc-username and --oidc-password")]
-    MissingOidcCredentials,
-    #[error("OIDC flow cannot be combined with positional user_id or expiry")]
-    InvalidOidcCreateTokenArgs,
     #[error("OIDC flow requires local Aruna HTTP address to be configured")]
     MissingArunaHttpAddress,
     #[error("Local bootstrap flow requires --name")]

--- a/aruna-doctor/src/main.rs
+++ b/aruna-doctor/src/main.rs
@@ -26,7 +26,7 @@ mod storage;
 mod test_support;
 mod tokens;
 
-/// Simple program to greet a person
+/// Operational CLI for inspecting, recovering and maintaining an Aruna node.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None, name = "aruna-doctor")]
 struct Cli {
@@ -39,7 +39,9 @@ pub enum Commands {
     CreateToken {
         #[arg(long)]
         oidc_username: String,
-        #[arg(long)]
+        /// OIDC password. Prefer `ARUNA_OIDC_PASSWORD`: a value passed on the
+        /// command line is visible to every process on the host.
+        #[arg(long, env = "ARUNA_OIDC_PASSWORD", hide_env_values = true)]
         oidc_password: String,
         #[arg(long, default_value = "openid")]
         oidc_scope: String,

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -1475,7 +1475,7 @@ mod tests {
                 .expect("usage counter ensure should probe storage");
             assert!(matches!(effect, StorageEffect::BatchRead { .. }));
             response_tx.send(StorageEvent::Error {
-                error: StorageError::ReadError,
+                error: StorageError::ReadError("boom".to_string()),
             });
         });
         let driver_ctx = test_driver_ctx(storage_handle);
@@ -1486,6 +1486,7 @@ mod tests {
             .to_string();
 
         assert!(error.contains("usage counter probe failed"));
+        assert!(error.contains("boom"), "storage cause missing: {error}");
         worker.join().expect("storage responder should finish");
     }
 

--- a/blob/src/bao_tree.rs
+++ b/blob/src/bao_tree.rs
@@ -155,6 +155,7 @@ pub struct OpenDalWriter {
     pub hasher: Hasher,
     idle_timeout: Duration,
     control_timeout: Duration,
+    written: u64,
 }
 
 pub struct BaoReadWriter {
@@ -221,7 +222,7 @@ impl AsyncSliceWriter for BaoReadWriter {
 
 impl AsyncSliceWriter for OpenDalWriter {
     async fn write_at(&mut self, offset: u64, data: &[u8]) -> std::io::Result<()> {
-        debug!("[OpenDalWriter] Try to write data with offset {}", offset);
+        self.check_offset(offset)?;
         with_transfer_idle_timeout(
             async {
                 self.writer
@@ -234,11 +235,12 @@ impl AsyncSliceWriter for OpenDalWriter {
         )
         .await?;
         self.hasher.update(data);
+        self.written += data.len() as u64;
         Ok(())
     }
 
     async fn write_bytes_at(&mut self, offset: u64, data: Bytes) -> std::io::Result<()> {
-        debug!("[OpenDalWriter] Try to write bytes with offset {}", offset);
+        self.check_offset(offset)?;
         with_transfer_idle_timeout(
             async {
                 self.writer
@@ -251,6 +253,7 @@ impl AsyncSliceWriter for OpenDalWriter {
         )
         .await?;
         self.hasher.update(&data);
+        self.written += data.len() as u64;
         Ok(())
     }
 
@@ -284,7 +287,23 @@ impl OpenDalWriter {
             hasher: Hasher::new(),
             idle_timeout,
             control_timeout,
+            written: 0,
         })
+    }
+
+    // The backend writer is append-only, so a non-sequential offset would
+    // silently reorder the replicated blob.
+    fn check_offset(&self, offset: u64) -> io::Result<()> {
+        if offset != self.written {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "bao write at offset {offset}, expected {} for append-only backend",
+                    self.written
+                ),
+            ));
+        }
+        Ok(())
     }
 
     pub async fn finalize(mut self) -> Result<(), BlobError> {
@@ -322,24 +341,7 @@ pub struct OpenDalReader {
 
 impl AsyncSliceReader for OpenDalReader {
     async fn read_at(&mut self, offset: u64, len: usize) -> std::io::Result<Bytes> {
-        // Jump to offset
-        with_transfer_idle_timeout(
-            self.stream.seek(std::io::SeekFrom::Start(offset)),
-            self.idle_timeout,
-            "seeking source blob for bao transfer",
-        )
-        .await?;
-
-        // Read bytes into buffer
-        let mut bs = vec![0u8; len];
-        with_transfer_idle_timeout(
-            self.stream.read_exact(&mut bs),
-            self.idle_timeout,
-            "reading source blob chunk for bao transfer",
-        )
-        .await?;
-
-        Ok(Bytes::from(bs))
+        self.read_exact_at(offset, len).await
     }
 
     async fn read_exact_at(&mut self, offset: u64, len: usize) -> std::io::Result<Bytes> {
@@ -389,7 +391,7 @@ impl OpenDalReader {
 
 #[cfg(test)]
 mod tests {
-    use super::{BaoReadWriter, idle_timeout_error, with_transfer_idle_timeout};
+    use super::{BaoReadWriter, OpenDalWriter, idle_timeout_error, with_transfer_idle_timeout};
     use iroh_io::AsyncSliceWriter;
     use std::io;
     use std::time::Duration;
@@ -460,5 +462,30 @@ mod tests {
             .finish(6, *blake3::hash(b"short").as_bytes())
             .unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn writer_rejects_gap() {
+        // The opendal writer appends, so a skipped offset must not be accepted.
+        let dir = tempfile::tempdir().unwrap();
+        let operator = opendal::Operator::from_iter::<opendal::services::Fs>(
+            [("root".to_string(), dir.path().to_str().unwrap().to_string())].into_iter(),
+        )
+        .unwrap()
+        .finish();
+        let mut writer = OpenDalWriter::new(
+            &operator,
+            "blob.bin",
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap();
+
+        writer.write_at(0, b"abc").await.unwrap();
+        let error = writer.write_at(7, b"d").await.unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        writer.write_at(3, b"d").await.unwrap();
     }
 }

--- a/blob/src/blob/backend.rs
+++ b/blob/src/blob/backend.rs
@@ -355,9 +355,15 @@ impl BlobHandler {
         marker: &ByteView,
         capacity: Option<u64>,
     ) -> Result<LoadUpdate, BlobError> {
-        let mut owner = self.storage.start_transaction(false).await.map_err(|_| {
-            BlobError::ReadError("failed to start hidden bucket transaction".to_string())
-        })?;
+        let mut owner = self
+            .storage
+            .start_transaction(false)
+            .await
+            .map_err(|error| {
+                BlobError::ReadError(format!(
+                    "failed to start hidden bucket transaction: {error}"
+                ))
+            })?;
         let Some(txn_id) = owner.id() else {
             return Err(BlobError::ReadError(
                 "hidden bucket transaction owner missing transaction".to_string(),
@@ -473,9 +479,13 @@ impl BlobHandler {
         key: &HiddenBlobKey,
         marker: &ByteView,
     ) -> Result<LoadUpdate, BlobError> {
-        let mut owner = self.storage.start_transaction(false).await.map_err(|_| {
-            BlobError::ReadError("failed to start hidden bucket release".to_string())
-        })?;
+        let mut owner = self
+            .storage
+            .start_transaction(false)
+            .await
+            .map_err(|error| {
+                BlobError::ReadError(format!("failed to start hidden bucket release: {error}"))
+            })?;
         let Some(txn_id) = owner.id() else {
             return Err(BlobError::ReadError(
                 "hidden bucket release owner missing transaction".to_string(),
@@ -711,9 +721,15 @@ impl BlobHandler {
     }
 
     pub(super) async fn clear_marker(&self, location: &BackendLocation) -> Result<(), BlobError> {
-        let mut owner = self.storage.start_transaction(false).await.map_err(|_| {
-            BlobError::ReadError("failed to start bucket reservation cleanup".to_string())
-        })?;
+        let mut owner = self
+            .storage
+            .start_transaction(false)
+            .await
+            .map_err(|error| {
+                BlobError::ReadError(format!(
+                    "failed to start bucket reservation cleanup: {error}"
+                ))
+            })?;
         let Some(txn_id) = owner.id() else {
             return Err(BlobError::ReadError(
                 "bucket reservation cleanup owner missing transaction".to_string(),
@@ -781,9 +797,15 @@ impl BlobHandler {
     }
 
     async fn release_marker(&self, location: &BackendLocation) -> Result<ReleaseUpdate, BlobError> {
-        let mut owner = self.storage.start_transaction(false).await.map_err(|_| {
-            BlobError::ReadError("failed to start bucket reservation release".to_string())
-        })?;
+        let mut owner = self
+            .storage
+            .start_transaction(false)
+            .await
+            .map_err(|error| {
+                BlobError::ReadError(format!(
+                    "failed to start bucket reservation release: {error}"
+                ))
+            })?;
         let Some(txn_id) = owner.id() else {
             return Err(BlobError::ReadError(
                 "bucket reservation release owner missing transaction".to_string(),
@@ -968,9 +990,13 @@ impl BlobHandler {
         capacity: Option<u64>,
         location: Option<&BackendLocation>,
     ) -> Result<LoadUpdate, BlobError> {
-        let mut owner = self.storage.start_transaction(false).await.map_err(|_| {
-            BlobError::ReadError("failed to start bucket stats transaction".to_string())
-        })?;
+        let mut owner = self
+            .storage
+            .start_transaction(false)
+            .await
+            .map_err(|error| {
+                BlobError::ReadError(format!("failed to start bucket stats transaction: {error}"))
+            })?;
         let Some(txn_id) = owner.id() else {
             return Err(BlobError::ReadError(
                 "bucket stats transaction owner missing transaction".to_string(),

--- a/blob/src/blob/io.rs
+++ b/blob/src/blob/io.rs
@@ -23,7 +23,7 @@ use opendal::{EntryMode, ErrorKind, Operator};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::future::Future;
-use std::ops::RangeBounds;
+use std::ops::{Bound, RangeBounds};
 use std::path::Path;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
@@ -45,6 +45,22 @@ enum HiddenCursor {
     Reservations {
         start_after: Option<Vec<u8>>,
     },
+}
+
+/// Resolves the requested bounds against the stored size so a range read can
+/// report how many bytes its stream yields.
+fn range_length(range: &impl RangeBounds<u64>, blob_size: u64) -> u64 {
+    let start = match range.start_bound() {
+        Bound::Included(start) => *start,
+        Bound::Excluded(start) => start.saturating_add(1),
+        Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound() {
+        Bound::Included(end) => end.saturating_add(1),
+        Bound::Excluded(end) => *end,
+        Bound::Unbounded => blob_size,
+    };
+    end.min(blob_size).saturating_sub(start)
 }
 
 /// Tenant writers open with an explicit chunk so a small-chunk stream cannot
@@ -1152,6 +1168,7 @@ impl BlobHandler {
             Ok(storage_path) => storage_path,
             Err(e) => return BlobEvent::Error(e),
         };
+        let stream_size = range_length(&range, location.blob_size);
         let reader = match timeout(
             self.control_plane_io_timeout(),
             operator.reader(&storage_path),
@@ -1194,7 +1211,7 @@ impl BlobHandler {
                     }
                 },
             )),
-            stream_size: 0,
+            stream_size,
         }
     }
 

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -12,7 +12,7 @@ use aruna_core::UserId;
 use aruna_core::alpn::Alpn;
 use aruna_core::effects::{BlobEffect, StagingSourceEffect, StorageEffect};
 use aruna_core::egress::EgressPolicy;
-use aruna_core::errors::{BlobError, ConversionError};
+use aruna_core::errors::{BlobError, ConversionError, StorageError};
 use aruna_core::events::{BlobEvent, Event, StagingSourceEvent, StorageEvent};
 use aruna_core::keyspaces::{
     BLOB_LOCATIONS_KEYSPACE, BUCKET_STATS_DB, GROUP_STORAGE_BACKEND_KEYSPACE,
@@ -1384,6 +1384,27 @@ async fn reports_range_size() {
         panic!("open range read failed")
     };
     assert_eq!(stream_size, 10);
+}
+
+#[tokio::test]
+async fn keeps_storage_cause() {
+    // The storage reason must reach the blob error, not be flattened into a
+    // fixed message that hides why the transaction never started.
+    let context = setup_blob_handle(4).await;
+    context.storage_handle.seal();
+    let handler = context.blob_handle.handler.clone();
+
+    let error = handler
+        .clear_marker(&make_test_location())
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains(&StorageError::Sealed.to_string()),
+        "storage cause missing: {error}"
+    );
 }
 
 #[tokio::test]

--- a/blob/src/blob/tests.rs
+++ b/blob/src/blob/tests.rs
@@ -1353,6 +1353,40 @@ async fn range_passes_writes() {
 }
 
 #[tokio::test]
+async fn reports_range_size() {
+    // Range reads must announce the bytes they yield, not zero.
+    let context = setup_blob_handle(16).await;
+    let handler = context.blob_handle.handler.clone();
+    let BlobEvent::WriteFinished { location } = handler
+        .write_blob(
+            "bucket",
+            "object.bin",
+            ResolvedBackend::node_default(),
+            test_user_id(),
+            stream_from_bytes(b"0123456789"),
+        )
+        .await
+    else {
+        panic!("blob write failed")
+    };
+
+    let BlobEvent::ReadFinished { blob, stream_size } =
+        handler.read_blob_range(location.clone(), 2..5).await
+    else {
+        panic!("range read failed")
+    };
+    assert_eq!(stream_size, 3);
+    let chunks: Vec<bytes::Bytes> = blob.try_collect().await.unwrap();
+    assert_eq!(chunks.concat(), b"234");
+
+    let BlobEvent::ReadFinished { stream_size, .. } = handler.read_blob_range(location, ..).await
+    else {
+        panic!("open range read failed")
+    };
+    assert_eq!(stream_size, 10);
+}
+
+#[tokio::test]
 async fn interlocked_writes_complete() {
     // Each body yields only once both writes stream concurrently; the old
     // sequential effect loop deadlocked here.

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -144,6 +144,10 @@ pub enum StorageError {
     CommitFailed,
     #[error("Transaction not found")]
     TransactionNotFound,
+    /// Transaction-cleanup tracking is full, so the effect was never enqueued.
+    /// Distinct from a conflict: re-running the same effect only spins.
+    #[error("Transaction cleanup capacity exhausted")]
+    CleanupCapacity,
     #[error("Keyspace error")]
     KeyspaceError,
     #[error("Read error")]
@@ -172,7 +176,10 @@ impl StorageError {
     /// storage actor at all. Every other failure leaves the commit either
     /// already applied or unknown, so its records may exist.
     pub fn proves_no_commit(&self) -> bool {
-        matches!(self, Self::TransactionConflict | Self::QueueFull)
+        matches!(
+            self,
+            Self::TransactionConflict | Self::QueueFull | Self::CleanupCapacity
+        )
     }
 }
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -148,12 +148,12 @@ pub enum StorageError {
     /// Distinct from a conflict: re-running the same effect only spins.
     #[error("Transaction cleanup capacity exhausted")]
     CleanupCapacity,
-    #[error("Keyspace error")]
-    KeyspaceError,
-    #[error("Read error")]
-    ReadError,
-    #[error("Write error")]
-    WriteError,
+    #[error("Keyspace error: {0}")]
+    KeyspaceError(String),
+    #[error("Read error: {0}")]
+    ReadError(String),
+    #[error("Write error: {0}")]
+    WriteError(String),
     #[error("Delete error")]
     DeleteError,
     #[error("Persist error: {0}")]

--- a/core/src/keyspaces.rs
+++ b/core/src/keyspaces.rs
@@ -196,3 +196,20 @@ pub const CRAQLE_TERMS_KEYSPACE: &str = "terms";
 pub const CRAQLE_QUADS_KEYSPACE: &str = "quads";
 pub const CRAQLE_GRAPHS_KEYSPACE: &str = "graphs";
 pub const CRAQLE_LOG_KEYSPACE: &str = "log";
+
+/// Cleanup keyspaces record the work a finished transaction still owes, so
+/// storage must admit their writes ahead of the ordinary write queue.
+pub fn is_cleanup_keyspace(key_space: &str) -> bool {
+    key_space == BLOB_CLEANUP_KEYSPACE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BLOB_CLEANUP_KEYSPACE, BLOB_LOCATIONS_KEYSPACE, is_cleanup_keyspace};
+
+    #[test]
+    fn classifies_cleanup_keyspace() {
+        assert!(is_cleanup_keyspace(BLOB_CLEANUP_KEYSPACE));
+        assert!(!is_cleanup_keyspace(BLOB_LOCATIONS_KEYSPACE));
+    }
+}

--- a/core/src/structs/realm.rs
+++ b/core/src/structs/realm.rs
@@ -436,6 +436,10 @@ impl RealmConfigDocument {
         // make every revocation reject forwarded requests until it replicated.
         canonical.revoked_tokens.clear();
         canonical.revocation_floor = 0;
+        // Request policies are excluded for the same reason: they never change
+        // where a request routes, the receiving node enforces its own set on
+        // arrival, and nodes that hold no realm-config bucket never see them.
+        canonical.request_policies.clear();
         let encoded = postcard::to_allocvec(&canonical)?;
         let mut hasher = blake3::Hasher::new();
         hasher.update(b"aruna-realm-config-v1");
@@ -1091,6 +1095,7 @@ mod test {
     use crate::admin_document_reducer::AdminDocumentReducerState;
     use crate::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
     use crate::auth::REVOCATION_GRACE_SECS;
+    use crate::request_policy::{PolicyKind, RequestPolicy};
     use crate::structs::{
         Actor, CandidatePlacementMap, DynamicDiscoveryMethod, KIND_LABEL_KEY,
         MetadataGroupReplicationOverride, MetadataPathReplicationOverride, OidcProviderConfig,
@@ -1288,6 +1293,24 @@ mod test {
 
         assert!(revoked.token_revoked(&crate::auth::bearer_token_hash("token"), 1_000));
         assert_eq!(config.digest().unwrap(), revoked.digest().unwrap());
+    }
+
+    #[test]
+    fn digest_ignores_policies() {
+        // A node holding no realm-config bucket never sees a policy set; if it
+        // moved the digest, that node could never forward a write again.
+        let config = RealmConfigDocument::new(RealmId([7u8; 32]), Vec::new(), 3);
+        let mut denied = config.clone();
+        denied.request_policies.push(RequestPolicy {
+            policy_id: Ulid::from_bytes([9u8; 16]),
+            name: "deny-writes".to_string(),
+            kind: PolicyKind::Deny,
+            when: None,
+            expression: "permission == 'write'".to_string(),
+            enabled: true,
+        });
+
+        assert_eq!(config.digest().unwrap(), denied.digest().unwrap());
     }
 
     #[test]

--- a/operations/src/add_group_role.rs
+++ b/operations/src/add_group_role.rs
@@ -967,7 +967,7 @@ fn apply_admin_reducer_updates(
     )?;
     admin_events.push(event);
 
-    for user_id in sorted_user_ids(&input.role.assigned_users) {
+    for user_id in crate::sorted_user_ids(&input.role.assigned_users) {
         let event = state.apply_operation(
             &input.actor,
             AdminDocumentOperation::GroupRoleUserAssignmentAdded {
@@ -1003,7 +1003,7 @@ fn materialize_group_role(
     let Some(auth_role) = auth_doc.roles.get_mut(&role.role_id) else {
         return;
     };
-    for user_id in sorted_user_ids(&role.assigned_users) {
+    for user_id in crate::sorted_user_ids(&role.assigned_users) {
         if materialized_assignments
             .get(&role.role_id)
             .is_some_and(|users| users.contains(&user_id))
@@ -1029,7 +1029,7 @@ fn newly_materialized_members(
     auth_doc: &GroupAuthorizationDocument,
     role: &Role,
 ) -> Vec<UserId> {
-    sorted_user_ids(&role.assigned_users)
+    crate::sorted_user_ids(&role.assigned_users)
         .into_iter()
         .filter(|user| {
             !user.is_nil()
@@ -1040,12 +1040,6 @@ fn newly_materialized_members(
                     .any(|role| role.assigned_users.contains(user))
         })
         .collect()
-}
-
-fn sorted_user_ids(user_ids: &HashSet<UserId>) -> Vec<UserId> {
-    let mut user_ids: Vec<_> = user_ids.iter().copied().collect();
-    user_ids.sort();
-    user_ids
 }
 
 #[cfg(test)]

--- a/operations/src/add_realm_role.rs
+++ b/operations/src/add_realm_role.rs
@@ -16,10 +16,9 @@ use aruna_core::structs::{
     Actor, AuthContext, Permission, RealmAuthorizationDocument, RealmId, Role,
 };
 use aruna_core::task::TaskEvent;
-use aruna_core::types::{Effects, Key, KeySpace, TxnId, UserId};
+use aruna_core::types::{Effects, Key, KeySpace, TxnId};
 use byteview::ByteView;
 use smallvec::smallvec;
-use std::collections::HashSet;
 use thiserror::Error;
 
 use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
@@ -645,7 +644,7 @@ fn apply_admin_reducer_updates(
     )?;
     admin_events.push(event);
 
-    for user_id in sorted_user_ids(&input.role.assigned_users) {
+    for user_id in crate::sorted_user_ids(&input.role.assigned_users) {
         let event = state.apply_operation(
             &input.actor,
             AdminDocumentOperation::RealmRoleUserAssignmentAdded {
@@ -678,7 +677,7 @@ fn materialize_realm_role(
     let Some(auth_role) = auth_doc.roles.get_mut(&role.role_id) else {
         return;
     };
-    for user_id in sorted_user_ids(&role.assigned_users) {
+    for user_id in crate::sorted_user_ids(&role.assigned_users) {
         if materialized_assignments
             .get(&role.role_id)
             .is_some_and(|users| users.contains(&user_id))
@@ -688,12 +687,6 @@ fn materialize_realm_role(
             auth_role.assigned_users.remove(&user_id);
         }
     }
-}
-
-fn sorted_user_ids(user_ids: &HashSet<UserId>) -> Vec<UserId> {
-    let mut user_ids: Vec<_> = user_ids.iter().copied().collect();
-    user_ids.sort();
-    user_ids
 }
 
 #[cfg(test)]

--- a/operations/src/auth.rs
+++ b/operations/src/auth.rs
@@ -33,6 +33,12 @@ pub trait ArunaBearerTokenValidationState: Sync {
     ) -> Result<bool, ArunaBearerTokenError>;
     async fn is_trusted_realm(&self, realm_id: &RealmId) -> bool;
 
+    /// The wall clock claim validation judges against, injectable so a test can
+    /// decide expiry and issuance skew without waiting on real time.
+    fn now_secs(&self) -> u64 {
+        unix_timestamp_secs()
+    }
+
     async fn issuer_decoding_key(
         &self,
         issuer_pubkey: &str,
@@ -186,7 +192,7 @@ pub async fn validate_aruna_bearer_token_claims<S>(
 where
     S: ArunaBearerTokenValidationState + ?Sized,
 {
-    let now = chrono::Utc::now().timestamp() as u64;
+    let now = state.now_secs();
     if now > claims.exp {
         return Err(ArunaBearerTokenError::Expired);
     }
@@ -407,8 +413,13 @@ mod tests {
         ));
     }
 
-    #[derive(Default)]
-    struct SkewState;
+    /// Judges claims against a fixed instant, so lifetime and skew bounds are
+    /// decided by the fixture rather than by when the test happens to run.
+    struct SkewState {
+        now: u64,
+    }
+
+    const FIXED_NOW: u64 = 1_800_000_000;
 
     #[async_trait]
     impl ArunaBearerTokenValidationState for SkewState {
@@ -422,6 +433,10 @@ mod tests {
 
         async fn is_trusted_realm(&self, _realm_id: &RealmId) -> bool {
             true
+        }
+
+        fn now_secs(&self) -> u64 {
+            self.now
         }
     }
 
@@ -442,29 +457,41 @@ mod tests {
     async fn rejects_aged_token() {
         // An overlong token must stay rejected as it ages: the bound is the
         // signed lifetime, not the validity still remaining.
-        let now = unix_timestamp_secs();
+        let state = SkewState { now: FIXED_NOW };
         let max = aruna_core::auth::MAX_BEARER_TOKEN_LIFETIME_SECS;
-        let claims = lifetime_claims(now - max, now + 600);
+        let claims = lifetime_claims(FIXED_NOW - max, FIXED_NOW + 600);
 
         assert!(matches!(
-            validate_aruna_bearer_token_claims(&SkewState, &claims).await,
+            validate_aruna_bearer_token_claims(&state, &claims).await,
             Err(ArunaBearerTokenError::LifetimeTooLong)
         ));
         // A token signed within the bound still validates.
-        validate_aruna_bearer_token_claims(&SkewState, &lifetime_claims(now, now + 600))
+        validate_aruna_bearer_token_claims(&state, &lifetime_claims(FIXED_NOW, FIXED_NOW + 600))
             .await
             .unwrap();
     }
 
     #[tokio::test]
     async fn rejects_future_issuance() {
-        let now = unix_timestamp_secs();
-        let skewed = now + aruna_core::auth::REVOCATION_GRACE_SECS + 60;
+        let state = SkewState { now: FIXED_NOW };
+        let skewed = FIXED_NOW + aruna_core::auth::REVOCATION_GRACE_SECS + 60;
 
         assert!(matches!(
-            validate_aruna_bearer_token_claims(&SkewState, &lifetime_claims(skewed, skewed + 600))
+            validate_aruna_bearer_token_claims(&state, &lifetime_claims(skewed, skewed + 600))
                 .await,
             Err(ArunaBearerTokenError::LifetimeTooLong)
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_expired_claims() {
+        // Expiry is decided by the injected clock, not by real time passing.
+        let state = SkewState { now: FIXED_NOW };
+        let claims = lifetime_claims(FIXED_NOW - 1200, FIXED_NOW - 600);
+
+        assert!(matches!(
+            validate_aruna_bearer_token_claims(&state, &claims).await,
+            Err(ArunaBearerTokenError::Expired)
         ));
     }
 

--- a/operations/src/blob_holders.rs
+++ b/operations/src/blob_holders.rs
@@ -175,7 +175,9 @@ impl Operation for RefreshBlobHoldersOperation {
                 }
                 other => self.unexpected("blob holder timer result", other),
             },
-            RefreshState::Init | RefreshState::Finish | RefreshState::Error => smallvec![],
+            RefreshState::Init | RefreshState::Finish | RefreshState::Error => {
+                self.unexpected("no event in a terminal state", event)
+            }
         }
     }
 
@@ -290,7 +292,9 @@ impl Operation for GetBlobHoldersOperation {
                 Event::Net(NetEvent::Dht(DhtEvent::Error { error })) => self.fail(error.into()),
                 other => self.unexpected("DHT get result", other),
             },
-            GetState::Init | GetState::Finish | GetState::Error => smallvec![],
+            GetState::Init | GetState::Finish | GetState::Error => {
+                self.unexpected("no event in a terminal state", event)
+            }
         }
     }
 
@@ -475,5 +479,37 @@ mod tests {
         })));
 
         assert_eq!(operation.finalize(), Ok(vec![other]));
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let mut refresh =
+            RefreshBlobHoldersOperation::new(realm_id, node(2), RoCrateLimits::default());
+
+        let effects = refresh.step(Event::Net(NetEvent::Dht(DhtEvent::PutComplete {
+            key: DhtKeyId::from_bytes([1; 32]),
+            remote_attempt_count: 1,
+            remote_store_count: 1,
+        })));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            refresh.finalize(),
+            Err(RefreshBlobHoldersError::UnexpectedEvent { .. })
+        ));
+
+        let mut get = GetBlobHoldersOperation::new([4; 32], realm_id, node(9));
+
+        let effects = get.step(Event::Net(NetEvent::Dht(DhtEvent::Error {
+            error: DhtError::Other("offline".to_string()),
+        })));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            get.finalize(),
+            Err(GetBlobHoldersError::UnexpectedEvent { .. })
+        ));
     }
 }

--- a/operations/src/connectors/repository.rs
+++ b/operations/src/connectors/repository.rs
@@ -147,7 +147,9 @@ pub fn parse_connector_iter(
             Ok((records, next_start_after))
         }
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::ReadError)),
+        _ => Err(StorageReadError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 
@@ -168,7 +170,9 @@ pub fn parse_blob_version_iter(
             Ok((records, next_start_after))
         }
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::ReadError)),
+        _ => Err(StorageReadError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 
@@ -188,7 +192,9 @@ pub(crate) fn parse_storage_read<T>(
             .map(|bytes| parse(bytes.as_ref()).map_err(StorageReadError::Conversion))
             .transpose(),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::ReadError)),
+        _ => Err(StorageReadError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -26,7 +26,7 @@ use byteview::ByteView;
 use smallvec::smallvec;
 use std::collections::HashSet;
 use thiserror::Error;
-use tracing::trace;
+use tracing::{trace, warn};
 use ulid::Ulid;
 
 use crate::placement::placement_ref_for_target;
@@ -536,7 +536,12 @@ impl CreateGroupOperation {
     fn handle_schedule_document_sync_outbox_drain(&mut self, event: Event) -> Effects {
         match event {
             Event::Task(TaskEvent::TimerScheduled { .. }) => self.finish_after_outbox_schedule(),
-            Event::Task(TaskEvent::Error { .. }) => self.finish_after_outbox_schedule(),
+            // The group is committed either way; the outbox drains on its next
+            // wake, so a scheduling failure only delays replication.
+            Event::Task(TaskEvent::Error { message, .. }) => {
+                warn!(%message, "Group document outbox drain was not scheduled");
+                self.finish_after_outbox_schedule()
+            }
             other => self.unexpected_event(
                 CreateGroupState::ScheduleDocumentSyncOutboxDrain,
                 "Event::Task(TaskEvent::TimerScheduled)",

--- a/operations/src/create_group.rs
+++ b/operations/src/create_group.rs
@@ -21,10 +21,9 @@ use aruna_core::structs::{
     group_owner_index_key, group_owner_index_prefix,
 };
 use aruna_core::task::TaskEvent;
-use aruna_core::types::{Effects, Key, UserId, Value};
+use aruna_core::types::{Effects, Key, Value};
 use byteview::ByteView;
 use smallvec::smallvec;
-use std::collections::HashSet;
 use thiserror::Error;
 use tracing::{trace, warn};
 use ulid::Ulid;
@@ -225,7 +224,7 @@ impl CreateGroupOperation {
             .iter()
             .find(|role| role.name == "admin")
             .ok_or(CreateGroupError::AdminRoleNotFound)?;
-        for user_id in sorted_user_ids(&admin_role.assigned_users) {
+        for user_id in crate::sorted_user_ids(&admin_role.assigned_users) {
             admin_events.push(reducer_state.apply_operation(
                 &self.config.actor,
                 AdminDocumentOperation::GroupRoleUserAssignmentAdded {
@@ -559,12 +558,6 @@ fn sorted_roles(auth_doc: &GroupAuthorizationDocument) -> Vec<&Role> {
             .then_with(|| left.role_id.cmp(&right.role_id))
     });
     roles
-}
-
-fn sorted_user_ids(user_ids: &HashSet<UserId>) -> Vec<UserId> {
-    let mut user_ids: Vec<_> = user_ids.iter().copied().collect();
-    user_ids.sort();
-    user_ids
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/operations/src/create_metadata_document.rs
+++ b/operations/src/create_metadata_document.rs
@@ -1923,7 +1923,7 @@ mod tests {
         assert_create_event_append(append.as_slice(), document_id, &actor);
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: aruna_core::errors::StorageError::WriteError,
+            error: aruna_core::errors::StorageError::WriteError("boom".to_string()),
         }));
         assert!(matches!(
             effects.as_slice(),
@@ -1933,7 +1933,7 @@ mod tests {
         assert_eq!(
             operation.finalize(),
             Err(CreateMetadataDocumentError::StorageError(
-                aruna_core::errors::StorageError::WriteError,
+                aruna_core::errors::StorageError::WriteError("boom".to_string()),
             ))
         );
     }

--- a/operations/src/create_realm.rs
+++ b/operations/src/create_realm.rs
@@ -15,7 +15,7 @@ use aruna_core::structs::{
     RealmAuthorizationDocument, RealmConfigDocument, RealmNodeKind, band_start,
     normalize_node_placement_input,
 };
-use aruna_core::structured_id::PlacementHandle;
+use aruna_core::structured_id::{FieldError, PlacementHandle};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, Value};
 use aruna_core::util::unix_timestamp_millis;
@@ -127,14 +127,15 @@ impl CreateRealmOperation {
         config_doc.placement_handle_ranges.push(creator_range);
         seed_placement_defaults(&mut config_doc);
         // The band's reserved first handle is the creator's JobControl handle.
+        let handle = PlacementHandle::new(creator_range.start)?;
+        let strategy_id = config_doc
+            .default_strategy_id
+            .ok_or(CreateRealmError::DefaultStrategyMissing)?;
         config_doc.placement_bindings.push(PlacementBinding {
-            handle: PlacementHandle::new(creator_range.start)
-                .expect("the first grantable handle is allocatable"),
+            handle,
             scope: PlacementScope::Realm(realm_id),
             document_class: DocumentClass::JobControl,
-            strategy_id: config_doc
-                .default_strategy_id
-                .expect("seed_default_placement sets a default strategy"),
+            strategy_id,
             allocator_range_id: Some(creator_range.range_id),
             allocated_by: Some(self.config.actor.node_id),
             allocated_at_ms: Some(unix_timestamp_millis()),
@@ -473,6 +474,10 @@ pub enum CreateRealmError {
     NodeLocationTooLong,
     #[error("No transaction found")]
     NoTransactionFound,
+    #[error(transparent)]
+    InvalidHandle(#[from] FieldError),
+    #[error("realm config seed produced no default placement strategy")]
+    DefaultStrategyMissing,
     #[error("creating realm did not finish")]
     NotFinished,
     #[error("Unexpected event in state {state:?}: expected {expected}, got {got}")]

--- a/operations/src/document_repository.rs
+++ b/operations/src/document_repository.rs
@@ -49,7 +49,7 @@ pub fn parse_document_bytes(event: Event) -> Result<Option<Vec<u8>>, StorageErro
             Ok(value.map(|bytes| bytes.to_vec()))
         }
         Event::Storage(StorageEvent::Error { error }) => Err(error),
-        _ => Err(StorageError::ReadError),
+        _ => Err(StorageError::ReadError("unexpected event".to_string())),
     }
 }
 
@@ -109,7 +109,7 @@ pub fn event_to_iter_values(event: Event) -> Result<Vec<(Key, ByteView)>, Storag
     match event {
         Event::Storage(StorageEvent::IterResult { values, .. }) => Ok(values),
         Event::Storage(StorageEvent::Error { error }) => Err(error),
-        _ => Err(StorageError::ReadError),
+        _ => Err(StorageError::ReadError("unexpected event".to_string())),
     }
 }
 

--- a/operations/src/driver.rs
+++ b/operations/src/driver.rs
@@ -2029,7 +2029,7 @@ mod test {
         let mut tracker = TransactionTracker::default();
         let started = Event::Storage(StorageEvent::TransactionStarted { txn_id: id });
         let failed = Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         });
         tracker.observe(Some(TransactionEffect::Start), &started);
         tracker.observe(Some(TransactionEffect::Abort(id)), &failed);

--- a/operations/src/driver.rs
+++ b/operations/src/driver.rs
@@ -750,7 +750,7 @@ impl TransactionTracker {
             (
                 Some(TransactionEffect::Commit(txn_id)),
                 Event::Storage(StorageEvent::Error {
-                    error: StorageError::QueueFull,
+                    error: StorageError::QueueFull | StorageError::CleanupCapacity,
                 }),
             ) => {
                 if self.states.contains_key(&txn_id) {
@@ -2020,6 +2020,20 @@ mod test {
         });
         tracker.observe(Some(TransactionEffect::Start), &started);
         tracker.observe(Some(TransactionEffect::Commit(id)), &queued);
+        assert_eq!(tracker.states.get(&id), Some(&TransactionState::Open));
+    }
+
+    #[test]
+    fn commit_capacity_kept() {
+        // Cleanup capacity proves no commit, so the transaction stays open, not uncertain.
+        let id = ulid::Ulid::generate();
+        let mut tracker = TransactionTracker::default();
+        let started = Event::Storage(StorageEvent::TransactionStarted { txn_id: id });
+        let exhausted = Event::Storage(StorageEvent::Error {
+            error: StorageError::CleanupCapacity,
+        });
+        tracker.observe(Some(TransactionEffect::Start), &started);
+        tracker.observe(Some(TransactionEffect::Commit(id)), &exhausted);
         assert_eq!(tracker.states.get(&id), Some(&TransactionState::Open));
     }
 

--- a/operations/src/get_group.rs
+++ b/operations/src/get_group.rs
@@ -275,7 +275,17 @@ impl Operation for GetGroupOperation {
             GetGroupState::GetGroup => self.handle_get_group(event),
             GetGroupState::GetAuthDoc => self.handle_get_auth_doc(event),
             GetGroupState::CommitTransaction => self.handle_commit_transaction(event),
-            GetGroupState::Init | GetGroupState::Finish | GetGroupState::Error => smallvec![],
+            // A terminal state owns no transaction to clean up, so this fails
+            // without the abort effects `unexpected_event` would emit.
+            GetGroupState::Init | GetGroupState::Finish | GetGroupState::Error => {
+                let got = format!("{event:?}");
+                let state = self.state;
+                self.fail(GetGroupError::UnexpectedEvent {
+                    state,
+                    expected: "no event",
+                    got,
+                })
+            }
         }
     }
 
@@ -361,5 +371,26 @@ mod test {
         assert_eq!(create_result.0, get_result.0);
 
         net_handle.shutdown().await;
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        use aruna_core::events::{Event, StorageEvent};
+        use aruna_core::operation::Operation;
+
+        let mut operation = GetGroupOperation::new(GetGroupConfig {
+            group_id: Ulid::from_bytes([1u8; 16]),
+        });
+
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted {
+            txn_id: Ulid::from_bytes([3u8; 16]),
+        }));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(crate::get_group::GetGroupError::UnexpectedEvent { .. })
+        ));
     }
 }

--- a/operations/src/group_backends/disable.rs
+++ b/operations/src/group_backends/disable.rs
@@ -201,7 +201,13 @@ impl Operation for SetDisabledOperation {
             DisableState::WriteRecord => self.handle_written(event),
             DisableState::CommitTransaction => self.handle_committed(event),
             DisableState::AbortTransaction => self.handle_aborted(event),
-            DisableState::Finish | DisableState::Error => smallvec![],
+            DisableState::Finish | DisableState::Error => {
+                self.fail(SetDisabledError::InvalidStateEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -397,6 +403,25 @@ mod tests {
             entries: Vec::new(),
         }));
 
+        assert!(matches!(
+            operation.finalize(),
+            Err(SetDisabledError::InvalidStateEvent { .. })
+        ));
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let group_id = Ulid::from_bytes([1u8; 16]);
+        let mut operation = SetDisabledOperation::new(group_id, backend_id(), true);
+        reading(&mut operation);
+        operation.step(read_result(record(group_id, false)));
+        written(&mut operation);
+        committed(&mut operation);
+
+        let effects = written(&mut operation);
+
+        assert!(effects.is_empty());
         assert!(matches!(
             operation.finalize(),
             Err(SetDisabledError::InvalidStateEvent { .. })

--- a/operations/src/group_backends/query.rs
+++ b/operations/src/group_backends/query.rs
@@ -44,6 +44,12 @@ impl GetGroupBackendOperation {
             output: None,
         }
     }
+
+    fn reject(&mut self) -> Effects {
+        self.state = QueryState::Error;
+        self.output = Some(Err(RecordReadError::Unexpected.into()));
+        smallvec![]
+    }
 }
 
 impl Operation for GetGroupBackendOperation {
@@ -75,7 +81,7 @@ impl Operation for GetGroupBackendOperation {
                 }
                 smallvec![]
             }
-            QueryState::Finish | QueryState::Error => smallvec![],
+            QueryState::Finish | QueryState::Error => self.reject(),
         }
     }
 
@@ -122,6 +128,12 @@ impl ListGroupBackendsOperation {
             txn_id: None,
         })
     }
+
+    fn reject(&mut self) -> Effects {
+        self.state = QueryState::Error;
+        self.output = Some(Err(RecordReadError::Unexpected.into()));
+        smallvec![]
+    }
 }
 
 impl Operation for ListGroupBackendsOperation {
@@ -156,7 +168,7 @@ impl Operation for ListGroupBackendsOperation {
                     smallvec![]
                 }
             },
-            QueryState::Finish | QueryState::Error => smallvec![],
+            QueryState::Finish | QueryState::Error => self.reject(),
         }
     }
 
@@ -176,8 +188,9 @@ impl Operation for ListGroupBackendsOperation {
 
 #[cfg(test)]
 mod tests {
+    use super::super::RecordReadError;
     use super::super::{index_key, index_prefix};
-    use super::{GetGroupBackendOperation, ListGroupBackendsOperation};
+    use super::{GetGroupBackendOperation, GroupBackendQueryError, ListGroupBackendsOperation};
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::GROUP_STORAGE_BACKEND_INDEX_KEYSPACE;
@@ -245,5 +258,38 @@ mod tests {
         }));
 
         assert_eq!(operation.finalize().unwrap(), vec![mine]);
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let stray = || {
+            Event::Storage(StorageEvent::ReadResult {
+                key: b"x".to_vec().into(),
+                value: None,
+            })
+        };
+
+        let mut get = GetGroupBackendOperation::new(Ulid::from_bytes([9u8; 16]));
+        get.start();
+        get.step(stray());
+        get.step(stray());
+        assert!(matches!(
+            get.finalize(),
+            Err(GroupBackendQueryError::Read(RecordReadError::Unexpected))
+        ));
+
+        let group_id = Ulid::from_bytes([1u8; 16]);
+        let mut list = ListGroupBackendsOperation::new(group_id);
+        list.start();
+        list.step(Event::Storage(StorageEvent::IterResult {
+            values: Vec::new(),
+            next_start_after: None,
+        }));
+        list.step(stray());
+        assert!(matches!(
+            list.finalize(),
+            Err(GroupBackendQueryError::Read(RecordReadError::Unexpected))
+        ));
     }
 }

--- a/operations/src/group_backends/remove.rs
+++ b/operations/src/group_backends/remove.rs
@@ -374,7 +374,13 @@ impl Operation for RemoveBackendOperation {
             RemoveState::DeleteRecords => self.handle_deleted(event),
             RemoveState::CommitTransaction => self.handle_committed(event),
             RemoveState::AbortTransaction => self.handle_aborted(event),
-            RemoveState::Finish | RemoveState::Error => smallvec![],
+            RemoveState::Finish | RemoveState::Error => {
+                self.fail(RemoveBackendError::InvalidStateEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -647,5 +653,33 @@ mod tests {
             txn_id: Ulid::from_bytes([9u8; 16]),
         }));
         assert_eq!(operation.finalize(), Err(RemoveBackendError::NotRemovable));
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let backend_id = Ulid::from_bytes([8u8; 16]);
+        let mut operation = RemoveBackendOperation::new(Ulid::from_bytes([1u8; 16]), backend_id);
+        operation.start();
+        operation.step(Event::Storage(StorageEvent::TransactionStarted {
+            txn_id: Ulid::from_bytes([9u8; 16]),
+        }));
+        operation.step(Event::Storage(StorageEvent::ReadResult {
+            key: b"x".to_vec().into(),
+            value: Some(record(backend_id, false).to_bytes().unwrap().into()),
+        }));
+        operation.step(Event::Storage(StorageEvent::TransactionAborted {
+            txn_id: Ulid::from_bytes([9u8; 16]),
+        }));
+
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionAborted {
+            txn_id: Ulid::from_bytes([9u8; 16]),
+        }));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(RemoveBackendError::InvalidStateEvent { .. })
+        ));
     }
 }

--- a/operations/src/group_backends/replace.rs
+++ b/operations/src/group_backends/replace.rs
@@ -271,7 +271,13 @@ impl Operation for ReplaceGroupBackendOperation {
             ReplaceState::WriteRecords => self.handle_written(event),
             ReplaceState::CommitTransaction => self.handle_committed(event),
             ReplaceState::AbortTransaction => self.handle_aborted(event),
-            ReplaceState::Finish | ReplaceState::Error => smallvec![],
+            ReplaceState::Finish | ReplaceState::Error => {
+                self.fail(CreateGroupBackendError::InvalidStateEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -489,6 +495,32 @@ mod tests {
         assert!(matches!(
             operation.finalize(),
             Err(CreateGroupBackendError::NotFound)
+        ));
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let backend_id = Ulid::from_bytes([9u8; 16]);
+        let mut operation =
+            ReplaceGroupBackendOperation::new(backend_id, input(Ulid::from_bytes([1u8; 16])));
+        operation.start();
+        operation.step(Event::Storage(StorageEvent::ReadResult {
+            key: b"x".to_vec().into(),
+            value: Some(
+                existing(Ulid::from_bytes([2u8; 16]), backend_id)
+                    .to_bytes()
+                    .unwrap()
+                    .into(),
+            ),
+        }));
+
+        let effects = operation.step(Event::Blob(BlobEvent::GroupBackendChecked));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(CreateGroupBackendError::InvalidStateEvent { .. })
         ));
     }
 }

--- a/operations/src/group_routing.rs
+++ b/operations/src/group_routing.rs
@@ -123,7 +123,9 @@ impl Operation for GroupRoutingInputsOperation {
                     Err(error) => self.fail(error.into()),
                 }
             }
-            LoadInputsState::Finish | LoadInputsState::Error => smallvec![],
+            LoadInputsState::Finish | LoadInputsState::Error => {
+                self.fail(RecordReadError::Unexpected.into())
+            }
         }
     }
 
@@ -274,7 +276,13 @@ impl Operation for PutGroupRoutingOperation {
                 self.output = Some(Ok(self.record.clone()));
                 smallvec![]
             }
-            PutGroupRoutingState::Finish | PutGroupRoutingState::Error => smallvec![],
+            PutGroupRoutingState::Finish | PutGroupRoutingState::Error => {
+                self.fail(PutGroupRoutingError::InvalidStateEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -381,7 +389,13 @@ impl Operation for GetGroupRoutingOperation {
                 self.output = Some(Ok(record));
                 smallvec![]
             }
-            GetGroupRoutingState::Finish | GetGroupRoutingState::Error => smallvec![],
+            GetGroupRoutingState::Finish | GetGroupRoutingState::Error => {
+                self.fail(GetGroupRoutingError::InvalidStateEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -409,8 +423,9 @@ impl Operation for GetGroupRoutingOperation {
 #[cfg(test)]
 mod tests {
     use super::{
-        GetGroupRoutingOperation, GroupRoutingInputsOperation, PutGroupRoutingError,
-        PutGroupRoutingOperation, routing_key,
+        GetGroupRoutingError, GetGroupRoutingOperation, GroupRoutingInputsError,
+        GroupRoutingInputsOperation, PutGroupRoutingError, PutGroupRoutingOperation,
+        RecordReadError, routing_key,
     };
     use crate::group_backends::{index_key, index_prefix};
     use aruna_core::effects::{Effect, StorageEffect};
@@ -645,5 +660,59 @@ mod tests {
         }));
 
         assert_eq!(operation.finalize().unwrap(), Some(Ok(Some(stored))));
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let stray = || {
+            Event::Storage(StorageEvent::DeleteResult {
+                key: routing_key(group()),
+            })
+        };
+
+        let mut inputs = GroupRoutingInputsOperation::new(group());
+        inputs.start();
+        inputs.step(Event::Storage(StorageEvent::ReadResult {
+            key: routing_key(group()),
+            value: None,
+        }));
+        inputs.step(Event::Storage(StorageEvent::IterResult {
+            values: Vec::new(),
+            next_start_after: None,
+        }));
+        inputs.step(stray());
+        assert!(matches!(
+            inputs.finalize(),
+            Err(GroupRoutingInputsError::Read(RecordReadError::Unexpected))
+        ));
+
+        let mut put = PutGroupRoutingOperation::new(
+            group(),
+            None,
+            aruna_core::UserId::default(),
+            SystemTime::UNIX_EPOCH,
+        );
+        loaded(&mut put, BTreeSet::new());
+        put.step(Event::Storage(StorageEvent::WriteResult {
+            key: routing_key(group()),
+        }));
+        put.step(stray());
+        assert!(matches!(
+            put.finalize(),
+            Err(PutGroupRoutingError::InvalidStateEvent { .. })
+        ));
+
+        let mut get = GetGroupRoutingOperation::new(group());
+        get.start();
+        get.step(Event::Storage(StorageEvent::ReadResult {
+            key: routing_key(group()),
+            value: None,
+        }));
+        get.step(stray());
+        assert!(matches!(
+            get.finalize(),
+            Err(GetGroupRoutingError::InvalidStateEvent { .. })
+        ));
     }
 }

--- a/operations/src/jobs/harvest.rs
+++ b/operations/src/jobs/harvest.rs
@@ -15,6 +15,7 @@ use aruna_core::structs::{
 use aruna_core::structured_id::StructuredId;
 use aruna_core::types::GroupId;
 use byteview::ByteView;
+use tracing::warn;
 use ulid::Ulid;
 
 use crate::create_metadata_document::{
@@ -133,6 +134,7 @@ async fn harvest(ctx: &JobContext, spec: &HarvestJobSpec) -> Result<HarvestCount
     // One restart per run at most: a provider that keeps rejecting its own
     // tokens must not be able to loop the listing back to the start forever.
     let mut restarted = false;
+    let mut warned_datestamp = false;
     let mut seen_tokens: HashSet<[u8; 32]> = HashSet::new();
     let started = tokio::time::Instant::now();
 
@@ -177,7 +179,19 @@ async fn harvest(ctx: &JobContext, spec: &HarvestJobSpec) -> Result<HarvestCount
 
         for record in &page.records {
             check_signals(ctx)?;
-            let datestamp_ms = parse_datestamp_ms(&record.header.datestamp).unwrap_or(0);
+            // An unparseable datestamp harvests as epoch zero; one warning per
+            // run names the offending value without flooding a large listing.
+            let datestamp_ms = parse_datestamp_ms(&record.header.datestamp).unwrap_or_else(|| {
+                if !warned_datestamp {
+                    warned_datestamp = true;
+                    warn!(
+                        datestamp = %record.header.datestamp,
+                        identifier = %record.header.identifier,
+                        "Unparseable OAI datestamp; harvesting the record as epoch zero"
+                    );
+                }
+                0
+            });
             overall_max = overall_max.max(datestamp_ms);
             apply_record(
                 ctx,

--- a/operations/src/jobs/import/upload.rs
+++ b/operations/src/jobs/import/upload.rs
@@ -767,7 +767,7 @@ mod tests {
         ));
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         assert!(matches!(
             effects.as_slice(),
@@ -789,7 +789,9 @@ mod tests {
         );
         assert_eq!(
             operation.finalize(),
-            Err(CreateRoCrateUploadError::Storage(StorageError::WriteError))
+            Err(CreateRoCrateUploadError::Storage(StorageError::WriteError(
+                "boom".to_string()
+            )))
         );
     }
 
@@ -803,7 +805,7 @@ mod tests {
             size: 7,
         }));
         let mut effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         for attempt in 0..3 {
             if attempt < 2 {
@@ -813,7 +815,7 @@ mod tests {
                 ));
             }
             effects = operation.step(Event::Storage(StorageEvent::Error {
-                error: StorageError::WriteError,
+                error: StorageError::WriteError("boom".to_string()),
             }));
         }
         let [
@@ -860,7 +862,9 @@ mod tests {
         );
         assert_eq!(
             operation.finalize(),
-            Err(CreateRoCrateUploadError::Storage(StorageError::WriteError))
+            Err(CreateRoCrateUploadError::Storage(StorageError::WriteError(
+                "boom".to_string()
+            )))
         );
     }
 
@@ -875,7 +879,7 @@ mod tests {
             size: 7,
         }));
         operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         operation.step(Event::Storage(StorageEvent::DeleteResult {
             key: upload_key(Ulid::from_bytes([2u8; 16])),
@@ -945,14 +949,14 @@ mod tests {
             assert!(matches!(
                 operation
                     .step(Event::Storage(StorageEvent::Error {
-                        error: StorageError::WriteError,
+                        error: StorageError::WriteError("boom".to_string()),
                     }))
                     .as_slice(),
                 [Effect::Storage(StorageEffect::Write { .. })]
             ));
         }
         let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
 
         assert!(matches!(
@@ -989,7 +993,7 @@ mod tests {
             size: 7,
         }));
         operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         assert!(matches!(
             operation.abort().as_slice(),

--- a/operations/src/jobs/lifecycle/admit.rs
+++ b/operations/src/jobs/lifecycle/admit.rs
@@ -467,7 +467,9 @@ impl Operation for AdmitSubmissionOperation {
                 Event::Storage(StorageEvent::Error { error }) => self.fail(error.into()),
                 other => self.unexpected("transaction abort", format!("{other:?}")),
             },
-            AdmitState::Init | AdmitState::Finish | AdmitState::Error => smallvec![],
+            AdmitState::Init | AdmitState::Finish | AdmitState::Error => {
+                self.unexpected("no event", format!("{event:?}"))
+            }
         }
     }
 
@@ -521,4 +523,46 @@ fn logical_record(spec: &LogicalJobSpec) -> JobRecord {
         WorkspaceMode::None => None,
     };
     record
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jobs::records::tests::fixture::{Family, REALM};
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let family = Family::new([1u8; 32]);
+        let spec = family.spec();
+        let job_id = spec.job_id;
+        let claim = family.claim(&spec);
+        let sign = |record| {
+            JobRecordFrame::new(family.sign(&family.holder, record)).expect("bounded record")
+        };
+        let mut operation = AdmitSubmissionOperation::new(AdmitSubmissionConfig {
+            realm_id: REALM,
+            local_node_id: family.holder.public(),
+            submission_id: family.submission_id,
+            request_digest: family.request_digest,
+            candidate: Box::new(AdmissionCandidate {
+                job_id,
+                spec: sign(JobFamilyRecord::Spec(Box::new(spec))),
+                claim: sign(JobFamilyRecord::Claim(claim)),
+            }),
+            now_ms: 3_000,
+            quota_refusal: None,
+            quota_revision: None,
+        });
+
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionCommitted {
+            txn_id: TxnId::generate(),
+        }));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(LifecycleError::UnexpectedEvent { .. })
+        ));
+    }
 }

--- a/operations/src/jobs/lifecycle/tests/uncertain_commit.rs
+++ b/operations/src/jobs/lifecycle/tests/uncertain_commit.rs
@@ -345,9 +345,18 @@ fn uncertain_never_drains() {
         (StorageError::TransactionConflict, CommitVerdict::Raced),
         (StorageError::CommitFailed, CommitVerdict::Uncertain),
         (StorageError::TransactionNotFound, CommitVerdict::Uncertain),
-        (StorageError::KeyspaceError, CommitVerdict::Uncertain),
-        (StorageError::ReadError, CommitVerdict::Uncertain),
-        (StorageError::WriteError, CommitVerdict::Uncertain),
+        (
+            StorageError::KeyspaceError("x".to_string()),
+            CommitVerdict::Uncertain,
+        ),
+        (
+            StorageError::ReadError("x".to_string()),
+            CommitVerdict::Uncertain,
+        ),
+        (
+            StorageError::WriteError("x".to_string()),
+            CommitVerdict::Uncertain,
+        ),
         (StorageError::DeleteError, CommitVerdict::Uncertain),
         (
             StorageError::PersistError("x".to_string()),

--- a/operations/src/jobs/lifecycle/tests/uncertain_commit.rs
+++ b/operations/src/jobs/lifecycle/tests/uncertain_commit.rs
@@ -345,6 +345,7 @@ fn uncertain_never_drains() {
         (StorageError::TransactionConflict, CommitVerdict::Raced),
         (StorageError::CommitFailed, CommitVerdict::Uncertain),
         (StorageError::TransactionNotFound, CommitVerdict::Uncertain),
+        (StorageError::CleanupCapacity, CommitVerdict::Retry),
         (
             StorageError::KeyspaceError("x".to_string()),
             CommitVerdict::Uncertain,

--- a/operations/src/jobs/lifecycle/witness.rs
+++ b/operations/src/jobs/lifecycle/witness.rs
@@ -122,17 +122,27 @@ fn jitter_ms(family: &JobFamilyId, node: NodeId, base_delay_ms: u64) -> u64 {
 /// deadline is kept, so re-arming can only ever bring a round forward.
 pub async fn arm_family(context: &DriverContext, family: JobFamilyId, now_ms: u64) {
     let Some(net) = context.net_handle.as_ref() else {
+        debug!(?family, "No net handle; witness fallback not armed");
         return;
     };
     let realm_id = *net.realm_id();
     let local = net.node_id();
     let Some(config) = load_realm_config(context, realm_id).await else {
+        warn!(
+            ?family,
+            "Realm config unavailable; witness fallback not armed"
+        );
         return;
     };
     let Some(view) = FamilyView::resolve(&config, realm_id, family) else {
+        warn!(
+            ?family,
+            "Family placement unresolved; witness fallback not armed"
+        );
         return;
     };
     let Some(rank) = witness_rank(view.holders(), &family, local) else {
+        debug!(?family, "Node is not a witness for this family");
         return;
     };
     let base = config.compute.witness_base_delay_ms;
@@ -142,7 +152,10 @@ pub async fn arm_family(context: &DriverContext, family: JobFamilyId, now_ms: u6
     };
     let existing = match read_deadline_index(context, &family).await {
         Ok(existing) => existing,
-        Err(_) => return,
+        Err(error) => {
+            warn!(?family, error = %error, "Witness deadline read failed");
+            return;
+        }
     };
     if existing
         .as_ref()

--- a/operations/src/jobs/records/tests/evidence.rs
+++ b/operations/src/jobs/records/tests/evidence.rs
@@ -432,7 +432,7 @@ fn refuses_partial_scan() {
     ));
 
     effects.extend(operation.step(Event::Storage(StorageEvent::Error {
-        error: StorageError::ReadError,
+        error: StorageError::ReadError("boom".to_string()),
     })));
     assert!(operation.is_complete());
     assert!(
@@ -442,6 +442,8 @@ fn refuses_partial_scan() {
     );
     assert_eq!(
         operation.finalize(),
-        Err(RecordStoreError::Storage(StorageError::ReadError))
+        Err(RecordStoreError::Storage(StorageError::ReadError(
+            "boom".to_string()
+        )))
     );
 }

--- a/operations/src/jobs/service.rs
+++ b/operations/src/jobs/service.rs
@@ -674,6 +674,7 @@ async fn joined_pid_job(
         }
         Err(AuthorizeError::PermissionDenied | AuthorizeError::Policy(_)) => Ok(None),
         Err(AuthorizeError::CheckFailed(error)) => Err(error),
+        Err(AuthorizeError::Storage(error)) => Err(error.to_string()),
     }
 }
 

--- a/operations/src/jobs/staging.rs
+++ b/operations/src/jobs/staging.rs
@@ -131,7 +131,9 @@ pub async fn run_staging_job(ctx: &JobContext, spec: &StagingJobSpec) -> JobRunO
                     checkpoint.phase = match spec.strategy {
                         StagingStrategy::Reference => StagingJobPhase::Registering,
                         StagingStrategy::Snapshot => StagingJobPhase::Writing,
-                        StagingStrategy::Sync => unreachable!(),
+                        StagingStrategy::Sync => {
+                            return permanent_error("sync is not a staging job strategy");
+                        }
                     };
                 }
                 Err(ItemFailure::Denied(message) | ItemFailure::Stage(message)) => {

--- a/operations/src/jobs/store.rs
+++ b/operations/src/jobs/store.rs
@@ -4391,4 +4391,22 @@ mod tests {
             .unwrap();
         assert_eq!(stored.state, JobState::Running);
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn capacity_not_conflict() {
+        // Cleanup-capacity exhaustion must fail fast, never feed the OCC retry.
+        let (storage, receivers) = StorageHandle::new();
+        let receiver = receivers.foreground;
+        let actor = std::thread::spawn(move || {
+            let (_effect, response_tx, ..) = receiver.recv().expect("commit effect arrives");
+            assert!(response_tx.send(StorageEvent::Error {
+                error: StorageError::CleanupCapacity,
+            }));
+        });
+
+        let result = commit_txn(&storage, Ulid::generate()).await;
+        actor.join().expect("storage actor finishes");
+
+        assert!(matches!(result, CommitResult::Failed(_)));
+    }
 }

--- a/operations/src/jobs/submit.rs
+++ b/operations/src/jobs/submit.rs
@@ -419,7 +419,9 @@ impl Operation for SubmitJobOperation {
                     self.finish_created()
                 }
             },
-            SubmitState::Finish | SubmitState::Error => smallvec![],
+            SubmitState::Finish | SubmitState::Error => {
+                self.fail(SubmitJobError::UnexpectedEvent(format!("{event:?}")))
+            }
         }
     }
 
@@ -980,5 +982,25 @@ mod tests {
             .unwrap();
         assert!(second.created);
         assert_ne!(second.job_id, first.job_id);
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let mut operation = operation(spec(None));
+        operation.start();
+        operation.step(Event::Storage(StorageEvent::TransactionCommitted {
+            txn_id: TxnId::generate(),
+        }));
+
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionAborted {
+            txn_id: TxnId::generate(),
+        }));
+
+        assert!(effects.is_empty());
+        let Err(SubmitJobError::UnexpectedEvent(got)) = operation.finalize() else {
+            panic!("a terminal state must reject a stray event");
+        };
+        assert!(got.contains("TransactionAborted"), "{got}");
     }
 }

--- a/operations/src/jobs/workflow/mod.rs
+++ b/operations/src/jobs/workflow/mod.rs
@@ -1378,16 +1378,12 @@ async fn finalize_cancel(
                     .await;
                     Box::pin(cleanup_and_crate(context, job_id, record)).await;
                 }
+                // Infrastructure evidence is no verdict on the job, so a confirmed
+                // stop terminalizes as the requested cancellation, never as Failed.
                 AttemptPhase::SystemError { reason } => {
+                    warn!(job_id = %job_id, %reason, "Cancelled attempt lost backend evidence");
                     let result = execution_result_for(bucket, None, Vec::new(), logs);
-                    let record = Box::pin(terminal_fail(
-                        storage,
-                        job_id,
-                        token,
-                        JobError::retryable(format!("backend infrastructure failure: {reason}")),
-                        result,
-                    ))
-                    .await;
+                    let record = Box::pin(terminal_cancel(storage, job_id, token, result)).await;
                     Box::pin(cleanup_and_crate(context, job_id, record)).await;
                 }
                 AttemptPhase::Cancelled | AttemptPhase::Submitted | AttemptPhase::Running => {
@@ -1954,6 +1950,7 @@ mod tests {
         logs_started: Notify,
         logs_release: Notify,
         logs_fail: AtomicBool,
+        cancel_lost: AtomicBool,
         cancels: AtomicUsize,
     }
 
@@ -1965,6 +1962,7 @@ mod tests {
                 logs_started: Notify::new(),
                 logs_release: Notify::new(),
                 logs_fail: AtomicBool::new(false),
+                cancel_lost: AtomicBool::new(false),
                 cancels: AtomicUsize::new(0),
             })
         }
@@ -2026,6 +2024,16 @@ mod tests {
         }
         async fn cancel(&self, _context: &FenceContext) -> Result<CancelEvidence, BackendError> {
             self.cancels.fetch_add(1, Ordering::Relaxed);
+            if self.cancel_lost.load(Ordering::Relaxed) {
+                return Ok(CancelEvidence::Stopped(AttemptStatus {
+                    phase: AttemptPhase::SystemError {
+                        reason: "node evicted".to_string(),
+                    },
+                    backend_ref: "c1".to_string(),
+                    started_at_ms: Some(1),
+                    finished_at_ms: Some(2),
+                }));
+            }
             Ok(CancelEvidence::AlreadyGone)
         }
         async fn fetch_logs(
@@ -2360,6 +2368,43 @@ mod tests {
             stored.last_error.as_ref().map(|error| error.kind),
             Some(JobErrorKind::Retryable)
         );
+    }
+
+    // A stopped cancellation whose only evidence is infrastructure must terminalize
+    // as Cancelled: a Failed row would read as a job-specific verdict.
+    #[tokio::test]
+    async fn cancel_lost_evidence() {
+        let dir = tempdir().unwrap();
+        let storage = FjallStorage::open(dir.path().to_str().unwrap()).unwrap();
+        let mut ctx = context(storage.clone());
+        Arc::get_mut(&mut ctx).unwrap().task_handle = None;
+        let (record, token, attempt) = ready_with_intent(&storage).await;
+        let job_id = record.job_id;
+        transition_external_to_running(&storage, job_id, token, Some(1), 6)
+            .await
+            .unwrap();
+        let stub = StubBackend::new(StubReconcile::NotFound);
+        stub.cancel_lost.store(true, Ordering::Relaxed);
+        stub.logs_release.notify_one();
+        let backend: Arc<dyn ExecutorBackend> = stub;
+
+        Box::pin(finalize_cancel(
+            &ctx,
+            job_id,
+            token,
+            &backend,
+            &fence(&attempt),
+            &execution_spec(),
+            "ws-test",
+        ))
+        .await;
+
+        let stored = read_job_record(&storage, job_id, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.state, JobState::Cancelled);
+        assert!(stored.finished_at_ms.is_some());
     }
 
     // A capture failing retryably on every pass must terminalize at the attempt cap.

--- a/operations/src/jobs/workflow/purge.rs
+++ b/operations/src/jobs/workflow/purge.rs
@@ -310,6 +310,7 @@ async fn authorize_object(
             JobError::permanent(format!("purge object authorization failed: {error}"))
         }
         AuthorizeError::CheckFailed(_)
+        | AuthorizeError::Storage(_)
         | AuthorizeError::Policy(PolicyEnforcementError::Unavailable(_)) => {
             JobError::retryable(format!("purge object authorization failed: {error}"))
         }

--- a/operations/src/jobs/workflow/workspace.rs
+++ b/operations/src/jobs/workflow/workspace.rs
@@ -1369,6 +1369,7 @@ fn storage_retryable(error: &StorageError) -> bool {
     matches!(
         error,
         StorageError::TransactionConflict
+            | StorageError::CleanupCapacity
             | StorageError::ReadError(_)
             | StorageError::WriteError(_)
             | StorageError::DeleteError
@@ -1675,6 +1676,9 @@ mod tests {
             StorageError::WriteError("io".to_string()),
             StorageError::DeleteError,
             StorageError::TransactionConflict,
+            // Capacity conditions prove no commit, so they stay infrastructure errors.
+            StorageError::CleanupCapacity,
+            StorageError::QueueFull,
         ] {
             assert!(storage_retryable(&error));
         }

--- a/operations/src/jobs/workflow/workspace.rs
+++ b/operations/src/jobs/workflow/workspace.rs
@@ -1369,8 +1369,8 @@ fn storage_retryable(error: &StorageError) -> bool {
     matches!(
         error,
         StorageError::TransactionConflict
-            | StorageError::ReadError
-            | StorageError::WriteError
+            | StorageError::ReadError(_)
+            | StorageError::WriteError(_)
             | StorageError::DeleteError
             | StorageError::PersistError(_)
             | StorageError::ChannelClosed
@@ -1663,6 +1663,27 @@ mod tests {
                 map(GetObjectError::ReferenceAdvanceExhausted).kind,
                 JobErrorKind::Permanent
             );
+        }
+    }
+
+    // Transient fjall faults now carry their source; classification must key on
+    // the variant, not on the payload.
+    #[test]
+    fn classifies_storage_retries() {
+        for error in [
+            StorageError::ReadError("io".to_string()),
+            StorageError::WriteError("io".to_string()),
+            StorageError::DeleteError,
+            StorageError::TransactionConflict,
+        ] {
+            assert!(storage_retryable(&error));
+        }
+
+        for error in [
+            StorageError::KeyspaceError("missing".to_string()),
+            StorageError::KeyNotFound,
+        ] {
+            assert!(!storage_retryable(&error));
         }
     }
 

--- a/operations/src/lib.rs
+++ b/operations/src/lib.rs
@@ -100,3 +100,12 @@ pub mod update_metadata_document;
 pub mod update_user;
 pub mod usage_stats;
 pub mod user_subject_index;
+
+/// Deterministic member order for records that several nodes must byte-match.
+pub(crate) fn sorted_user_ids(
+    user_ids: &std::collections::HashSet<aruna_core::types::UserId>,
+) -> Vec<aruna_core::types::UserId> {
+    let mut user_ids: Vec<_> = user_ids.iter().copied().collect();
+    user_ids.sort();
+    user_ids
+}

--- a/operations/src/list_users.rs
+++ b/operations/src/list_users.rs
@@ -217,7 +217,10 @@ impl Operation for ListUsersOperation {
         match self.state {
             ListUsersState::Auth => self.handle_auth_result(event),
             ListUsersState::ListUsers => self.handle_list_users(event),
-            ListUsersState::Init | ListUsersState::Finish | ListUsersState::Error => smallvec![],
+            ListUsersState::Init | ListUsersState::Finish | ListUsersState::Error => {
+                let got = format!("{event:?}");
+                self.unexpected_event("no event in a terminal state", got)
+            }
         }
     }
 
@@ -236,7 +239,7 @@ impl Operation for ListUsersOperation {
 
 #[cfg(test)]
 mod tests {
-    use super::{ListUsersInput, ListUsersOperation, ListUsersOutput};
+    use super::{ListUsersError, ListUsersInput, ListUsersOperation, ListUsersOutput};
     use aruna_core::effects::{Effect, IterStart, StorageEffect};
     use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
     use aruna_core::operation::Operation;
@@ -400,5 +403,23 @@ mod tests {
 
         assert!(effects.is_empty());
         assert!(operation.finalize().is_err());
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let realm_id = RealmId::from_bytes([7u8; 32]);
+        let mut operation = ListUsersOperation::new(input(realm_id, 10, None));
+
+        let effects = operation.step(Event::Storage(StorageEvent::IterResult {
+            values: Vec::new(),
+            next_start_after: None,
+        }));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(ListUsersError::UnexpectedEvent { .. })
+        ));
     }
 }

--- a/operations/src/metadata/audit.rs
+++ b/operations/src/metadata/audit.rs
@@ -880,7 +880,9 @@ async fn authorize_admin(
         Err(AuthorizeError::PermissionDenied | AuthorizeError::Policy(_)) => {
             Err(MetadataReadError::Forbidden)
         }
-        Err(AuthorizeError::CheckFailed(_)) => Err(MetadataReadError::Unavailable),
+        Err(AuthorizeError::CheckFailed(_) | AuthorizeError::Storage(_)) => {
+            Err(MetadataReadError::Unavailable)
+        }
     }
 }
 

--- a/operations/src/metadata/forward.rs
+++ b/operations/src/metadata/forward.rs
@@ -2401,6 +2401,9 @@ async fn authorize_write(
             Err(ForwardAuthError::Forbidden)
         }
         Err(AuthorizeError::CheckFailed(error)) => Err(ForwardAuthError::Unavailable(error)),
+        Err(AuthorizeError::Storage(error)) => {
+            Err(ForwardAuthError::Unavailable(error.to_string()))
+        }
     }
 }
 

--- a/operations/src/metadata/handle.rs
+++ b/operations/src/metadata/handle.rs
@@ -2083,7 +2083,7 @@ impl MetadataHandle {
                     .await
                     {
                         Ok(()) => {}
-                        Err(AuthorizeError::CheckFailed(_)) => {
+                        Err(AuthorizeError::CheckFailed(_) | AuthorizeError::Storage(_)) => {
                             return MetadataTransportMessage::Reject("mirror_internal".to_string());
                         }
                         Err(_) => {
@@ -2151,7 +2151,7 @@ impl MetadataHandle {
         .await
         {
             Ok(()) => {}
-            Err(AuthorizeError::CheckFailed(_)) => {
+            Err(AuthorizeError::CheckFailed(_) | AuthorizeError::Storage(_)) => {
                 return MetadataTransportMessage::Reject("mirror_internal".to_string());
             }
             Err(_) => return MetadataTransportMessage::Reject("access_denied".to_string()),

--- a/operations/src/metadata/repository.rs
+++ b/operations/src/metadata/repository.rs
@@ -437,7 +437,7 @@ pub fn parse_registry_read(
             .transpose(),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
         _ => Err(StorageReadError::Storage(
-            aruna_core::errors::StorageError::ReadError,
+            aruna_core::errors::StorageError::ReadError("unexpected event".to_string()),
         )),
     }
 }
@@ -454,7 +454,7 @@ pub fn parse_materialization_status_read(
             .transpose(),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
         _ => Err(StorageReadError::Storage(
-            aruna_core::errors::StorageError::ReadError,
+            aruna_core::errors::StorageError::ReadError("unexpected event".to_string()),
         )),
     }
 }
@@ -471,7 +471,7 @@ pub fn parse_graph_lifecycle_read(
             .transpose(),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
         _ => Err(StorageReadError::Storage(
-            aruna_core::errors::StorageError::ReadError,
+            aruna_core::errors::StorageError::ReadError("unexpected event".to_string()),
         )),
     }
 }
@@ -495,7 +495,7 @@ pub fn parse_registry_iter(
         }
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
         _ => Err(StorageReadError::Storage(
-            aruna_core::errors::StorageError::ReadError,
+            aruna_core::errors::StorageError::ReadError("unexpected event".to_string()),
         )),
     }
 }
@@ -530,7 +530,7 @@ pub async fn delete_index_keys(
         Event::Storage(StorageEvent::BatchDeleteResult { .. }) => Ok(count),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
         _ => Err(StorageReadError::Storage(
-            aruna_core::errors::StorageError::WriteError,
+            aruna_core::errors::StorageError::WriteError("unexpected event".to_string()),
         )),
     }
 }

--- a/operations/src/metadata/timestamp_index.rs
+++ b/operations/src/metadata/timestamp_index.rs
@@ -222,7 +222,9 @@ fn parse_iter(event: Event) -> Result<IndexBatch, StorageReadError> {
             next_start_after,
         }) => Ok((values, next_start_after)),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::ReadError)),
+        _ => Err(StorageReadError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 

--- a/operations/src/metadata/visibility_index.rs
+++ b/operations/src/metadata/visibility_index.rs
@@ -199,7 +199,9 @@ async fn read_index_datestamp(
             .transpose()
             .map_err(StorageReadError::Conversion),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::ReadError)),
+        _ => Err(StorageReadError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 
@@ -294,7 +296,9 @@ async fn read_state(context: &DriverContext) -> Result<Option<VisibilityState>, 
             value.and_then(|value| postcard::from_bytes::<VisibilityState>(value.as_ref()).ok())
         ),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::ReadError)),
+        _ => Err(StorageReadError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 
@@ -317,7 +321,9 @@ async fn write_state(
     match event {
         Event::Storage(StorageEvent::WriteResult { .. }) => Ok(()),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::WriteError)),
+        _ => Err(StorageReadError::Storage(StorageError::WriteError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 
@@ -341,7 +347,9 @@ fn parse_scan(event: Event) -> Result<IndexBatch, StorageReadError> {
             next_start_after,
         }) => Ok((values, next_start_after)),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::ReadError)),
+        _ => Err(StorageReadError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 
@@ -772,7 +780,9 @@ async fn write_index_keys(
     match event {
         Event::Storage(StorageEvent::BatchWriteResult { .. }) => Ok(()),
         Event::Storage(StorageEvent::Error { error }) => Err(StorageReadError::Storage(error)),
-        _ => Err(StorageReadError::Storage(StorageError::WriteError)),
+        _ => Err(StorageReadError::Storage(StorageError::WriteError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -2625,7 +2625,7 @@ mod tests {
     }
 
     #[test]
-    fn refuses_non_management_node() {
+    fn refuses_server_node() {
         // An authorized caller still may not mutate placement on a server node.
         let realm_id = RealmId::from_bytes([1; 32]);
         let actor = actor(realm_id);

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -7,23 +7,24 @@ use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, IterStart, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, StorageEvent};
+use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::{
     ADMIN_DOCUMENT_STATE_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE, METADATA_INDEX_KEYSPACE,
     METADATA_PENDING_PROJECTION_KEYSPACE,
 };
 use aruna_core::metadata::MetadataCreateEventRecord;
-use aruna_core::operation::Operation;
+use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, metadata_pending_projection_target,
     stale_admin_document_conflict_delete_entries,
 };
 use aruna_core::structs::{
-    Actor, BindingError, BindingScope, BucketPlan, CandidatePlacementMap, CompletionProof,
-    DEFAULT_LOCATION, DEFAULT_NODE_WEIGHT, DocumentClass, MetadataRegistryRecord,
-    NodePlacementEntry, PlacementBinding, PlacementOverride, PlacementRef, PlacementScope,
-    PlacementStrategy, RealmConfigDocument, RealmNodeKind, StrategyBinding, TransitionPlan,
+    Actor, AuthContext, BindingError, BindingScope, BucketPlan, CandidatePlacementMap,
+    CompletionProof, DEFAULT_LOCATION, DEFAULT_NODE_WEIGHT, DocumentClass, MetadataRegistryRecord,
+    NodePlacementEntry, Permission, PlacementBinding, PlacementOverride, PlacementRef,
+    PlacementScope, PlacementStrategy, RealmConfigDocument, RealmNodeKind, StrategyBinding,
+    TransitionPlan, policy_admin_path,
 };
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, KeySpace, TxnId, Value};
@@ -33,6 +34,7 @@ use thiserror::Error;
 use tracing::warn;
 use ulid::Ulid;
 
+use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
@@ -629,6 +631,9 @@ pub struct MutateRealmPlacementConfig {
 #[derive(Debug, PartialEq)]
 pub struct MutateRealmPlacementOperation {
     actor: Actor,
+    /// Set when a caller's token has to be authorized: the node-internal
+    /// mutation paths originate their own changes and carry no token.
+    auth_context: Option<AuthContext>,
     mutations: Vec<RealmPlacementMutation>,
     txn_id: Option<TxnId>,
     state: MutateRealmPlacementState,
@@ -645,6 +650,7 @@ struct StrategyRemovalCheck {
 #[derive(Debug, Clone, PartialEq)]
 enum MutateRealmPlacementState {
     Init,
+    Auth,
     StartTransaction,
     ReadCurrent,
     ReadRegistryReferences {
@@ -714,8 +720,19 @@ pub enum MutateRealmPlacementError {
 }
 
 impl MutateRealmPlacementOperation {
+    /// Node-internal entry: the node originates the mutation itself, so only the
+    /// per-mutation node authorization applies.
     pub fn new(config: MutateRealmPlacementConfig) -> Self {
         Self::batch(config.actor, vec![config.mutation])
+    }
+
+    /// Caller-facing entry: the token must hold WRITE on the realm configuration
+    /// admin path and only a management node may serve it.
+    pub fn authorized(config: MutateRealmPlacementConfig, auth_context: AuthContext) -> Self {
+        Self {
+            auth_context: Some(auth_context),
+            ..Self::batch(config.actor, vec![config.mutation])
+        }
     }
 
     /// One transaction, one reduced event per mutation, applied in order
@@ -724,6 +741,7 @@ impl MutateRealmPlacementOperation {
     pub fn batch(actor: Actor, mutations: Vec<RealmPlacementMutation>) -> Self {
         Self {
             actor,
+            auth_context: None,
             mutations,
             txn_id: None,
             state: MutateRealmPlacementState::Init,
@@ -880,6 +898,18 @@ impl MutateRealmPlacementOperation {
         let Some(document_value) = document_value else {
             return Err(MutateRealmPlacementError::RealmConfigNotFound);
         };
+        // A caller's request is served by management nodes only; a node's own
+        // mutations stay governed by the per-mutation node authorization.
+        if self.auth_context.is_some()
+            && !is_management(
+                &RealmConfigDocument::from_bytes(&document_value)?,
+                self.actor.node_id,
+            )
+        {
+            return Err(MutateRealmPlacementError::Unauthorized {
+                node_id: self.actor.node_id,
+            });
+        }
         let strategy_id = match self.mutations.as_slice() {
             [RealmPlacementMutation::RemoveStrategy(strategy_id)] => {
                 let document = RealmConfigDocument::from_bytes(&document_value)?;
@@ -993,14 +1023,52 @@ impl Operation for MutateRealmPlacementOperation {
     type Error = MutateRealmPlacementError;
 
     fn start(&mut self) -> Effects {
-        self.state = MutateRealmPlacementState::StartTransaction;
-        smallvec![Effect::Storage(StorageEffect::StartTransaction {
-            read: false,
-        })]
+        let Some(auth_context) = self.auth_context.clone() else {
+            self.state = MutateRealmPlacementState::StartTransaction;
+            return smallvec![Effect::Storage(StorageEffect::StartTransaction {
+                read: false,
+            })];
+        };
+        if auth_context.realm_id != self.actor.realm_id {
+            return self.fail(MutateRealmPlacementError::Unauthorized {
+                node_id: self.actor.node_id,
+            });
+        }
+        self.state = MutateRealmPlacementState::Auth;
+        smallvec![Effect::SubOperation(boxed_suboperation(
+            CheckPermissionsOperation::new(CheckPermissionsConfig {
+                auth_context,
+                path: policy_admin_path(self.actor.realm_id),
+                required_permission: Permission::WRITE,
+            }),
+            |allowed| Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }),
+        ))]
     }
 
     fn step(&mut self, event: Event) -> Effects {
         match self.state.clone() {
+            MutateRealmPlacementState::Auth => match event {
+                Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }) => {
+                    match allowed {
+                        Ok(true) => {
+                            self.state = MutateRealmPlacementState::StartTransaction;
+                            smallvec![Effect::Storage(StorageEffect::StartTransaction {
+                                read: false,
+                            })]
+                        }
+                        Ok(false) => self.fail(MutateRealmPlacementError::Unauthorized {
+                            node_id: self.actor.node_id,
+                        }),
+                        Err(error) => {
+                            warn!(error = %error, "Realm placement authorization check failed");
+                            self.fail(MutateRealmPlacementError::Unauthorized {
+                                node_id: self.actor.node_id,
+                            })
+                        }
+                    }
+                }
+                other => self.unexpected_event("authorization result", format!("{other:?}")),
+            },
             MutateRealmPlacementState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
                     self.emit_read_current(txn_id)
@@ -1234,9 +1302,11 @@ impl Operation for MutateRealmPlacementOperation {
 /// Drives a realm placement mutation, then — when it drains the local node —
 /// kicks the installed outbox drain owner so records accepted before holdership
 /// loss are retried without creating a second concurrent drainer or replacing a
-/// persisted failure deadline.
+/// persisted failure deadline. `auth_context` carries the requesting caller's
+/// token, and is `None` for a mutation the node originates itself.
 pub async fn drive_realm_placement_mutation(
     config: MutateRealmPlacementConfig,
+    auth_context: Option<AuthContext>,
     context: &crate::driver::DriverContext,
 ) -> Result<RealmConfigDocument, MutateRealmPlacementError> {
     let drains_node = matches!(
@@ -1245,7 +1315,11 @@ pub async fn drive_realm_placement_mutation(
             if entry.draining
                 && context.net_handle.as_ref().map(|net| net.node_id()) == Some(entry.node_id)
     );
-    let outcome = crate::driver::drive(MutateRealmPlacementOperation::new(config), context).await;
+    let operation = match auth_context {
+        Some(auth_context) => MutateRealmPlacementOperation::authorized(config, auth_context),
+        None => MutateRealmPlacementOperation::new(config),
+    };
+    let outcome = crate::driver::drive(operation, context).await;
     if outcome.is_ok() && drains_node && context.net_handle.is_some() {
         crate::task_incoming::drive_document_sync_outbox_drain(std::sync::Arc::new(
             context.clone(),
@@ -2487,5 +2561,99 @@ mod tests {
             Err(MutateRealmPlacementError::InvalidInput(reason))
                 if reason.contains("does not cover bucket")
         ));
+    }
+
+    fn auth(actor: &Actor) -> AuthContext {
+        AuthContext {
+            user_id: actor.user_id,
+            realm_id: actor.realm_id,
+            path_restrictions: None,
+        }
+    }
+
+    fn placement_config(actor: &Actor) -> MutateRealmPlacementConfig {
+        MutateRealmPlacementConfig {
+            actor: actor.clone(),
+            mutation: RealmPlacementMutation::SetDefaultStrategy(Ulid::from_bytes([2; 16])),
+        }
+    }
+
+    #[test]
+    fn authorized_checks_permission() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            MutateRealmPlacementOperation::authorized(placement_config(&actor), auth(&actor));
+        let effects = operation.start();
+        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
+        let emitted = format!("{effects:?}");
+        assert!(emitted.contains(&policy_admin_path(realm_id)));
+        assert!(emitted.contains("WRITE"));
+    }
+
+    #[test]
+    fn denied_is_terminal() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            MutateRealmPlacementOperation::authorized(placement_config(&actor), auth(&actor));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(false) },
+        ));
+        assert!(effects.is_empty());
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(MutateRealmPlacementError::Unauthorized {
+                node_id: actor.node_id,
+            })
+        );
+    }
+
+    #[test]
+    fn internal_skips_authorization() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(realm_id);
+        let mut operation = MutateRealmPlacementOperation::new(placement_config(&actor));
+        assert_eq!(
+            operation.start().as_slice(),
+            &[Effect::Storage(StorageEffect::StartTransaction {
+                read: false
+            })]
+        );
+    }
+
+    #[test]
+    fn refuses_non_management_node() {
+        // An authorized caller still may not mutate placement on a server node.
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(realm_id);
+        let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        document.ensure_node(actor.node_id, RealmNodeKind::Server);
+        let mut operation =
+            MutateRealmPlacementOperation::authorized(placement_config(&actor), auth(&actor));
+        operation.start();
+        operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
+        ));
+        operation.step(Event::Storage(StorageEvent::TransactionStarted {
+            txn_id: Ulid::from_bytes([7; 16]),
+        }));
+        operation.step(Event::Storage(StorageEvent::BatchReadResult {
+            values: vec![
+                (
+                    Key::from(vec![0u8]),
+                    Some(document.to_bytes(&actor).unwrap().into()),
+                ),
+                (Key::from(vec![1u8]), None),
+            ],
+        }));
+        assert_eq!(
+            operation.finalize(),
+            Err(MutateRealmPlacementError::Unauthorized {
+                node_id: actor.node_id,
+            })
+        );
     }
 }

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -6,7 +6,7 @@ use aruna_core::admin_document_reducer::{
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, IterStart, StorageEffect};
-use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::{
     ADMIN_DOCUMENT_STATE_KEYSPACE, METADATA_EVENT_LOG_KEYSPACE, METADATA_INDEX_KEYSPACE,
@@ -1061,9 +1061,14 @@ impl Operation for MutateRealmPlacementOperation {
                         }),
                         Err(error) => {
                             warn!(error = %error, "Realm placement authorization check failed");
-                            self.fail(MutateRealmPlacementError::Unauthorized {
-                                node_id: self.actor.node_id,
-                            })
+                            match error {
+                                AuthorizationError::StorageError(error) => {
+                                    self.fail(MutateRealmPlacementError::StorageError(error))
+                                }
+                                _ => self.fail(MutateRealmPlacementError::Unauthorized {
+                                    node_id: self.actor.node_id,
+                                }),
+                            }
                         }
                     }
                 }

--- a/operations/src/mutate_realm_placement.rs
+++ b/operations/src/mutate_realm_placement.rs
@@ -2617,6 +2617,30 @@ mod tests {
     }
 
     #[test]
+    fn capacity_not_denied() {
+        // Storage exhaustion inside the check is infrastructure, not a verdict.
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            MutateRealmPlacementOperation::authorized(placement_config(&actor), auth(&actor));
+        operation.start();
+        operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult {
+                allowed: Err(AuthorizationError::StorageError(
+                    StorageError::CleanupCapacity,
+                )),
+            },
+        ));
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(MutateRealmPlacementError::StorageError(
+                StorageError::CleanupCapacity
+            ))
+        );
+    }
+
+    #[test]
     fn internal_skips_authorization() {
         let realm_id = RealmId::from_bytes([1; 32]);
         let actor = actor(realm_id);

--- a/operations/src/native_reference.rs
+++ b/operations/src/native_reference.rs
@@ -377,6 +377,9 @@ async fn prepare_reference(
             AuthorizeError::CheckFailed(error) => {
                 return Err(NativeReferenceReject::Unavailable(error));
             }
+            AuthorizeError::Storage(error) => {
+                return Err(NativeReferenceReject::Unavailable(error.to_string()));
+            }
         }
     }
 

--- a/operations/src/notifications/emit.rs
+++ b/operations/src/notifications/emit.rs
@@ -300,7 +300,7 @@ mod tests {
         ));
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         assert!(effects.is_empty());
         assert!(operation.is_complete());
@@ -321,7 +321,7 @@ mod tests {
         ));
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         match effects.as_slice() {
             [Effect::Storage(StorageEffect::AbortTransaction { txn_id: aborted })] => {
@@ -353,7 +353,7 @@ mod tests {
         ));
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         match effects.as_slice() {
             [Effect::Storage(StorageEffect::AbortTransaction { txn_id: aborted })] => {

--- a/operations/src/permission_rules.rs
+++ b/operations/src/permission_rules.rs
@@ -584,9 +584,6 @@ impl Operation for PermissionRulesOperation {
     }
 
     fn step(&mut self, event: Event) -> Effects {
-        if self.is_complete() {
-            return smallvec![];
-        }
         let event = match self.fail_on_storage(event) {
             Ok(event) => event,
             Err(effects) => return effects,
@@ -991,6 +988,38 @@ mod test {
             auth_context: AuthContext::anonymous(realm_id),
             path: format!("/{realm_id}/admin"),
         });
+
+        let effects = operation.step(Event::Storage(StorageEvent::ReadResult {
+            key: Vec::new().into(),
+            value: None,
+        }));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(AuthorizationError::UnexpectedEvent { .. })
+        ));
+    }
+
+    // A completed collection must reject a late event instead of ignoring it.
+    #[test]
+    fn finished_rejects_event() {
+        let realm_id = RealmId([16u8; 32]);
+        let txn_id = Ulid::from(17u128);
+        let mut operation = PermissionRulesOperation::new_with_txn(
+            PermissionRulesConfig {
+                auth_context: AuthContext::anonymous(realm_id),
+                path: format!("/{realm_id}/admin"),
+            },
+            txn_id,
+        );
+        operation.start();
+        let realm = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+        operation.step(Event::Storage(StorageEvent::ReadResult {
+            key: Vec::new().into(),
+            value: Some(postcard::to_allocvec(&realm).unwrap().into()),
+        }));
+        assert!(operation.is_complete());
 
         let effects = operation.step(Event::Storage(StorageEvent::ReadResult {
             key: Vec::new().into(),

--- a/operations/src/permission_rules.rs
+++ b/operations/src/permission_rules.rs
@@ -599,7 +599,9 @@ impl Operation for PermissionRulesOperation {
             PermissionRulesState::CollectRules => self.handle_commit(event),
             PermissionRulesState::Finish
             | PermissionRulesState::Init
-            | PermissionRulesState::Error => smallvec![],
+            | PermissionRulesState::Error => {
+                self.unexpected_event(self.state, "no event", format!("{event:?}"))
+            }
         }
     }
 
@@ -631,6 +633,7 @@ mod test {
 
     use aruna_core::UserId;
     use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::errors::AuthorizationError;
     use aruna_core::events::{Event, StorageEvent};
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::operation::Operation;
@@ -978,5 +981,26 @@ mod test {
         assert!(effects.is_empty());
         assert!(failed.is_complete());
         assert!(failed.finalize().is_err());
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let realm_id = RealmId([6u8; 32]);
+        let mut operation = PermissionRulesOperation::new(PermissionRulesConfig {
+            auth_context: AuthContext::anonymous(realm_id),
+            path: format!("/{realm_id}/admin"),
+        });
+
+        let effects = operation.step(Event::Storage(StorageEvent::ReadResult {
+            key: Vec::new().into(),
+            value: None,
+        }));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(AuthorizationError::UnexpectedEvent { .. })
+        ));
     }
 }

--- a/operations/src/permission_rules.rs
+++ b/operations/src/permission_rules.rs
@@ -372,6 +372,8 @@ impl PermissionRulesOperation {
         ) = (self.state, event)
         {
             if self.txn_id == Some(txn_id) {
+                // The transaction is committed, so no later failure may abort it.
+                self.txn_id = None;
                 match self.emit_rules() {
                     Ok(effects) => effects,
                     Err(err) => self.fail(err),
@@ -1001,23 +1003,31 @@ mod test {
         ));
     }
 
-    // A completed collection must reject a late event instead of ignoring it.
+    // A completed collection must reject a late event without aborting the
+    // transaction it already committed.
     #[test]
     fn finished_rejects_event() {
         let realm_id = RealmId([16u8; 32]);
         let txn_id = Ulid::from(17u128);
-        let mut operation = PermissionRulesOperation::new_with_txn(
-            PermissionRulesConfig {
-                auth_context: AuthContext::anonymous(realm_id),
-                path: format!("/{realm_id}/admin"),
-            },
-            txn_id,
-        );
+        let mut operation = PermissionRulesOperation::new(PermissionRulesConfig {
+            auth_context: AuthContext::anonymous(realm_id),
+            path: format!("/{realm_id}/admin"),
+        });
         operation.start();
+        operation.step(Event::Storage(StorageEvent::TransactionStarted { txn_id }));
         let realm = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
-        operation.step(Event::Storage(StorageEvent::ReadResult {
+        let effects = operation.step(Event::Storage(StorageEvent::ReadResult {
             key: Vec::new().into(),
             value: Some(postcard::to_allocvec(&realm).unwrap().into()),
+        }));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Storage(StorageEffect::CommitTransaction {
+                txn_id: committed
+            })] if *committed == txn_id
+        ));
+        operation.step(Event::Storage(StorageEvent::TransactionCommitted {
+            txn_id,
         }));
         assert!(operation.is_complete());
 

--- a/operations/src/persistent_id.rs
+++ b/operations/src/persistent_id.rs
@@ -72,7 +72,9 @@ pub fn parse_mapping_read(event: Event) -> Result<Option<PersistentIdMapping>, P
             })
             .transpose(),
         Event::Storage(StorageEvent::Error { error }) => Err(PersistentIdError::Storage(error)),
-        _ => Err(PersistentIdError::Storage(StorageError::ReadError)),
+        _ => Err(PersistentIdError::Storage(StorageError::ReadError(
+            "unexpected event".to_string(),
+        ))),
     }
 }
 
@@ -223,9 +225,11 @@ pub async fn admin_withdraw_persistent_id(
             Ok(Some(mapping)) => mapping,
             Ok(None) => {
                 abort_transaction(ctx, txn_id).await;
-                let existing = read_mapping(ctx, document_id)
-                    .await?
-                    .ok_or(PersistentIdError::Storage(StorageError::ReadError))?;
+                let existing = read_mapping(ctx, document_id).await?.ok_or_else(|| {
+                    PersistentIdError::Storage(StorageError::ReadError(
+                        "persistent id mapping missing".to_string(),
+                    ))
+                })?;
                 return Ok((existing, false));
             }
             Err(error) => {

--- a/operations/src/replication/version_replication.rs
+++ b/operations/src/replication/version_replication.rs
@@ -3843,7 +3843,7 @@ mod tests {
         }));
 
         op.step(Event::Storage(StorageEvent::Error {
-            error: aruna_core::errors::StorageError::ReadError,
+            error: aruna_core::errors::StorageError::ReadError("boom".to_string()),
         }));
 
         assert!(matches!(

--- a/operations/src/request_authorization.rs
+++ b/operations/src/request_authorization.rs
@@ -7,7 +7,7 @@ use crate::driver::{DriverContext, drive};
 use crate::request_policy::{
     PolicyEnforcementError, PolicyRequestExtras, enforce_policies, policy_request_with,
 };
-use aruna_core::errors::AuthorizationError;
+use aruna_core::errors::{AuthorizationError, StorageError};
 use aruna_core::structs::{AuthContext, Permission, RealmId};
 use thiserror::Error;
 
@@ -17,6 +17,10 @@ pub enum AuthorizeError {
     PermissionDenied,
     #[error(transparent)]
     Policy(#[from] PolicyEnforcementError),
+    /// Storage failed while deciding the request: an infrastructure fault that
+    /// callers must not present as an authorization verdict.
+    #[error(transparent)]
+    Storage(StorageError),
     #[error("authorization check failed: {0}")]
     CheckFailed(String),
 }
@@ -48,6 +52,7 @@ pub async fn authorize(
         | AuthorizationError::InvalidGroupId
         | AuthorizationError::GroupNotFound
         | AuthorizationError::AuthDocNotFound => AuthorizeError::PermissionDenied,
+        AuthorizationError::StorageError(error) => AuthorizeError::Storage(error),
         other => AuthorizeError::CheckFailed(other.to_string()),
     })?;
     if !allowed {

--- a/operations/src/s3/upload_part.rs
+++ b/operations/src/s3/upload_part.rs
@@ -1032,7 +1032,7 @@ mod test {
         op.txn_id = Some(txn_id);
 
         let effects = op.step(Event::Storage(StorageEvent::Error {
-            error: StorageError::WriteError,
+            error: StorageError::WriteError("boom".to_string()),
         }));
         assert_eq!(
             effects.as_slice(),

--- a/operations/src/set_group_policies.rs
+++ b/operations/src/set_group_policies.rs
@@ -4,7 +4,7 @@ use aruna_core::admin_document_reducer::{
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
-use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, REALM_CONFIG_KEYSPACE};
 use aruna_core::operation::{Operation, boxed_suboperation};
@@ -343,7 +343,12 @@ impl Operation for SetGroupPoliciesOperation {
                         Ok(false) => self.fail(SetGroupPoliciesError::Unauthorized),
                         Err(error) => {
                             warn!(error = %error, "Group policy authorization check failed");
-                            self.fail(SetGroupPoliciesError::Unauthorized)
+                            match error {
+                                AuthorizationError::StorageError(error) => {
+                                    self.fail(SetGroupPoliciesError::StorageError(error))
+                                }
+                                _ => self.fail(SetGroupPoliciesError::Unauthorized),
+                            }
                         }
                     }
                 }

--- a/operations/src/set_group_policies.rs
+++ b/operations/src/set_group_policies.rs
@@ -501,6 +501,7 @@ mod tests {
     use crate::get_group::{GetGroupConfig, GetGroupOperation};
     use aruna_core::UserId;
     use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::errors::{AuthorizationError, StorageError};
     use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::operation::Operation;
@@ -745,6 +746,34 @@ mod tests {
         assert_eq!(
             operation.finalize(),
             Err(SetGroupPoliciesError::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn capacity_not_denied() {
+        // Storage exhaustion inside the check is infrastructure, not a verdict.
+        let realm_id = RealmId([23u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation = SetGroupPoliciesOperation::new(group_config(
+            &actor,
+            Ulid::from_bytes([5u8; 16]),
+            Vec::new(),
+            None,
+        ));
+        operation.start();
+        operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult {
+                allowed: Err(AuthorizationError::StorageError(
+                    StorageError::CleanupCapacity,
+                )),
+            },
+        ));
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(SetGroupPoliciesError::StorageError(
+                StorageError::CleanupCapacity
+            ))
         );
     }
 

--- a/operations/src/set_group_policies.rs
+++ b/operations/src/set_group_policies.rs
@@ -5,15 +5,17 @@ use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, StorageEvent};
+use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::{ADMIN_DOCUMENT_STATE_KEYSPACE, REALM_CONFIG_KEYSPACE};
-use aruna_core::operation::Operation;
+use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::request_policy::{RequestPolicy, policy_set_hash, validate_policy_set};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
-use aruna_core::structs::{Actor, GroupAuthorizationDocument, PlacementRef, RealmConfigDocument};
+use aruna_core::structs::{
+    Actor, AuthContext, GroupAuthorizationDocument, Permission, PlacementRef, RealmConfigDocument,
+};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, GroupId, Key, KeySpace, TxnId, Value};
 use byteview::ByteView;
@@ -21,6 +23,7 @@ use smallvec::smallvec;
 use thiserror::Error;
 use tracing::warn;
 
+use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
@@ -29,6 +32,9 @@ use crate::placement::placement_ref_for_target;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetGroupPoliciesConfig {
     pub actor: Actor,
+    /// The caller's own token context, so a path-restricted credential stays
+    /// restricted; it is never derived from `actor`.
+    pub auth_context: AuthContext,
     pub group_id: GroupId,
     pub policies: Vec<RequestPolicy>,
     /// When set, the write applies only if the stored set still hashes to it,
@@ -53,6 +59,7 @@ pub struct SetGroupPoliciesOperation {
 #[derive(Debug, Clone, PartialEq)]
 enum SetGroupPoliciesState {
     Init,
+    Auth,
     StartTransaction,
     ReadCurrent,
     WriteDocumentAndAdminState {
@@ -85,6 +92,8 @@ pub enum SetGroupPoliciesError {
     AdminDocumentReducerError(#[from] AdminDocumentReducerError),
     #[error("group authorization document missing")]
     GroupAuthDocNotFound,
+    #[error("caller may not write the group configuration")]
+    Unauthorized,
     #[error("stored policy set changed")]
     StaleHash,
     #[error("invalid policy set: {reason}")]
@@ -118,6 +127,13 @@ impl SetGroupPoliciesOperation {
         DocumentSyncTarget::GroupAuthorization {
             group_id: self.config.group_id,
         }
+    }
+
+    fn admin_config_path(&self) -> String {
+        format!(
+            "/{}/g/{}/admin/config",
+            self.config.actor.realm_id, self.config.group_id
+        )
     }
 
     fn admin_target(&self) -> AdminDocumentTarget {
@@ -299,14 +315,40 @@ impl Operation for SetGroupPoliciesOperation {
     type Error = SetGroupPoliciesError;
 
     fn start(&mut self) -> Effects {
-        self.state = SetGroupPoliciesState::StartTransaction;
-        smallvec![Effect::Storage(StorageEffect::StartTransaction {
-            read: false
-        })]
+        if self.config.auth_context.realm_id != self.config.actor.realm_id {
+            return self.fail(SetGroupPoliciesError::Unauthorized);
+        }
+        self.state = SetGroupPoliciesState::Auth;
+        smallvec![Effect::SubOperation(boxed_suboperation(
+            CheckPermissionsOperation::new(CheckPermissionsConfig {
+                auth_context: self.config.auth_context.clone(),
+                path: self.admin_config_path(),
+                required_permission: Permission::WRITE,
+            }),
+            |allowed| Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }),
+        ))]
     }
 
     fn step(&mut self, event: Event) -> Effects {
         match self.state.clone() {
+            SetGroupPoliciesState::Auth => match event {
+                Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }) => {
+                    match allowed {
+                        Ok(true) => {
+                            self.state = SetGroupPoliciesState::StartTransaction;
+                            smallvec![Effect::Storage(StorageEffect::StartTransaction {
+                                read: false
+                            })]
+                        }
+                        Ok(false) => self.fail(SetGroupPoliciesError::Unauthorized),
+                        Err(error) => {
+                            warn!(error = %error, "Group policy authorization check failed");
+                            self.fail(SetGroupPoliciesError::Unauthorized)
+                        }
+                    }
+                }
+                other => self.unexpected_event("authorization result", format!("{other:?}")),
+            },
             SetGroupPoliciesState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
                     self.emit_read_current(txn_id)
@@ -453,12 +495,66 @@ mod tests {
     use crate::driver::{DriverContext, drive};
     use crate::get_group::{GetGroupConfig, GetGroupOperation};
     use aruna_core::UserId;
+    use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
+    use aruna_core::keyspaces::AUTH_KEYSPACE;
+    use aruna_core::operation::Operation;
     use aruna_core::request_policy::RequestPolicy;
-    use aruna_core::structs::{Actor, RealmId};
+    use aruna_core::structs::{Actor, AuthContext, RealmAuthorizationDocument, RealmId};
     use aruna_storage::storage::FjallStorage;
     use aruna_tasks::TaskHandle;
     use tempfile::tempdir;
     use ulid::Ulid;
+
+    fn actor(realm_id: RealmId) -> Actor {
+        Actor {
+            node_id: iroh::SecretKey::from_bytes(&[3u8; 32]).public(),
+            user_id: UserId::local(Ulid::from_bytes([4u8; 16]), realm_id),
+            realm_id,
+        }
+    }
+
+    fn auth(actor: &Actor) -> AuthContext {
+        AuthContext {
+            user_id: actor.user_id,
+            realm_id: actor.realm_id,
+            path_restrictions: None,
+        }
+    }
+
+    fn group_config(
+        actor: &Actor,
+        group_id: Ulid,
+        policies: Vec<RequestPolicy>,
+        expected_hash: Option<[u8; 32]>,
+    ) -> SetGroupPoliciesConfig {
+        SetGroupPoliciesConfig {
+            actor: actor.clone(),
+            auth_context: auth(actor),
+            group_id,
+            policies,
+            expected_hash,
+        }
+    }
+
+    /// The group creator holds the group admin role, but the permission
+    /// sub-operation also needs the realm authorization document to exist.
+    async fn seed_realm_doc(context: &DriverContext, actor: &Actor) {
+        let document = RealmAuthorizationDocument::new_default_realm_doc(actor.realm_id);
+        match context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: AUTH_KEYSPACE.to_string(),
+                key: (*actor.realm_id.as_bytes()).into(),
+                value: document.to_bytes(actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
 
     fn policy(expression: &str) -> RequestPolicy {
         RequestPolicy {
@@ -483,11 +579,7 @@ mod tests {
             compute_handle: None,
         };
         let realm_id = RealmId([23u8; 32]);
-        let actor = Actor {
-            node_id: iroh::SecretKey::from_bytes(&[3u8; 32]).public(),
-            user_id: UserId::local(Ulid::from_bytes([4u8; 16]), realm_id),
-            realm_id,
-        };
+        let actor = actor(realm_id);
         let (group, _) = drive(
             CreateGroupOperation::new(CreateGroupConfig {
                 actor: actor.clone(),
@@ -498,6 +590,7 @@ mod tests {
         )
         .await
         .unwrap();
+        seed_realm_doc(&context, &actor).await;
         (dir, context, actor, group.group_id)
     }
 
@@ -507,12 +600,7 @@ mod tests {
         let (_dir, context, actor, group_id) = setup_group().await;
         let policies = vec![policy("permission == 'write'")];
         let document = drive(
-            SetGroupPoliciesOperation::new(SetGroupPoliciesConfig {
-                actor: actor.clone(),
-                group_id,
-                policies: policies.clone(),
-                expected_hash: None,
-            }),
+            SetGroupPoliciesOperation::new(group_config(&actor, group_id, policies.clone(), None)),
             &context,
         )
         .await
@@ -537,24 +625,24 @@ mod tests {
         let empty_hash = policy_set_hash(&[]);
         let first = vec![policy("permission == 'write'")];
         drive(
-            SetGroupPoliciesOperation::new(SetGroupPoliciesConfig {
-                actor: actor.clone(),
+            SetGroupPoliciesOperation::new(group_config(
+                &actor,
                 group_id,
-                policies: first.clone(),
-                expected_hash: Some(empty_hash),
-            }),
+                first.clone(),
+                Some(empty_hash),
+            )),
             &context,
         )
         .await
         .unwrap();
 
         let stale = drive(
-            SetGroupPoliciesOperation::new(SetGroupPoliciesConfig {
-                actor: actor.clone(),
+            SetGroupPoliciesOperation::new(group_config(
+                &actor,
                 group_id,
-                policies: vec![policy("permission == 'read'")],
-                expected_hash: Some(empty_hash),
-            }),
+                vec![policy("permission == 'read'")],
+                Some(empty_hash),
+            )),
             &context,
         )
         .await;
@@ -574,12 +662,12 @@ mod tests {
         // An uncompilable expression is refused at administration time.
         let (_dir, context, actor, group_id) = setup_group().await;
         let result = drive(
-            SetGroupPoliciesOperation::new(SetGroupPoliciesConfig {
-                actor,
+            SetGroupPoliciesOperation::new(group_config(
+                &actor,
                 group_id,
-                policies: vec![policy("path.startsWith(")],
-                expected_hash: None,
-            }),
+                vec![policy("path.startsWith(")],
+                None,
+            )),
             &context,
         )
         .await;
@@ -587,5 +675,93 @@ mod tests {
             result,
             Err(SetGroupPoliciesError::InvalidPolicies { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn refuses_unauthorized_caller() {
+        // A realm member outside the group's admin role writes nothing.
+        let (_dir, context, actor, group_id) = setup_group().await;
+        let outsider = Actor {
+            user_id: UserId::local(Ulid::from_bytes([8u8; 16]), actor.realm_id),
+            ..actor.clone()
+        };
+        let error = drive(
+            SetGroupPoliciesOperation::new(group_config(
+                &outsider,
+                group_id,
+                vec![policy("permission == 'write'")],
+                None,
+            )),
+            &context,
+        )
+        .await
+        .expect_err("an unauthorized caller is refused");
+        assert_eq!(error, SetGroupPoliciesError::Unauthorized);
+
+        let (_, auth_doc) = drive(
+            GetGroupOperation::new(GetGroupConfig { group_id }),
+            &context,
+        )
+        .await
+        .unwrap();
+        assert!(auth_doc.policies.is_empty());
+    }
+
+    #[test]
+    fn start_checks_permission() {
+        let realm_id = RealmId([23u8; 32]);
+        let group_id = Ulid::from_bytes([5u8; 16]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetGroupPoliciesOperation::new(group_config(&actor, group_id, Vec::new(), None));
+        let effects = operation.start();
+        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
+        let emitted = format!("{effects:?}");
+        assert!(emitted.contains(&format!("/{realm_id}/g/{group_id}/admin/config")));
+        assert!(emitted.contains("WRITE"));
+    }
+
+    #[test]
+    fn denied_is_terminal() {
+        let realm_id = RealmId([23u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation = SetGroupPoliciesOperation::new(group_config(
+            &actor,
+            Ulid::from_bytes([5u8; 16]),
+            Vec::new(),
+            None,
+        ));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(false) },
+        ));
+        assert!(effects.is_empty());
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(SetGroupPoliciesError::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn allowed_starts_transaction() {
+        let realm_id = RealmId([23u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation = SetGroupPoliciesOperation::new(group_config(
+            &actor,
+            Ulid::from_bytes([5u8; 16]),
+            Vec::new(),
+            None,
+        ));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
+        ));
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::Storage(StorageEffect::StartTransaction {
+                read: false
+            })]
+        );
     }
 }

--- a/operations/src/set_realm_compute.rs
+++ b/operations/src/set_realm_compute.rs
@@ -12,20 +12,23 @@ use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, StorageEvent};
+use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
-use aruna_core::operation::Operation;
+use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
-use aruna_core::structs::{Actor, RealmComputeConfig, RealmConfigDocument};
+use aruna_core::structs::{
+    Actor, AuthContext, Permission, RealmComputeConfig, RealmConfigDocument, policy_admin_path,
+};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, KeySpace, TxnId, Value};
 use smallvec::smallvec;
 use thiserror::Error;
 use tracing::warn;
 
+use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
@@ -34,6 +37,9 @@ use crate::placement::placement_ref_for_target;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetRealmComputeConfig {
     pub actor: Actor,
+    /// The caller's own token context, so a path-restricted credential stays
+    /// restricted; it is never derived from `actor`.
+    pub auth_context: AuthContext,
     /// The complete compute configuration; it replaces the stored one.
     pub compute: RealmComputeConfig,
 }
@@ -49,6 +55,7 @@ pub struct SetRealmComputeOperation {
 #[derive(Debug, Clone, PartialEq)]
 enum SetRealmComputeState {
     Init,
+    Auth,
     StartTransaction,
     ReadCurrent,
     WriteDocumentAndAdminState {
@@ -78,6 +85,8 @@ pub enum SetRealmComputeError {
     AdminDocumentReducerError(#[from] AdminDocumentReducerError),
     #[error("realm config document missing")]
     RealmConfigNotFound,
+    #[error("caller may not write the realm configuration")]
+    Unauthorized,
     #[error("invalid compute configuration: {reason}")]
     InvalidCompute { reason: String },
     #[error("missing active transaction")]
@@ -255,14 +264,40 @@ impl Operation for SetRealmComputeOperation {
     type Error = SetRealmComputeError;
 
     fn start(&mut self) -> Effects {
-        self.state = SetRealmComputeState::StartTransaction;
-        smallvec![Effect::Storage(StorageEffect::StartTransaction {
-            read: false
-        })]
+        if self.config.auth_context.realm_id != self.config.actor.realm_id {
+            return self.fail(SetRealmComputeError::Unauthorized);
+        }
+        self.state = SetRealmComputeState::Auth;
+        smallvec![Effect::SubOperation(boxed_suboperation(
+            CheckPermissionsOperation::new(CheckPermissionsConfig {
+                auth_context: self.config.auth_context.clone(),
+                path: policy_admin_path(self.config.actor.realm_id),
+                required_permission: Permission::WRITE,
+            }),
+            |allowed| Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }),
+        ))]
     }
 
     fn step(&mut self, event: Event) -> Effects {
         match self.state.clone() {
+            SetRealmComputeState::Auth => match event {
+                Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }) => {
+                    match allowed {
+                        Ok(true) => {
+                            self.state = SetRealmComputeState::StartTransaction;
+                            smallvec![Effect::Storage(StorageEffect::StartTransaction {
+                                read: false
+                            })]
+                        }
+                        Ok(false) => self.fail(SetRealmComputeError::Unauthorized),
+                        Err(error) => {
+                            warn!(error = %error, "Realm compute authorization check failed");
+                            self.fail(SetRealmComputeError::Unauthorized)
+                        }
+                    }
+                }
+                other => self.unexpected_event("authorization result", format!("{other:?}")),
+            },
             SetRealmComputeState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
                     self.emit_read_current(txn_id)
@@ -394,7 +429,10 @@ mod tests {
     use aruna_core::compute_quota::ComputeQuota;
     use aruna_core::document::DocumentSyncTarget;
     use aruna_core::events::StorageEvent;
-    use aruna_core::structs::{GroupComputeQuota, LocationLink, RealmId};
+    use aruna_core::keyspaces::AUTH_KEYSPACE;
+    use aruna_core::structs::{
+        GroupComputeQuota, LocationLink, RealmAuthorizationDocument, RealmId,
+    };
     use aruna_core::types::UserId;
     use tempfile::tempdir;
     use ulid::Ulid;
@@ -415,6 +453,44 @@ mod tests {
             node_id: iroh::SecretKey::from_bytes(&[1u8; 32]).public(),
             user_id: UserId::local(Ulid::from_bytes([1u8; 16]), realm_id),
             realm_id,
+        }
+    }
+
+    fn auth(actor: &Actor) -> AuthContext {
+        AuthContext {
+            user_id: actor.user_id,
+            realm_id: actor.realm_id,
+            path_restrictions: None,
+        }
+    }
+
+    fn compute_config(actor: &Actor, compute: RealmComputeConfig) -> SetRealmComputeConfig {
+        SetRealmComputeConfig {
+            actor: actor.clone(),
+            auth_context: auth(actor),
+            compute,
+        }
+    }
+
+    /// The realm admin role only grants what the operation checks, so the
+    /// permission sub-operation decides on stored rules like production does.
+    async fn seed_realm_admin(ctx: &DriverContext, actor: &Actor) {
+        let mut document = RealmAuthorizationDocument::new_default_realm_doc(actor.realm_id);
+        for role in document.roles.values_mut() {
+            role.assigned_users.insert(actor.user_id);
+        }
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: AUTH_KEYSPACE.to_string(),
+                key: (*actor.realm_id.as_bytes()).into(),
+                value: document.to_bytes(actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
         }
     }
 
@@ -469,12 +545,10 @@ mod tests {
             &RealmConfigDocument::new(realm_id, Vec::new(), 3),
         )
         .await;
+        seed_realm_admin(&ctx, &actor).await;
 
         let stored = drive(
-            SetRealmComputeOperation::new(SetRealmComputeConfig {
-                actor: actor.clone(),
-                compute: configured(),
-            }),
+            SetRealmComputeOperation::new(compute_config(&actor, configured())),
             &ctx,
         )
         .await
@@ -508,23 +582,114 @@ mod tests {
             &RealmConfigDocument::new(realm_id, Vec::new(), 3),
         )
         .await;
+        seed_realm_admin(&ctx, &actor).await;
 
+        let invalid = RealmComputeConfig {
+            links: vec![LocationLink {
+                from: "eu-west".to_string(),
+                to: "us-east".to_string(),
+                bandwidth_bytes_per_sec: 0,
+            }],
+            ..RealmComputeConfig::default()
+        };
         let error = drive(
-            SetRealmComputeOperation::new(SetRealmComputeConfig {
-                actor,
-                compute: RealmComputeConfig {
-                    links: vec![LocationLink {
-                        from: "eu-west".to_string(),
-                        to: "us-east".to_string(),
-                        bandwidth_bytes_per_sec: 0,
-                    }],
-                    ..RealmComputeConfig::default()
-                },
-            }),
+            SetRealmComputeOperation::new(compute_config(&actor, invalid)),
             &ctx,
         )
         .await
         .expect_err("a zero bandwidth link is refused");
         assert!(matches!(error, SetRealmComputeError::InvalidCompute { .. }));
+    }
+
+    #[tokio::test]
+    async fn refuses_unauthorized_caller() {
+        // Nothing is written when the caller holds no realm-config write.
+        let dir = tempdir().unwrap();
+        let ctx = context(dir.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([2u8; 32]);
+        let actor = actor(realm_id);
+        seed(
+            &ctx,
+            &actor,
+            &RealmConfigDocument::new(realm_id, Vec::new(), 3),
+        )
+        .await;
+        let mut document = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+        document.roles.clear();
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: AUTH_KEYSPACE.to_string(),
+                key: (*realm_id.as_bytes()).into(),
+                value: document.to_bytes(&actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        let error = drive(
+            SetRealmComputeOperation::new(compute_config(&actor, configured())),
+            &ctx,
+        )
+        .await
+        .expect_err("an unauthorized caller is refused");
+        assert_eq!(error, SetRealmComputeError::Unauthorized);
+
+        let reread = drive(GetRealmConfigOperation::new(realm_id), &ctx)
+            .await
+            .expect("config reads");
+        assert_eq!(reread.compute, RealmComputeConfig::default());
+    }
+
+    #[test]
+    fn start_checks_permission() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmComputeOperation::new(compute_config(&actor, RealmComputeConfig::default()));
+        let effects = operation.start();
+        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
+        let emitted = format!("{effects:?}");
+        assert!(emitted.contains(&policy_admin_path(realm_id)));
+        assert!(emitted.contains("WRITE"));
+    }
+
+    #[test]
+    fn denied_is_terminal() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmComputeOperation::new(compute_config(&actor, RealmComputeConfig::default()));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(false) },
+        ));
+        assert!(effects.is_empty());
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(SetRealmComputeError::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn allowed_starts_transaction() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmComputeOperation::new(compute_config(&actor, RealmComputeConfig::default()));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
+        ));
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::Storage(StorageEffect::StartTransaction {
+                read: false
+            })]
+        );
     }
 }

--- a/operations/src/set_realm_compute.rs
+++ b/operations/src/set_realm_compute.rs
@@ -32,6 +32,7 @@ use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::mutate_realm_placement::is_management;
 use crate::placement::placement_ref_for_target;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -87,6 +88,8 @@ pub enum SetRealmComputeError {
     RealmConfigNotFound,
     #[error("caller may not write the realm configuration")]
     Unauthorized,
+    #[error("this node is not a realm management node")]
+    NotManagementNode,
     #[error("invalid compute configuration: {reason}")]
     InvalidCompute { reason: String },
     #[error("missing active transaction")]
@@ -162,6 +165,9 @@ impl SetRealmComputeOperation {
             return Err(SetRealmComputeError::RealmConfigNotFound);
         };
         let mut document = RealmConfigDocument::from_bytes(&document_value)?;
+        if !is_management(&document, self.config.actor.node_id) {
+            return Err(SetRealmComputeError::NotManagementNode);
+        }
 
         let target = self.admin_target();
         let previous_reducer_state = reducer_state_value
@@ -431,7 +437,7 @@ mod tests {
     use aruna_core::events::StorageEvent;
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::structs::{
-        GroupComputeQuota, LocationLink, RealmAuthorizationDocument, RealmId,
+        GroupComputeQuota, LocationLink, RealmAuthorizationDocument, RealmId, RealmNodeKind,
     };
     use aruna_core::types::UserId;
     use tempfile::tempdir;
@@ -494,6 +500,12 @@ mod tests {
         }
     }
 
+    fn management_config(realm_id: RealmId, actor: &Actor) -> RealmConfigDocument {
+        let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        document.ensure_node(actor.node_id, RealmNodeKind::Management);
+        document
+    }
+
     async fn seed(ctx: &DriverContext, actor: &Actor, document: &RealmConfigDocument) {
         let target = DocumentSyncTarget::RealmConfig {
             realm_id: actor.realm_id,
@@ -539,12 +551,7 @@ mod tests {
         let ctx = context(dir.path().to_str().unwrap());
         let realm_id = RealmId::from_bytes([1u8; 32]);
         let actor = actor(realm_id);
-        seed(
-            &ctx,
-            &actor,
-            &RealmConfigDocument::new(realm_id, Vec::new(), 3),
-        )
-        .await;
+        seed(&ctx, &actor, &management_config(realm_id, &actor)).await;
         seed_realm_admin(&ctx, &actor).await;
 
         let stored = drive(
@@ -576,12 +583,7 @@ mod tests {
         let ctx = context(dir.path().to_str().unwrap());
         let realm_id = RealmId::from_bytes([1u8; 32]);
         let actor = actor(realm_id);
-        seed(
-            &ctx,
-            &actor,
-            &RealmConfigDocument::new(realm_id, Vec::new(), 3),
-        )
-        .await;
+        seed(&ctx, &actor, &management_config(realm_id, &actor)).await;
         seed_realm_admin(&ctx, &actor).await;
 
         let invalid = RealmComputeConfig {
@@ -608,12 +610,7 @@ mod tests {
         let ctx = context(dir.path().to_str().unwrap());
         let realm_id = RealmId::from_bytes([2u8; 32]);
         let actor = actor(realm_id);
-        seed(
-            &ctx,
-            &actor,
-            &RealmConfigDocument::new(realm_id, Vec::new(), 3),
-        )
-        .await;
+        seed(&ctx, &actor, &management_config(realm_id, &actor)).await;
         let mut document = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
         document.roles.clear();
         match ctx
@@ -637,6 +634,33 @@ mod tests {
         .await
         .expect_err("an unauthorized caller is refused");
         assert_eq!(error, SetRealmComputeError::Unauthorized);
+
+        let reread = drive(GetRealmConfigOperation::new(realm_id), &ctx)
+            .await
+            .expect("config reads");
+        assert_eq!(reread.compute, RealmComputeConfig::default());
+    }
+
+    #[tokio::test]
+    async fn refuses_server_node() {
+        // A realm admin token still may not write the config on a server node:
+        // peers reject a realm-config event whose origin is not management.
+        let dir = tempdir().unwrap();
+        let ctx = context(dir.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([5u8; 32]);
+        let actor = actor(realm_id);
+        let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        document.ensure_node(actor.node_id, RealmNodeKind::Server);
+        seed(&ctx, &actor, &document).await;
+        seed_realm_admin(&ctx, &actor).await;
+
+        let error = drive(
+            SetRealmComputeOperation::new(compute_config(&actor, configured())),
+            &ctx,
+        )
+        .await
+        .expect_err("a server node is refused");
+        assert_eq!(error, SetRealmComputeError::NotManagementNode);
 
         let reread = drive(GetRealmConfigOperation::new(realm_id), &ctx)
             .await

--- a/operations/src/set_realm_compute.rs
+++ b/operations/src/set_realm_compute.rs
@@ -705,6 +705,30 @@ mod tests {
     }
 
     #[test]
+    fn capacity_not_denied() {
+        // Storage exhaustion inside the check is infrastructure, not a verdict.
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmComputeOperation::new(compute_config(&actor, RealmComputeConfig::default()));
+        operation.start();
+        operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult {
+                allowed: Err(AuthorizationError::StorageError(
+                    StorageError::CleanupCapacity,
+                )),
+            },
+        ));
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(SetRealmComputeError::StorageError(
+                StorageError::CleanupCapacity
+            ))
+        );
+    }
+
+    #[test]
     fn allowed_starts_transaction() {
         let realm_id = RealmId::from_bytes([1u8; 32]);
         let actor = actor(realm_id);

--- a/operations/src/set_realm_compute.rs
+++ b/operations/src/set_realm_compute.rs
@@ -11,7 +11,7 @@ use aruna_core::admin_document_reducer::{
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
-use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
 use aruna_core::operation::{Operation, boxed_suboperation};
@@ -298,7 +298,12 @@ impl Operation for SetRealmComputeOperation {
                         Ok(false) => self.fail(SetRealmComputeError::Unauthorized),
                         Err(error) => {
                             warn!(error = %error, "Realm compute authorization check failed");
-                            self.fail(SetRealmComputeError::Unauthorized)
+                            match error {
+                                AuthorizationError::StorageError(error) => {
+                                    self.fail(SetRealmComputeError::StorageError(error))
+                                }
+                                _ => self.fail(SetRealmComputeError::Unauthorized),
+                            }
                         }
                     }
                 }

--- a/operations/src/set_realm_policies.rs
+++ b/operations/src/set_realm_policies.rs
@@ -5,21 +5,22 @@ use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, StorageEvent};
+use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
-use aruna_core::operation::Operation;
+use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::request_policy::{RequestPolicy, policy_set_hash, validate_policy_set};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
-use aruna_core::structs::{Actor, RealmConfigDocument};
+use aruna_core::structs::{Actor, AuthContext, Permission, RealmConfigDocument, policy_admin_path};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, KeySpace, TxnId, Value};
 use smallvec::smallvec;
 use thiserror::Error;
 use tracing::warn;
 
+use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
@@ -28,6 +29,9 @@ use crate::placement::placement_ref_for_target;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetRealmPoliciesConfig {
     pub actor: Actor,
+    /// The caller's own token context, so a path-restricted credential stays
+    /// restricted; it is never derived from `actor`.
+    pub auth_context: AuthContext,
     pub policies: Vec<RequestPolicy>,
     /// When set, the write applies only if the stored set still hashes to it,
     /// compared inside the write transaction to close the check/use window.
@@ -48,6 +52,7 @@ pub struct SetRealmPoliciesOperation {
 #[derive(Debug, Clone, PartialEq)]
 enum SetRealmPoliciesState {
     Init,
+    Auth,
     StartTransaction,
     ReadCurrent,
     WriteDocumentAndAdminState {
@@ -77,6 +82,8 @@ pub enum SetRealmPoliciesError {
     AdminDocumentReducerError(#[from] AdminDocumentReducerError),
     #[error("realm config document missing")]
     RealmConfigNotFound,
+    #[error("caller may not write the realm configuration")]
+    Unauthorized,
     #[error("stored policy set changed")]
     StaleHash,
     #[error("invalid policy set: {reason}")]
@@ -257,14 +264,40 @@ impl Operation for SetRealmPoliciesOperation {
     type Error = SetRealmPoliciesError;
 
     fn start(&mut self) -> Effects {
-        self.state = SetRealmPoliciesState::StartTransaction;
-        smallvec![Effect::Storage(StorageEffect::StartTransaction {
-            read: false
-        })]
+        if self.config.auth_context.realm_id != self.config.actor.realm_id {
+            return self.fail(SetRealmPoliciesError::Unauthorized);
+        }
+        self.state = SetRealmPoliciesState::Auth;
+        smallvec![Effect::SubOperation(boxed_suboperation(
+            CheckPermissionsOperation::new(CheckPermissionsConfig {
+                auth_context: self.config.auth_context.clone(),
+                path: policy_admin_path(self.config.actor.realm_id),
+                required_permission: Permission::WRITE,
+            }),
+            |allowed| Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }),
+        ))]
     }
 
     fn step(&mut self, event: Event) -> Effects {
         match self.state.clone() {
+            SetRealmPoliciesState::Auth => match event {
+                Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }) => {
+                    match allowed {
+                        Ok(true) => {
+                            self.state = SetRealmPoliciesState::StartTransaction;
+                            smallvec![Effect::Storage(StorageEffect::StartTransaction {
+                                read: false
+                            })]
+                        }
+                        Ok(false) => self.fail(SetRealmPoliciesError::Unauthorized),
+                        Err(error) => {
+                            warn!(error = %error, "Realm policy authorization check failed");
+                            self.fail(SetRealmPoliciesError::Unauthorized)
+                        }
+                    }
+                }
+                other => self.unexpected_event("authorization result", format!("{other:?}")),
+            },
             SetRealmPoliciesState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
                     self.emit_read_current(txn_id)
@@ -394,12 +427,69 @@ mod tests {
     use crate::driver::{DriverContext, drive};
     use crate::get_realm_config::GetRealmConfigOperation;
     use aruna_core::UserId;
+    use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
+    use aruna_core::keyspaces::AUTH_KEYSPACE;
+    use aruna_core::operation::Operation;
     use aruna_core::request_policy::RequestPolicy;
-    use aruna_core::structs::{Actor, RealmId};
+    use aruna_core::structs::{
+        Actor, AuthContext, RealmAuthorizationDocument, RealmId, policy_admin_path,
+    };
     use aruna_storage::storage::FjallStorage;
     use aruna_tasks::TaskHandle;
     use tempfile::tempdir;
     use ulid::Ulid;
+
+    fn actor(realm_id: RealmId) -> Actor {
+        Actor {
+            node_id: iroh::SecretKey::from_bytes(&[3u8; 32]).public(),
+            user_id: UserId::local(Ulid::from_bytes([4u8; 16]), realm_id),
+            realm_id,
+        }
+    }
+
+    fn auth(actor: &Actor) -> AuthContext {
+        AuthContext {
+            user_id: actor.user_id,
+            realm_id: actor.realm_id,
+            path_restrictions: None,
+        }
+    }
+
+    fn policies_config(
+        actor: &Actor,
+        policies: Vec<RequestPolicy>,
+        expected_hash: Option<[u8; 32]>,
+    ) -> SetRealmPoliciesConfig {
+        SetRealmPoliciesConfig {
+            actor: actor.clone(),
+            auth_context: auth(actor),
+            policies,
+            expected_hash,
+        }
+    }
+
+    /// Realm creation leaves the admin role unassigned, so the fixture claims it
+    /// for the actor the permission sub-operation then decides on.
+    async fn seed_realm_admin(context: &DriverContext, actor: &Actor) {
+        let mut document = RealmAuthorizationDocument::new_default_realm_doc(actor.realm_id);
+        for role in document.roles.values_mut() {
+            role.assigned_users.insert(actor.user_id);
+        }
+        match context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: AUTH_KEYSPACE.to_string(),
+                key: (*actor.realm_id.as_bytes()).into(),
+                value: document.to_bytes(actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
 
     fn policy(expression: &str) -> RequestPolicy {
         RequestPolicy {
@@ -424,11 +514,7 @@ mod tests {
             compute_handle: None,
         };
         let realm_id = RealmId([21u8; 32]);
-        let actor = Actor {
-            node_id: iroh::SecretKey::from_bytes(&[3u8; 32]).public(),
-            user_id: UserId::local(Ulid::from_bytes([4u8; 16]), realm_id),
-            realm_id,
-        };
+        let actor = actor(realm_id);
         drive(
             CreateRealmOperation::new(CreateRealmConfig {
                 actor: actor.clone(),
@@ -442,6 +528,7 @@ mod tests {
         )
         .await
         .unwrap();
+        seed_realm_admin(&context, &actor).await;
         (dir, context, actor)
     }
 
@@ -451,11 +538,7 @@ mod tests {
         let (_dir, context, actor) = setup_realm().await;
         let policies = vec![policy("permission == 'write'")];
         let document = drive(
-            SetRealmPoliciesOperation::new(SetRealmPoliciesConfig {
-                actor: actor.clone(),
-                policies: policies.clone(),
-                expected_hash: None,
-            }),
+            SetRealmPoliciesOperation::new(policies_config(&actor, policies.clone(), None)),
             &context,
         )
         .await
@@ -477,22 +560,22 @@ mod tests {
         let empty_hash = policy_set_hash(&[]);
         let first = vec![policy("permission == 'write'")];
         drive(
-            SetRealmPoliciesOperation::new(SetRealmPoliciesConfig {
-                actor: actor.clone(),
-                policies: first.clone(),
-                expected_hash: Some(empty_hash),
-            }),
+            SetRealmPoliciesOperation::new(policies_config(
+                &actor,
+                first.clone(),
+                Some(empty_hash),
+            )),
             &context,
         )
         .await
         .unwrap();
 
         let stale = drive(
-            SetRealmPoliciesOperation::new(SetRealmPoliciesConfig {
-                actor: actor.clone(),
-                policies: vec![policy("permission == 'read'")],
-                expected_hash: Some(empty_hash),
-            }),
+            SetRealmPoliciesOperation::new(policies_config(
+                &actor,
+                vec![policy("permission == 'read'")],
+                Some(empty_hash),
+            )),
             &context,
         )
         .await;
@@ -509,11 +592,11 @@ mod tests {
         // An uncompilable expression is refused at administration time.
         let (_dir, context, actor) = setup_realm().await;
         let result = drive(
-            SetRealmPoliciesOperation::new(SetRealmPoliciesConfig {
-                actor,
-                policies: vec![policy("path.startsWith(")],
-                expected_hash: None,
-            }),
+            SetRealmPoliciesOperation::new(policies_config(
+                &actor,
+                vec![policy("path.startsWith(")],
+                None,
+            )),
             &context,
         )
         .await;
@@ -521,5 +604,80 @@ mod tests {
             result,
             Err(SetRealmPoliciesError::InvalidPolicies { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn refuses_unauthorized_caller() {
+        // A realm member without the admin role writes nothing.
+        let (_dir, context, actor) = setup_realm().await;
+        let outsider = Actor {
+            user_id: UserId::local(Ulid::from_bytes([9u8; 16]), actor.realm_id),
+            ..actor.clone()
+        };
+        let error = drive(
+            SetRealmPoliciesOperation::new(policies_config(
+                &outsider,
+                vec![policy("permission == 'write'")],
+                None,
+            )),
+            &context,
+        )
+        .await
+        .expect_err("an unauthorized caller is refused");
+        assert_eq!(error, SetRealmPoliciesError::Unauthorized);
+
+        let read = drive(GetRealmConfigOperation::new(actor.realm_id), &context)
+            .await
+            .unwrap();
+        assert!(read.request_policies.is_empty());
+    }
+
+    #[test]
+    fn start_checks_permission() {
+        let realm_id = RealmId([21u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmPoliciesOperation::new(policies_config(&actor, Vec::new(), None));
+        let effects = operation.start();
+        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
+        let emitted = format!("{effects:?}");
+        assert!(emitted.contains(&policy_admin_path(realm_id)));
+        assert!(emitted.contains("WRITE"));
+    }
+
+    #[test]
+    fn denied_is_terminal() {
+        let realm_id = RealmId([21u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmPoliciesOperation::new(policies_config(&actor, Vec::new(), None));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(false) },
+        ));
+        assert!(effects.is_empty());
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(SetRealmPoliciesError::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn allowed_starts_transaction() {
+        let realm_id = RealmId([21u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmPoliciesOperation::new(policies_config(&actor, Vec::new(), None));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
+        ));
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::Storage(StorageEffect::StartTransaction {
+                read: false
+            })]
+        );
     }
 }

--- a/operations/src/set_realm_policies.rs
+++ b/operations/src/set_realm_policies.rs
@@ -440,6 +440,7 @@ mod tests {
     use aruna_core::UserId;
     use aruna_core::document::DocumentSyncTarget;
     use aruna_core::effects::{Effect, StorageEffect};
+    use aruna_core::errors::{AuthorizationError, StorageError};
     use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::operation::Operation;
@@ -721,6 +722,30 @@ mod tests {
         assert_eq!(
             operation.finalize(),
             Err(SetRealmPoliciesError::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn capacity_not_denied() {
+        // Storage exhaustion inside the check is infrastructure, not a verdict.
+        let realm_id = RealmId([21u8; 32]);
+        let actor = actor(realm_id);
+        let mut operation =
+            SetRealmPoliciesOperation::new(policies_config(&actor, Vec::new(), None));
+        operation.start();
+        operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult {
+                allowed: Err(AuthorizationError::StorageError(
+                    StorageError::CleanupCapacity,
+                )),
+            },
+        ));
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(SetRealmPoliciesError::StorageError(
+                StorageError::CleanupCapacity
+            ))
         );
     }
 

--- a/operations/src/set_realm_policies.rs
+++ b/operations/src/set_realm_policies.rs
@@ -24,6 +24,7 @@ use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::mutate_realm_placement::is_management;
 use crate::placement::placement_ref_for_target;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -84,6 +85,8 @@ pub enum SetRealmPoliciesError {
     RealmConfigNotFound,
     #[error("caller may not write the realm configuration")]
     Unauthorized,
+    #[error("this node is not a realm management node")]
+    NotManagementNode,
     #[error("stored policy set changed")]
     StaleHash,
     #[error("invalid policy set: {reason}")]
@@ -157,6 +160,9 @@ impl SetRealmPoliciesOperation {
             return Err(SetRealmPoliciesError::RealmConfigNotFound);
         };
         let mut document = RealmConfigDocument::from_bytes(&document_value)?;
+        if !is_management(&document, self.config.actor.node_id) {
+            return Err(SetRealmPoliciesError::NotManagementNode);
+        }
 
         if let Some(expected) = self.config.expected_hash
             && policy_set_hash(&document.request_policies) != expected
@@ -427,13 +433,15 @@ mod tests {
     use crate::driver::{DriverContext, drive};
     use crate::get_realm_config::GetRealmConfigOperation;
     use aruna_core::UserId;
+    use aruna_core::document::DocumentSyncTarget;
     use aruna_core::effects::{Effect, StorageEffect};
     use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
     use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::operation::Operation;
     use aruna_core::request_policy::RequestPolicy;
     use aruna_core::structs::{
-        Actor, AuthContext, RealmAuthorizationDocument, RealmId, policy_admin_path,
+        Actor, AuthContext, RealmAuthorizationDocument, RealmConfigDocument, RealmId,
+        RealmNodeKind, policy_admin_path,
     };
     use aruna_storage::storage::FjallStorage;
     use aruna_tasks::TaskHandle;
@@ -530,6 +538,54 @@ mod tests {
         .unwrap();
         seed_realm_admin(&context, &actor).await;
         (dir, context, actor)
+    }
+
+    /// Replaces the stored realm config with one that ranks the actor's node as
+    /// a plain server, which realm creation never produces.
+    async fn seed_server_config(context: &DriverContext, actor: &Actor) {
+        let mut document = RealmConfigDocument::new(actor.realm_id, Vec::new(), 3);
+        document.ensure_node(actor.node_id, RealmNodeKind::Server);
+        let target = DocumentSyncTarget::RealmConfig {
+            realm_id: actor.realm_id,
+        };
+        match context
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: target.storage_keyspace().to_string(),
+                key: target.storage_key(),
+                value: document.to_bytes(actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn refuses_server_node() {
+        // A realm admin token still may not write the config on a server node:
+        // peers reject a realm-config event whose origin is not management.
+        let (_dir, context, actor) = setup_realm().await;
+        seed_server_config(&context, &actor).await;
+
+        let error = drive(
+            SetRealmPoliciesOperation::new(policies_config(
+                &actor,
+                vec![policy("permission == 'write'")],
+                None,
+            )),
+            &context,
+        )
+        .await
+        .expect_err("a server node is refused");
+        assert!(matches!(error, SetRealmPoliciesError::NotManagementNode));
+
+        let read = drive(GetRealmConfigOperation::new(actor.realm_id), &context)
+            .await
+            .unwrap();
+        assert!(read.request_policies.is_empty());
     }
 
     #[tokio::test]

--- a/operations/src/set_realm_policies.rs
+++ b/operations/src/set_realm_policies.rs
@@ -4,7 +4,7 @@ use aruna_core::admin_document_reducer::{
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
-use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
 use aruna_core::operation::{Operation, boxed_suboperation};
@@ -298,7 +298,12 @@ impl Operation for SetRealmPoliciesOperation {
                         Ok(false) => self.fail(SetRealmPoliciesError::Unauthorized),
                         Err(error) => {
                             warn!(error = %error, "Realm policy authorization check failed");
-                            self.fail(SetRealmPoliciesError::Unauthorized)
+                            match error {
+                                AuthorizationError::StorageError(error) => {
+                                    self.fail(SetRealmPoliciesError::StorageError(error))
+                                }
+                                _ => self.fail(SetRealmPoliciesError::Unauthorized),
+                            }
                         }
                     }
                 }

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -667,7 +667,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refuses_non_management_node() {
+    async fn refuses_server_node() {
         // A realm admin token still may not write the config on a server node.
         let dir = tempdir().unwrap();
         let ctx = test_ctx(dir.path().to_str().unwrap());
@@ -731,7 +731,7 @@ mod tests {
     }
 
     #[test]
-    fn foreign_realm_token_denied() {
+    fn foreign_token_denied() {
         let realm_id = RealmId::from_bytes([1; 32]);
         let actor = actor(1, realm_id);
         let mut config = quota_config(&actor, custom_quota());

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -6,7 +6,7 @@ use aruna_core::admin_document_reducer::{
 use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
-use aruna_core::errors::{ConversionError, StorageError};
+use aruna_core::errors::{AuthorizationError, ConversionError, StorageError};
 use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
 use aruna_core::operation::{Operation, boxed_suboperation};
@@ -288,7 +288,12 @@ impl Operation for SetRealmQuotaOperation {
                         Ok(false) => self.fail(SetRealmQuotaError::Unauthorized),
                         Err(error) => {
                             warn!(error = %error, "Realm quota authorization check failed");
-                            self.fail(SetRealmQuotaError::Unauthorized)
+                            match error {
+                                AuthorizationError::StorageError(error) => {
+                                    self.fail(SetRealmQuotaError::StorageError(error))
+                                }
+                                _ => self.fail(SetRealmQuotaError::Unauthorized),
+                            }
                         }
                     }
                 }

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -7,28 +7,35 @@ use aruna_core::admin_documents::{AdminDocumentOperation, AdminDocumentTarget};
 use aruna_core::document::{DocumentSyncOutboxEvent, DocumentSyncTarget};
 use aruna_core::effects::{Effect, StorageEffect};
 use aruna_core::errors::{ConversionError, StorageError};
-use aruna_core::events::{Event, StorageEvent};
+use aruna_core::events::{Event, StorageEvent, SubOperationEvent};
 use aruna_core::keyspaces::ADMIN_DOCUMENT_STATE_KEYSPACE;
-use aruna_core::operation::Operation;
+use aruna_core::operation::{Operation, boxed_suboperation};
 use aruna_core::storage_entries::{
     admin_document_conflict_write_entries, admin_document_reducer_state_key,
     admin_document_reducer_state_write_entry, stale_admin_document_conflict_delete_entries,
 };
-use aruna_core::structs::{Actor, QuotaConfig, RealmConfigDocument};
+use aruna_core::structs::{
+    Actor, AuthContext, Permission, QuotaConfig, RealmConfigDocument, policy_admin_path,
+};
 use aruna_core::task::TaskEvent;
 use aruna_core::types::{Effects, Key, KeySpace, TxnId, Value};
 use smallvec::smallvec;
 use thiserror::Error;
 use tracing::warn;
 
+use crate::check_permissions::{CheckPermissionsConfig, CheckPermissionsOperation};
 use crate::document_sync_outbox::{
     new_outbox_record_with_id, outbox_write_entry, schedule_outbox_drain_effect,
 };
+use crate::mutate_realm_placement::is_management;
 use crate::placement::placement_ref_for_target;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetRealmQuotaConfig {
     pub actor: Actor,
+    /// The caller's own token context, so a path-restricted credential stays
+    /// restricted; it is never derived from `actor`.
+    pub auth_context: AuthContext,
     pub quota: QuotaConfig,
 }
 
@@ -43,6 +50,7 @@ pub struct SetRealmQuotaOperation {
 #[derive(Debug, Clone, PartialEq)]
 enum SetRealmQuotaState {
     Init,
+    Auth,
     StartTransaction,
     ReadCurrent,
     WriteDocumentAndAdminState {
@@ -72,6 +80,10 @@ pub enum SetRealmQuotaError {
     AdminDocumentReducerError(#[from] AdminDocumentReducerError),
     #[error("realm config document missing")]
     RealmConfigNotFound,
+    #[error("caller may not write the realm configuration")]
+    Unauthorized,
+    #[error("this node is not a realm management node")]
+    NotManagementNode,
     #[error("invalid quota configuration: {reason}")]
     InvalidQuota { reason: String },
     #[error("missing active transaction")]
@@ -142,6 +154,9 @@ impl SetRealmQuotaOperation {
             return Err(SetRealmQuotaError::RealmConfigNotFound);
         };
         let mut document = RealmConfigDocument::from_bytes(&document_value)?;
+        if !is_management(&document, self.config.actor.node_id) {
+            return Err(SetRealmQuotaError::NotManagementNode);
+        }
 
         let target = self.admin_target();
         let previous_reducer_state = reducer_state_value
@@ -245,14 +260,40 @@ impl Operation for SetRealmQuotaOperation {
     type Error = SetRealmQuotaError;
 
     fn start(&mut self) -> Effects {
-        self.state = SetRealmQuotaState::StartTransaction;
-        smallvec![Effect::Storage(StorageEffect::StartTransaction {
-            read: false
-        })]
+        if self.config.auth_context.realm_id != self.config.actor.realm_id {
+            return self.fail(SetRealmQuotaError::Unauthorized);
+        }
+        self.state = SetRealmQuotaState::Auth;
+        smallvec![Effect::SubOperation(boxed_suboperation(
+            CheckPermissionsOperation::new(CheckPermissionsConfig {
+                auth_context: self.config.auth_context.clone(),
+                path: policy_admin_path(self.config.actor.realm_id),
+                required_permission: Permission::WRITE,
+            }),
+            |allowed| Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }),
+        ))]
     }
 
     fn step(&mut self, event: Event) -> Effects {
         match self.state.clone() {
+            SetRealmQuotaState::Auth => match event {
+                Event::SubOperation(SubOperationEvent::AuthorizationResult { allowed }) => {
+                    match allowed {
+                        Ok(true) => {
+                            self.state = SetRealmQuotaState::StartTransaction;
+                            smallvec![Effect::Storage(StorageEffect::StartTransaction {
+                                read: false
+                            })]
+                        }
+                        Ok(false) => self.fail(SetRealmQuotaError::Unauthorized),
+                        Err(error) => {
+                            warn!(error = %error, "Realm quota authorization check failed");
+                            self.fail(SetRealmQuotaError::Unauthorized)
+                        }
+                    }
+                }
+                other => self.unexpected_event("authorization result", format!("{other:?}")),
+            },
             SetRealmQuotaState::StartTransaction => match event {
                 Event::Storage(StorageEvent::TransactionStarted { txn_id }) => {
                     self.emit_read_current(txn_id)
@@ -443,8 +484,10 @@ mod tests {
     use crate::get_realm_config::GetRealmConfigOperation;
     use aruna_core::document::DocumentSyncTarget;
     use aruna_core::events::StorageEvent;
+    use aruna_core::keyspaces::AUTH_KEYSPACE;
     use aruna_core::structs::{
-        GroupQuotaOverride, RealmConfigDocument, RealmId, UserGroupCapOverride,
+        GroupQuotaOverride, RealmAuthorizationDocument, RealmConfigDocument, RealmId,
+        RealmNodeKind, UserGroupCapOverride,
     };
     use aruna_core::types::UserId;
     use tempfile::tempdir;
@@ -467,6 +510,50 @@ mod tests {
             user_id: UserId::local(Ulid::from_bytes([seed; 16]), realm_id),
             realm_id,
         }
+    }
+
+    fn auth(actor: &Actor) -> AuthContext {
+        AuthContext {
+            user_id: actor.user_id,
+            realm_id: actor.realm_id,
+            path_restrictions: None,
+        }
+    }
+
+    fn quota_config(actor: &Actor, quota: QuotaConfig) -> SetRealmQuotaConfig {
+        SetRealmQuotaConfig {
+            actor: actor.clone(),
+            auth_context: auth(actor),
+            quota,
+        }
+    }
+
+    /// The realm admin role only grants what the operation checks, so the
+    /// permission sub-operation decides on stored rules like production does.
+    async fn seed_realm_admin(ctx: &DriverContext, actor: &Actor) {
+        let mut document = RealmAuthorizationDocument::new_default_realm_doc(actor.realm_id);
+        for role in document.roles.values_mut() {
+            role.assigned_users.insert(actor.user_id);
+        }
+        match ctx
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: AUTH_KEYSPACE.to_string(),
+                key: (*actor.realm_id.as_bytes()).into(),
+                value: document.to_bytes(actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await
+        {
+            Event::Storage(StorageEvent::WriteResult { .. }) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    fn management_config(realm_id: RealmId, actor: &Actor) -> RealmConfigDocument {
+        let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        document.ensure_node(actor.node_id, RealmNodeKind::Management);
+        document
     }
 
     async fn seed_config(ctx: &DriverContext, actor: &Actor, document: &RealmConfigDocument) {
@@ -513,15 +600,13 @@ mod tests {
         let ctx = test_ctx(dir.path().to_str().unwrap());
         let realm_id = RealmId::from_bytes([1; 32]);
         let actor = actor(1, realm_id);
-        let document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        let document = management_config(realm_id, &actor);
         seed_config(&ctx, &actor, &document).await;
+        seed_realm_admin(&ctx, &actor).await;
 
         let quota = custom_quota();
         let stored = drive(
-            SetRealmQuotaOperation::new(SetRealmQuotaConfig {
-                actor: actor.clone(),
-                quota: quota.clone(),
-            }),
+            SetRealmQuotaOperation::new(quota_config(&actor, quota.clone())),
             &ctx,
         )
         .await
@@ -541,8 +626,9 @@ mod tests {
         let ctx = test_ctx(dir.path().to_str().unwrap());
         let realm_id = RealmId::from_bytes([1; 32]);
         let actor = actor(1, realm_id);
-        let document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        let document = management_config(realm_id, &actor);
         seed_config(&ctx, &actor, &document).await;
+        seed_realm_admin(&ctx, &actor).await;
 
         let quota = QuotaConfig {
             max_devices_per_user: Some(4),
@@ -550,7 +636,7 @@ mod tests {
         };
 
         let error = drive(
-            SetRealmQuotaOperation::new(SetRealmQuotaConfig { actor, quota }),
+            SetRealmQuotaOperation::new(quota_config(&actor, quota)),
             &ctx,
         )
         .await
@@ -569,17 +655,90 @@ mod tests {
         let ctx = test_ctx(dir.path().to_str().unwrap());
         let realm_id = RealmId::from_bytes([2; 32]);
         let actor = actor(2, realm_id);
+        seed_realm_admin(&ctx, &actor).await;
 
         let error = drive(
-            SetRealmQuotaOperation::new(SetRealmQuotaConfig {
-                actor,
-                quota: QuotaConfig::default(),
-            }),
+            SetRealmQuotaOperation::new(quota_config(&actor, QuotaConfig::default())),
             &ctx,
         )
         .await
         .unwrap_err();
         assert_eq!(error, SetRealmQuotaError::RealmConfigNotFound);
+    }
+
+    #[tokio::test]
+    async fn refuses_non_management_node() {
+        // A realm admin token still may not write the config on a server node.
+        let dir = tempdir().unwrap();
+        let ctx = test_ctx(dir.path().to_str().unwrap());
+        let realm_id = RealmId::from_bytes([5; 32]);
+        let actor = actor(5, realm_id);
+        let mut document = RealmConfigDocument::new(realm_id, Vec::new(), 3);
+        document.ensure_node(actor.node_id, RealmNodeKind::Server);
+        seed_config(&ctx, &actor, &document).await;
+        seed_realm_admin(&ctx, &actor).await;
+
+        let error = drive(
+            SetRealmQuotaOperation::new(quota_config(&actor, custom_quota())),
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, SetRealmQuotaError::NotManagementNode);
+    }
+
+    #[test]
+    fn start_checks_permission() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(1, realm_id);
+        let mut operation = SetRealmQuotaOperation::new(quota_config(&actor, custom_quota()));
+        let effects = operation.start();
+        assert!(matches!(effects.as_slice(), [Effect::SubOperation(_)]));
+        let emitted = format!("{effects:?}");
+        assert!(emitted.contains(&policy_admin_path(realm_id)));
+        assert!(emitted.contains("WRITE"));
+    }
+
+    #[test]
+    fn denied_is_terminal() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(1, realm_id);
+        let mut operation = SetRealmQuotaOperation::new(quota_config(&actor, custom_quota()));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(false) },
+        ));
+        assert!(effects.is_empty());
+        assert!(operation.is_complete());
+        assert_eq!(operation.finalize(), Err(SetRealmQuotaError::Unauthorized));
+    }
+
+    #[test]
+    fn allowed_starts_transaction() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(1, realm_id);
+        let mut operation = SetRealmQuotaOperation::new(quota_config(&actor, custom_quota()));
+        operation.start();
+        let effects = operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult { allowed: Ok(true) },
+        ));
+        assert_eq!(
+            effects.as_slice(),
+            &[Effect::Storage(StorageEffect::StartTransaction {
+                read: false
+            })]
+        );
+    }
+
+    #[test]
+    fn foreign_realm_token_denied() {
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(1, realm_id);
+        let mut config = quota_config(&actor, custom_quota());
+        config.auth_context.realm_id = RealmId::from_bytes([2; 32]);
+        let mut operation = SetRealmQuotaOperation::new(config);
+        assert!(operation.start().is_empty());
+        assert_eq!(operation.finalize(), Err(SetRealmQuotaError::Unauthorized));
     }
 
     #[test]

--- a/operations/src/set_realm_quota.rs
+++ b/operations/src/set_realm_quota.rs
@@ -719,6 +719,29 @@ mod tests {
     }
 
     #[test]
+    fn capacity_not_denied() {
+        // Storage exhaustion inside the check is infrastructure, not a verdict.
+        let realm_id = RealmId::from_bytes([1; 32]);
+        let actor = actor(1, realm_id);
+        let mut operation = SetRealmQuotaOperation::new(quota_config(&actor, custom_quota()));
+        operation.start();
+        operation.step(Event::SubOperation(
+            SubOperationEvent::AuthorizationResult {
+                allowed: Err(AuthorizationError::StorageError(
+                    StorageError::CleanupCapacity,
+                )),
+            },
+        ));
+        assert!(operation.is_complete());
+        assert_eq!(
+            operation.finalize(),
+            Err(SetRealmQuotaError::StorageError(
+                StorageError::CleanupCapacity
+            ))
+        );
+    }
+
+    #[test]
     fn allowed_starts_transaction() {
         let realm_id = RealmId::from_bytes([1; 32]);
         let actor = actor(1, realm_id);

--- a/operations/src/staging/reference.rs
+++ b/operations/src/staging/reference.rs
@@ -100,7 +100,7 @@ pub async fn materialize_reference(
     {
         Event::Storage(StorageEvent::TransactionStarted { txn_id }) => txn_id,
         Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
-        _ => return Err(StorageError::WriteError.into()),
+        _ => return Err(StorageError::WriteError("unexpected event".to_string()).into()),
     };
 
     let result: Result<(Ulid, bool), MaterializeReferenceError> = async {
@@ -162,7 +162,11 @@ pub async fn materialize_reference(
                 Event::Storage(StorageEvent::Error { error }) => {
                     return Err(MaterializeReferenceError::Storage(error));
                 }
-                _ => return Err(MaterializeReferenceError::Storage(StorageError::WriteError)),
+                _ => {
+                    return Err(MaterializeReferenceError::Storage(
+                        StorageError::WriteError("unexpected event".to_string()),
+                    ));
+                }
             }
         }
         let was_live = existing_version.is_some_and(|version| !version.is_deleted());
@@ -223,7 +227,9 @@ pub async fn materialize_reference(
             Event::Storage(StorageEvent::Error { error }) => {
                 Err(MaterializeReferenceError::Storage(error))
             }
-            _ => Err(MaterializeReferenceError::Storage(StorageError::WriteError)),
+            _ => Err(MaterializeReferenceError::Storage(
+                StorageError::WriteError("unexpected event".to_string()),
+            )),
         }
     }
     .await;
@@ -283,7 +289,7 @@ async fn apply_storage_effect(
     match send_storage_effect(context, effect).await? {
         Event::Storage(StorageEvent::WriteResult { .. })
         | Event::Storage(StorageEvent::DeleteResult { .. }) => Ok(()),
-        _ => Err(StorageError::WriteError.into()),
+        _ => Err(StorageError::WriteError("unexpected event".to_string()).into()),
     }
 }
 
@@ -374,7 +380,7 @@ async fn read_current_pointer(
             .transpose()
             .map_err(Into::into),
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
-        _ => Err(StorageError::ReadError.into()),
+        _ => Err(StorageError::ReadError("unexpected event".to_string()).into()),
     }
 }
 
@@ -400,7 +406,7 @@ async fn read_blob_version(
             .transpose()
             .map_err(Into::into),
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
-        _ => Err(StorageError::ReadError.into()),
+        _ => Err(StorageError::ReadError("unexpected event".to_string()).into()),
     }
 }
 
@@ -424,7 +430,7 @@ async fn guard_resolved_connector_unchanged(
             .map(|value| SourceConnector::from_bytes(value.as_ref()))
             .transpose()?,
         Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
-        _ => return Err(StorageError::ReadError.into()),
+        _ => return Err(StorageError::ReadError("unexpected event".to_string()).into()),
     };
 
     if current_connector.as_ref() != Some(resolved_connector) {
@@ -445,7 +451,7 @@ async fn guard_resolved_connector_unchanged(
             .map(|value| SourceConnectorSecret::from_bytes(value.as_ref()))
             .transpose()?,
         Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
-        _ => return Err(StorageError::ReadError.into()),
+        _ => return Err(StorageError::ReadError("unexpected event".to_string()).into()),
     };
 
     let current_secret_fingerprint = current_secret.as_ref().map(secret_fingerprint);
@@ -477,7 +483,7 @@ async fn guard_expected_bucket(
             .map(|value| BucketInfo::from_bytes(value.as_ref()))
             .transpose()?,
         Event::Storage(StorageEvent::Error { error }) => return Err(error.into()),
-        _ => return Err(StorageError::ReadError.into()),
+        _ => return Err(StorageError::ReadError("unexpected event".to_string()).into()),
     };
     if expected.group_id != group_id
         || current.as_ref().map(BucketInfo::identity) != Some(expected.identity())

--- a/operations/src/staging/reference.rs
+++ b/operations/src/staging/reference.rs
@@ -68,7 +68,7 @@ pub enum MaterializeReferenceError {
     Purge(#[from] PurgeFenceError),
 }
 
-pub async fn materialize_reference(
+pub async fn stage_reference_blob(
     context: &DriverContext,
     input: MaterializeReferenceInput,
 ) -> Result<MaterializeReferenceResult, MaterializeReferenceError> {
@@ -273,13 +273,6 @@ fn source_metadata_matches(left: &SourceMetadata, right: &SourceMetadata) -> boo
         && left.content_type == right.content_type
         && left.etag == right.etag
         && left.last_modified == right.last_modified
-}
-
-pub async fn stage_reference_blob(
-    context: &DriverContext,
-    input: MaterializeReferenceInput,
-) -> Result<MaterializeReferenceResult, MaterializeReferenceError> {
-    materialize_reference(context, input).await
 }
 
 async fn apply_storage_effect(
@@ -807,7 +800,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn materialize_reference_retains_historical_hash_path_and_writes_blob_version() {
+    async fn reference_keeps_history() {
+        // The prior version's hash-path entry survives while the new reference
+        // version is written.
         let test_context = setup_driver_context().await;
         let context = &test_context.driver_context;
         let group_id = Ulid::generate();
@@ -849,7 +844,7 @@ mod tests {
         let (server, endpoint) = spawn_reference_server("ref-data").await;
         let connector = create_http_connector(context, group_id, &endpoint).await;
 
-        let result = materialize_reference(
+        let result = stage_reference_blob(
             context,
             MaterializeReferenceInput {
                 group_id,
@@ -938,7 +933,7 @@ mod tests {
         let (server, endpoint) = spawn_reference_server("ref-data").await;
         let connector = create_http_connector(context, group_id, &endpoint).await;
 
-        let result = materialize_reference(
+        let result = stage_reference_blob(
             context,
             MaterializeReferenceInput {
                 group_id,
@@ -1019,8 +1014,8 @@ mod tests {
             expected_bucket,
         };
 
-        let first = materialize_reference(context, input.clone()).await.unwrap();
-        let second = materialize_reference(context, input).await.unwrap();
+        let first = stage_reference_blob(context, input.clone()).await.unwrap();
+        let second = stage_reference_blob(context, input).await.unwrap();
         server.abort();
         let _ = server.await;
 

--- a/operations/src/staging/snapshot.rs
+++ b/operations/src/staging/snapshot.rs
@@ -214,7 +214,7 @@ async fn read_value(
     {
         Event::Storage(StorageEvent::ReadResult { value, .. }) => Ok(value),
         Event::Storage(StorageEvent::Error { error }) => Err(error.into()),
-        _ => Err(StorageError::ReadError.into()),
+        _ => Err(StorageError::ReadError("unexpected event".to_string()).into()),
     }
 }
 

--- a/operations/src/staging/snapshot.rs
+++ b/operations/src/staging/snapshot.rs
@@ -62,7 +62,7 @@ pub enum MaterializeSnapshotError {
     Gate(#[from] GateContextError),
 }
 
-pub async fn materialize_snapshot(
+pub async fn stage_snapshot_blob(
     context: &DriverContext,
     input: MaterializeSnapshotInput,
 ) -> Result<MaterializeSnapshotResult, MaterializeSnapshotError> {
@@ -218,13 +218,6 @@ async fn read_value(
     }
 }
 
-pub async fn stage_snapshot_blob(
-    context: &DriverContext,
-    input: MaterializeSnapshotInput,
-) -> Result<MaterializeSnapshotResult, MaterializeSnapshotError> {
-    materialize_snapshot(context, input).await
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,11 +267,11 @@ mod tests {
             restrictions: None,
         };
 
-        let first = materialize_snapshot(context, input.clone()).await.unwrap();
-        let second = materialize_snapshot(context, input.clone()).await.unwrap();
+        let first = stage_snapshot_blob(context, input.clone()).await.unwrap();
+        let second = stage_snapshot_blob(context, input.clone()).await.unwrap();
         let mut manual = input;
         manual.retry_key = None;
-        let third = materialize_snapshot(context, manual).await.unwrap();
+        let third = stage_snapshot_blob(context, manual).await.unwrap();
         server.abort();
         let _ = server.await;
 

--- a/operations/src/sync_mirror_repair.rs
+++ b/operations/src/sync_mirror_repair.rs
@@ -538,6 +538,9 @@ async fn authorize_repair(
             Err(SyncMirrorRepairError::Mirror("access_denied".to_string()))
         }
         Err(AuthorizeError::CheckFailed(error)) => Err(SyncMirrorRepairError::Mirror(error)),
+        Err(AuthorizeError::Storage(error)) => {
+            Err(SyncMirrorRepairError::Mirror(error.to_string()))
+        }
     }
 }
 

--- a/operations/src/sync_relationship.rs
+++ b/operations/src/sync_relationship.rs
@@ -360,7 +360,13 @@ impl Operation for StoreSyncRelationshipOperation {
                 expected: "operation start",
                 received: event,
             }),
-            StoreState::Finish | StoreState::Error => smallvec![],
+            StoreState::Finish | StoreState::Error => {
+                self.fail(SyncRelationshipError::UnexpectedEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -463,7 +469,13 @@ impl Operation for ListSyncRelationshipsOperation {
                 expected: "operation start",
                 received: event,
             }),
-            ListState::Finish | ListState::Error => smallvec![],
+            ListState::Finish | ListState::Error => {
+                self.fail(SyncRelationshipError::UnexpectedEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -565,7 +577,13 @@ impl Operation for GetSyncRelationshipOperation {
                 expected: "operation start",
                 received: event,
             }),
-            GetState::Finish | GetState::Error => smallvec![],
+            GetState::Finish | GetState::Error => {
+                self.fail(SyncRelationshipError::UnexpectedEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -659,7 +677,13 @@ impl Operation for DeleteSyncRelationshipOperation {
                 expected: "operation start",
                 received: event,
             }),
-            DeleteState::Finish | DeleteState::Error => smallvec![],
+            DeleteState::Finish | DeleteState::Error => {
+                self.fail(SyncRelationshipError::UnexpectedEvent {
+                    state: "terminal",
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -885,5 +909,66 @@ mod tests {
             .unwrap();
             assert_eq!(stored.len(), 1);
         }
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let stray = || {
+            Event::Storage(StorageEvent::DeleteResult {
+                key: Vec::<u8>::new().into(),
+            })
+        };
+        let page = || {
+            Event::Storage(StorageEvent::IterResult {
+                values: Vec::new(),
+                next_start_after: None,
+            })
+        };
+        let record = relationship(1, "source-a", "target-a");
+
+        let mut store = StoreSyncRelationshipOperation::new(
+            record.clone(),
+            SyncRelationshipDirection::Outgoing,
+        );
+        store.start();
+        store.step(Event::Storage(StorageEvent::WriteResult {
+            key: Vec::<u8>::new().into(),
+        }));
+        store.step(stray());
+        assert!(matches!(
+            store.finalize(),
+            Err(SyncRelationshipError::UnexpectedEvent { .. })
+        ));
+
+        let mut list =
+            ListSyncRelationshipsOperation::new(SyncRelationshipDirection::Outgoing, None);
+        list.start();
+        list.step(page());
+        list.step(stray());
+        assert!(matches!(
+            list.finalize(),
+            Err(SyncRelationshipError::UnexpectedEvent { .. })
+        ));
+
+        let mut get =
+            GetSyncRelationshipOperation::new(record.id, SyncRelationshipDirection::Outgoing);
+        get.start();
+        get.step(page());
+        get.step(stray());
+        assert!(matches!(
+            get.finalize(),
+            Err(SyncRelationshipError::UnexpectedEvent { .. })
+        ));
+
+        let mut delete =
+            DeleteSyncRelationshipOperation::new(record, SyncRelationshipDirection::Outgoing);
+        delete.start();
+        delete.step(stray());
+        delete.step(stray());
+        assert!(matches!(
+            delete.finalize(),
+            Err(SyncRelationshipError::UnexpectedEvent { .. })
+        ));
     }
 }

--- a/operations/src/update_metadata_document.rs
+++ b/operations/src/update_metadata_document.rs
@@ -1854,7 +1854,7 @@ mod tests {
         assert_no_graph_mutation_or_sync(effects.as_slice());
 
         let effects = operation.step(Event::Storage(StorageEvent::Error {
-            error: aruna_core::errors::StorageError::WriteError,
+            error: aruna_core::errors::StorageError::WriteError("boom".to_string()),
         }));
 
         assert_no_graph_mutation_or_sync(effects.as_slice());
@@ -1862,7 +1862,7 @@ mod tests {
         assert_eq!(
             operation.finalize(),
             Err(UpdateMetadataDocumentError::StorageError(
-                aruna_core::errors::StorageError::WriteError
+                aruna_core::errors::StorageError::WriteError("boom".to_string())
             ))
         );
     }

--- a/operations/src/update_user.rs
+++ b/operations/src/update_user.rs
@@ -636,7 +636,10 @@ impl Operation for UpdateUserOperation {
                 self.handle_schedule_admin_document_outbox_drain(event, user)
             }
             UpdateUserState::AnnounceUser { user } => self.handle_announce_user(event, user),
-            UpdateUserState::Init | UpdateUserState::Finish | UpdateUserState::Error => smallvec![],
+            UpdateUserState::Init | UpdateUserState::Finish | UpdateUserState::Error => {
+                let got = format!("{event:?}");
+                self.unexpected_event("no event", got)
+            }
         }
     }
 
@@ -1374,5 +1377,23 @@ mod tests {
             operation.finalize().unwrap_err(),
             UpdateUserError::PlacementFenced
         );
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let realm_id = RealmId::from_bytes([2u8; 32]);
+        let user_id = UserId::local(Ulid::from_bytes([3u8; 16]), realm_id);
+        let mut operation = UpdateUserOperation::new(input(realm_id, user_id, user_id));
+
+        let effects = operation.step(Event::Storage(StorageEvent::TransactionStarted {
+            txn_id: TxnId::generate(),
+        }));
+
+        assert!(effects.is_empty());
+        assert!(matches!(
+            operation.finalize(),
+            Err(UpdateUserError::UnexpectedEvent { .. })
+        ));
     }
 }

--- a/operations/src/usage_stats.rs
+++ b/operations/src/usage_stats.rs
@@ -559,7 +559,7 @@ impl Operation for LoadUsageCountersOperation {
             LoadUsageCountersState::ReadGlobal => self.handle_global_read(event),
             LoadUsageCountersState::Init
             | LoadUsageCountersState::Finish
-            | LoadUsageCountersState::Error => smallvec![],
+            | LoadUsageCountersState::Error => self.unexpected_event("no event", event),
         }
     }
 
@@ -1011,7 +1011,13 @@ impl Operation for RebuildUsageStatsOperation {
                 self.handle_stale_counters_deleted(event)
             }
             RebuildUsageStatsState::CommitTransaction => self.handle_transaction_committed(event),
-            RebuildUsageStatsState::Finish | RebuildUsageStatsState::Error => smallvec![],
+            RebuildUsageStatsState::Finish | RebuildUsageStatsState::Error => {
+                self.emit_error(RebuildUsageStatsError::InvalidStateEvent {
+                    state: self.state.clone(),
+                    expected: "no event",
+                    received: event,
+                })
+            }
         }
     }
 
@@ -3142,5 +3148,34 @@ mod tests {
                 .map(|bytes| UsageCounters::from_bytes(&bytes).unwrap().logical_bytes),
             Some(15)
         );
+    }
+
+    // A state that expects no event must reject one instead of ignoring it.
+    #[test]
+    fn terminal_rejects_event() {
+        let stray = || {
+            Event::Storage(StorageEvent::TransactionCommitted {
+                txn_id: TxnId::generate(),
+            })
+        };
+
+        let mut load = LoadUsageCountersOperation::new(USAGE_GLOBAL_KEY.to_vec());
+        load.step(stray());
+        assert!(matches!(
+            load.finalize(),
+            Err(LoadUsageCountersError::UnexpectedEvent { .. })
+        ));
+
+        let mut rebuild = RebuildUsageStatsOperation::new();
+        rebuild.start();
+        rebuild.step(stray());
+        rebuild.step(stray());
+        assert!(matches!(
+            rebuild.finalize(),
+            Err(RebuildUsageStatsError::InvalidStateEvent {
+                state: RebuildUsageStatsState::Error,
+                ..
+            })
+        ));
     }
 }

--- a/operations/tests/auth_validation.rs
+++ b/operations/tests/auth_validation.rs
@@ -4,6 +4,7 @@ use aruna_core::UserId;
 use aruna_core::auth::bearer_token_hash;
 use aruna_core::keys::generate_signing_key;
 use aruna_core::structs::{RealmId, TokenClaims};
+use aruna_core::util::unix_timestamp_secs;
 use aruna_operations::auth::{
     ArunaBearerTokenError, ArunaBearerTokenValidationState, validate_aruna_bearer_token,
 };
@@ -17,11 +18,24 @@ use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use ulid::Ulid;
 
-#[derive(Default)]
 struct TestAuthState {
+    /// One clock reading per state: claim validation and the token the test
+    /// signs are judged against the same instant.
+    now: u64,
     revoked_hashes: HashSet<String>,
     trusted_realms: HashSet<RealmId>,
     revocation_reads: AtomicUsize,
+}
+
+impl Default for TestAuthState {
+    fn default() -> Self {
+        Self {
+            now: unix_timestamp_secs(),
+            revoked_hashes: HashSet::new(),
+            trusted_realms: HashSet::new(),
+            revocation_reads: AtomicUsize::new(0),
+        }
+    }
 }
 
 #[async_trait]
@@ -37,6 +51,10 @@ impl ArunaBearerTokenValidationState for TestAuthState {
 
     async fn is_trusted_realm(&self, realm_id: &RealmId) -> bool {
         self.trusted_realms.contains(realm_id)
+    }
+
+    fn now_secs(&self) -> u64 {
+        self.now
     }
 }
 
@@ -94,12 +112,11 @@ async fn rejects_bad_signature() {
 #[tokio::test]
 async fn rejects_expired_token() {
     let (realm_signing_key, realm_id, user_id) = realm_fixture();
-    let now = chrono::Utc::now().timestamp().max(0) as u64;
-    let mut claims = token_claims(realm_id, user_id);
-    claims.iat = now.saturating_sub(7200);
-    claims.exp = now.saturating_sub(3600);
-    let token = sign_token(&realm_signing_key, &claims);
     let state = trusted_state(realm_id);
+    let mut claims = token_claims(realm_id, user_id);
+    claims.iat = state.now.saturating_sub(7200);
+    claims.exp = state.now.saturating_sub(3600);
+    let token = sign_token(&realm_signing_key, &claims);
 
     let error = validate_aruna_bearer_token(&state, &token)
         .await
@@ -230,7 +247,7 @@ fn trusted_state(realm_id: RealmId) -> TestAuthState {
 }
 
 fn token_claims(realm_id: RealmId, user_id: UserId) -> TokenClaims {
-    let now = chrono::Utc::now().timestamp().max(0) as u64;
+    let now = unix_timestamp_secs();
     TokenClaims {
         sub: user_id.to_string(),
         iss: realm_id.to_string(),

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -647,6 +647,11 @@ async fn set_write_policy(
                     user_id: realm.user_id,
                     realm_id: realm.realm_id,
                 },
+                auth_context: AuthContext {
+                    user_id: realm.user_id,
+                    realm_id: realm.realm_id,
+                    path_restrictions: None,
+                },
                 policies: vec![policy.clone()],
                 expected_hash: None,
             }),
@@ -900,7 +905,11 @@ async fn install_realm_config(
         config.seed_job_control(node.net.node_id(), band as u32);
     }
 
-    let realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+    // The realm user administers this realm, so the admin role names it.
+    let mut realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+    for role in realm_auth.roles.values_mut() {
+        role.assigned_users.insert(realm.user_id);
+    }
     let trusted = HashSet::from([realm_id]);
     for node in nodes {
         let actor = Actor {

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -639,7 +639,9 @@ async fn set_write_policy(
         expression: "permission == 'write'".to_string(),
         enabled: true,
     };
-    for node in nodes {
+    // Only the sync-eligible nodes are management members, and a realm-config
+    // write on any other node is refused before it can diverge.
+    for node in nodes.iter().filter(|node| node.sync_eligible) {
         drive(
             SetRealmPoliciesOperation::new(SetRealmPoliciesConfig {
                 actor: Actor {

--- a/operations/tests/metadata_forwarding.rs
+++ b/operations/tests/metadata_forwarding.rs
@@ -185,10 +185,13 @@ async fn forwarded_policy_denies() -> Result<(), Box<dyn std::error::Error>> {
     let error = drive_forwarded_create(&realm, user_node, group_id, document_id)
         .await
         .expect_err("a routed write denied by policy must not be accepted");
-    assert!(matches!(
-        error.downcast_ref::<MetadataWriteError>(),
-        Some(MetadataWriteError::Forbidden)
-    ));
+    assert!(
+        matches!(
+            error.downcast_ref::<MetadataWriteError>(),
+            Some(MetadataWriteError::Forbidden)
+        ),
+        "unexpected forwarded create error: {error}"
+    );
 
     shutdown(nodes).await;
     Ok(())

--- a/operations/tests/rocrate_drivers.rs
+++ b/operations/tests/rocrate_drivers.rs
@@ -1227,7 +1227,7 @@ fn storage_proxy(
             while let Ok((effect, response, _span, _queued, _in_flight)) = receiver.recv() {
                 if thread_faulty.load(Ordering::Acquire) && bucket_read(&effect) {
                     response.send(StorageEvent::Error {
-                        error: StorageError::ReadError,
+                        error: StorageError::ReadError("boom".to_string()),
                     });
                     continue;
                 }

--- a/operations/tests/topology/mod.rs
+++ b/operations/tests/topology/mod.rs
@@ -559,6 +559,7 @@ impl Topology {
                         actor: actor.clone(),
                         mutation: mutation.clone(),
                     },
+                    None,
                     node.context.as_ref(),
                 ),
             )
@@ -1125,6 +1126,7 @@ async fn install_realm_config(
                         candidate_map_epoch: 1,
                     },
                 },
+                None,
                 nodes[0].context.as_ref(),
             ),
         )

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -191,7 +191,7 @@ impl Store {
                     .or_insert_with(|| ks.clone())
                     .clone())
             }
-            Err(_) => Err(StorageError::KeyspaceError),
+            Err(error) => Err(StorageError::KeyspaceError(error.to_string())),
         }
     }
 }
@@ -1922,7 +1922,7 @@ impl FjallStorage {
             .db
             .write_tx()
             .map(|tx| tx.durability(Some(self.persist_policy.as_fjall())))
-            .map_err(|_| StorageError::WriteError)
+            .map_err(|error| StorageError::WriteError(error.to_string()))
     }
 
     fn commit_buffered_write_tx(&self, tx: fjall::OptimisticWriteTx) -> Result<(), StorageError> {
@@ -1936,9 +1936,9 @@ impl FjallStorage {
                 Span::current().record("commit_ms", duration_ms(commit_started.elapsed()));
                 Err(StorageError::TransactionConflict)
             }
-            Err(_) => {
+            Err(error) => {
                 Span::current().record("commit_ms", duration_ms(commit_started.elapsed()));
-                Err(StorageError::WriteError)
+                Err(StorageError::WriteError(error.to_string()))
             }
         }
     }
@@ -2052,8 +2052,8 @@ impl FjallStorage {
                         key,
                         value: value_opt.map(|v| v.into()),
                     },
-                    Err(_e) => StorageEvent::Error {
-                        error: StorageError::ReadError,
+                    Err(error) => StorageEvent::Error {
+                        error: StorageError::ReadError(error.to_string()),
                     },
                 },
                 Some(Txn::Write(txn)) => match txn.get(keyspace, &key) {
@@ -2061,8 +2061,8 @@ impl FjallStorage {
                         key,
                         value: value_opt.map(|v| v.into()),
                     },
-                    Err(_e) => StorageEvent::Error {
-                        error: StorageError::ReadError,
+                    Err(error) => StorageEvent::Error {
+                        error: StorageError::ReadError(error.to_string()),
                     },
                 },
                 None => StorageEvent::Error {
@@ -2422,8 +2422,8 @@ fn store_read(store: &Store, keyspace: OptimisticTxKeyspace, key: ByteView) -> S
             key,
             value: value_opt.map(|v| v.into()),
         },
-        Err(_e) => StorageEvent::Error {
-            error: StorageError::ReadError,
+        Err(error) => StorageEvent::Error {
+            error: StorageError::ReadError(error.to_string()),
         },
     }
 }
@@ -2441,9 +2441,9 @@ fn batch_read_with<R: Readable>(
         };
         match reader.get(&keyspace, &key) {
             Ok(value_opt) => values.push((key, value_opt.map(Into::into))),
-            Err(_e) => {
+            Err(error) => {
                 return StorageEvent::Error {
-                    error: StorageError::ReadError,
+                    error: StorageError::ReadError(error.to_string()),
                 };
             }
         }
@@ -2483,8 +2483,8 @@ fn read_last_with<R: Readable>(
             values: vec![(ByteView::from(key.as_ref()), ByteView::from(value.as_ref()))],
             next_start_after: None,
         },
-        Err(_) => StorageEvent::Error {
-            error: StorageError::ReadError,
+        Err(error) => StorageEvent::Error {
+            error: StorageError::ReadError(error.to_string()),
         },
     }
 }
@@ -3162,7 +3162,9 @@ fn collect_page(iter: fjall::Iter, limit: usize) -> Result<PageResult, StorageEr
     let mut values: Vec<(ByteView, ByteView)> = Vec::with_capacity(limit.min(1024));
 
     while let Some(guard) = iter.next() {
-        let (key, value) = guard.into_inner().map_err(|_| StorageError::ReadError)?;
+        let (key, value) = guard
+            .into_inner()
+            .map_err(|error| StorageError::ReadError(error.to_string()))?;
         values.push((ByteView::from(key.as_ref()), ByteView::from(value.as_ref())));
 
         if values.len() == limit {

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -992,7 +992,7 @@ fn cleanup_effect(effect: &StorageEffect) -> Option<(Ulid, CleanupKind)> {
 fn is_cleanup_write(effect: &StorageEffect) -> bool {
     matches!(
         effect,
-        StorageEffect::Write { key_space, .. } if key_space == aruna_core::keyspaces::BLOB_CLEANUP_KEYSPACE
+        StorageEffect::Write { key_space, .. } if aruna_core::keyspaces::is_cleanup_keyspace(key_space)
     )
 }
 

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -214,6 +214,9 @@ struct StorageMetrics {
     requests_total: AtomicU64,
     errors_total: AtomicU64,
     conflicts_total: AtomicU64,
+    /// Errors that end the request. Conflicts are excluded: callers retry them,
+    /// and the retry is counted again under `requests_total`.
+    failed_total: AtomicU64,
     in_flight: AtomicU64,
     channel_closed: Arc<AtomicBool>,
     sealed: AtomicBool,
@@ -263,6 +266,7 @@ pub struct StorageMetricsSnapshot {
     pub requests_total: u64,
     pub errors_total: u64,
     pub conflicts_total: u64,
+    /// Errors that ended the request, excluding the conflicts callers retry.
     pub failed_total: u64,
     pub channel_closed: bool,
     pub sealed: bool,
@@ -506,12 +510,11 @@ impl StorageHandle {
     }
 
     pub fn snapshot_metrics(&self) -> StorageMetricsSnapshot {
-        let errors_total = self.metrics.errors_total.load(Ordering::Relaxed);
         StorageMetricsSnapshot {
             requests_total: self.metrics.requests_total.load(Ordering::Relaxed),
-            errors_total,
+            errors_total: self.metrics.errors_total.load(Ordering::Relaxed),
             conflicts_total: self.metrics.conflicts_total.load(Ordering::Relaxed),
-            failed_total: errors_total,
+            failed_total: self.metrics.failed_total.load(Ordering::Relaxed),
             channel_closed: self.metrics.channel_closed.load(Ordering::Relaxed),
             sealed: self.is_sealed(),
             rejected_writes: self.rejected_writes(),
@@ -905,6 +908,8 @@ impl StorageHandle {
 
         if matches!(error, StorageError::TransactionConflict) {
             self.metrics.conflicts_total.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.metrics.failed_total.fetch_add(1, Ordering::Relaxed);
         }
 
         if matches!(error, StorageError::ChannelClosed) {
@@ -5372,7 +5377,8 @@ mod tests {
         assert_eq!(metrics_after_conflict.requests_total, 2);
         assert_eq!(metrics_after_conflict.errors_total, 2);
         assert_eq!(metrics_after_conflict.conflicts_total, 1);
-        assert_eq!(metrics_after_conflict.failed_total, 2);
+        // A retryable conflict is not a failed request.
+        assert_eq!(metrics_after_conflict.failed_total, 1);
         assert_eq!(
             metrics_after_conflict.last_error,
             Some("Transaction conflict".to_string())

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1027,7 +1027,7 @@ fn reserve_cleanup(
 
     if previous.is_none() {
         if pending.len() >= MAX_TRANSACTION_CLEANUP {
-            return Err(StorageError::TransactionConflict);
+            return Err(StorageError::CleanupCapacity);
         }
         pending.insert(
             txn_id,
@@ -1958,7 +1958,7 @@ impl FjallStorage {
                 .expect("transaction cleanup mutex poisoned");
             if pending.len() >= MAX_TRANSACTION_CLEANUP {
                 return StorageEvent::Error {
-                    error: StorageError::TransactionConflict,
+                    error: StorageError::CleanupCapacity,
                 };
             }
             if pending.contains_key(&candidate) {
@@ -4368,6 +4368,31 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_cap_distinct() {
+        // Capacity exhaustion is not a conflict, so retry loops must not spin on it.
+        let mut pending = std::collections::BTreeMap::new();
+        for index in 0..super::MAX_TRANSACTION_CLEANUP {
+            pending.insert(
+                Ulid::from_parts(index as u64, 0),
+                super::CleanupEntry {
+                    kind: super::CleanupKind::Open,
+                    attempts: 0,
+                    queued: false,
+                },
+            );
+        }
+
+        assert!(matches!(
+            super::reserve_cleanup(
+                &mut pending,
+                Ulid::from_parts(u64::MAX, 0),
+                super::CleanupKind::Abort,
+            ),
+            Err(StorageError::CleanupCapacity)
+        ));
+    }
+
+    #[test]
     fn unknown_commit_runs() {
         let dir = tempdir().unwrap();
         let db = fjall::OptimisticTxDatabase::builder(dir.path())
@@ -4642,7 +4667,7 @@ mod tests {
                 .send_storage_effect(StorageEffect::StartTransaction { read: true })
                 .await,
             Event::Storage(StorageEvent::Error {
-                error: StorageError::TransactionConflict
+                error: StorageError::CleanupCapacity
             })
         ));
 


### PR DESCRIPTION
Every REST operation is now documented in one structure (lead sentence, Authentication, Behavior, Limits, Errors, with multi-line examples), enforced by the OpenAPI guard tests, and the remaining findings from the operational-hardening review and the codebase audit are fixed.

## Changes
- OpenAPI: all 153 operations restructured into the shared section layout with summaries of at most eight words, multi-line examples and every tag described; a structure guard (`structure_gaps`, `rejects_flat_docs`, non-empty examples) and a structured top-level description keep it that way.
- Authorization moved into the five realm and group configuration operations (permission sub-operation, realm check, and for realm-config writes the management-node requirement peers already enforce); the REST choke point stays in front of them for request policies.
- Request policies are excluded from the realm-config routing digest: with any policy installed, forwarded writes from user nodes were permanently undeliverable.
- Job outcomes: a cancelled attempt without backend evidence ends as cancelled; terminal operation states reject unexpected events; permission rules never abort a committed transaction.
- Storage: a distinct `CleanupCapacity` error (transient for jobs, 503 for clients) instead of a fake conflict; fjall and blob backend causes preserved in error messages; `failed_total` counted on its own; keyspace classification in core.
- Blob: the opendal writer rejects non-sequential offsets, `read_at` delegates, range reads report their size.
- API mappings: a still-referenced connector answers 409; staging submissions classify errors like job submissions; missing realm config on policy writes answers 404; declarations completed for 501/503/403 cases.
- Doctor password read from `ARUNA_OIDC_PASSWORD`; README corrected; unused workspace dependencies and dead doctor error variants removed; the tracked development `.env` explains itself; staging entry forwarders removed; shared `sorted_user_ids`; warnings on previously silent returns; bearer-token validation on an injectable clock.

## References
Follows #455 and #460.
