### PR TITLE
fix: broken reconcile, notebook sessions and read-only access

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,6 +32,8 @@ jobs:
       # nextest runs one process per test, so %m merges each binary's counters
       # into one file instead of writing a profraw per test process.
       LLVM_PROFILE_FILE: cargo-test-%m.profraw
+      # Instrumented frames are larger, so deep async tests overflow the 2 MiB default.
+      RUST_MIN_STACK: 8388608
 
     steps:
       - name: Check out repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "craqle"
 version = "0.2.0"
-source = "git+https://github.com/arunaengine/craqle?branch=main#9f1b9e45c5b93d6ea4f8b159166754a7a141700e"
+source = "git+https://github.com/arunaengine/craqle?rev=fb9f16380ed3e4b39d7d6055d416645ce839efac#fb9f16380ed3e4b39d7d6055d416645ce839efac"
 dependencies = [
  "blake3",
  "chrono",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "irokle"
 version = "0.1.3"
-source = "git+https://github.com/arunaengine/irokle.git?rev=ebd4abd142f66816a16492c615525809f6c8b663#ebd4abd142f66816a16492c615525809f6c8b663"
+source = "git+https://github.com/arunaengine/irokle.git?rev=59e787058667bb6b400ab01fbd9a1698b88256f5#59e787058667bb6b400ab01fbd9a1698b88256f5"
 dependencies = [
  "blake3",
  "bytes",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "irokle-derive"
 version = "0.1.0"
-source = "git+https://github.com/arunaengine/irokle.git?rev=ebd4abd142f66816a16492c615525809f6c8b663#ebd4abd142f66816a16492c615525809f6c8b663"
+source = "git+https://github.com/arunaengine/irokle.git?rev=59e787058667bb6b400ab01fbd9a1698b88256f5#59e787058667bb6b400ab01fbd9a1698b88256f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,13 +28,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -44,9 +54,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -1623,7 +1633,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1689,37 +1699,26 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
- "aead",
- "chacha20 0.9.1",
- "cipher",
- "poly1305",
- "zeroize",
+ "aead 0.6.1",
+ "chacha20",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
 ]
 
 [[package]]
@@ -1743,8 +1742,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -2129,6 +2139,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -2139,7 +2150,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "crypto_secretbox",
  "curve25519-dalek 4.1.3",
  "salsa20",
@@ -2153,10 +2164,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
- "aead",
- "cipher",
+ "aead 0.5.2",
+ "cipher 0.4.4",
  "generic-array",
- "poly1305",
+ "poly1305 0.8.0",
  "salsa20",
  "subtle",
  "zeroize",
@@ -2199,7 +2210,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -3779,6 +3790,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -6115,7 +6135,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.1",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -6127,7 +6157,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -6615,7 +6645,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.2",
+ "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -7478,7 +7508,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -9160,6 +9190,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
  "opentelemetry_sdk",
  "postcard",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rmcp",
  "rustls",
  "serde",
@@ -334,7 +334,7 @@ dependencies = [
  "postcard",
  "prometheus-client",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rmcp",
  "s3s",
  "serde",
@@ -377,7 +377,7 @@ dependencies = [
  "md5",
  "opendal",
  "postcard",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustix",
  "serde",
  "sha1 0.11.0",
@@ -463,7 +463,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "toml 1.1.5+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "tracing",
  "ulid 3.0.0",
  "zeroize",
@@ -499,7 +499,7 @@ dependencies = [
  "jsonwebtoken",
  "postcard",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
+checksum = "4f10dafd0c8d2e51ae9a748805777613ed0bbe17bf586b76c8311f45c020a32f"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.145.0"
+version = "1.146.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e6320417a37c8a62f78b443d0b4cf628b57cd340a09b0eb56173d47cc94e93"
+checksum = "37b5ffaae346b9bd486ebdc3eb7053ec8ab8a1ad0f19a332eefeff036ed559e6"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1844,9 +1844,9 @@ checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
+checksum = "58a6d0db8759036a783bc7c3f7a07f8cef3bf9470eb1db3bc86e8bcd1c5d0fe8"
 dependencies = [
  "brotli",
  "compression-core",
@@ -3814,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "iroh"
@@ -3852,7 +3852,7 @@ dependencies = [
  "portable-atomic",
  "portmapper",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -3978,7 +3978,7 @@ dependencies = [
  "pin-project",
  "postcard",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -4676,7 +4676,7 @@ dependencies = [
  "n0-future",
  "ndk-context",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustc-hash",
  "rustls",
  "simple-dns",
@@ -5300,7 +5300,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.39.4",
  "reqsign-core",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -6953,11 +6953,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -7047,9 +7047,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
+checksum = "b88db56b8ae316560e9e868b6b978ea940f27cb883323fc90e07435e44158f5c"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -7063,7 +7063,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -7080,9 +7080,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
+checksum = "873b730df6f0a9b74b13eb514e0dca4c2db0d8b68b74af98a2e9bf3f9d436585"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7102,7 +7102,7 @@ dependencies = [
  "oxrdf",
  "oxrdfio",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -7306,9 +7306,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -8713,9 +8713,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -9261,9 +9261,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1489,7 +1489,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1513,7 +1513,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1984,8 +1984,8 @@ dependencies = [
 
 [[package]]
 name = "craqle"
-version = "0.2.0"
-source = "git+https://github.com/arunaengine/craqle?rev=fb9f16380ed3e4b39d7d6055d416645ce839efac#fb9f16380ed3e4b39d7d6055d416645ce839efac"
+version = "0.2.1"
+source = "git+https://github.com/arunaengine/craqle?rev=67a3eba114c3e5321bd94b09f2df99219c2e0b96#67a3eba114c3e5321bd94b09f2df99219c2e0b96"
 dependencies = [
  "blake3",
  "chrono",
@@ -2287,7 +2287,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2298,7 +2298,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2338,7 +2338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2523,7 +2523,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2658,6 +2658,9 @@ name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2718,7 +2721,7 @@ checksum = "0590c4a94da3372e83493b956755a6e2266830b6e4e3b101afe66e3f39477b91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2738,7 +2741,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3030,7 +3033,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3762,6 +3765,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,8 +4047,8 @@ dependencies = [
 
 [[package]]
 name = "irokle"
-version = "0.1.3"
-source = "git+https://github.com/arunaengine/irokle.git?rev=59e787058667bb6b400ab01fbd9a1698b88256f5#59e787058667bb6b400ab01fbd9a1698b88256f5"
+version = "0.1.4"
+source = "git+https://github.com/arunaengine/irokle.git?rev=dcce9593adf21b14c8c8214c7ad7c180777be303#dcce9593adf21b14c8c8214c7ad7c180777be303"
 dependencies = [
  "blake3",
  "bytes",
@@ -4046,11 +4068,11 @@ dependencies = [
 [[package]]
 name = "irokle-derive"
 version = "0.1.0"
-source = "git+https://github.com/arunaengine/irokle.git?rev=59e787058667bb6b400ab01fbd9a1698b88256f5#59e787058667bb6b400ab01fbd9a1698b88256f5"
+source = "git+https://github.com/arunaengine/irokle.git?rev=dcce9593adf21b14c8c8214c7ad7c180777be303#dcce9593adf21b14c8c8214c7ad7c180777be303"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5671,7 +5693,7 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
  "oxhttp",
- "oxiri",
+ "oxiri 0.2.11",
  "oxrdf",
  "oxrdfio",
  "oxsdatatypes",
@@ -5700,13 +5722,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4ed3a7192fa19f5f48f99871f2755047fabefd7f222f12a1df1773796a102"
 
 [[package]]
+name = "oxiri"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6bd0ef560f078e41ce2ebf370cce217e7fb2c3695ffa87541151c9de94e83a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oxjsonld"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86a3e89e005662e60327027f45ec7cefd0472404e01831b5d83a3ac522cfabe0"
 dependencies = [
  "json-event-parser",
- "oxiri",
+ "oxiri 0.2.11",
  "oxrdf",
  "ryu-js",
  "thiserror 2.0.20",
@@ -5720,7 +5751,7 @@ checksum = "4be15186205eb60ddbdc2fb47cb25df472c7f399bbe119b68c0972b6b6dd46ea"
 dependencies = [
  "hex",
  "oxilangtag",
- "oxiri",
+ "oxiri 0.2.11",
  "oxsdatatypes",
  "rand 0.9.5",
  "serde",
@@ -5748,7 +5779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71853d12051879f3e424c6864e978f5f5cbecd8e86a9817adbccaefccac9d61d"
 dependencies = [
  "oxilangtag",
- "oxiri",
+ "oxiri 0.2.11",
  "oxrdf",
  "quick-xml 0.37.5",
  "thiserror 2.0.20",
@@ -5771,7 +5802,7 @@ checksum = "b1d0fe19fa62a6a102f85b052bbd86e3cdc3360cd6a338d01bab1a6743bf1d8e"
 dependencies = [
  "memchr",
  "oxilangtag",
- "oxiri",
+ "oxiri 0.2.11",
  "oxrdf",
  "thiserror 2.0.20",
 ]
@@ -6268,9 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "prefixmap"
-version = "0.3.10"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad8bdda04fc975f90c1c223aedd8ee8d7dcfb6bc9d5e5a36bcbd8eed0133eea"
+checksum = "d419af1ed828277f1f41d56ae4b794f8e720e0414420a0b2b4182461ce681e54"
 dependencies = [
  "colored",
  "indexmap",
@@ -6287,7 +6318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6790,7 +6821,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7127,7 +7158,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7174,9 +7205,9 @@ dependencies = [
 
 [[package]]
 name = "rudof_config"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06182074ece9a28169eca164273d26df6fea8a760d4b82a017738cf6dc309549"
+checksum = "071940f649dc18b8e5fc79b6e7c64cad69858fb606bdf3e341230dca9691b21c"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -7186,13 +7217,14 @@ dependencies = [
 
 [[package]]
 name = "rudof_iri"
-version = "0.3.10"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ad494fd6cb6e53320b6c06e760ab403465331b1f790d40bb280afae7427587"
+checksum = "0ed989b455d11bc8e3b28ea01414c1748f270747329cb23ad86961bda45df8fe"
 dependencies = [
  "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "indexmap",
- "oxiri",
+ "oxiri 0.3.1",
  "oxrdf",
  "proptest",
  "reqwest 0.12.28",
@@ -7203,18 +7235,19 @@ dependencies = [
 
 [[package]]
 name = "rudof_rdf"
-version = "0.3.10"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d670212065352d56fcd1211cf0b301663a34cc7be92a160e57b075823c461cdc"
+checksum = "01db71de7b7498bd0a50993cabbf428a4d88fd7e568c05011dcd742f75d43719"
 dependencies = [
  "colored",
  "const_format",
  "csv",
  "getrandom 0.3.4",
+ "include_dir",
  "once_cell",
  "oxigraph",
  "oxilangtag",
- "oxiri",
+ "oxiri 0.3.1",
  "oxjsonld",
  "oxrdf",
  "oxrdfio",
@@ -7226,6 +7259,7 @@ dependencies = [
  "regex",
  "rudof_config",
  "rudof_iri",
+ "rudof_viz",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -7235,6 +7269,26 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "rudof_typing"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a8ac577b3711eceb0601db9343a1699b8aa580290215da0865e72bd2c7dca6"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "rudof_viz"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d161d194d35b2655cdab38a55fda780147465d2fcc7dc6e5ceb30f9b32829a"
+dependencies = [
+ "serde",
+ "tempfile",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7554,7 +7608,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7722,7 +7776,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7733,7 +7787,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7768,7 +7822,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7865,12 +7919,13 @@ dependencies = [
 
 [[package]]
 name = "shacl"
-version = "0.3.10"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c3c63507861b5636903053f601e510a2ce409c5895aa895f9d7023697f516"
+checksum = "04db282af6708ea9cf3692e7c455ad89ce866c5a3390bebbff4cd2c146c9fbff"
 dependencies = [
  "anyhow",
  "dashmap",
+ "either",
  "indoc",
  "itertools",
  "petgraph 0.8.3",
@@ -7879,6 +7934,7 @@ dependencies = [
  "rudof_config",
  "rudof_iri",
  "rudof_rdf",
+ "rudof_typing",
  "rust_decimal",
  "serde",
  "thiserror 2.0.20",
@@ -8038,7 +8094,7 @@ dependencies = [
  "hex",
  "json-event-parser",
  "md-5",
- "oxiri",
+ "oxiri 0.2.11",
  "oxrdf",
  "oxsdatatypes",
  "rand 0.9.5",
@@ -8059,7 +8115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef3c186ffb9bf2dde7c5edd5528583f309fcb819b5773cf0e313194a990304f"
 dependencies = [
  "oxilangtag",
- "oxiri",
+ "oxiri 0.2.11",
  "oxrdf",
  "peg",
  "rand 0.9.5",
@@ -8218,9 +8274,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8321,9 +8377,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
+checksum = "861facfabd71044968f364837f9a083b56464ba5a59079f88706ee5c451ca069"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8544,7 +8600,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8647,7 +8703,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -9097,7 +9153,7 @@ checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -10023,7 +10079,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "craqle"
 version = "0.2.1"
-source = "git+https://github.com/arunaengine/craqle?rev=67a3eba114c3e5321bd94b09f2df99219c2e0b96#67a3eba114c3e5321bd94b09f2df99219c2e0b96"
+source = "git+https://github.com/arunaengine/craqle?rev=1803d8ba1376cc2a3285ab009738ed7194c610ec#1803d8ba1376cc2a3285ab009738ed7194c610ec"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,16 +1940,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -3352,83 +3342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "hickory-proto",
- "http 1.5.0",
- "idna",
- "ipnet",
- "jni 0.22.4",
- "rand 0.10.2",
- "rustls",
- "thiserror 2.0.20",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni 0.22.4",
- "once_cell",
- "prefix-trie",
- "rand 0.10.2",
- "ring",
- "thiserror 2.0.20",
- "tinyvec",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipconfig",
- "ipnet",
- "jni 0.22.4",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot",
- "rand 0.10.2",
- "resolv-conf",
- "rustls",
- "smallvec",
- "system-configuration",
- "thiserror 2.0.20",
- "tokio",
- "tokio-rustls",
- "tracing",
-]
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,15 +3817,12 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "iroh"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329552fad4e46b5ccb4439d5635216f6289eec2c46f3fde4bc732d762694b9e5"
+checksum = "b2f8d1cfffc83efe39a1031aab423ce09cb8048071baba550508931e9a81ce46"
 dependencies = [
  "backon",
  "blake3",
@@ -3924,7 +3834,6 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "futures-util",
  "getrandom 0.4.3",
- "hickory-resolver",
  "http 1.5.0",
  "ipnet",
  "iroh-base",
@@ -3961,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccf4cde68a02ef03c0095ab2c031c6adfe508f3bc8e7c258558a027ebe64a8e"
+checksum = "ffd1efd1aaecd68d4d1b0727a30c5811f43fb822843e48f65f6e5db3b7256cc9"
 dependencies = [
  "curve25519-dalek 5.0.0",
  "data-encoding",
@@ -3980,18 +3889,17 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a41224eb0140a5c519935d4073fc6b236d174080be401f9bf7da126b2ee3aa4"
+checksum = "80276761b56e904e26ea71d0863beef0bb8d5ab6b639cbd1338e4b615209e3a1"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
  "derive_more",
- "hickory-resolver",
  "iroh-base",
+ "n0-dns-resolver",
  "n0-error",
  "n0-future",
- "ndk-context",
  "portable-atomic",
  "rand 0.10.2",
  "rustls",
@@ -4044,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5f6f07e2c9b0c4bc82e2864be09f4aea4320165d5316e668616dbc822f428a"
+checksum = "beb2294a9749d6a25fd7cd8bcf0fccd932f20716d4f967d85d3f23c7135ae6a2"
 dependencies = [
  "blake3",
  "bytes",
@@ -4054,7 +3962,6 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "getrandom 0.4.3",
- "hickory-resolver",
  "http 1.5.0",
  "http-body-util",
  "hyper",
@@ -4741,23 +4648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moka"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
-]
-
-[[package]]
 name = "murmur3"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4771,6 +4661,31 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "n0-dns-resolver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535c99c9a786bee714155d2ee4fc2477405c2c43536e1bc6a51de09a0d1448f7"
+dependencies = [
+ "derive_more",
+ "ipconfig",
+ "jni 0.22.4",
+ "lru 0.18.4",
+ "n0-error",
+ "n0-future",
+ "ndk-context",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "rustc-hash",
+ "rustls",
+ "simple-dns",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "webpki-roots",
+]
 
 [[package]]
 name = "n0-error"
@@ -5044,9 +4959,9 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "noq"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e6c57353d26be91a242f0ec96073066c4481a03f6be874daafb18902394515"
+checksum = "b78be567e796cfa74bb9bdc4117790af2d505eb887019cf8803244353eb09d89"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5066,9 +4981,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a46813e306c29c4f86357b6ffa39a8e1c97bb274b9a296a19a56d62e4111225"
+checksum = "7c1e5b6fe668491eca022f745a0a9402585626c73a7b839b3424ace15d6a9c8f"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -5093,9 +5008,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56d621ed2c1773b5356ab39cc68c819f8d0103f7493d8661c4a5f5f8ea55f40"
+checksum = "4dc50afea61aff926e150a36c31f06094608848e114a3fe667d76ec233163b1c"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5325,10 +5240,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -6317,17 +6228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
-]
-
-[[package]]
 name = "prefixmap"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7093,12 +6993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7454,7 +7348,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -7681,7 +7575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -8352,12 +8246,12 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+checksum = "501336eb7ba9e417300a6a0fa985721065467aa83a6dcf0422a8e43e4c0328fa"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 
@@ -8396,12 +8290,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tantivy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,8 +421,8 @@ dependencies = [
  "nix",
  "rustix",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "tar",
  "tempfile",
  "tokio",
@@ -7793,19 +7793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serdect"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,12 +9190,6 @@ dependencies = [
  "crypto-common 0.2.2",
  "ctutils",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "aruna"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "aruna-api",
  "aruna-blob",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-api"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "ahash 0.8.12",
  "aruna-blob",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-blob"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "aruna-core",
  "aruna-net",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-compute"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "aruna-core",
  "async-trait",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-compute-helper"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "rustix",
  "serde_json",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-core"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-doctor"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "ahash 0.8.12",
  "aruna",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-net"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "aruna-core",
  "aruna-storage",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-operations"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "aruna-blob",
  "aruna-compute",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-storage"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "aruna-core",
  "async-trait",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-tasks"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 dependencies = [
  "aruna-core",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tar",
  "tempfile",
  "tokio",
@@ -2336,7 +2337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7857,6 +7858,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9250,6 +9264,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
  "byteview",
  "chrono",
  "crypto_box",
- "dirs",
+ "dirs 7.0.0",
  "dotenvy",
  "ed25519-dalek 3.0.0",
  "flate2",
@@ -2467,6 +2467,15 @@ name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d57d423b3c82e89b9a24ca3091fee61f456a26edbd28d26c65906f4bc1dcd8f"
 dependencies = [
  "dirs-sys",
 ]
@@ -7097,7 +7106,7 @@ version = "0.6.0"
 source = "git+https://github.com/arunaengine/ro-crate-rs.git?rev=d60e99123d6e73d7730717ef30ce546da84e1177#d60e99123d6e73d7730717ef30ce546da84e1177"
 dependencies = [
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "log",
  "oxrdf",
  "oxrdfio",
@@ -7139,7 +7148,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06182074ece9a28169eca164273d26df6fea8a760d4b82a017738cf6dc309549"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "serde",
  "thiserror 2.0.20",
  "toml 0.9.12+spec-1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7452,9 +7452,9 @@ checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "s3s"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe1bd31748cb69848c2cf4028cecdadf5f8299ef3b02a83e21b20e7bda3aba9"
+checksum = "652451a66fefda01a13dc7df24aa2af9e70c7058f98bc08fe2f7c552eaa9f1e3"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -7482,6 +7482,7 @@ dependencies = [
  "numeric_cast",
  "pin-project-lite",
  "quick-xml 0.41.0",
+ "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -7499,6 +7500,7 @@ dependencies = [
  "transform-stream",
  "url",
  "urlencoding",
+ "xxhash-rust",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ k8s-openapi = { version = "0.28", features = ["v1_32"] }
 s3s = "0.14.1"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = { version = "1.0.151", features = ["raw_value"] }
+serde_yaml = "0.9.34"
 sha1 = "0.11.0"
 sha2 = "0.11.0"
 smallvec = "1.15.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,9 @@ cel-interpreter = "0.10.0"
 chacha20poly1305 = "0.11.0"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.6", features = ["derive", "env"] }
-craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", features = [
+# Pinned instead of tracking main: craqle's main pins a newer irokle whose
+# smallvec 1.16 requirement collides with the kube serde-saphyr cap.
+craqle = { git = "https://github.com/arunaengine/craqle", rev = "fb9f16380ed3e4b39d7d6055d416645ce839efac", features = [
     "iroh",
     "shacl-core",
 ] }
@@ -98,7 +100,7 @@ hyper-util = { version = "0.1.20", features = [
 ipnet = "2.12.2"
 iroh = "1.2.0"
 # Pinned to the exact revision craqle uses so one irokle crate is resolved.
-irokle = { git = "https://github.com/arunaengine/irokle.git", rev = "ebd4abd142f66816a16492c615525809f6c8b663", features = [
+irokle = { git = "https://github.com/arunaengine/irokle.git", rev = "59e787058667bb6b400ab01fbd9a1698b88256f5", features = [
     "fjall",
     "iroh",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ aruna-tasks = { path = "tasks" }
 
 # Third-party crates
 ahash = "0.8.12"
-async-compression = { version = "0.4.44", default-features = false, features = [
+async-compression = { version = "0.4.46", default-features = false, features = [
     "tokio",
     "deflate",
 ] }
@@ -50,7 +50,7 @@ aws-config = { version = "1.12.0", default-features = false, features = [
     "default-https-client",
     "rt-tokio",
 ] }
-aws-sdk-s3 = { version = "1.145.0", default-features = false, features = [
+aws-sdk-s3 = { version = "1.146.0", default-features = false, features = [
     "default-https-client",
     "http-1x",
     "rt-tokio",
@@ -95,7 +95,7 @@ hyper-util = { version = "0.1.20", features = [
     "tokio",
     "service",
 ] }
-ipnet = "2.12.1"
+ipnet = "2.12.2"
 iroh = "1.2.0"
 # Pinned to the exact revision craqle uses so one irokle crate is resolved.
 irokle = { git = "https://github.com/arunaengine/irokle.git", rev = "ebd4abd142f66816a16492c615525809f6c8b663", features = [
@@ -138,18 +138,18 @@ prometheus-client = "0.25"
 proptest = "1.11.0"
 quick-xml = "0.42.0"
 rand = "0.10.2"
-reqwest = { version = "0.13.4", default-features = false, features = [
+reqwest = { version = "0.13.5", default-features = false, features = [
     "json",
     "rustls",
     "stream",
 ] }
-rmcp = { version = "3.2.0", default-features = false, features = [
+rmcp = { version = "3.3.0", default-features = false, features = [
     "server",
     "macros",
     "transport-streamable-http-server",
 ] }
 rustix = { version = "1.1.4", features = ["fs", "process"] }
-rustls = { version = "0.23.43", features = ["ring"] }
+rustls = { version = "0.23.44", features = ["ring"] }
 kube = { version = "4.2.0", default-features = false, features = [
     "client",
     "jsonpatch",
@@ -174,7 +174,7 @@ tar = "0.4.46"
 tempfile = "3.27.0"
 thiserror = "2.0.20"
 tokio = { version = "1.53.1", features = ["full", "tracing"] }
-toml = "1.1.5"
+toml = "1.1.6"
 tokio-util = { version = "0.7.19", features = ["compat", "io-util", "rt"] }
 tower = { version = "0.5.3", features = ["limit"] }
 tower-http = { version = "0.7.1", features = ["compression-br", "compression-gzip", "cors", "fs", "timeout"] }
@@ -190,7 +190,7 @@ tracing-subscriber = { version = "0.3.23", features = [
 ulid = { version = "3.0.0", features = ["serde"] }
 unicode-normalization = "0.1.25"
 url = "2.5.8"
-uuid = { version = "1.26.0", features = ["v4"] }
+uuid = { version = "1.26.1", features = ["v4"] }
 utoipa = { version = "5.5.0", features = [
     "chrono",
     "axum_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", featu
 crc-fast = "1.10.0"
 crossfire = "3.1.20"
 crypto_box = "0.9.1"
-dirs = "6.0.0"
+dirs = "7.0.0"
 dotenvy = "0.15.7"
 ed25519-dalek = { version = "3.0.0", features = ["pem"] }
 fjall = "3.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ hyper-util = { version = "0.1.20", features = [
     "service",
 ] }
 ipnet = "2.12.1"
-iroh = "1.1.0"
+iroh = "1.2.0"
 # Pinned to the exact revision craqle uses so one irokle crate is resolved.
 irokle = { git = "https://github.com/arunaengine/irokle.git", rev = "ebd4abd142f66816a16492c615525809f6c8b663", features = [
     "fjall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ k8s-openapi = { version = "0.28", features = ["v1_32"] }
 s3s = "0.15.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = { version = "1.0.151", features = ["raw_value"] }
-serde_yaml = "0.9.34"
+serde-saphyr = "0.0.29"
 sha1 = "0.11.0"
 sha2 = "0.11.0"
 smallvec = "1.15.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,9 @@ cel-interpreter = "0.10.0"
 chacha20poly1305 = "0.11.0"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.6", features = ["derive", "env"] }
-# Pinned instead of tracking main: craqle's main pins a newer irokle whose
-# smallvec 1.16 requirement collides with the kube serde-saphyr cap.
-craqle = { git = "https://github.com/arunaengine/craqle", rev = "fb9f16380ed3e4b39d7d6055d416645ce839efac", features = [
+# Pinned to the craqle revision carrying the merged irokle sync fixes with the
+# relaxed smallvec requirement, which the kube serde-saphyr cap needs.
+craqle = { git = "https://github.com/arunaengine/craqle", rev = "67a3eba114c3e5321bd94b09f2df99219c2e0b96", features = [
     "iroh",
     "shacl-core",
 ] }
@@ -100,7 +100,7 @@ hyper-util = { version = "0.1.20", features = [
 ipnet = "2.12.2"
 iroh = "1.2.0"
 # Pinned to the exact revision craqle uses so one irokle crate is resolved.
-irokle = { git = "https://github.com/arunaengine/irokle.git", rev = "59e787058667bb6b400ab01fbd9a1698b88256f5", features = [
+irokle = { git = "https://github.com/arunaengine/irokle.git", rev = "dcce9593adf21b14c8c8214c7ad7c180777be303", features = [
     "fjall",
     "iroh",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ bollard = "0.21.1"
 byteview = "0.10.2"
 bytes = "1.12.1"
 cel-interpreter = "0.10.0"
-chacha20poly1305 = "0.10.1"
+chacha20poly1305 = "0.11.0"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.6", features = ["derive", "env"] }
 craqle = { git = "https://github.com/arunaengine/craqle", branch = "main", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ kube = { version = "4.2.0", default-features = false, features = [
     "ws",
 ] }
 k8s-openapi = { version = "0.28", features = ["v1_32"] }
-s3s = "0.14.1"
+s3s = "0.15.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = { version = "1.0.151", features = ["raw_value"] }
 serde_yaml = "0.9.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 
 [workspace.package]
 description = "A federated data orchestration network"
-version = "3.0.0-alpha.78"
+version = "3.0.0-alpha.79"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/arunaengine/aruna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.6", features = ["derive", "env"] }
 # Pinned to the craqle revision carrying the merged irokle sync fixes with the
 # relaxed smallvec requirement, which the kube serde-saphyr cap needs.
-craqle = { git = "https://github.com/arunaengine/craqle", rev = "67a3eba114c3e5321bd94b09f2df99219c2e0b96", features = [
+craqle = { git = "https://github.com/arunaengine/craqle", rev = "1803d8ba1376cc2a3285ab009738ed7194c610ec", features = [
     "iroh",
     "shacl-core",
 ] }

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ Kubernetes the Aruna node's controller service account needs the `create` verb o
 the node talks to a session's kernel through an exec into the running pod. The task workload
 service account stays unprivileged, with its token unmounted.
 
+On a Cilium cluster the S3 endpoint often resolves to the ingress load balancer, and Cilium treats
+that traffic as its reserved `ingress` entity, which no `ipBlock` rule matches. The node therefore
+also writes the CiliumNetworkPolicy `aruna-compute-s3-ingress`, so its service account needs
+`create`, `get` and `patch` on `ciliumnetworkpolicies.cilium.io` in the compute namespace. Without
+that permission the node logs a warning and leaves the policy alone; clusters without the CRD skip
+it. DNS egress is allowed by port with no peer, because a node-local resolver runs on a host
+address that is neither a pod nor a CIDR peer.
+
 The session images are built from `scripts/session-python` and `scripts/session-deno`, which share
 the helper in `scripts/session-helper`. Build them with their `build.sh`; the runtime catalog names
 `harbor.computational.bio.uni-giessen.de/aruna/aruna-session-python:0.2.0` and `harbor.computational.bio.uni-giessen.de/aruna/aruna-session-deno:0.1.0`.

--- a/README.md
+++ b/README.md
@@ -188,13 +188,20 @@ Kubernetes the Aruna node's controller service account needs the `create` verb o
 the node talks to a session's kernel through an exec into the running pod. The task workload
 service account stays unprivileged, with its token unmounted.
 
-On a Cilium cluster the S3 endpoint often resolves to the ingress load balancer, and Cilium treats
-that traffic as its reserved `ingress` entity, which no `ipBlock` rule matches. The node therefore
-also writes the CiliumNetworkPolicy `aruna-compute-s3-ingress`, so its service account needs
-`create`, `get` and `patch` on `ciliumnetworkpolicies.cilium.io` in the compute namespace. Without
-that permission the node logs a warning and leaves the policy alone; clusters without the CRD skip
-it. DNS egress is allowed by port with no peer, because a node-local resolver runs on a host
-address that is neither a pod nor a CIDR peer.
+Some clusters need policies the standard Kubernetes ones cannot express. List those manifests in
+`ARUNA_COMPUTE_K8S_POLICY_MANIFESTS`, a comma-separated list of YAML files and directories; a
+directory contributes its `*.yaml` and `*.yml` files in name order, and a file may hold several
+documents. Every document needs an `apiVersion`, a `kind` and a `metadata.name`, and its namespace
+must be absent or the compute namespace. The node applies them next to its own network policies at
+startup and before each job, so its service account needs `create`, `get` and `patch` on those
+kinds in that namespace. An unreadable file, an invalid document or a kind the cluster does not
+serve stops the node.
+
+A Cilium cluster is the common case: the S3 endpoint often resolves to the ingress load balancer,
+and Cilium treats that traffic as its reserved `ingress` entity, which no `ipBlock` rule matches. A
+CiliumNetworkPolicy with `toEntities: [ingress]` on the S3 port, selecting pods labelled
+`aruna-engine.org/network: s3`, opens it. DNS egress is allowed by port with no peer, because a
+node-local resolver runs on a host address that is neither a pod nor a CIDR peer.
 
 The session images are built from `scripts/session-python` and `scripts/session-deno`, which share
 the helper in `scripts/session-helper`. Build them with their `build.sh`; the runtime catalog names

--- a/api/src/routes/credentials.rs
+++ b/api/src/routes/credentials.rs
@@ -1,10 +1,12 @@
 use crate::auth::require_unrestricted_realm_auth;
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
+use aruna_core::permission_path::readable_roots;
 use aruna_core::structs::{
     AuthContext, PathRestriction, Permission, UserAccess, blob_group_permission_path,
 };
 use aruna_operations::driver::drive;
+use aruna_operations::get_group::{GetGroupConfig, GetGroupError, GetGroupOperation};
 use aruna_operations::s3::create_user_access::{
     CreateUserAccessConfig, CreateUserAccessError, CreateUserAccessOperation,
     DEFAULT_CREDENTIAL_TTL,
@@ -281,9 +283,9 @@ pub async fn list_s3_credentials(
     summary = "Create an S3 credential for a group",
     description = r#"Issues an S3 access key and a one-time secret bound to a group, for the calling user.
 
-**Authentication**: realm bearer token with WRITE on the group's data path. A path-restricted token
-may be used: the credential inherits the caller's restrictions narrowed to the group data root and
-can never widen them.
+**Authentication**: realm bearer token with READ or WRITE on the group's data path, or on a part of
+it. A path-restricted token may be used: the credential inherits the caller's restrictions narrowed
+to the group data root and can never widen them.
 
 **Behavior**
 - The credential is always issued to the calling user, so no caller can mint one for somebody else.
@@ -324,7 +326,7 @@ can never widen them.
         ),
         (status = 400, description = "The group id is not a ULID, the lifetime is out of range, or a restriction is malformed or exceeds the count limit", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
-        (status = 403, description = "Token belongs to another realm, the caller lacks WRITE on the group data path, or a restriction reaches outside the group root or the caller's own grant", body = ErrorResponse),
+        (status = 403, description = "Token belongs to another realm, the caller may read no part of the group data path, or a restriction reaches outside the group root or the caller's own grant", body = ErrorResponse),
         (status = 409, description = "The caller already holds 16 active credentials; revoke or let one expire first", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
@@ -353,11 +355,10 @@ pub async fn create_s3_credentials(
     {
         return Err(ServerError::BadRequest);
     }
-    let group_root = blob_group_permission_path(realm_id, group_id, state.get_node_id());
     let path_restrictions =
         build_credential_restrictions(&auth, &state, group_id, request.path_restrictions.clone())
             .await?;
-    authorize_credential_issuance(&auth, &state, &group_root, path_restrictions.as_deref()).await?;
+    authorize_credential_issuance(&auth, &state, group_id, path_restrictions.as_deref()).await?;
     let path_restrictions = path_restrictions.as_deref().map(serialize_restrictions);
     if let Some(restrictions) = path_restrictions.as_deref()
         && aruna_core::permission_path::validate_restriction_limits(restrictions).is_err()
@@ -681,29 +682,36 @@ fn merge_effective_restrictions(
     }
 }
 
+/// A credential never exceeds the caller's own grant, so any member who may
+/// read part of the group data may take one; only a caller left without an
+/// allowed scope is refused.
 async fn authorize_credential_issuance(
     auth: &AuthContext,
     state: &ServerState,
-    group_root: &str,
+    group_id: Ulid,
     effective_restrictions: Option<&[NormalizedRestriction]>,
 ) -> ServerResult<()> {
+    let group_root =
+        blob_group_permission_path(state.get_realm_id(), group_id, state.get_node_id());
     let effective_auth = AuthContext {
         path_restrictions: effective_restrictions.map(serialize_restrictions),
         ..auth.clone()
     };
 
     let Some(effective_restrictions) = effective_restrictions else {
-        return check_permission(
-            &effective_auth,
-            state,
-            group_root.to_string(),
-            Permission::WRITE,
-        )
-        .await;
+        for permission in [Permission::WRITE, Permission::READ] {
+            match check_permission(&effective_auth, state, group_root.clone(), permission).await {
+                Ok(()) => return Ok(()),
+                Err(ServerError::Forbidden) => continue,
+                Err(err) => return Err(err),
+            }
+        }
+
+        return authorize_group_subpath(&effective_auth, state, group_id, &group_root).await;
     };
 
     for restriction in effective_restrictions {
-        if restriction.permission != Permission::WRITE {
+        if restriction.permission == Permission::DENY {
             continue;
         }
 
@@ -711,7 +719,7 @@ async fn authorize_credential_issuance(
             &effective_auth,
             state,
             restriction.scope.authorization_probe_path(),
-            Permission::WRITE,
+            restriction.permission.clone(),
         )
         .await
         {
@@ -722,6 +730,33 @@ async fn authorize_credential_issuance(
     }
 
     Err(ServerError::Forbidden)
+}
+
+/// Accepts a member whose roles reach only a part of the group data, such as a
+/// single dataset folder, because every S3 request is still authorized against
+/// those roles.
+async fn authorize_group_subpath(
+    auth: &AuthContext,
+    state: &ServerState,
+    group_id: Ulid,
+    group_root: &str,
+) -> ServerResult<()> {
+    let (_, authorization) = drive(
+        GetGroupOperation::new(GetGroupConfig { group_id }),
+        &state.get_ctx(),
+    )
+    .await
+    .map_err(|error| match error {
+        GetGroupError::GroupNotFound | GetGroupError::AuthDocNotFound => ServerError::Forbidden,
+        _ => ServerError::InternalError(error.to_string()),
+    })?;
+
+    let granted = authorization.user_permissions(auth.user_id);
+    if readable_roots(&granted, auth.path_restrictions.as_deref(), group_root).is_empty() {
+        return Err(ServerError::Forbidden);
+    }
+
+    Ok(())
 }
 
 async fn check_permission(
@@ -907,6 +942,216 @@ mod tests {
         .unwrap();
 
         (dir, state, auth, access_key_id)
+    }
+
+    /// Group whose only role for the caller carries the given permissions.
+    async fn scoped_state(
+        permissions: Vec<(String, Permission)>,
+    ) -> (TempDir, Arc<ServerState>, AuthContext, Ulid) {
+        use std::collections::{HashMap, HashSet};
+        let (dir, state, auth) = test_state().await;
+        let realm_id = state.get_realm_id();
+        let node_id = state.get_node_id();
+        let group_id = Ulid::from_bytes([7u8; 16]);
+        let actor = Actor {
+            node_id,
+            user_id: auth.user_id,
+            realm_id,
+        };
+        let role_id = Ulid::from_bytes([8u8; 16]);
+        let group_auth = GroupAuthorizationDocument {
+            group_id,
+            roles: HashMap::from([(
+                role_id,
+                aruna_core::structs::Role {
+                    role_id,
+                    name: "scoped".to_string(),
+                    permissions: permissions.into_iter().collect(),
+                    assigned_users: HashSet::from([auth.user_id]),
+                },
+            )]),
+            policies: Vec::new(),
+        };
+        let group = Group {
+            display_name: "scoped-group".to_string(),
+            group_id,
+            realm_id,
+            roles: group_auth.roles.keys().copied().collect(),
+            owner: auth.user_id,
+        };
+        for (key_space, key, value) in [
+            (
+                REALM_CONFIG_KEYSPACE,
+                realm_id.as_bytes().to_vec(),
+                RealmConfigDocument::default_for_realm(realm_id, Vec::new())
+                    .to_bytes(&actor)
+                    .unwrap(),
+            ),
+            (
+                AUTH_KEYSPACE,
+                realm_id.as_bytes().to_vec(),
+                RealmAuthorizationDocument::new_default_realm_doc(realm_id)
+                    .to_bytes(&actor)
+                    .unwrap(),
+            ),
+            (
+                AUTH_KEYSPACE,
+                group_id.to_bytes().to_vec(),
+                group_auth.to_bytes(&actor).unwrap(),
+            ),
+            (
+                GROUP_KEYSPACE,
+                group_id.to_bytes().to_vec(),
+                group.to_bytes(&actor).unwrap(),
+            ),
+        ] {
+            state
+                .get_ctx()
+                .storage_handle
+                .send_storage_effect(StorageEffect::Write {
+                    key_space: key_space.to_string(),
+                    key: key.into(),
+                    value: value.into(),
+                    txn_id: None,
+                })
+                .await;
+        }
+
+        (dir, state, auth, group_id)
+    }
+
+    async fn create_credential(
+        state: &Arc<ServerState>,
+        auth: &AuthContext,
+        group_id: Ulid,
+        path_restrictions: Option<Vec<CreateS3PathRestriction>>,
+    ) -> ServerResult<(StatusCode, Json<CreateS3CredentialsResponse>)> {
+        create_s3_credentials(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            Json(CreateS3CredentialsRequest {
+                group_id: group_id.to_string(),
+                expires_in_seconds: None,
+                path_restrictions,
+            }),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn viewer_takes_credential() {
+        // Read on the group data root is enough: the credential cannot widen it.
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let group_id = Ulid::from_bytes([7u8; 16]);
+        let (_dir, state, auth, group_id) = scoped_state(vec![(
+            format!("/{realm_id}/g/{group_id}/data/**"),
+            Permission::READ,
+        )])
+        .await;
+
+        let (status, _) = create_credential(&state, &auth, group_id, None)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::CREATED);
+
+        let (status, Json(response)) = create_credential(
+            &state,
+            &auth,
+            group_id,
+            Some(vec![CreateS3PathRestriction {
+                pattern: "shared/**".to_string(),
+                permission: "READ".to_string(),
+            }]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(status, StatusCode::CREATED);
+        assert!(!response.access_secret.is_empty());
+    }
+
+    #[tokio::test]
+    async fn viewer_cannot_write() {
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let group_id = Ulid::from_bytes([7u8; 16]);
+        let (_dir, state, auth, group_id) = scoped_state(vec![(
+            format!("/{realm_id}/g/{group_id}/data/**"),
+            Permission::READ,
+        )])
+        .await;
+
+        let error = create_credential(
+            &state,
+            &auth,
+            group_id,
+            Some(vec![CreateS3PathRestriction {
+                pattern: "shared/**".to_string(),
+                permission: "WRITE".to_string(),
+            }]),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ServerError::Forbidden));
+    }
+
+    #[tokio::test]
+    async fn subpath_takes_credential() {
+        // Read on one folder of the group data is a real grant, so issuance
+        // must not demand write on the whole data root.
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let group_id = Ulid::from_bytes([7u8; 16]);
+        let node_id = iroh::SecretKey::from_bytes(&[2u8; 32]).public();
+        let group_root = blob_group_permission_path(realm_id, group_id, node_id);
+        let (_dir, state, auth, group_id) = scoped_state(vec![(
+            format!("{group_root}/study/imaging/**"),
+            Permission::READ,
+        )])
+        .await;
+
+        let (status, _) = create_credential(&state, &auth, group_id, None)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::CREATED);
+
+        let (status, _) = create_credential(
+            &state,
+            &auth,
+            group_id,
+            Some(vec![CreateS3PathRestriction {
+                pattern: "study/imaging/**".to_string(),
+                permission: "READ".to_string(),
+            }]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(status, StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn outsider_refused() {
+        let (_dir, state, auth, group_id) = scoped_state(vec![(
+            "/other/g/group/data/**".to_string(),
+            Permission::WRITE,
+        )])
+        .await;
+
+        let error = create_credential(&state, &auth, group_id, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ServerError::Forbidden));
+
+        let error = create_credential(
+            &state,
+            &auth,
+            group_id,
+            Some(vec![CreateS3PathRestriction {
+                pattern: "study/**".to_string(),
+                permission: "READ".to_string(),
+            }]),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(error, ServerError::Forbidden));
     }
 
     #[tokio::test]

--- a/api/src/routes/credentials.rs
+++ b/api/src/routes/credentials.rs
@@ -1,12 +1,12 @@
 use crate::auth::require_unrestricted_realm_auth;
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
-use aruna_core::permission_path::readable_roots;
+use aruna_core::errors::AuthorizationError;
 use aruna_core::structs::{
     AuthContext, PathRestriction, Permission, UserAccess, blob_group_permission_path,
 };
 use aruna_operations::driver::drive;
-use aruna_operations::get_group::{GetGroupConfig, GetGroupError, GetGroupOperation};
+use aruna_operations::permission_rules::reachable_roots;
 use aruna_operations::s3::create_user_access::{
     CreateUserAccessConfig, CreateUserAccessError, CreateUserAccessOperation,
     DEFAULT_CREDENTIAL_TTL,
@@ -707,7 +707,7 @@ async fn authorize_credential_issuance(
             }
         }
 
-        return authorize_group_subpath(&effective_auth, state, group_id, &group_root).await;
+        return authorize_group_subpath(&effective_auth, state, &group_root).await;
     };
 
     for restriction in effective_restrictions {
@@ -738,21 +738,18 @@ async fn authorize_credential_issuance(
 async fn authorize_group_subpath(
     auth: &AuthContext,
     state: &ServerState,
-    group_id: Ulid,
     group_root: &str,
 ) -> ServerResult<()> {
-    let (_, authorization) = drive(
-        GetGroupOperation::new(GetGroupConfig { group_id }),
-        &state.get_ctx(),
-    )
-    .await
-    .map_err(|error| match error {
-        GetGroupError::GroupNotFound | GetGroupError::AuthDocNotFound => ServerError::Forbidden,
-        _ => ServerError::InternalError(error.to_string()),
-    })?;
-
-    let granted = authorization.user_permissions(auth.user_id);
-    if readable_roots(&granted, auth.path_restrictions.as_deref(), group_root).is_empty() {
+    let roots = reachable_roots(&state.get_ctx(), auth, group_root)
+        .await
+        .map_err(|error| match error {
+            AuthorizationError::AuthDocNotFound
+            | AuthorizationError::GroupNotFound
+            | AuthorizationError::InvalidRealmId
+            | AuthorizationError::InvalidGroupId => ServerError::Forbidden,
+            _ => ServerError::InternalError(error.to_string()),
+        })?;
+    if roots.is_empty() {
         return Err(ServerError::Forbidden);
     }
 
@@ -1125,6 +1122,59 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(status, StatusCode::CREATED);
+    }
+
+    /// Adds a realm role denying the caller every group subtree.
+    async fn write_realm_deny(state: &Arc<ServerState>, auth: &AuthContext) {
+        use std::collections::{HashMap, HashSet};
+        let realm_id = state.get_realm_id();
+        let actor = Actor {
+            node_id: state.get_node_id(),
+            user_id: auth.user_id,
+            realm_id,
+        };
+        let mut realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+        let role_id = Ulid::from_bytes([11u8; 16]);
+        realm_auth.roles.insert(
+            role_id,
+            aruna_core::structs::Role {
+                role_id,
+                name: "data-deny".to_string(),
+                permissions: HashMap::from([(format!("/{realm_id}/g/**"), Permission::DENY)]),
+                assigned_users: HashSet::from([auth.user_id]),
+            },
+        );
+        state
+            .get_ctx()
+            .storage_handle
+            .send_storage_effect(StorageEffect::Write {
+                key_space: AUTH_KEYSPACE.to_string(),
+                key: realm_id.as_bytes().to_vec().into(),
+                value: realm_auth.to_bytes(&actor).unwrap().into(),
+                txn_id: None,
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn deny_refuses_credential() {
+        // A realm deny on the group data outranks the folder role, so the
+        // subpath member may not mint a credential for it either.
+        let realm_id = RealmId::from_bytes([1u8; 32]);
+        let group_id = Ulid::from_bytes([7u8; 16]);
+        let node_id = iroh::SecretKey::from_bytes(&[2u8; 32]).public();
+        let group_root = blob_group_permission_path(realm_id, group_id, node_id);
+        let (_dir, state, auth, group_id) = scoped_state(vec![(
+            format!("{group_root}/study/imaging/**"),
+            Permission::READ,
+        )])
+        .await;
+        write_realm_deny(&state, &auth).await;
+
+        let error = create_credential(&state, &auth, group_id, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ServerError::Forbidden));
     }
 
     #[tokio::test]

--- a/api/src/routes/credentials/sessions.rs
+++ b/api/src/routes/credentials/sessions.rs
@@ -5,9 +5,7 @@ use super::{
 use crate::auth::{ValidatedArunaBearerTokenCarrier, require_realm_auth};
 use crate::error::{ErrorResponse, ServerError, ServerResult};
 use crate::server_state::ServerState;
-use aruna_core::structs::{
-    AuthContext, PathRestriction, S3_SESSION_ACCESS_PREFIX, S3Session, blob_group_permission_path,
-};
+use aruna_core::structs::{AuthContext, PathRestriction, S3_SESSION_ACCESS_PREFIX, S3Session};
 use aruna_operations::driver::drive;
 use aruna_operations::get_group::{GetGroupConfig, GetGroupError, GetGroupOperation};
 use aruna_operations::s3::session::{
@@ -89,8 +87,8 @@ pub struct ListS3SessionsResponse {
     summary = "Exchange a bearer token for an S3 session",
     description = r#"Issues a short-lived, node-local S3 session for an explicitly selected group.
 
-**Authentication**: realm bearer token, membership in the requested group, and WRITE under the
-effective token restrictions on that group's data path.
+**Authentication**: realm bearer token, membership in the requested group, and an effective read or
+write scope on that group's data path. A read-only member receives a read-only session.
 
 **Behavior**
 - The group is always taken from `group_id` and is never inferred from membership order.
@@ -134,7 +132,7 @@ effective token restrictions on that group's data path.
         ),
         (status = 400, description = "group_id is not a ULID", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token, or one with no remaining lifetime", body = ErrorResponse),
-        (status = 403, description = "The caller is not a member of the group, or lacks effective WRITE on its data path", body = ErrorResponse)
+        (status = 403, description = "The caller is not a member of the group, or its effective token restrictions leave no allowed scope on the group data path", body = ErrorResponse)
     ),
     security(("bearer_auth" = []))
 )]
@@ -388,10 +386,8 @@ async fn session_scope(
     group_id: Ulid,
 ) -> ServerResult<Option<Vec<PathRestriction>>> {
     ensure_membership(state, auth, group_id).await?;
-    let group_root =
-        blob_group_permission_path(state.get_realm_id(), group_id, state.get_node_id());
     let restrictions = build_credential_restrictions(auth, state, group_id, None).await?;
-    authorize_credential_issuance(auth, state, &group_root, restrictions.as_deref()).await?;
+    authorize_credential_issuance(auth, state, group_id, restrictions.as_deref()).await?;
     Ok(restrictions.as_deref().map(serialize_restrictions))
 }
 

--- a/api/src/routes/job_session.rs
+++ b/api/src/routes/job_session.rs
@@ -840,7 +840,7 @@ pub async fn stage_inputs(
             Err(error) => {
                 failed.push(FailedInputResponse {
                     dest_key,
-                    error: error.to_string(),
+                    error: error.public_message(),
                 });
                 refusal = refusal.or(Some(error));
             }

--- a/api/src/routes/job_session.rs
+++ b/api/src/routes/job_session.rs
@@ -846,7 +846,11 @@ pub async fn stage_inputs(
             }
         }
     }
-    session.touch();
+    // A call that staged nothing made no progress, so it must not keep the
+    // session alive.
+    if !staged.is_empty() {
+        session.touch();
+    }
     inputs_outcome(staged, failed, refusal)
 }
 
@@ -1698,11 +1702,14 @@ mod tests {
     #[tokio::test]
     async fn keeps_refusal_reason() {
         // Nothing landed, so the caller keeps the coded refusal instead of a
-        // 202 that claims a partial result.
+        // 202 that claims a partial result, and the session is not kept alive.
         let owner = user(2);
         let (_dir, state, job_id, _helper) = build_node(owner).await;
+        let session = registry_session(&state, job_id).expect("session is live");
+        let quiet = session.snapshot().last_event_id;
+
         let response = stage_inputs(
-            State(state),
+            State(state.clone()),
             Extension(auth_for(owner)),
             Path(job_id.to_string()),
             Json(SessionInputsRequest {
@@ -1710,7 +1717,9 @@ mod tests {
             }),
         )
         .await;
+
         assert!(matches!(response, Err(ServerError::NotFound)));
+        assert_eq!(session.snapshot().last_event_id, quiet);
     }
 
     #[tokio::test]

--- a/api/src/routes/job_session.rs
+++ b/api/src/routes/job_session.rs
@@ -189,11 +189,21 @@ pub struct PendingInputResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+pub struct FailedInputResponse {
+    pub dest_key: String,
+    /// Why this item did not land, so the caller can retry or drop it.
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 pub struct SessionInputsResponse {
     pub staged: Vec<StagedInputResponse>,
     /// Sources that need a staging job of their own. Empty today: a source on
     /// another node is refused instead, and the caller imports it first.
     pub pending: Vec<PendingInputResponse>,
+    /// Items that did not land, named so a partial result stays reconcilable.
+    #[serde(default)]
+    pub failed: Vec<FailedInputResponse>,
 }
 
 /// The caller's session job on this node. Absence and foreign ownership are
@@ -763,6 +773,8 @@ like cancel, and each source additionally needs the caller's read permission on 
 - Every staged object is recorded in the session inventory and listed in the job report at the end,
   with the node, version and hash it came from.
 - Staging resets the session's idle timer.
+- Destination keys are checked before anything is copied. Once one object landed the answer stays
+  202 and every item that failed after it is named in `failed`.
 
 **Limits** (refused with 400)
 - At most 64 items per call, and a `dest_key` that is relative and traversal-free.
@@ -772,9 +784,9 @@ like cancel, and each source additionally needs the caller's read permission on 
         "items": [{"bucket": "source-data", "key": "input.txt", "dest_key": "data/input.txt"}]
     })),
     responses(
-        (status = 202, description = "The objects were staged", body = SessionInputsResponse, example = json!({
+        (status = 202, description = "The objects that landed, with every later failure in `failed`", body = SessionInputsResponse, example = json!({
             "staged": [{"dest_key": "data/input.txt", "bytes": 12, "blake3": "f3a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f",
-                "source_node_id": "node-1", "version_id": "01JJRSVERSION0123456789ABC"}], "pending": []
+                "source_node_id": "node-1", "version_id": "01JJRSVERSION0123456789ABC"}], "pending": [], "failed": []
         })),
         (status = 400, description = "An invalid destination key, too many items, or a source on another node", body = ErrorResponse),
         (status = 401, description = "Missing or invalid bearer token", body = ErrorResponse),
@@ -804,24 +816,81 @@ pub async fn stage_inputs(
     let bucket = record.workspace_bucket.clone().ok_or_else(|| {
         ServerError::InternalError("a session has no workspace bucket".to_string())
     })?;
-    let mut staged = Vec::with_capacity(request.items.len());
+    let node_id = state.get_node_id().to_string();
+    let mut items = Vec::with_capacity(request.items.len());
     for item in request.items {
-        let entry = stage_one(&state, &auth, &bucket, item).await?;
-        session.record_input(StagedInput {
-            dest_key: entry.dest_key.clone(),
-            bytes: entry.bytes,
-            blake3: entry.blake3.clone(),
-            source_node_id: entry.source_node_id.clone(),
-            version_id: entry.version_id.clone(),
-        });
-        staged.push(entry);
-        session.touch();
+        let dest_key = check_item(&item, &node_id)?;
+        items.push((item, dest_key));
+    }
+    let mut staged = Vec::with_capacity(items.len());
+    let mut failed = Vec::new();
+    let mut refusal = None;
+    for (item, dest_key) in items {
+        match stage_one(&state, &auth, &bucket, item, &dest_key).await {
+            Ok(entry) => {
+                session.record_input(StagedInput {
+                    dest_key: entry.dest_key.clone(),
+                    bytes: entry.bytes,
+                    blake3: entry.blake3.clone(),
+                    source_node_id: entry.source_node_id.clone(),
+                    version_id: entry.version_id.clone(),
+                });
+                staged.push(entry);
+            }
+            Err(error) => {
+                failed.push(FailedInputResponse {
+                    dest_key,
+                    error: error.to_string(),
+                });
+                refusal = refusal.or(Some(error));
+            }
+        }
+    }
+    session.touch();
+    inputs_outcome(staged, failed, refusal)
+}
+
+/// Transport checks every item must pass before the first copy, so a refused
+/// key never leaves part of a call staged.
+fn check_item(item: &SessionInputRequest, node_id: &str) -> ServerResult<String> {
+    let dest_key = item.dest_key.trim();
+    if dest_key.is_empty()
+        || dest_key.starts_with('/')
+        || dest_key.split('/').any(|part| part == "..")
+    {
+        return Err(ServerError::BadRequestMessage(
+            "a destination key is relative and carries no `..`".to_string(),
+        ));
+    }
+    if let Some(source) = item.source_node_id.as_deref()
+        && source != node_id
+    {
+        return Err(ServerError::BadRequestMessage(
+            "a source on another node must be imported into a bucket of this node first"
+                .to_string(),
+        ));
+    }
+    Ok(dest_key.to_string())
+}
+
+/// A call that staged something answers 202 and names what failed after it. A
+/// call that staged nothing keeps the refusal its first item earned.
+fn inputs_outcome(
+    staged: Vec<StagedInputResponse>,
+    failed: Vec<FailedInputResponse>,
+    refusal: Option<ServerError>,
+) -> ServerResult<Response> {
+    if staged.is_empty()
+        && let Some(error) = refusal
+    {
+        return Err(error);
     }
     Ok((
         StatusCode::ACCEPTED,
         Json(SessionInputsResponse {
             staged,
             pending: Vec::new(),
+            failed,
         }),
     )
         .into_response())
@@ -846,25 +915,9 @@ async fn stage_one(
     auth: &AuthContext,
     bucket: &str,
     item: SessionInputRequest,
+    dest_key: &str,
 ) -> ServerResult<StagedInputResponse> {
-    let dest_key = item.dest_key.trim();
-    if dest_key.is_empty()
-        || dest_key.starts_with('/')
-        || dest_key.split('/').any(|part| part == "..")
-    {
-        return Err(ServerError::BadRequestMessage(
-            "a destination key is relative and carries no `..`".to_string(),
-        ));
-    }
     let node_id = state.get_node_id();
-    if let Some(source) = item.source_node_id.as_deref()
-        && source != node_id.to_string()
-    {
-        return Err(ServerError::BadRequestMessage(
-            "a source on another node must be imported into a bucket of this node first"
-                .to_string(),
-        ));
-    }
     let context = state.get_ctx();
     let source_info = bucket_info(&context, &item.bucket).await?;
     let dest_info = bucket_info(&context, bucket).await?;
@@ -1612,6 +1665,76 @@ mod tests {
         if let Some(session) = registry_session(state, job_id) {
             session.end(EndReason::Ended);
         }
+    }
+
+    fn input(bucket: &str, dest_key: &str) -> SessionInputRequest {
+        SessionInputRequest {
+            bucket: bucket.to_string(),
+            key: "input.txt".to_string(),
+            version_id: None,
+            source_node_id: None,
+            dest_key: dest_key.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn checks_keys_first() {
+        // A traversing key in a later item must refuse the whole call, before
+        // the first source is even looked up.
+        let owner = user(2);
+        let (_dir, state, job_id, _helper) = build_node(owner).await;
+        let response = stage_inputs(
+            State(state),
+            Extension(auth_for(owner)),
+            Path(job_id.to_string()),
+            Json(SessionInputsRequest {
+                items: vec![input("source", "data/a.txt"), input("source", "../escape")],
+            }),
+        )
+        .await;
+        assert!(matches!(response, Err(ServerError::BadRequestMessage(_))));
+    }
+
+    #[tokio::test]
+    async fn keeps_refusal_reason() {
+        // Nothing landed, so the caller keeps the coded refusal instead of a
+        // 202 that claims a partial result.
+        let owner = user(2);
+        let (_dir, state, job_id, _helper) = build_node(owner).await;
+        let response = stage_inputs(
+            State(state),
+            Extension(auth_for(owner)),
+            Path(job_id.to_string()),
+            Json(SessionInputsRequest {
+                items: vec![input("missing", "data/a.txt")],
+            }),
+        )
+        .await;
+        assert!(matches!(response, Err(ServerError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn reports_failed_items() {
+        let staged = vec![StagedInputResponse {
+            dest_key: "data/a.txt".to_string(),
+            bytes: 4,
+            blake3: String::new(),
+            source_node_id: node().to_string(),
+            version_id: String::new(),
+        }];
+        let failed = vec![FailedInputResponse {
+            dest_key: "data/b.txt".to_string(),
+            error: "Not found".to_string(),
+        }];
+        let response = inputs_outcome(staged, failed, Some(ServerError::NotFound))
+            .expect("a partial result is accepted");
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("the body reads");
+        let body: SessionInputsResponse = serde_json::from_slice(&bytes).expect("the body parses");
+        assert_eq!(body.staged.len(), 1);
+        assert_eq!(body.failed[0].dest_key, "data/b.txt");
     }
 
     /// The parsed body of a session read.

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -1,4 +1,5 @@
 use super::s3_server::S3OpLabel;
+use super::scope::resolve_scope;
 use super::util::{get_s3_operation_permission, is_anonymous_object_read_operation};
 use crate::rate_limit::{LocalKey, LocalLease, LocalPermit};
 use aruna_core::credential_encryption::{CredentialEncryptionKey, EncryptedS3Secret};
@@ -27,6 +28,7 @@ use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::sync::Arc;
 use std::time::SystemTime;
+use tracing::debug;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Access {
@@ -178,7 +180,7 @@ impl S3Access for AuthProvider {
         // the handler against one loaded policy set. Prior credential, issuer, expiry,
         // revocation, and ownership checks keep anonymous/cross-group requests fail-closed.
         if cx.s3_op().name() != "DeleteObjects" {
-            authorize(
+            match authorize(
                 self.driver_ctx.as_ref(),
                 self.realm_id,
                 &auth_context,
@@ -187,7 +189,14 @@ impl S3Access for AuthProvider {
                 extras.clone(),
             )
             .await
-            .map_err(map_authorize_error)?;
+            {
+                Ok(()) => {}
+                Err(AuthorizeError::PermissionDenied) if is_listing_operation(&operation_name) => {
+                    self.admit_subpath_listing(cx, &user_access, &path, &operation_name)
+                        .await?;
+                }
+                Err(error) => return Err(map_authorize_error(error)),
+            }
         }
 
         if let Some(token_hash) = session_token_hash {
@@ -208,6 +217,15 @@ impl S3Access for AuthProvider {
         cx.extensions_mut().insert(user_access);
         Ok(())
     }
+}
+
+/// Listings a member holding only part of a bucket may still run, because their
+/// result is narrowed to that part.
+fn is_listing_operation(operation_name: &str) -> bool {
+    matches!(
+        operation_name,
+        "ListBuckets" | "HeadBucket" | "ListObjects" | "ListObjectsV2"
+    )
 }
 
 /// Maps an authorization failure to an S3 error, keeping RBAC and policy denials
@@ -559,6 +577,37 @@ impl AuthProvider {
             },
             auth_context,
         ))
+    }
+
+    /// Admits a listing whose caller reaches only part of the requested path,
+    /// and hands the resolved scope to the handler so the page stays inside it.
+    /// A caller without any such scope keeps the ordinary denial.
+    async fn admit_subpath_listing(
+        &self,
+        cx: &mut S3AccessContext<'_>,
+        user_access: &UserAccess,
+        path: &str,
+        operation_name: &str,
+    ) -> S3Result<()> {
+        let has_bucket = cx.s3_path().get_bucket_name().is_some();
+        let group_id = cx
+            .extensions_mut()
+            .get::<BucketInfo>()
+            .map(|bucket_info| bucket_info.group_id)
+            .unwrap_or(user_access.group_id);
+        let scope = resolve_scope(self.driver_ctx.as_ref(), user_access, group_id, path).await?;
+        if scope.is_empty() {
+            return Err(map_authorize_error(AuthorizeError::PermissionDenied));
+        }
+
+        debug!(
+            operation = operation_name,
+            "Narrowing listing to the caller's permitted subpaths"
+        );
+        if has_bucket {
+            cx.extensions_mut().insert(scope);
+        }
+        Ok(())
     }
 
     fn group_data_path(&self, group_id: ulid::Ulid) -> String {

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -12,7 +12,9 @@ use aruna_core::{NodeId, UserId};
 use aruna_operations::driver::{DriverContext, drive};
 use aruna_operations::get_realm_config::GetRealmConfigOperation;
 use aruna_operations::request_authorization::{AuthorizeError, authorize};
-use aruna_operations::request_policy::PolicyRequestExtras;
+use aruna_operations::request_policy::{
+    PolicyRequestExtras, enforce_policies, policy_request_with,
+};
 use aruna_operations::s3::get_bucket_info::{GetBucketInfoError, GetBucketInfoOperation};
 use aruna_operations::s3::get_user_access::{GetUserAccessError, GetUserAccessOperation};
 use aruna_operations::s3::session::{
@@ -192,8 +194,14 @@ impl S3Access for AuthProvider {
             {
                 Ok(()) => {}
                 Err(AuthorizeError::PermissionDenied) if is_listing_operation(&operation_name) => {
-                    self.admit_subpath_listing(cx, &user_access, &path, &operation_name)
-                        .await?;
+                    self.admit_subpath_listing(
+                        cx,
+                        &user_access,
+                        &auth_context,
+                        &path,
+                        extras.clone(),
+                    )
+                    .await?;
                 }
                 Err(error) => return Err(map_authorize_error(error)),
             }
@@ -586,22 +594,27 @@ impl AuthProvider {
         &self,
         cx: &mut S3AccessContext<'_>,
         user_access: &UserAccess,
+        auth_context: &AuthContext,
         path: &str,
-        operation_name: &str,
+        extras: PolicyRequestExtras,
     ) -> S3Result<()> {
         let has_bucket = cx.s3_path().get_bucket_name().is_some();
-        let group_id = cx
-            .extensions_mut()
-            .get::<BucketInfo>()
-            .map(|bucket_info| bucket_info.group_id)
-            .unwrap_or(user_access.group_id);
-        let scope = resolve_scope(self.driver_ctx.as_ref(), user_access, group_id, path).await?;
+        let scope = resolve_scope(self.driver_ctx.as_ref(), user_access, path).await?;
         if scope.is_empty() {
             return Err(map_authorize_error(AuthorizeError::PermissionDenied));
         }
+        // The ordinary path enforces policies after RBAC, so an admitted
+        // listing runs them too instead of skipping the verdict.
+        enforce_policies(
+            self.driver_ctx.as_ref(),
+            self.realm_id,
+            &policy_request_with(path, &Permission::READ, Some(auth_context), extras),
+        )
+        .await
+        .map_err(|error| map_authorize_error(AuthorizeError::Policy(error)))?;
 
         debug!(
-            operation = operation_name,
+            path = path,
             "Narrowing listing to the caller's permitted subpaths"
         );
         if has_bucket {

--- a/api/src/s3/auth.rs
+++ b/api/src/s3/auth.rs
@@ -228,11 +228,12 @@ impl S3Access for AuthProvider {
 }
 
 /// Listings a member holding only part of a bucket may still run, because their
-/// result is narrowed to that part.
+/// result is narrowed to that part. The location probe leads the listings every
+/// AWS client makes, so it is admitted with them.
 fn is_listing_operation(operation_name: &str) -> bool {
     matches!(
         operation_name,
-        "ListBuckets" | "HeadBucket" | "ListObjects" | "ListObjectsV2"
+        "ListBuckets" | "HeadBucket" | "GetBucketLocation" | "ListObjects" | "ListObjectsV2"
     )
 }
 

--- a/api/src/s3/mod.rs
+++ b/api/src/s3/mod.rs
@@ -5,4 +5,5 @@ mod error;
 pub mod multipart_join;
 pub mod s3_server;
 pub mod s3_service;
+mod scope;
 pub mod util;

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -13,6 +13,7 @@ use crate::s3::multipart_join::{
     CompletionFailure, CompletionRegistry, await_completion, completion_registry,
 };
 use crate::s3::s3_server::DeleteObjectsBody;
+use crate::s3::scope::{SubpathScope, resolve_scope};
 use crate::s3::util::{
     checked_size, checksum_response_hashes, convert_input, declared_trailer_algorithm,
     multipart_checksum_type_from_s3, parse_completed_part, parse_copy_source,
@@ -324,7 +325,15 @@ impl ArunaS3Service {
                 Err(s3_error!(InternalError, "{}", message))
             }
             Err(error @ AuthorizeError::Storage(_)) => Err(map_authorize_error(error)),
-            Err(_) => Ok(false),
+            // A member whose roles reach only a folder inside this bucket still
+            // owns the bucket holding it, so it stays visible.
+            Err(_) => {
+                Ok(
+                    !resolve_scope(&self.state, user_access, bucket_info.group_id, &bucket_path)
+                        .await?
+                        .is_empty(),
+                )
+            }
         }
     }
 
@@ -946,6 +955,7 @@ impl ArunaS3Service {
         input: LOV2I,
         owner: Option<Owner>,
         url_encoded: bool,
+        scope: Option<&SubpathScope>,
     ) -> S3Result<ObjectListingPage> {
         let result = drive(ListObjectsV2Operation::new(input), &self.state)
             .await
@@ -961,9 +971,12 @@ impl ArunaS3Service {
             }
         };
 
+        // A page narrowed to the caller's subpaths may come back shorter; the
+        // continuation token still describes the underlying listing.
         let contents: Vec<Object> = result
             .objects
             .into_iter()
+            .filter(|object| scope.is_none_or(|scope| scope.allows_key(&object.head.key)))
             .map(|object| {
                 let response_fields = self.build_object_response_fields(
                     object.location.as_ref(),
@@ -985,6 +998,7 @@ impl ArunaS3Service {
         let common_prefixes: Vec<CommonPrefix> = result
             .common_prefixes
             .into_iter()
+            .filter(|prefix| scope.is_none_or(|scope| scope.allows_prefix(prefix)))
             .map(|prefix| CommonPrefix {
                 prefix: Some(encode_field(prefix)),
             })
@@ -996,6 +1010,25 @@ impl ArunaS3Service {
             continuation_token: result.continuation_token,
         })
     }
+}
+
+/// The narrowed read scope of a listing, resolved by the access hook. A prefix
+/// that overlaps no allowed subpath is refused, and a caller who may read the
+/// whole bucket needs no filtering.
+fn listing_scope(
+    extensions: &http::Extensions,
+    prefix: Option<&str>,
+) -> S3Result<Option<SubpathScope>> {
+    let Some(scope) = extensions.get::<SubpathScope>().cloned() else {
+        return Ok(None);
+    };
+    if scope.covers_all() {
+        return Ok(None);
+    }
+    if !scope.allows_prefix(prefix.unwrap_or_default()) {
+        return Err(s3_error!(AccessDenied, "Permission denied"));
+    }
+    Ok(Some(scope))
 }
 
 /// One page of a shared object listing before protocol-specific mapping.
@@ -1388,6 +1421,7 @@ impl S3 for ArunaS3Service {
             s3_error!(UnexpectedContent, "Missing user context")
         })?;
         let bucket_info = req.extensions.get::<BucketInfo>().cloned();
+        let scope = listing_scope(&req.extensions, req.input.prefix.as_deref())?;
         let requested_continuation_token = req.input.continuation_token.clone();
         let continuation_token = Self::decode_list_objects_v2_continuation_token(
             requested_continuation_token.as_deref(),
@@ -1438,6 +1472,7 @@ impl S3 for ArunaS3Service {
                 },
                 owner,
                 url_encoded,
+                scope.as_ref(),
             )
             .await?;
 
@@ -1486,6 +1521,7 @@ impl S3 for ArunaS3Service {
             s3_error!(UnexpectedContent, "Missing user context")
         })?;
         let bucket_info = req.extensions.get::<BucketInfo>().cloned();
+        let scope = listing_scope(&req.extensions, req.input.prefix.as_deref())?;
         let max_keys = match req.input.max_keys {
             None => ListObjectsV2Operation::DEFAULT_MAX_KEYS,
             Some(max_keys) => usize::try_from(max_keys)
@@ -1543,6 +1579,7 @@ impl S3 for ArunaS3Service {
                 },
                 owner,
                 url_encoded,
+                scope.as_ref(),
             )
             .await?;
 
@@ -4649,6 +4686,243 @@ mod tests {
             .into_iter()
             .filter_map(|bucket| bucket.name)
             .collect()
+    }
+
+    /// A node whose caller holds one role granting read on `study/imaging`
+    /// only, with a second bucket and sibling keys the role never reaches.
+    async fn subpath_node() -> (TempDir, ArunaS3Service, UserAccess, Ulid) {
+        use std::collections::{HashMap, HashSet};
+        let realm_id = RealmId([51u8; 32]);
+        let node_id = iroh::SecretKey::from_bytes(&[51u8; 32]).public();
+        let (storage_dir, service) = parser_service(realm_id, node_id);
+        let group_id = Ulid::generate();
+        let user_access = test_user_access(group_id, realm_id);
+        let actor = Actor {
+            node_id,
+            user_id: user_access.user_identity,
+            realm_id,
+        };
+        let role_id = Ulid::generate();
+        let group_auth = GroupAuthorizationDocument {
+            group_id,
+            roles: HashMap::from([(
+                role_id,
+                aruna_core::structs::Role {
+                    role_id,
+                    name: "imaging-reader".to_string(),
+                    permissions: HashMap::from([(
+                        format!(
+                            "{}/imaging/**",
+                            blob_bucket_permission_path(realm_id, group_id, node_id, "study")
+                        ),
+                        Permission::READ,
+                    )]),
+                    assigned_users: HashSet::from([user_access.user_identity]),
+                },
+            )]),
+            policies: Vec::new(),
+        };
+        let group = aruna_core::structs::Group {
+            display_name: "imaging".to_string(),
+            group_id,
+            realm_id,
+            owner: user_access.user_identity,
+            roles: group_auth.roles.keys().copied().collect(),
+        };
+        write_realm_config(&service.state.storage_handle, realm_id, &actor).await;
+        write_storage_value(
+            &service.state.storage_handle,
+            AUTH_KEYSPACE,
+            realm_id.as_bytes().to_vec(),
+            RealmAuthorizationDocument::new_default_realm_doc(realm_id)
+                .to_bytes(&actor)
+                .unwrap(),
+        )
+        .await;
+        write_storage_value(
+            &service.state.storage_handle,
+            AUTH_KEYSPACE,
+            group_id.to_bytes().to_vec(),
+            group_auth.to_bytes(&actor).unwrap(),
+        )
+        .await;
+        write_storage_value(
+            &service.state.storage_handle,
+            aruna_core::keyspaces::GROUP_KEYSPACE,
+            group_id.to_bytes().to_vec(),
+            group.to_bytes(&actor).unwrap(),
+        )
+        .await;
+        for bucket in ["study", "other"] {
+            write_storage_value(
+                &service.state.storage_handle,
+                S3_BUCKET_KEYSPACE,
+                bucket.as_bytes().to_vec(),
+                test_bucket_info(group_id, user_access.user_identity)
+                    .to_bytes()
+                    .unwrap(),
+            )
+            .await;
+        }
+        seed_materialized_keys(
+            &service.state.storage_handle,
+            "study",
+            &[
+                "imaging/scan-a",
+                "imaging/scan-b",
+                "sequencing/reads",
+                "notes.txt",
+            ],
+            user_access.user_identity,
+            UNIX_EPOCH,
+        )
+        .await;
+
+        (storage_dir, service, user_access, group_id)
+    }
+
+    async fn subpath_request(
+        service: &ArunaS3Service,
+        user_access: &UserAccess,
+        group_id: Ulid,
+        prefix: Option<&str>,
+    ) -> S3Request<ListObjectsV2Input> {
+        let scope = resolve_scope(
+            &service.state,
+            user_access,
+            group_id,
+            &blob_bucket_permission_path(service.realm_id, group_id, service.node_id, "study"),
+        )
+        .await
+        .unwrap();
+        assert!(!scope.is_empty());
+        let mut extensions = Extensions::new();
+        extensions.insert(user_access.clone());
+        extensions.insert(test_bucket_info(group_id, user_access.user_identity));
+        extensions.insert(scope);
+        test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                bucket: "study".to_string(),
+                delimiter: Some("/".to_string()),
+                max_keys: Some(10),
+                prefix: prefix.map(str::to_string),
+                ..Default::default()
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn subpath_sees_bucket() {
+        // Only the bucket holding the granted folder may appear.
+        let (_storage_dir, service, user_access, _group_id) = subpath_node().await;
+        let mut extensions = Extensions::new();
+        extensions.insert(user_access);
+        extensions.insert(PolicyRequestExtras::operation("s3.ListBuckets"));
+        let request = S3Request {
+            input: ListBucketsInput::default(),
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let response = service.list_buckets(request).await.unwrap();
+        let buckets: Vec<String> = response
+            .output
+            .buckets
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|bucket| bucket.name)
+            .collect();
+        assert_eq!(buckets, vec!["study"]);
+    }
+
+    #[tokio::test]
+    async fn subpath_hides_siblings() {
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+
+        let request = subpath_request(&service, &user_access, group_id, None).await;
+        let output = service.list_objects_v2(request).await.unwrap().output;
+        let prefixes: Vec<String> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|prefix| prefix.prefix)
+            .collect();
+        assert_eq!(prefixes, vec!["imaging/"]);
+        assert!(output.contents.unwrap_or_default().is_empty());
+        assert_eq!(output.is_truncated, Some(false));
+
+        let request = subpath_request(&service, &user_access, group_id, Some("imaging/")).await;
+        let output = service.list_objects_v2(request).await.unwrap().output;
+        let keys: Vec<String> = output
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|object| object.key)
+            .collect();
+        assert_eq!(keys, vec!["imaging/scan-a", "imaging/scan-b"]);
+    }
+
+    #[tokio::test]
+    async fn subpath_refuses_sibling() {
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+
+        let request = subpath_request(&service, &user_access, group_id, Some("sequencing/")).await;
+        let error = service.list_objects_v2(request).await.unwrap_err();
+        assert_eq!(error.code(), &s3s::S3ErrorCode::AccessDenied);
+    }
+
+    #[tokio::test]
+    async fn object_path_decides() {
+        // Object reads stay authorized at their own path, inside and outside
+        // the granted folder.
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+        let auth_context = AuthContext {
+            user_id: user_access.user_identity,
+            realm_id: service.realm_id,
+            path_restrictions: None,
+            session: None,
+        };
+        let object_path = |key: &str| {
+            aruna_core::structs::blob_object_permission_path(
+                service.realm_id,
+                group_id,
+                service.node_id,
+                "study",
+                key,
+            )
+        };
+
+        assert!(
+            authorize(
+                &service.state,
+                service.realm_id,
+                &auth_context,
+                &object_path("imaging/scan-a"),
+                &Permission::READ,
+                PolicyRequestExtras::operation("s3.GetObject"),
+            )
+            .await
+            .is_ok()
+        );
+        assert!(
+            authorize(
+                &service.state,
+                service.realm_id,
+                &auth_context,
+                &object_path("sequencing/reads"),
+                &Permission::READ,
+                PolicyRequestExtras::operation("s3.GetObject"),
+            )
+            .await
+            .is_err()
+        );
     }
 
     #[tokio::test]

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -950,6 +950,42 @@ impl ArunaS3Service {
             .transpose()
     }
 
+    async fn readable_prefix(
+        &self,
+        input: &LOV2I,
+        prefix: String,
+        scope: &SubpathScope,
+        remaining_pages: &mut usize,
+    ) -> S3Result<bool> {
+        let mut input = LOV2I {
+            prefix: Some(prefix),
+            delimiter: None,
+            continuation_token: None,
+            start_after: None,
+            max_keys: None,
+            ..input.clone()
+        };
+        loop {
+            consume_scope_page(remaining_pages)?;
+            let result = drive(ListObjectsV2Operation::new(input.clone()), &self.state)
+                .await
+                .and_then(|result| result.transpose())
+                .map_err(IntoS3Error::into_s3_error)?
+                .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
+            if result
+                .objects
+                .iter()
+                .any(|object| scope.allows_key(&object.head.key))
+            {
+                return Ok(true);
+            }
+            let Some(token) = result.continuation_token else {
+                return Ok(false);
+            };
+            input.continuation_token = Some(token);
+        }
+    }
+
     /// Runs one listing page shared by ListObjects and ListObjectsV2. A narrowed
     /// page that shows nothing keeps reading, so its marker can name a visible
     /// entry instead of a key the caller may not see.
@@ -961,7 +997,17 @@ impl ArunaS3Service {
         scope: Option<&SubpathScope>,
     ) -> S3Result<ObjectListingPage> {
         let mut input = input;
+        let mut remaining_pages = 100;
+        if scope.is_some() {
+            input.max_keys = Some(
+                input
+                    .max_keys
+                    .unwrap_or(ListObjectsV2Operation::DEFAULT_MAX_KEYS)
+                    .min(remaining_pages - 1),
+            );
+        }
         loop {
+            consume_scope_page(&mut remaining_pages)?;
             let result = drive(ListObjectsV2Operation::new(input.clone()), &self.state)
                 .await
                 .and_then(|result| result.transpose())
@@ -981,11 +1027,18 @@ impl ArunaS3Service {
                 .into_iter()
                 .filter(|object| scope.is_none_or(|scope| scope.allows_key(&object.head.key)))
                 .collect();
-            let prefixes: Vec<String> = result
-                .common_prefixes
-                .into_iter()
-                .filter(|prefix| scope.is_none_or(|scope| scope.allows_prefix(prefix)))
-                .collect();
+            let mut prefixes = Vec::new();
+            for prefix in result.common_prefixes {
+                if let Some(scope) = scope
+                    && (!scope.allows_prefix(&prefix)
+                        || !self
+                            .readable_prefix(&input, prefix.clone(), scope, &mut remaining_pages)
+                            .await?)
+                {
+                    continue;
+                }
+                prefixes.push(prefix);
+            }
 
             if let Some(token) = result.continuation_token.clone()
                 && scope.is_some()
@@ -1040,9 +1093,20 @@ impl ArunaS3Service {
     }
 }
 
+/// Caps aggregate listing work, including probes beneath common prefixes.
+fn consume_scope_page(remaining_pages: &mut usize) -> S3Result<()> {
+    *remaining_pages = remaining_pages.checked_sub(1).ok_or_else(|| {
+        s3_error!(
+            SlowDown,
+            "Listing scan limit reached; request a narrower prefix"
+        )
+    })?;
+    Ok(())
+}
+
 /// The narrowed read scope of a listing, resolved by the access hook. A prefix
-/// that overlaps no allowed subpath is refused, and a caller who may read the
-/// whole bucket needs no filtering.
+/// that overlaps no allowed subpath is refused. Concrete keys remain filtered
+/// even when a navigable prefix covers the bucket root.
 fn listing_scope(
     extensions: &http::Extensions,
     prefix: Option<&str>,
@@ -1050,9 +1114,6 @@ fn listing_scope(
     let Some(scope) = extensions.get::<SubpathScope>().cloned() else {
         return Ok(None);
     };
-    if scope.covers_all() {
-        return Ok(None);
-    }
     if !scope.allows_prefix(prefix.unwrap_or_default()) {
         return Err(s3_error!(AccessDenied, "Permission denied"));
     }
@@ -5111,6 +5172,192 @@ mod tests {
 
         assert_eq!(keys, vec!["imaging/scan-a", "imaging/scan-b"]);
         assert!(token.is_none());
+    }
+
+    #[tokio::test]
+    async fn exact_listing_scope() {
+        let (_storage_dir, service, mut user_access, group_id) = subpath_node().await;
+        grant_group_owner(&service, &user_access, group_id).await;
+        seed_materialized_keys(
+            &service.state.storage_handle,
+            "study",
+            &["imaging", "imaging/private/key"],
+            user_access.user_identity,
+            UNIX_EPOCH,
+        )
+        .await;
+        let root =
+            blob_bucket_permission_path(service.realm_id, group_id, service.node_id, "study");
+        for (suffix, expected) in [("/imaging", vec!["imaging"]), ("", vec![])] {
+            user_access.path_restrictions = Some(vec![PathRestriction {
+                pattern: format!("{root}{suffix}"),
+                permission: Permission::READ,
+            }]);
+            for delimiter in [None, Some("/".to_string())] {
+                let mut request = subpath_request(&service, &user_access, group_id, None).await;
+                request.input.delimiter = delimiter;
+                let output = service.list_objects_v2(request).await.unwrap().output;
+                let keys: Vec<_> = output
+                    .contents
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|object| object.key)
+                    .collect();
+                assert_eq!(keys, expected);
+                assert!(output.common_prefixes.unwrap_or_default().is_empty());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn denied_listing_keys() {
+        let (_storage_dir, service, mut user_access, group_id) = subpath_node().await;
+        seed_materialized_keys(
+            &service.state.storage_handle,
+            "study",
+            &[
+                "imaging/private/key",
+                "imaging/public/secret.txt",
+                "imaging/public/open.txt",
+                "imaging/hidden/secret.txt",
+            ],
+            user_access.user_identity,
+            UNIX_EPOCH,
+        )
+        .await;
+        let root =
+            blob_bucket_permission_path(service.realm_id, group_id, service.node_id, "study");
+        user_access.path_restrictions = Some(
+            [
+                ("imaging/**", Permission::READ),
+                ("imaging/private/**", Permission::DENY),
+                ("imaging/*/secret*", Permission::DENY),
+            ]
+            .into_iter()
+            .map(|(key, permission)| PathRestriction {
+                pattern: format!("{root}/{key}"),
+                permission,
+            })
+            .collect(),
+        );
+        let mut request = subpath_request(&service, &user_access, group_id, None).await;
+        request.input.delimiter = None;
+        let output = service.list_objects_v2(request).await.unwrap().output;
+        let keys: Vec<_> = output
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|object| object.key)
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                "imaging/public/open.txt",
+                "imaging/scan-a",
+                "imaging/scan-b"
+            ]
+        );
+        let request = subpath_request(&service, &user_access, group_id, Some("imaging/")).await;
+        let output = service.list_objects_v2(request).await.unwrap().output;
+        let prefixes: Vec<_> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|prefix| prefix.prefix)
+            .collect();
+        assert_eq!(prefixes, vec!["imaging/public/"]);
+    }
+
+    #[tokio::test]
+    async fn scoped_scan_bounded() {
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+        let keys: Vec<_> = (0..101).map(|index| format!("hidden/{index:03}")).collect();
+        seed_materialized_keys(
+            &service.state.storage_handle,
+            "study",
+            &keys.iter().map(String::as_str).collect::<Vec<_>>(),
+            user_access.user_identity,
+            UNIX_EPOCH,
+        )
+        .await;
+        let request = paged_request(&service, &user_access, group_id, None).await;
+        let error = service.list_objects_v2(request).await.unwrap_err();
+        assert_eq!(error.code(), &s3s::S3ErrorCode::SlowDown);
+    }
+
+    #[tokio::test]
+    async fn prefix_pages_progress() {
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+        let keys: Vec<_> = (0..101)
+            .map(|index| format!("imaging/{index:03}/key"))
+            .collect();
+        seed_materialized_keys(
+            &service.state.storage_handle,
+            "study",
+            &keys.iter().map(String::as_str).collect::<Vec<_>>(),
+            user_access.user_identity,
+            UNIX_EPOCH,
+        )
+        .await;
+        let mut request = subpath_request(&service, &user_access, group_id, Some("imaging/")).await;
+        request.input.max_keys = Some(0);
+        let output = service.list_objects_v2(request).await.unwrap().output;
+        assert!(output.contents.unwrap_or_default().is_empty());
+        assert!(output.common_prefixes.unwrap_or_default().is_empty());
+        assert!(output.next_continuation_token.is_none());
+        let mut token = None;
+        let mut prefixes = Vec::new();
+        for _ in 0..3 {
+            let mut request =
+                subpath_request(&service, &user_access, group_id, Some("imaging/")).await;
+            request.input.max_keys = None;
+            request.input.continuation_token = token.take();
+            let output = service.list_objects_v2(request).await.unwrap().output;
+            prefixes.extend(
+                output
+                    .common_prefixes
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|prefix| prefix.prefix),
+            );
+            token = output.next_continuation_token;
+            if token.is_none() {
+                break;
+            }
+        }
+        assert!(token.is_none());
+        assert_eq!(
+            prefixes,
+            (0..101)
+                .map(|index| format!("imaging/{index:03}/"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn prefix_token_precedence() {
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+        seed_materialized_keys(
+            &service.state.storage_handle,
+            "study",
+            &["imaging/a/key", "imaging/b/key"],
+            user_access.user_identity,
+            UNIX_EPOCH,
+        )
+        .await;
+        let mut request = subpath_request(&service, &user_access, group_id, Some("imaging/")).await;
+        request.input.start_after = Some("imaging/z".to_string());
+        let token = scoped_marker("study", Some("imaging/0"), None).unwrap();
+        request.input.continuation_token =
+            ArunaS3Service::encode_list_objects_v2_continuation_token(token.as_ref()).unwrap();
+        let output = service.list_objects_v2(request).await.unwrap().output;
+        let prefixes: Vec<_> = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|prefix| prefix.prefix)
+            .collect();
+        assert_eq!(prefixes, vec!["imaging/a/", "imaging/b/"]);
     }
 
     #[tokio::test]

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -325,14 +325,15 @@ impl ArunaS3Service {
                 Err(s3_error!(InternalError, "{}", message))
             }
             Err(error @ AuthorizeError::Storage(_)) => Err(map_authorize_error(error)),
+            // A policy verdict is the decision itself, so it hides the bucket
+            // instead of falling back to the role subtrees.
+            Err(AuthorizeError::Policy(_)) => Ok(false),
             // A member whose roles reach only a folder inside this bucket still
             // owns the bucket holding it, so it stays visible.
-            Err(_) => {
-                Ok(
-                    !resolve_scope(&self.state, user_access, bucket_info.group_id, &bucket_path)
-                        .await?
-                        .is_empty(),
-                )
+            Err(AuthorizeError::PermissionDenied) => {
+                Ok(!resolve_scope(&self.state, user_access, &bucket_path)
+                    .await?
+                    .is_empty())
             }
         }
     }
@@ -4790,7 +4791,6 @@ mod tests {
         let scope = resolve_scope(
             &service.state,
             user_access,
-            group_id,
             &blob_bucket_permission_path(service.realm_id, group_id, service.node_id, "study"),
         )
         .await
@@ -4840,6 +4840,142 @@ mod tests {
             .filter_map(|bucket| bucket.name)
             .collect();
         assert_eq!(buckets, vec!["study"]);
+    }
+
+    /// Adds a realm role that denies the caller the whole group data subtree.
+    async fn write_realm_deny(service: &ArunaS3Service, user_access: &UserAccess) {
+        use std::collections::{HashMap, HashSet};
+        let realm_id = service.realm_id;
+        let actor = Actor {
+            node_id: service.node_id,
+            user_id: user_access.user_identity,
+            realm_id,
+        };
+        let mut realm_auth = RealmAuthorizationDocument::new_default_realm_doc(realm_id);
+        let role_id = Ulid::generate();
+        realm_auth.roles.insert(
+            role_id,
+            aruna_core::structs::Role {
+                role_id,
+                name: "data-deny".to_string(),
+                permissions: HashMap::from([(format!("/{realm_id}/g/**"), Permission::DENY)]),
+                assigned_users: HashSet::from([user_access.user_identity]),
+            },
+        );
+        write_storage_value(
+            &service.state.storage_handle,
+            AUTH_KEYSPACE,
+            realm_id.as_bytes().to_vec(),
+            realm_auth.to_bytes(&actor).unwrap(),
+        )
+        .await;
+    }
+
+    async fn write_deny_policy(service: &ArunaS3Service, user_access: &UserAccess) {
+        let realm_id = service.realm_id;
+        let mut config = RealmConfigDocument::default_for_realm(realm_id, Vec::new());
+        config
+            .request_policies
+            .push(aruna_core::request_policy::RequestPolicy {
+                policy_id: Ulid::generate(),
+                name: "no-reads".to_string(),
+                kind: aruna_core::request_policy::PolicyKind::Deny,
+                when: None,
+                expression: "permission == 'read'".to_string(),
+                enabled: true,
+            });
+        let actor = Actor {
+            node_id: service.node_id,
+            user_id: user_access.user_identity,
+            realm_id,
+        };
+        write_storage_value(
+            &service.state.storage_handle,
+            REALM_CONFIG_KEYSPACE,
+            realm_id.as_bytes().to_vec(),
+            config.to_bytes(&actor).unwrap(),
+        )
+        .await;
+    }
+
+    async fn listed_buckets(service: &ArunaS3Service, user_access: &UserAccess) -> Vec<String> {
+        let mut extensions = Extensions::new();
+        extensions.insert(user_access.clone());
+        extensions.insert(PolicyRequestExtras::operation("s3.ListBuckets"));
+        let request = S3Request {
+            input: ListBucketsInput::default(),
+            method: Method::GET,
+            uri: Uri::from_static("/"),
+            headers: HeaderMap::new(),
+            extensions,
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+        service
+            .list_buckets(request)
+            .await
+            .unwrap()
+            .output
+            .buckets
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|bucket| bucket.name)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn deny_hides_subpath() {
+        // A realm deny outranks the group role that grants the folder, so no
+        // listing, head or bucket visibility survives it.
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+        write_realm_deny(&service, &user_access).await;
+
+        let scope = resolve_scope(
+            &service.state,
+            &user_access,
+            &blob_bucket_permission_path(service.realm_id, group_id, service.node_id, "study"),
+        )
+        .await
+        .unwrap();
+        assert!(scope.is_empty());
+        assert!(listed_buckets(&service, &user_access).await.is_empty());
+    }
+
+    /// Replaces the seeded folder role with the owner's default roles, so the
+    /// caller reads the whole bucket and only a policy can refuse it.
+    async fn grant_group_owner(service: &ArunaS3Service, user_access: &UserAccess, group_id: Ulid) {
+        let actor = Actor {
+            node_id: service.node_id,
+            user_id: user_access.user_identity,
+            realm_id: service.realm_id,
+        };
+        write_storage_value(
+            &service.state.storage_handle,
+            AUTH_KEYSPACE,
+            group_id.to_bytes().to_vec(),
+            GroupAuthorizationDocument::new_default_group_doc(
+                user_access.user_identity,
+                service.realm_id,
+                group_id,
+            )
+            .to_bytes(&actor)
+            .unwrap(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn policy_hides_bucket() {
+        // A policy denial is the verdict itself, never a reason to fall back on
+        // the caller's role subtrees.
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+        grant_group_owner(&service, &user_access, group_id).await;
+        assert!(!listed_buckets(&service, &user_access).await.is_empty());
+
+        write_deny_policy(&service, &user_access).await;
+        assert!(listed_buckets(&service, &user_access).await.is_empty());
     }
 
     #[tokio::test]

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -2556,9 +2556,14 @@ impl S3 for ArunaS3Service {
                     checksum_crc32: encoded.checksum_crc32,
                     checksum_crc32c: encoded.checksum_crc32c,
                     checksum_crc64nvme: encoded.checksum_crc64nvme,
+                    checksum_md5: None,
                     checksum_sha1: encoded.checksum_sha1,
                     checksum_sha256: encoded.checksum_sha256,
+                    checksum_sha512: None,
                     checksum_type: encoded.checksum_type,
+                    checksum_xxhash128: None,
+                    checksum_xxhash3: None,
+                    checksum_xxhash64: None,
                 }
             })
         } else {
@@ -2597,8 +2602,13 @@ impl S3 for ArunaS3Service {
                             checksum_crc32: checksums.checksum_crc32,
                             checksum_crc32c: checksums.checksum_crc32c,
                             checksum_crc64nvme: checksums.checksum_crc64nvme,
+                            checksum_md5: None,
                             checksum_sha1: checksums.checksum_sha1,
                             checksum_sha256: checksums.checksum_sha256,
+                            checksum_sha512: None,
+                            checksum_xxhash128: None,
+                            checksum_xxhash3: None,
+                            checksum_xxhash64: None,
                         }
                     })
                     .collect();
@@ -2793,8 +2803,13 @@ impl S3 for ArunaS3Service {
                     checksum_crc32: checksums.checksum_crc32,
                     checksum_crc32c: checksums.checksum_crc32c,
                     checksum_crc64nvme: checksums.checksum_crc64nvme,
+                    checksum_md5: None,
                     checksum_sha1: checksums.checksum_sha1,
                     checksum_sha256: checksums.checksum_sha256,
+                    checksum_sha512: None,
+                    checksum_xxhash128: None,
+                    checksum_xxhash3: None,
+                    checksum_xxhash64: None,
                 }
             })
             .collect();

--- a/api/src/s3/s3_service.rs
+++ b/api/src/s3/s3_service.rs
@@ -950,7 +950,9 @@ impl ArunaS3Service {
             .transpose()
     }
 
-    /// Runs one listing page shared by ListObjects and ListObjectsV2.
+    /// Runs one listing page shared by ListObjects and ListObjectsV2. A narrowed
+    /// page that shows nothing keeps reading, so its marker can name a visible
+    /// entry instead of a key the caller may not see.
     async fn run_object_listing(
         &self,
         input: LOV2I,
@@ -958,58 +960,83 @@ impl ArunaS3Service {
         url_encoded: bool,
         scope: Option<&SubpathScope>,
     ) -> S3Result<ObjectListingPage> {
-        let result = drive(ListObjectsV2Operation::new(input), &self.state)
-            .await
-            .and_then(|result| result.transpose())
-            .map_err(IntoS3Error::into_s3_error)?
-            .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
+        let mut input = input;
+        loop {
+            let result = drive(ListObjectsV2Operation::new(input.clone()), &self.state)
+                .await
+                .and_then(|result| result.transpose())
+                .map_err(IntoS3Error::into_s3_error)?
+                .ok_or_else(|| s3_error!(InternalError, "Failed to list objects"))?;
 
-        let encode_field = |value: String| -> String {
-            if url_encoded {
-                utf8_percent_encode(&value, S3_URL_ENCODE_SET).to_string()
-            } else {
-                value
-            }
-        };
-
-        // A page narrowed to the caller's subpaths may come back shorter; the
-        // continuation token still describes the underlying listing.
-        let contents: Vec<Object> = result
-            .objects
-            .into_iter()
-            .filter(|object| scope.is_none_or(|scope| scope.allows_key(&object.head.key)))
-            .map(|object| {
-                let response_fields = self.build_object_response_fields(
-                    object.location.as_ref(),
-                    None,
-                    object.source_metadata.as_ref(),
-                    object.last_refresh,
-                    object.version_created_at,
-                );
-                Object {
-                    e_tag: response_fields.e_tag,
-                    key: Some(encode_field(object.head.key)),
-                    last_modified: response_fields.last_modified,
-                    owner: owner.clone(),
-                    size: response_fields.content_length,
-                    ..Default::default()
+            let encode_field = |value: String| -> String {
+                if url_encoded {
+                    utf8_percent_encode(&value, S3_URL_ENCODE_SET).to_string()
+                } else {
+                    value
                 }
-            })
-            .collect();
-        let common_prefixes: Vec<CommonPrefix> = result
-            .common_prefixes
-            .into_iter()
-            .filter(|prefix| scope.is_none_or(|scope| scope.allows_prefix(prefix)))
-            .map(|prefix| CommonPrefix {
-                prefix: Some(encode_field(prefix)),
-            })
-            .collect();
+            };
 
-        Ok(ObjectListingPage {
-            contents,
-            common_prefixes,
-            continuation_token: result.continuation_token,
-        })
+            let visible: Vec<_> = result
+                .objects
+                .into_iter()
+                .filter(|object| scope.is_none_or(|scope| scope.allows_key(&object.head.key)))
+                .collect();
+            let prefixes: Vec<String> = result
+                .common_prefixes
+                .into_iter()
+                .filter(|prefix| scope.is_none_or(|scope| scope.allows_prefix(prefix)))
+                .collect();
+
+            if let Some(token) = result.continuation_token.clone()
+                && scope.is_some()
+                && visible.is_empty()
+                && prefixes.is_empty()
+            {
+                input.continuation_token = Some(token);
+                continue;
+            }
+
+            let scoped = scoped_marker(
+                &input.bucket,
+                visible.last().map(|object| object.head.key.as_str()),
+                prefixes.last().map(String::as_str),
+            )?;
+            let contents: Vec<Object> = visible
+                .into_iter()
+                .map(|object| {
+                    let response_fields = self.build_object_response_fields(
+                        object.location.as_ref(),
+                        None,
+                        object.source_metadata.as_ref(),
+                        object.last_refresh,
+                        object.version_created_at,
+                    );
+                    Object {
+                        e_tag: response_fields.e_tag,
+                        key: Some(encode_field(object.head.key)),
+                        last_modified: response_fields.last_modified,
+                        owner: owner.clone(),
+                        size: response_fields.content_length,
+                        ..Default::default()
+                    }
+                })
+                .collect();
+            let common_prefixes: Vec<CommonPrefix> = prefixes
+                .into_iter()
+                .map(|prefix| CommonPrefix {
+                    prefix: Some(encode_field(prefix)),
+                })
+                .collect();
+
+            return Ok(ObjectListingPage {
+                contents,
+                common_prefixes,
+                continuation_token: match scope {
+                    Some(_) => result.continuation_token.and(scoped),
+                    None => result.continuation_token,
+                },
+            });
+        }
     }
 }
 
@@ -1075,6 +1102,25 @@ fn next_marker_for(
     } else {
         None
     }
+}
+
+/// The marker of the last entry a narrowed page actually showed, so a truncated
+/// listing resumes from a visible entry instead of an out-of-scope key.
+fn scoped_marker(
+    bucket: &str,
+    last_key: Option<&str>,
+    last_prefix: Option<&str>,
+) -> S3Result<Option<ListObjectsV2ContinuationToken>> {
+    let group = last_prefix.filter(|prefix| last_key.is_none_or(|key| *prefix > key));
+    let Some(entry) = group.or(last_key) else {
+        return Ok(None);
+    };
+    let last_key = BlobHeadKey::object_prefix(bucket, entry)
+        .map_err(|_| s3_error!(InternalError, "Invalid listing marker"))?;
+    Ok(Some(ListObjectsV2ContinuationToken {
+        last_key,
+        last_common_prefix: group.map(str::to_string),
+    }))
 }
 
 /// Names the last entry of a truncated page, preferring the common prefix the
@@ -5003,6 +5049,68 @@ mod tests {
             .filter_map(|object| object.key)
             .collect();
         assert_eq!(keys, vec!["imaging/scan-a", "imaging/scan-b"]);
+    }
+
+    async fn paged_request(
+        service: &ArunaS3Service,
+        user_access: &UserAccess,
+        group_id: Ulid,
+        token: Option<String>,
+    ) -> S3Request<ListObjectsV2Input> {
+        let scope = resolve_scope(
+            &service.state,
+            user_access,
+            &blob_bucket_permission_path(service.realm_id, group_id, service.node_id, "study"),
+        )
+        .await
+        .unwrap();
+        let mut extensions = Extensions::new();
+        extensions.insert(user_access.clone());
+        extensions.insert(test_bucket_info(group_id, user_access.user_identity));
+        extensions.insert(scope);
+        test_list_objects_v2_request(
+            extensions,
+            ListObjectsV2Input {
+                bucket: "study".to_string(),
+                max_keys: Some(1),
+                continuation_token: token,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn marker_stays_scoped() {
+        // Paging one key at a time crosses keys the caller may not see, so no
+        // token may name one and the last page must admit it is the last.
+        let (_storage_dir, service, user_access, group_id) = subpath_node().await;
+        let mut token = None;
+        let mut keys: Vec<String> = Vec::new();
+
+        for _ in 0..4 {
+            let request = paged_request(&service, &user_access, group_id, token.clone()).await;
+            let output = service.list_objects_v2(request).await.unwrap().output;
+            keys.extend(
+                output
+                    .contents
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|object| object.key),
+            );
+            token = output.next_continuation_token;
+            assert_eq!(output.is_truncated, Some(token.is_some()));
+            let Some(encoded) = token.clone() else {
+                break;
+            };
+            let decoded = ArunaS3Service::decode_list_objects_v2_continuation_token(Some(&encoded))
+                .unwrap()
+                .unwrap();
+            let head = BlobHeadKey::from_bytes(&decoded.last_key).unwrap();
+            assert!(head.key.starts_with("imaging/"), "leaked {}", head.key);
+        }
+
+        assert_eq!(keys, vec!["imaging/scan-a", "imaging/scan-b"]);
+        assert!(token.is_none());
     }
 
     #[tokio::test]

--- a/api/src/s3/scope.rs
+++ b/api/src/s3/scope.rs
@@ -2,11 +2,10 @@
 //! access hook resolves them once and the listing handlers narrow their page to
 //! them, while every concrete object path stays an ordinary permission check.
 
-use aruna_core::permission_path::readable_roots;
-use aruna_core::structs::UserAccess;
-use aruna_core::types::GroupId;
-use aruna_operations::driver::{DriverContext, drive};
-use aruna_operations::get_group::{GetGroupConfig, GetGroupError, GetGroupOperation};
+use aruna_core::errors::AuthorizationError;
+use aruna_core::structs::{AuthContext, UserAccess};
+use aruna_operations::driver::DriverContext;
+use aruna_operations::permission_rules::reachable_roots;
 use s3s::{S3Result, s3_error};
 
 /// Key prefixes inside one bucket the caller may read. An empty prefix stands
@@ -61,31 +60,31 @@ impl SubpathScope {
     }
 }
 
-/// Resolves the subtrees at or below `root` the caller reaches through its group
-/// roles, narrowed by the credential's own restrictions. A group without an
-/// authorization document grants nothing instead of failing the request.
+/// Resolves the subtrees at or below `root` the caller reaches through its
+/// realm and group roles, narrowed by the credential's own restrictions. A
+/// missing realm or group document grants nothing instead of failing.
 pub(crate) async fn resolve_scope(
     context: &DriverContext,
     user_access: &UserAccess,
-    group_id: GroupId,
     root: &str,
 ) -> S3Result<SubpathScope> {
-    let authorization =
-        match drive(GetGroupOperation::new(GetGroupConfig { group_id }), context).await {
-            Ok((_, authorization)) => authorization,
-            Err(GetGroupError::GroupNotFound | GetGroupError::AuthDocNotFound) => {
-                return Ok(SubpathScope::default());
-            }
-            Err(error) => {
-                return Err(s3_error!(InternalError, "{}", error.to_string()));
-            }
-        };
-
-    let granted = authorization.user_permissions(user_access.user_identity);
-    Ok(SubpathScope::from_roots(
-        readable_roots(&granted, user_access.path_restrictions.as_deref(), root),
-        root,
-    ))
+    let auth_context = AuthContext {
+        user_id: user_access.user_identity,
+        realm_id: user_access.user_identity.realm_id,
+        path_restrictions: user_access.path_restrictions.clone(),
+        session: None,
+    };
+    let roots = match reachable_roots(context, &auth_context, root).await {
+        Ok(roots) => roots,
+        Err(
+            AuthorizationError::AuthDocNotFound
+            | AuthorizationError::GroupNotFound
+            | AuthorizationError::InvalidRealmId
+            | AuthorizationError::InvalidGroupId,
+        ) => return Ok(SubpathScope::default()),
+        Err(error) => return Err(s3_error!(InternalError, "{}", error.to_string())),
+    };
+    Ok(SubpathScope::from_roots(roots, root))
 }
 
 #[cfg(test)]

--- a/api/src/s3/scope.rs
+++ b/api/src/s3/scope.rs
@@ -1,0 +1,131 @@
+//! Read scopes for callers whose roles reach only a part of a bucket: the
+//! access hook resolves them once and the listing handlers narrow their page to
+//! them, while every concrete object path stays an ordinary permission check.
+
+use aruna_core::permission_path::readable_roots;
+use aruna_core::structs::UserAccess;
+use aruna_core::types::GroupId;
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::get_group::{GetGroupConfig, GetGroupError, GetGroupOperation};
+use s3s::{S3Result, s3_error};
+
+/// Key prefixes inside one bucket the caller may read. An empty prefix stands
+/// for the whole bucket, and an empty scope for no access at all.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SubpathScope {
+    prefixes: Vec<String>,
+}
+
+impl SubpathScope {
+    /// Turns absolute permission roots into key prefixes relative to `root`.
+    fn from_roots(roots: Vec<String>, root: &str) -> Self {
+        let inside = format!("{root}/");
+        let prefixes = roots
+            .into_iter()
+            .filter_map(|candidate| {
+                if candidate == root {
+                    Some(String::new())
+                } else {
+                    candidate.strip_prefix(&inside).map(str::to_string)
+                }
+            })
+            .collect();
+        Self { prefixes }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.prefixes.is_empty()
+    }
+
+    /// Whether the caller may read the whole bucket, which needs no filtering.
+    pub(crate) fn covers_all(&self) -> bool {
+        self.prefixes.iter().any(String::is_empty)
+    }
+
+    /// Whether a key lies inside an allowed prefix.
+    pub(crate) fn allows_key(&self, key: &str) -> bool {
+        self.prefixes.iter().any(|prefix| {
+            prefix.is_empty() || key == prefix || key.starts_with(&format!("{prefix}/"))
+        })
+    }
+
+    /// Whether a listing prefix is an ancestor of, equal to, or inside an
+    /// allowed prefix. A request prefix without such an overlap is refused.
+    pub(crate) fn allows_prefix(&self, prefix: &str) -> bool {
+        self.prefixes.iter().any(|allowed| {
+            allowed.is_empty()
+                || allowed.starts_with(prefix)
+                || prefix == allowed
+                || prefix.starts_with(&format!("{allowed}/"))
+        })
+    }
+}
+
+/// Resolves the subtrees at or below `root` the caller reaches through its group
+/// roles, narrowed by the credential's own restrictions. A group without an
+/// authorization document grants nothing instead of failing the request.
+pub(crate) async fn resolve_scope(
+    context: &DriverContext,
+    user_access: &UserAccess,
+    group_id: GroupId,
+    root: &str,
+) -> S3Result<SubpathScope> {
+    let authorization =
+        match drive(GetGroupOperation::new(GetGroupConfig { group_id }), context).await {
+            Ok((_, authorization)) => authorization,
+            Err(GetGroupError::GroupNotFound | GetGroupError::AuthDocNotFound) => {
+                return Ok(SubpathScope::default());
+            }
+            Err(error) => {
+                return Err(s3_error!(InternalError, "{}", error.to_string()));
+            }
+        };
+
+    let granted = authorization.user_permissions(user_access.user_identity);
+    Ok(SubpathScope::from_roots(
+        readable_roots(&granted, user_access.path_restrictions.as_deref(), root),
+        root,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubpathScope;
+
+    fn imaging_scope() -> SubpathScope {
+        SubpathScope::from_roots(
+            vec!["/realm/g/group/data/node/study/imaging".to_string()],
+            "/realm/g/group/data/node/study",
+        )
+    }
+
+    #[test]
+    fn allows_scoped_keys() {
+        let scope = imaging_scope();
+        assert!(!scope.is_empty());
+        assert!(!scope.covers_all());
+        assert!(scope.allows_key("imaging/scan.tif"));
+        assert!(scope.allows_key("imaging"));
+        assert!(!scope.allows_key("imaging-2/scan.tif"));
+        assert!(!scope.allows_key("sequencing/reads.fastq"));
+    }
+
+    #[test]
+    fn keeps_scope_prefixes() {
+        let scope = imaging_scope();
+        assert!(scope.allows_prefix(""));
+        assert!(scope.allows_prefix("imaging/"));
+        assert!(scope.allows_prefix("imaging/2026/"));
+        assert!(!scope.allows_prefix("sequencing/"));
+    }
+
+    #[test]
+    fn root_covers_all() {
+        let scope = SubpathScope::from_roots(
+            vec!["/realm/g/group/data/node/study".to_string()],
+            "/realm/g/group/data/node/study",
+        );
+        assert!(scope.covers_all());
+        assert!(scope.allows_key("sequencing/reads.fastq"));
+    }
+}

--- a/api/src/s3/scope.rs
+++ b/api/src/s3/scope.rs
@@ -3,21 +3,30 @@
 //! them, while every concrete object path stays an ordinary permission check.
 
 use aruna_core::errors::AuthorizationError;
-use aruna_core::structs::{AuthContext, UserAccess};
-use aruna_operations::driver::DriverContext;
-use aruna_operations::permission_rules::reachable_roots;
+use aruna_core::permission_path::readable_roots;
+use aruna_core::structs::{AuthContext, PathRestriction, Permission, UserAccess};
+use aruna_operations::driver::{DriverContext, drive};
+use aruna_operations::permission_rules::{
+    PermissionRules, PermissionRulesConfig, PermissionRulesOperation,
+};
 use s3s::{S3Result, s3_error};
 
-/// Key prefixes inside one bucket the caller may read. An empty prefix stands
-/// for the whole bucket, and an empty scope for no access at all.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Navigable key prefixes and the rules deciding each concrete key's access.
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct SubpathScope {
     prefixes: Vec<String>,
+    root: String,
+    rules: PermissionRules,
 }
 
 impl SubpathScope {
     /// Turns absolute permission roots into key prefixes relative to `root`.
-    fn from_roots(roots: Vec<String>, root: &str) -> Self {
+    fn from_rules(
+        rules: PermissionRules,
+        restrictions: Option<&[PathRestriction]>,
+        root: &str,
+    ) -> Self {
+        let roots = readable_roots(&rules.direct_patterns(), restrictions, root);
         let inside = format!("{root}/");
         let prefixes = roots
             .into_iter()
@@ -29,23 +38,21 @@ impl SubpathScope {
                 }
             })
             .collect();
-        Self { prefixes }
+        Self {
+            prefixes,
+            root: root.to_string(),
+            rules,
+        }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
         self.prefixes.is_empty()
     }
 
-    /// Whether the caller may read the whole bucket, which needs no filtering.
-    pub(crate) fn covers_all(&self) -> bool {
-        self.prefixes.iter().any(String::is_empty)
-    }
-
-    /// Whether a key lies inside an allowed prefix.
+    /// Applies the ordinary permission decision, including denies and restrictions.
     pub(crate) fn allows_key(&self, key: &str) -> bool {
-        self.prefixes.iter().any(|prefix| {
-            prefix.is_empty() || key == prefix || key.starts_with(&format!("{prefix}/"))
-        })
+        self.rules
+            .allows(&format!("{}/{key}", self.root), &Permission::READ)
     }
 
     /// Whether a listing prefix is an ancestor of, equal to, or inside an
@@ -74,8 +81,16 @@ pub(crate) async fn resolve_scope(
         path_restrictions: user_access.path_restrictions.clone(),
         session: None,
     };
-    let roots = match reachable_roots(context, &auth_context, root).await {
-        Ok(roots) => roots,
+    let rules = match drive(
+        PermissionRulesOperation::new(PermissionRulesConfig {
+            auth_context,
+            path: root.to_string(),
+        }),
+        context,
+    )
+    .await
+    {
+        Ok(rules) => rules,
         Err(
             AuthorizationError::AuthDocNotFound
             | AuthorizationError::GroupNotFound
@@ -84,34 +99,58 @@ pub(crate) async fn resolve_scope(
         ) => return Ok(SubpathScope::default()),
         Err(error) => return Err(s3_error!(InternalError, "{}", error.to_string())),
     };
-    Ok(SubpathScope::from_roots(roots, root))
+    Ok(SubpathScope::from_rules(
+        rules,
+        user_access.path_restrictions.as_deref(),
+        root,
+    ))
 }
 
 #[cfg(test)]
 mod tests {
+    use aruna_core::structs::{PathRestriction, Permission, Role};
+    use aruna_operations::permission_rules::{CollectedRole, PermissionRules};
+
     use super::SubpathScope;
 
-    fn imaging_scope() -> SubpathScope {
-        SubpathScope::from_roots(
-            vec!["/realm/g/group/data/node/study/imaging".to_string()],
-            "/realm/g/group/data/node/study",
+    fn test_scope(
+        patterns: &[(&str, Permission)],
+        restrictions: Option<&[PathRestriction]>,
+    ) -> SubpathScope {
+        let root = "/realm/g/group/data/node/study";
+        let rules = PermissionRules::from_roles(
+            vec![CollectedRole {
+                role: Role {
+                    role_id: Default::default(),
+                    name: "reader".to_string(),
+                    permissions: patterns
+                        .iter()
+                        .map(|(key, permission)| (format!("{root}/{key}"), permission.clone()))
+                        .collect(),
+                    assigned_users: Default::default(),
+                },
+                direct: true,
+                public: false,
+            }],
+            restrictions,
         )
+        .unwrap();
+        SubpathScope::from_rules(rules, restrictions, root)
     }
 
     #[test]
     fn allows_scoped_keys() {
-        let scope = imaging_scope();
+        let scope = test_scope(&[("imaging/**", Permission::READ)], None);
         assert!(!scope.is_empty());
-        assert!(!scope.covers_all());
         assert!(scope.allows_key("imaging/scan.tif"));
-        assert!(scope.allows_key("imaging"));
+        assert!(!scope.allows_key("imaging"));
         assert!(!scope.allows_key("imaging-2/scan.tif"));
         assert!(!scope.allows_key("sequencing/reads.fastq"));
     }
 
     #[test]
     fn keeps_scope_prefixes() {
-        let scope = imaging_scope();
+        let scope = test_scope(&[("imaging/**", Permission::READ)], None);
         assert!(scope.allows_prefix(""));
         assert!(scope.allows_prefix("imaging/"));
         assert!(scope.allows_prefix("imaging/2026/"));
@@ -119,12 +158,43 @@ mod tests {
     }
 
     #[test]
-    fn root_covers_all() {
-        let scope = SubpathScope::from_roots(
-            vec!["/realm/g/group/data/node/study".to_string()],
-            "/realm/g/group/data/node/study",
+    fn exact_stays_exact() {
+        let scope = test_scope(&[("imaging", Permission::READ)], None);
+        assert!(scope.allows_key("imaging"));
+        assert!(!scope.allows_key("imaging/private/key"));
+    }
+
+    #[test]
+    fn denies_filter_keys() {
+        let scope = test_scope(
+            &[
+                ("**", Permission::READ),
+                ("imaging/private/**", Permission::DENY),
+                ("imaging/*/secret*", Permission::DENY),
+            ],
+            None,
         );
-        assert!(scope.covers_all());
+        assert!(scope.allows_prefix(""));
         assert!(scope.allows_key("sequencing/reads.fastq"));
+        assert!(!scope.allows_key("imaging/private/key"));
+        assert!(!scope.allows_key("imaging/public/secret.txt"));
+    }
+
+    #[test]
+    fn restrictions_filter_keys() {
+        let restrictions = [
+            PathRestriction {
+                pattern: "/realm/g/group/data/node/study/imaging/**".to_string(),
+                permission: Permission::READ,
+            },
+            PathRestriction {
+                pattern: "/realm/g/group/data/node/study/imaging/*/secret*".to_string(),
+                permission: Permission::DENY,
+            },
+        ];
+        let scope = test_scope(&[("**", Permission::READ)], Some(&restrictions));
+        assert!(scope.allows_key("imaging/public/key"));
+        assert!(!scope.allows_key("imaging/public/secret.txt"));
+        assert!(!scope.allows_key("sequencing/reads.fastq"));
     }
 }

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -1434,9 +1434,13 @@ async fn build_kubernetes(
             storage_class,
             helper_image,
             pull_deadline: env_duration("ARUNA_COMPUTE_K8S_PULL_DEADLINE", 300)?,
-            s3_cidrs,
+            s3_cidrs: if workspace.is_some() {
+                s3_cidrs
+            } else {
+                Vec::new()
+            },
             s3_port,
-            s3_mount_driver,
+            s3_mount_driver: s3_mount_driver.filter(|_| workspace.is_some()),
             policy_manifests,
             service_account: dotenvy::var("ARUNA_COMPUTE_K8S_SERVICE_ACCOUNT")
                 .unwrap_or_else(|_| aruna_compute::DEFAULT_WORKLOAD_SA.to_string()),

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -1363,6 +1363,43 @@ async fn build_apptainer(
         .into())
 }
 
+/// The pod-facing S3 endpoint sessions and direct-S3 tasks read, or `None` in
+/// the local-only profile, which exposes no S3 listener for them at all.
+#[cfg(any(feature = "kubernetes", test))]
+fn kubernetes_workspace(
+    local_only: bool,
+    endpoint: Option<&str>,
+) -> Result<Option<String>, ComputeBuildError> {
+    if local_only {
+        return Ok(None);
+    }
+    let endpoint = endpoint.ok_or_else(|| {
+        "Kubernetes executor requires ARUNA_COMPUTE_S3_URL or S3_PUBLIC_URL".to_string()
+    })?;
+    if container_local_endpoint(endpoint) {
+        return Err("Kubernetes executor requires a pod-reachable S3_PUBLIC_URL"
+            .to_string()
+            .into());
+    }
+    Ok(Some(endpoint.to_string()))
+}
+
+/// The port the S3 network policy opens. Without an explicit setting it follows
+/// the endpoint pods actually connect to, so policy and endpoint cannot drift.
+#[cfg(any(feature = "kubernetes", test))]
+fn session_s3_port(setting: Option<&str>, endpoint: Option<&str>) -> Result<u16, String> {
+    if let Some(value) = setting {
+        return value
+            .trim()
+            .parse::<u16>()
+            .map_err(|_| "ARUNA_COMPUTE_K8S_S3_PORT must be a valid port".to_string());
+    }
+    Ok(endpoint
+        .and_then(|value| reqwest::Url::parse(value).ok())
+        .and_then(|url| url.port_or_known_default())
+        .unwrap_or(443))
+}
+
 #[cfg(feature = "kubernetes")]
 async fn build_kubernetes(
     config: &Config,
@@ -1376,10 +1413,14 @@ async fn build_kubernetes(
         .map(|value| parse_s3_cidrs(&value))
         .transpose()?
         .unwrap_or_default();
-    let s3_port = dotenvy::var("ARUNA_COMPUTE_K8S_S3_PORT")
-        .map(|value| value.parse::<u16>())
-        .unwrap_or(Ok(443))
-        .map_err(|_| "ARUNA_COMPUTE_K8S_S3_PORT must be a valid port".to_string())?;
+    let workspace = kubernetes_workspace(
+        env_true("ARUNA_COMPUTE_LOCAL_ONLY"),
+        compute_s3_endpoint(config).as_deref(),
+    )?;
+    let s3_port = session_s3_port(
+        dotenvy::var("ARUNA_COMPUTE_K8S_S3_PORT").ok().as_deref(),
+        workspace.as_deref(),
+    )?;
     let s3_mount_driver = read_mount_driver();
     let backend = aruna_compute::executor::kubernetes::KubernetesBackend::with_config(
         aruna_compute::KubernetesConfig {
@@ -1412,10 +1453,13 @@ async fn build_kubernetes(
         .apply_network()
         .await
         .map_err(|error| ComputeBuildError::Unavailable(error.to_string()))?;
-    info!("Kubernetes executor backend enabled");
+    info!(
+        local_only = workspace.is_none(),
+        "Kubernetes executor backend enabled"
+    );
     Ok(aruna_compute::ExecutorRegistry::new()
         .with_backend(Arc::new(backend))
-        .with_workspace_endpoint(compute_s3_endpoint(config), "eu-central-1".to_string()))
+        .with_workspace_endpoint(workspace, "eu-central-1".to_string()))
 }
 
 #[cfg(not(feature = "kubernetes"))]
@@ -1599,7 +1643,7 @@ fn env_path(name: &str) -> Option<std::path::PathBuf> {
         .map(std::path::PathBuf::from)
 }
 
-#[cfg(any(feature = "docker", test))]
+#[cfg(any(feature = "docker", feature = "kubernetes", test))]
 fn container_local_endpoint(endpoint: &str) -> bool {
     let Some(host) = reqwest::Url::parse(endpoint)
         .ok()
@@ -1766,6 +1810,46 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn derives_s3_port() {
+        // An explicit setting stays authoritative; otherwise the policy port is
+        // the one pods reach the endpoint on.
+        assert_eq!(session_s3_port(Some("9000"), None), Ok(9000));
+        assert_eq!(
+            session_s3_port(Some("9000"), Some("https://s3.example.test")),
+            Ok(9000)
+        );
+        assert!(session_s3_port(Some("no"), None).is_err());
+        assert_eq!(session_s3_port(None, None), Ok(443));
+        assert_eq!(
+            session_s3_port(None, Some("https://s3.example.test")),
+            Ok(443)
+        );
+        assert_eq!(
+            session_s3_port(None, Some("http://s3.example.test")),
+            Ok(80)
+        );
+        assert_eq!(
+            session_s3_port(None, Some("https://s3.example.test:9000/")),
+            Ok(9000)
+        );
+    }
+
+    #[test]
+    fn guards_pod_endpoint() {
+        // A pod cannot reach the controller's loopback, so an unreachable
+        // endpoint must refuse startup instead of staging unreadable data.
+        assert_eq!(kubernetes_workspace(true, None).unwrap(), None);
+        assert_eq!(
+            kubernetes_workspace(false, Some("https://s3.example.test")).unwrap(),
+            Some("https://s3.example.test".to_string())
+        );
+        assert!(kubernetes_workspace(false, None).is_err());
+        assert!(kubernetes_workspace(false, Some("http://127.0.0.1:9000")).is_err());
+        assert!(kubernetes_workspace(false, Some("http://0.0.0.0:9000")).is_err());
+        assert!(kubernetes_workspace(false, Some("http://localhost:9000")).is_err());
     }
 
     #[test]

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -1406,6 +1406,12 @@ async fn build_kubernetes(
     aruna_compute::ExecutorBackend::health(&backend)
         .await
         .map_err(|error| ComputeBuildError::Unavailable(error.to_string()))?;
+    // Pods keep the policy they started with, so already running sessions only
+    // get a repaired one once the node applies it again.
+    backend
+        .apply_network()
+        .await
+        .map_err(|error| ComputeBuildError::Unavailable(error.to_string()))?;
     info!("Kubernetes executor backend enabled");
     Ok(aruna_compute::ExecutorRegistry::new()
         .with_backend(Arc::new(backend))

--- a/aruna/src/main.rs
+++ b/aruna/src/main.rs
@@ -1422,6 +1422,11 @@ async fn build_kubernetes(
         workspace.as_deref(),
     )?;
     let s3_mount_driver = read_mount_driver();
+    let policy_manifests = dotenvy::var("ARUNA_COMPUTE_K8S_POLICY_MANIFESTS")
+        .ok()
+        .map(|value| policy_paths(&value))
+        .transpose()?
+        .unwrap_or_default();
     let backend = aruna_compute::executor::kubernetes::KubernetesBackend::with_config(
         aruna_compute::KubernetesConfig {
             namespace: dotenvy::var("ARUNA_COMPUTE_K8S_NAMESPACE")
@@ -1432,6 +1437,7 @@ async fn build_kubernetes(
             s3_cidrs,
             s3_port,
             s3_mount_driver,
+            policy_manifests,
             service_account: dotenvy::var("ARUNA_COMPUTE_K8S_SERVICE_ACCOUNT")
                 .unwrap_or_else(|_| aruna_compute::DEFAULT_WORKLOAD_SA.to_string()),
             execution_location: dotenvy::var("ARUNA_COMPUTE_K8S_EXECUTION_LOCATION")
@@ -1475,6 +1481,46 @@ fn env_true(name: &str) -> bool {
     dotenvy::var(name)
         .map(|value| matches!(value.as_str(), "1" | "true" | "yes"))
         .unwrap_or(false)
+}
+
+/// Expands a comma-separated list of manifest files and directories. A
+/// directory contributes its YAML files in name order.
+#[cfg(feature = "kubernetes")]
+fn policy_paths(value: &str) -> Result<Vec<std::path::PathBuf>, String> {
+    let mut paths = Vec::new();
+    for entry in value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+    {
+        let path = std::path::PathBuf::from(entry);
+        let metadata = std::fs::metadata(&path).map_err(|error| {
+            format!("ARUNA_COMPUTE_K8S_POLICY_MANIFESTS entry `{entry}` is unreadable: {error}")
+        })?;
+        if !metadata.is_dir() {
+            paths.push(path);
+            continue;
+        }
+        let mut found = Vec::new();
+        for file in std::fs::read_dir(&path).map_err(|error| {
+            format!("ARUNA_COMPUTE_K8S_POLICY_MANIFESTS entry `{entry}` is unreadable: {error}")
+        })? {
+            let file = file
+                .map_err(|error| {
+                    format!("ARUNA_COMPUTE_K8S_POLICY_MANIFESTS entry `{entry}`: {error}")
+                })?
+                .path();
+            if file
+                .extension()
+                .is_some_and(|suffix| suffix == "yaml" || suffix == "yml")
+            {
+                found.push(file);
+            }
+        }
+        found.sort();
+        paths.append(&mut found);
+    }
+    Ok(paths)
 }
 
 #[cfg(feature = "kubernetes")]
@@ -1920,6 +1966,25 @@ mod tests {
         assert!(parse_s3_cidrs("10.0.0.0/33").is_err());
         assert!(parse_s3_cidrs("2001:db8::/129").is_err());
         assert!(parse_s3_cidrs("invalid/8").is_err());
+    }
+
+    #[cfg(feature = "kubernetes")]
+    #[test]
+    fn expands_policy_paths() {
+        let dir = tempdir().expect("temp dir");
+        for name in ["b.yaml", "a.yml", "notes.txt"] {
+            std::fs::write(dir.path().join(name), "").expect("write entry");
+        }
+        let single = dir.path().join("b.yaml");
+
+        let paths = policy_paths(&format!(" {}, {} ", dir.path().display(), single.display()))
+            .expect("the paths expand");
+
+        assert_eq!(
+            paths,
+            [dir.path().join("a.yml"), dir.path().join("b.yaml"), single]
+        );
+        assert!(policy_paths(&dir.path().join("missing").display().to_string()).is_err());
     }
 
     #[tokio::test]

--- a/aruna/tests/credentials.rs
+++ b/aruna/tests/credentials.rs
@@ -183,8 +183,9 @@ async fn broader_request_than_auth_scope_is_rejected() -> TestResult<()> {
     Ok(())
 }
 
+// A read-only request narrows a write scope: the credential is issued as READ.
 #[tokio::test]
-async fn read_only_effective_scope_is_rejected() -> TestResult<()> {
+async fn readonly_scope_stored() -> TestResult<()> {
     let seed = spawn_seed_node().await?;
     let admin_token = create_bearer_token(
         seed.context.as_ref(),
@@ -206,18 +207,25 @@ async fn read_only_effective_scope_is_rejected() -> TestResult<()> {
         }],
     )?;
 
-    let response = post_credentials(
+    let credentials = create_s3_credentials_with_restrictions_via_http(
         &seed.base_url,
         &scoped_token,
         &group.group_id,
         Some(vec![create_request_restriction(
-            auth_scope,
+            auth_scope.clone(),
             Permission::READ,
         )]),
     )
     .await?;
+    let access = get_user_access(seed.context.as_ref(), &credentials.access_key_id).await?;
 
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        access.path_restrictions,
+        Some(vec![PathRestriction {
+            pattern: auth_scope,
+            permission: Permission::READ,
+        }])
+    );
 
     seed.shutdown().await;
     Ok(())

--- a/compute/Cargo.toml
+++ b/compute/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 default = ["docker", "apptainer", "kubernetes"]
 docker = ["dep:bollard"]
 apptainer = ["dep:nix", "dep:rustix"]
-kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:json-patch", "dep:serde_yaml"]
+kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:json-patch", "dep:serde-saphyr"]
 
 [dependencies]
 aruna-core = { workspace = true }
@@ -23,7 +23,7 @@ futures-util = { workspace = true }
 ipnet = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true, optional = true }
+serde-saphyr = { workspace = true, optional = true }
 tar = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/compute/Cargo.toml
+++ b/compute/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 default = ["docker", "apptainer", "kubernetes"]
 docker = ["dep:bollard"]
 apptainer = ["dep:nix", "dep:rustix"]
-kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:json-patch"]
+kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:json-patch", "dep:serde_yaml"]
 
 [dependencies]
 aruna-core = { workspace = true }
@@ -23,6 +23,7 @@ futures-util = { workspace = true }
 ipnet = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true, optional = true }
 tar = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/compute/src/executor/config.rs
+++ b/compute/src/executor/config.rs
@@ -97,6 +97,9 @@ pub struct KubernetesConfig {
     pub s3_port: u16,
     /// CSI driver name for S3 mounts; `None` disables the feature.
     pub s3_mount_driver: Option<String>,
+    /// Manifest files the operator adds to the compute namespace, such as a
+    /// network policy for a cluster the standard policies cannot express.
+    pub policy_manifests: Vec<PathBuf>,
     /// Placement location of the worker nodes, which are not the controller's
     /// site. Empty means the operator has not declared it, so this backend
     /// advertises no location or labels at all instead of the controller's.
@@ -126,6 +129,7 @@ impl Default for KubernetesConfig {
             s3_cidrs: Vec::new(),
             s3_port: 443,
             s3_mount_driver: None,
+            policy_manifests: Vec::new(),
             execution_location: String::new(),
             execution_labels: BTreeMap::new(),
             node_selector: BTreeMap::new(),

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -1059,7 +1059,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_dns_by_port() {
+    fn allows_dns_port() {
         // A host-network resolver such as node-local DNS is neither a kube-system
         // pod nor a CIDR peer under Cilium, so the DNS rule carries no peer.
         let mut config = config();

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -424,11 +424,7 @@ pub fn network_policies(config: &KubernetesConfig) -> Result<Vec<NetworkPolicy>,
             "ingress":[],
             "egress":[
                 {"to":cidrs,"ports":[{"protocol":"TCP","port":config.s3_port}]},
-                {"to":[{"namespaceSelector":{"matchLabels":{
-                    "kubernetes.io/metadata.name":"kube-system"
-                }}}],"ports":[
-                    {"protocol":"UDP","port":53},{"protocol":"TCP","port":53}
-                ]}
+                {"ports":[{"protocol":"UDP","port":53},{"protocol":"TCP","port":53}]}
             ]
         }
     }))
@@ -983,18 +979,23 @@ mod tests {
     }
 
     #[test]
-    fn restricts_dns_egress() {
+    fn allows_dns_by_port() {
+        // A host-network resolver such as node-local DNS is neither a kube-system
+        // pod nor a CIDR peer under Cilium, so the DNS rule carries no peer.
         let mut config = config();
         config.s3_cidrs.push("10.0.0.0/8".to_string());
 
         let policies = network_policies(&config).unwrap();
         let policy = serde_json::to_value(&policies[1]).unwrap();
-        let peer = &policy["spec"]["egress"][1]["to"][0];
+        let s3 = &policy["spec"]["egress"][0];
+        let dns = &policy["spec"]["egress"][1];
 
-        assert_eq!(
-            peer["namespaceSelector"]["matchLabels"]["kubernetes.io/metadata.name"],
-            "kube-system"
-        );
-        assert!(peer.get("ipBlock").is_none());
+        assert_eq!(s3["to"][0]["ipBlock"]["cidr"], "10.0.0.0/8");
+        assert_eq!(s3["ports"][0]["port"], 443);
+        assert!(dns.get("to").is_none());
+        assert_eq!(dns["ports"][0]["protocol"], "UDP");
+        assert_eq!(dns["ports"][0]["port"], 53);
+        assert_eq!(dns["ports"][1]["protocol"], "TCP");
+        assert_eq!(dns["ports"][1]["port"], 53);
     }
 }

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use aruna_core::compute::{
     BackendError, FenceContext, NetworkAccess, StagingMode, TaskSpec, normalize_container_path,
@@ -7,6 +7,7 @@ use aruna_core::compute::{
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolume, PersistentVolumeClaim, Pod, Secret};
 use k8s_openapi::api::networking::v1::NetworkPolicy;
+use kube::api::DynamicObject;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -14,9 +15,6 @@ use super::{EPOCH_ANNOTATION, GENERATION_ANNOTATION, ROLE_LABEL, STATE_ANNOTATIO
 use crate::executor::config::KubernetesConfig;
 use crate::executor::staging::StageLayout;
 use crate::executor::{digest_pinned, enforced_limit};
-
-/// Cilium-native companion of the `aruna-compute-s3` network policy.
-pub const CILIUM_S3_POLICY: &str = "aruna-compute-s3-ingress";
 
 pub const WORKSPACE_PATH: &str = "/workspace";
 pub const MARKER_PATH: &str = "/aruna-marker/marker";
@@ -435,23 +433,83 @@ pub fn network_policies(config: &KubernetesConfig) -> Result<Vec<NetworkPolicy>,
     Ok(vec![deny, s3])
 }
 
-/// Cilium classifies pod-to-Ingress traffic as the reserved `ingress` entity,
-/// which no ipBlock rule can match, so the S3 port needs a native rule too.
-pub fn cilium_ingress_policy(config: &KubernetesConfig) -> serde_json::Value {
-    json!({
-        "apiVersion":"cilium.io/v2",
-        "kind":"CiliumNetworkPolicy",
-        "metadata":{"name":CILIUM_S3_POLICY,"namespace":config.namespace},
-        "spec":{
-            "endpointSelector":{"matchLabels":{"aruna-engine.org/network":"s3"}},
-            "egress":[{
-                "toEntities":["ingress"],
-                "toPorts":[{"ports":[
-                    {"port":config.s3_port.to_string(),"protocol":"TCP"}
-                ]}]
-            }]
+/// An operator manifest with the file it was read from, so a later discovery
+/// or apply failure can name that file.
+#[derive(Clone, Debug)]
+pub struct PolicyManifest {
+    pub source: PathBuf,
+    pub object: DynamicObject,
+}
+
+/// Reads the configured manifest files, including multi-document files. The
+/// node applies these objects itself, so a broken document is refused here.
+pub fn policy_manifests(config: &KubernetesConfig) -> Result<Vec<PolicyManifest>, BackendError> {
+    let mut manifests = Vec::new();
+    for path in &config.policy_manifests {
+        let text = std::fs::read_to_string(path).map_err(|error| {
+            BackendError::InvalidSpec(format!(
+                "policy manifest `{}` is unreadable: {error}",
+                path.display()
+            ))
+        })?;
+        for (index, document) in serde_yaml::Deserializer::from_str(&text).enumerate() {
+            let value = serde_json::Value::deserialize(document)
+                .map_err(|error| policy_error(path, index, &error.to_string()))?;
+            if value.is_null() {
+                continue;
+            }
+            manifests.push(PolicyManifest {
+                source: path.clone(),
+                object: policy_object(config, path, index, value)?,
+            });
         }
-    })
+    }
+    Ok(manifests)
+}
+
+/// Namespaced objects only: the node applies them in its compute namespace.
+fn policy_object(
+    config: &KubernetesConfig,
+    path: &Path,
+    index: usize,
+    mut value: serde_json::Value,
+) -> Result<DynamicObject, BackendError> {
+    for field in ["apiVersion", "kind"] {
+        if named_field(&value, field).is_none() {
+            return Err(policy_error(path, index, &format!("has no {field}")));
+        }
+    }
+    if named_field(&value["metadata"], "name").is_none() {
+        return Err(policy_error(path, index, "has no metadata.name"));
+    }
+    match value["metadata"].get("namespace") {
+        None | Some(serde_json::Value::Null) => {
+            value["metadata"]["namespace"] = json!(config.namespace);
+        }
+        Some(namespace) if namespace.as_str() == Some(config.namespace.as_str()) => {}
+        Some(_) => {
+            return Err(policy_error(
+                path,
+                index,
+                &format!("is not in namespace `{}`", config.namespace),
+            ));
+        }
+    }
+    serde_json::from_value(value).map_err(|error| policy_error(path, index, &error.to_string()))
+}
+
+fn named_field<'a>(value: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|text| !text.trim().is_empty())
+}
+
+fn policy_error(path: &Path, index: usize, detail: &str) -> BackendError {
+    BackendError::InvalidSpec(format!(
+        "policy manifest `{}` document {index} {detail}",
+        path.display()
+    ))
 }
 
 pub fn marker_name(name: &str) -> String {
@@ -1001,27 +1059,6 @@ mod tests {
     }
 
     #[test]
-    fn builds_cilium_policy() {
-        // Pod to Ingress traffic is the reserved `ingress` entity, which the
-        // Kubernetes policy's CIDR peers can never match.
-        let mut config = config();
-        config.s3_port = 8443;
-
-        let policy = cilium_ingress_policy(&config);
-        let egress = &policy["spec"]["egress"][0];
-
-        assert_eq!(policy["kind"], "CiliumNetworkPolicy");
-        assert_eq!(policy["metadata"]["name"], CILIUM_S3_POLICY);
-        assert_eq!(
-            policy["spec"]["endpointSelector"]["matchLabels"]["aruna-engine.org/network"],
-            "s3"
-        );
-        assert_eq!(egress["toEntities"][0], "ingress");
-        assert_eq!(egress["toPorts"][0]["ports"][0]["port"], "8443");
-        assert_eq!(egress["toPorts"][0]["ports"][0]["protocol"], "TCP");
-    }
-
-    #[test]
     fn allows_dns_by_port() {
         // A host-network resolver such as node-local DNS is neither a kube-system
         // pod nor a CIDR peer under Cilium, so the DNS rule carries no peer.
@@ -1040,5 +1077,94 @@ mod tests {
         assert_eq!(dns["ports"][0]["port"], 53);
         assert_eq!(dns["ports"][1]["protocol"], "TCP");
         assert_eq!(dns["ports"][1]["port"], 53);
+    }
+
+    fn policy_file(dir: &Path, name: &str, text: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, text).expect("write manifest");
+        path
+    }
+
+    #[test]
+    fn loads_policy_documents() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = policy_file(
+            dir.path(),
+            "policies.yaml",
+            "---\napiVersion: cilium.io/v2\nkind: CiliumNetworkPolicy\nmetadata:\n  name: s3-ingress\n---\napiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: extra\n  namespace: compute\n",
+        );
+        let mut config = config();
+        config.policy_manifests = vec![path.clone()];
+
+        let manifests = policy_manifests(&config).expect("the documents load");
+
+        assert_eq!(manifests.len(), 2);
+        assert_eq!(manifests[0].source, path);
+        assert_eq!(
+            manifests[0].object.types.as_ref().expect("types").kind,
+            "CiliumNetworkPolicy"
+        );
+        assert_eq!(
+            manifests[0].object.metadata.namespace.as_deref(),
+            Some("compute")
+        );
+        assert_eq!(manifests[1].object.metadata.name.as_deref(), Some("extra"));
+    }
+
+    #[test]
+    fn refuses_foreign_namespace() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = policy_file(
+            dir.path(),
+            "foreign.yaml",
+            "apiVersion: cilium.io/v2\nkind: CiliumNetworkPolicy\nmetadata:\n  name: s3\n  namespace: other\n",
+        );
+        let mut config = config();
+        config.policy_manifests = vec![path];
+
+        let error = policy_manifests(&config).expect_err("a foreign namespace is refused");
+
+        let message = error.to_string();
+        assert!(message.contains("foreign.yaml"), "{message}");
+        assert!(message.contains("document 0"), "{message}");
+        assert!(message.contains("namespace `compute`"), "{message}");
+    }
+
+    #[test]
+    fn refuses_broken_document() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing_kind = policy_file(
+            dir.path(),
+            "kindless.yaml",
+            "apiVersion: cilium.io/v2\nmetadata:\n  name: s3\n",
+        );
+        let missing_name = policy_file(
+            dir.path(),
+            "nameless.yaml",
+            "apiVersion: cilium.io/v2\nkind: CiliumNetworkPolicy\nmetadata: {}\n",
+        );
+        let mut config = config();
+        config.policy_manifests = vec![missing_kind];
+        let kind_error =
+            policy_manifests(&config).expect_err("a document without a kind is refused");
+        config.policy_manifests = vec![missing_name];
+        let name_error =
+            policy_manifests(&config).expect_err("a document without a name is refused");
+
+        let kind_error = kind_error.to_string();
+        let name_error = name_error.to_string();
+        assert!(kind_error.contains("kindless.yaml") && kind_error.contains("has no kind"));
+        assert!(name_error.contains("nameless.yaml") && name_error.contains("metadata.name"));
+    }
+
+    #[test]
+    fn refuses_unreadable_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut config = config();
+        config.policy_manifests = vec![dir.path().join("missing.yaml")];
+
+        let error = policy_manifests(&config).expect_err("a missing file is refused");
+
+        assert!(error.to_string().contains("missing.yaml"), "{error}");
     }
 }

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -452,9 +452,9 @@ pub fn policy_manifests(config: &KubernetesConfig) -> Result<Vec<PolicyManifest>
                 path.display()
             ))
         })?;
-        for (index, document) in serde_yaml::Deserializer::from_str(&text).enumerate() {
-            let value = serde_json::Value::deserialize(document)
-                .map_err(|error| policy_error(path, index, &error.to_string()))?;
+        let documents: Vec<serde_json::Value> = serde_saphyr::from_multiple(&text)
+            .map_err(|error| policy_error(path, 0, &error.to_string()))?;
+        for (index, value) in documents.into_iter().enumerate() {
             if value.is_null() {
                 continue;
             }

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -15,6 +15,9 @@ use crate::executor::config::KubernetesConfig;
 use crate::executor::staging::StageLayout;
 use crate::executor::{digest_pinned, enforced_limit};
 
+/// Cilium-native companion of the `aruna-compute-s3` network policy.
+pub const CILIUM_S3_POLICY: &str = "aruna-compute-s3-ingress";
+
 pub const WORKSPACE_PATH: &str = "/workspace";
 pub const MARKER_PATH: &str = "/aruna-marker/marker";
 pub const SENTINEL_PATH: &str = "/workspace/.aruna-stage";
@@ -430,6 +433,25 @@ pub fn network_policies(config: &KubernetesConfig) -> Result<Vec<NetworkPolicy>,
     }))
     .map_err(manifest_error)?;
     Ok(vec![deny, s3])
+}
+
+/// Cilium classifies pod-to-Ingress traffic as the reserved `ingress` entity,
+/// which no ipBlock rule can match, so the S3 port needs a native rule too.
+pub fn cilium_ingress_policy(config: &KubernetesConfig) -> serde_json::Value {
+    json!({
+        "apiVersion":"cilium.io/v2",
+        "kind":"CiliumNetworkPolicy",
+        "metadata":{"name":CILIUM_S3_POLICY,"namespace":config.namespace},
+        "spec":{
+            "endpointSelector":{"matchLabels":{"aruna-engine.org/network":"s3"}},
+            "egress":[{
+                "toEntities":["ingress"],
+                "toPorts":[{"ports":[
+                    {"port":config.s3_port.to_string(),"protocol":"TCP"}
+                ]}]
+            }]
+        }
+    })
 }
 
 pub fn marker_name(name: &str) -> String {
@@ -976,6 +998,27 @@ mod tests {
             job.spec.unwrap().template.metadata.unwrap().labels.unwrap()["aruna-engine.org/network"],
             "task"
         );
+    }
+
+    #[test]
+    fn builds_cilium_policy() {
+        // Pod to Ingress traffic is the reserved `ingress` entity, which the
+        // Kubernetes policy's CIDR peers can never match.
+        let mut config = config();
+        config.s3_port = 8443;
+
+        let policy = cilium_ingress_policy(&config);
+        let egress = &policy["spec"]["egress"][0];
+
+        assert_eq!(policy["kind"], "CiliumNetworkPolicy");
+        assert_eq!(policy["metadata"]["name"], CILIUM_S3_POLICY);
+        assert_eq!(
+            policy["spec"]["endpointSelector"]["matchLabels"]["aruna-engine.org/network"],
+            "s3"
+        );
+        assert_eq!(egress["toEntities"][0], "ingress");
+        assert_eq!(egress["toPorts"][0]["ports"][0]["port"], "8443");
+        assert_eq!(egress["toPorts"][0]["ports"][0]["protocol"], "TCP");
     }
 
     #[test]

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -32,6 +32,7 @@ use kube::api::{
     Preconditions,
 };
 use kube::api::{DynamicObject, GroupVersionKind};
+use kube::discovery::Scope;
 use kube::{Client, ResourceExt};
 use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
@@ -48,9 +49,9 @@ use super::{BackendCaps, ExecutorBackend, SessionChannel, digest_pinned};
 mod manifest;
 
 use manifest::{
-    CILIUM_S3_POLICY, HELPER_PATH, StageMarker, WORKSPACE_PATH, cilium_ingress_policy, helper_pod,
-    job_manifest, marker_manifest, marker_name, mount_buckets, mount_name, mount_pv_manifest,
-    mount_pvc_manifest, needs_workspace, network_policies, pvc_manifest, secret_manifest,
+    HELPER_PATH, PolicyManifest, StageMarker, WORKSPACE_PATH, helper_pod, job_manifest,
+    marker_manifest, marker_name, mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest,
+    needs_workspace, network_policies, policy_manifests, pvc_manifest, secret_manifest,
     secret_name, workspace_name,
 };
 
@@ -74,6 +75,7 @@ const MAX_TERMINATION_DETAIL: usize = 2048;
 pub struct KubernetesBackend {
     client: Client,
     config: KubernetesConfig,
+    policies: Vec<PolicyManifest>,
 }
 
 impl KubernetesBackend {
@@ -84,7 +86,12 @@ impl KubernetesBackend {
 
     pub fn from_client(client: Client, config: KubernetesConfig) -> Result<Self, BackendError> {
         validate_config(&config)?;
-        Ok(Self { client, config })
+        let policies = policy_manifests(&config)?;
+        Ok(Self {
+            client,
+            config,
+            policies,
+        })
     }
 
     pub fn config(&self) -> &KubernetesConfig {
@@ -302,41 +309,49 @@ impl KubernetesBackend {
                 .await
                 .map_err(kube_error)?;
         }
-        self.apply_cilium().await
+        self.apply_manifests().await
     }
 
-    /// Opens the S3 port towards the Cilium ingress entity, which no ipBlock
-    /// rule can match. A cluster without the CRD keeps the policies above.
-    async fn apply_cilium(&self) -> Result<(), BackendError> {
-        if self.config.s3_cidrs.is_empty() {
-            return Ok(());
-        }
-        let gvk = GroupVersionKind::gvk("cilium.io", "v2", "CiliumNetworkPolicy");
-        let Ok((resource, _)) = kube::discovery::pinned_kind(&self.client, &gvk).await else {
-            tracing::debug!(
-                namespace = %self.config.namespace,
-                "Cilium network policies are not served by this cluster"
-            );
-            return Ok(());
-        };
-        let policies: Api<DynamicObject> =
-            Api::namespaced_with(self.client.clone(), &self.config.namespace, &resource);
-        let policy = cilium_ingress_policy(&self.config);
-        let params = PatchParams::apply("aruna-compute");
-        match policies
-            .patch(CILIUM_S3_POLICY, &params, &Patch::Apply(&policy))
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(error) if api_code(&error) == Some(403) => {
-                tracing::warn!(
-                    namespace = %self.config.namespace,
-                    "The node may not create, get or patch ciliumnetworkpolicies.cilium.io"
-                );
-                Ok(())
+    /// Applies the operator's own manifests in the compute namespace. The
+    /// operator listed them deliberately, so an unknown kind is an error.
+    async fn apply_manifests(&self) -> Result<(), BackendError> {
+        let params = PatchParams::apply("aruna-compute").force();
+        for manifest in &self.policies {
+            let source = manifest.source.display();
+            let gvk = manifest
+                .object
+                .types
+                .as_ref()
+                .and_then(|types| GroupVersionKind::try_from(types).ok())
+                .ok_or_else(|| {
+                    BackendError::InvalidSpec(format!("policy manifest `{source}` has no kind"))
+                })?;
+            let (resource, capabilities) = kube::discovery::pinned_kind(&self.client, &gvk)
+                .await
+                .map_err(|error| {
+                BackendError::Api(format!(
+                    "policy manifest `{source}` kind {} is not served: {error}",
+                    gvk.kind
+                ))
+            })?;
+            if capabilities.scope != Scope::Namespaced {
+                return Err(BackendError::InvalidSpec(format!(
+                    "policy manifest `{source}` kind {} is not namespaced",
+                    gvk.kind
+                )));
             }
-            Err(error) => Err(kube_error(error)),
+            let objects: Api<DynamicObject> =
+                Api::namespaced_with(self.client.clone(), &self.config.namespace, &resource);
+            objects
+                .patch(
+                    &manifest.object.name_any(),
+                    &params,
+                    &Patch::Apply(&manifest.object),
+                )
+                .await
+                .map_err(kube_error)?;
         }
+        Ok(())
     }
 
     async fn remove_helpers(&self, context: &FenceContext) -> Result<(), BackendError> {
@@ -2460,6 +2475,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: fake_client(|_, _| (404, status_json(404))),
             config: test_config(),
+            policies: Vec::new(),
         };
 
         let evidence = backend
@@ -2517,6 +2533,7 @@ mod tests {
         let backend = KubernetesBackend {
             client,
             config: test_config(),
+            policies: Vec::new(),
         };
 
         backend.cleanup(&context()).await.unwrap();
@@ -2557,6 +2574,7 @@ mod tests {
         let backend = KubernetesBackend {
             client,
             config: test_config(),
+            policies: Vec::new(),
         };
 
         let evidence = backend.cancel(&context()).await.unwrap();
@@ -2631,6 +2649,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: fake_client(|_, _| (404, status_json(404))),
             config: test_config(),
+            policies: Vec::new(),
         };
         let cancel = CancellationToken::new();
 
@@ -2723,6 +2742,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: probe_client(disabled.clone()),
             config: test_config(),
+            policies: Vec::new(),
         };
         backend.health().await.unwrap();
         assert!(
@@ -2739,6 +2759,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: probe_client(enabled.clone()),
             config,
+            policies: Vec::new(),
         };
         backend.health().await.unwrap();
         assert!(
@@ -2757,6 +2778,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: fake_client(|_, _| (200, json!({}))),
             config: test_config(),
+            policies: Vec::new(),
         };
         assert!(!backend.capabilities().session);
 
@@ -2765,6 +2787,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: fake_client(|_, _| (200, json!({}))),
             config,
+            policies: Vec::new(),
         };
         assert!(backend.capabilities().session);
     }
@@ -2790,7 +2813,11 @@ mod tests {
         });
         let mut config = test_config();
         config.s3_cidrs.push("10.0.0.0/8".to_string());
-        let backend = KubernetesBackend { client, config };
+        let backend = KubernetesBackend {
+            client,
+            config,
+            policies: Vec::new(),
+        };
 
         backend.apply_network().await.expect("the policies apply");
 
@@ -2809,9 +2836,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn patches_cilium_policy() {
-        // Only a Cilium-native policy can name the ingress entity the session
-        // reaches its S3 endpoint through.
+    async fn patches_policy_manifest() {
+        // The kind comes from discovery, so the apply must reach the plural
+        // path of the operator's own kind in the compute namespace.
         let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let recorder = seen.clone();
         let client = fake_client(move |method, path| {
@@ -2838,19 +2865,32 @@ mod tests {
                 200,
                 json!({
                     "apiVersion":"cilium.io/v2","kind":"CiliumNetworkPolicy",
-                    "metadata":{"name":CILIUM_S3_POLICY,"namespace":"compute"}
+                    "metadata":{"name":"s3-ingress","namespace":"compute"}
                 }),
             )
         });
-        let mut config = test_config();
-        config.s3_cidrs.push("10.0.0.0/8".to_string());
-        let backend = KubernetesBackend { client, config };
+        let object = serde_json::from_value(json!({
+            "apiVersion":"cilium.io/v2","kind":"CiliumNetworkPolicy",
+            "metadata":{"name":"s3-ingress","namespace":"compute"}
+        }))
+        .expect("build the manifest");
+        let backend = KubernetesBackend {
+            client,
+            config: test_config(),
+            policies: vec![PolicyManifest {
+                source: std::path::PathBuf::from("policies.yaml"),
+                object,
+            }],
+        };
 
-        backend.apply_cilium().await.expect("the policy applies");
+        backend
+            .apply_manifests()
+            .await
+            .expect("the manifest applies");
 
         let seen = seen.lock().expect("read requests").clone();
         assert!(seen.iter().any(|entry| entry
-            == &format!("PATCH /apis/cilium.io/v2/namespaces/compute/ciliumnetworkpolicies/{CILIUM_S3_POLICY}")));
+            == "PATCH /apis/cilium.io/v2/namespaces/compute/ciliumnetworkpolicies/s3-ingress"));
     }
 
     const POD_START: &str = "2027-01-01T00:00:00Z";
@@ -3022,6 +3062,7 @@ mod tests {
         let backend = KubernetesBackend {
             client,
             config: test_config(),
+            policies: Vec::new(),
         };
 
         let status = backend.status(&context()).await.unwrap();
@@ -3057,6 +3098,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: stuck_client(),
             config: test_config(),
+            policies: Vec::new(),
         };
 
         let status = backend.status(&context()).await.unwrap();
@@ -3076,6 +3118,7 @@ mod tests {
         let backend = KubernetesBackend {
             client: stuck_client(),
             config: test_config(),
+            policies: Vec::new(),
         };
 
         let tails = backend

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -1731,10 +1731,30 @@ fn repeated_wait(reason: &str) -> bool {
     )
 }
 
+/// A registry that refuses the reference outright (unknown name, no access)
+/// answers the same on every retry, so waiting out the deadline gains nothing.
+fn pull_refused(reason: &str, message: Option<&str>) -> bool {
+    if !matches!(reason, "ErrImagePull" | "ImagePullBackOff") {
+        return false;
+    }
+    let message = message.unwrap_or_default().to_ascii_lowercase();
+    [
+        "401 unauthorized",
+        "403 forbidden",
+        "404 not found",
+        "manifest unknown",
+        "name unknown",
+        "pull access denied",
+        "repository does not exist",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle))
+}
+
 /// Kubernetes retries a failing image pull forever, so the Job counts such a
-/// Pod as active and never reports a terminal condition. A malformed reference
-/// fails at once; a repeated failure fails once it outlives `deadline`, which
-/// is anchored at the Pod start and so also covers scheduling.
+/// Pod as active and never reports a terminal condition. A malformed or refused
+/// reference fails at once; a repeated failure fails once it outlives
+/// `deadline`, which is anchored at the Pod start and so also covers scheduling.
 fn pod_stuck_reason(pod: &Pod, deadline: Duration, now: Timestamp) -> Option<String> {
     let status = pod.status.as_ref()?;
     let waited = status
@@ -1751,7 +1771,10 @@ fn pod_stuck_reason(pod: &Pod, deadline: Duration, now: Timestamp) -> Option<Str
         .find_map(|container| {
             let waiting = container.state.as_ref()?.waiting.as_ref()?;
             let reason = waiting.reason.as_deref()?;
-            if reason != "InvalidImageName" && !(repeated_wait(reason) && waited > deadline) {
+            if reason != "InvalidImageName"
+                && !pull_refused(reason, waiting.message.as_deref())
+                && !(repeated_wait(reason) && waited > deadline)
+            {
                 return None;
             }
             let detail = waiting.message.as_deref().unwrap_or("no detail reported");
@@ -2932,6 +2955,24 @@ mod tests {
         let reason = pod_stuck_reason(&pod, Duration::from_secs(300), probe_now(1))
             .expect("reject invalid image");
         assert!(reason.contains("InvalidImageName"), "{reason}");
+    }
+
+    #[test]
+    fn fails_refused_pull() {
+        // A registry refusal is final, so a single try already ends the attempt.
+        let pod = task_pod(
+            json!({"waiting":{"reason":"ErrImagePull","message":
+                "failed to authorize: unexpected status from GET request: 403 Forbidden"}}),
+            POD_START,
+        );
+        let reason = pod_stuck_reason(&pod, Duration::from_secs(300), probe_now(1))
+            .expect("reject refused pull");
+        assert!(reason.contains("403 Forbidden"), "{reason}");
+        let pod = task_pod(
+            json!({"waiting":{"reason":"ErrImagePull","message":"rpc error: manifest unknown"}}),
+            POD_START,
+        );
+        assert!(pod_stuck_reason(&pod, Duration::from_secs(300), probe_now(1)).is_some());
     }
 
     #[test]

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -31,6 +31,7 @@ use kube::api::{
     Api, AttachParams, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams,
     Preconditions,
 };
+use kube::api::{DynamicObject, GroupVersionKind};
 use kube::{Client, ResourceExt};
 use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
@@ -47,9 +48,10 @@ use super::{BackendCaps, ExecutorBackend, SessionChannel, digest_pinned};
 mod manifest;
 
 use manifest::{
-    HELPER_PATH, StageMarker, WORKSPACE_PATH, helper_pod, job_manifest, marker_manifest,
-    marker_name, mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest, needs_workspace,
-    network_policies, pvc_manifest, secret_manifest, secret_name, workspace_name,
+    CILIUM_S3_POLICY, HELPER_PATH, StageMarker, WORKSPACE_PATH, cilium_ingress_policy, helper_pod,
+    job_manifest, marker_manifest, marker_name, mount_buckets, mount_name, mount_pv_manifest,
+    mount_pvc_manifest, needs_workspace, network_policies, pvc_manifest, secret_manifest,
+    secret_name, workspace_name,
 };
 
 pub const EPOCH_ANNOTATION: &str = "aruna-engine.org/attempt-epoch";
@@ -300,7 +302,41 @@ impl KubernetesBackend {
                 .await
                 .map_err(kube_error)?;
         }
-        Ok(())
+        self.apply_cilium().await
+    }
+
+    /// Opens the S3 port towards the Cilium ingress entity, which no ipBlock
+    /// rule can match. A cluster without the CRD keeps the policies above.
+    async fn apply_cilium(&self) -> Result<(), BackendError> {
+        if self.config.s3_cidrs.is_empty() {
+            return Ok(());
+        }
+        let gvk = GroupVersionKind::gvk("cilium.io", "v2", "CiliumNetworkPolicy");
+        let Ok((resource, _)) = kube::discovery::pinned_kind(&self.client, &gvk).await else {
+            tracing::debug!(
+                namespace = %self.config.namespace,
+                "Cilium network policies are not served by this cluster"
+            );
+            return Ok(());
+        };
+        let policies: Api<DynamicObject> =
+            Api::namespaced_with(self.client.clone(), &self.config.namespace, &resource);
+        let policy = cilium_ingress_policy(&self.config);
+        let params = PatchParams::apply("aruna-compute");
+        match policies
+            .patch(CILIUM_S3_POLICY, &params, &Patch::Apply(&policy))
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(error) if api_code(&error) == Some(403) => {
+                tracing::warn!(
+                    namespace = %self.config.namespace,
+                    "The node may not create, get or patch ciliumnetworkpolicies.cilium.io"
+                );
+                Ok(())
+            }
+            Err(error) => Err(kube_error(error)),
+        }
     }
 
     async fn remove_helpers(&self, context: &FenceContext) -> Result<(), BackendError> {
@@ -2770,6 +2806,51 @@ mod tests {
                 .all(|entry| entry.contains("networkpolicies"))
         );
         assert!(patched[1].contains("aruna-compute-s3"));
+    }
+
+    #[tokio::test]
+    async fn patches_cilium_policy() {
+        // Only a Cilium-native policy can name the ingress entity the session
+        // reaches its S3 endpoint through.
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let client = fake_client(move |method, path| {
+            recorder
+                .lock()
+                .expect("record requests")
+                .push(format!("{method} {path}"));
+            if path == "/apis/cilium.io/v2" {
+                return (
+                    200,
+                    json!({
+                        "kind":"APIResourceList","apiVersion":"v1",
+                        "groupVersion":"cilium.io/v2",
+                        "resources":[{
+                            "name":"ciliumnetworkpolicies",
+                            "singularName":"ciliumnetworkpolicy",
+                            "namespaced":true,"kind":"CiliumNetworkPolicy",
+                            "verbs":["create","get","patch"]
+                        }]
+                    }),
+                );
+            }
+            (
+                200,
+                json!({
+                    "apiVersion":"cilium.io/v2","kind":"CiliumNetworkPolicy",
+                    "metadata":{"name":CILIUM_S3_POLICY,"namespace":"compute"}
+                }),
+            )
+        });
+        let mut config = test_config();
+        config.s3_cidrs.push("10.0.0.0/8".to_string());
+        let backend = KubernetesBackend { client, config };
+
+        backend.apply_cilium().await.expect("the policy applies");
+
+        let seen = seen.lock().expect("read requests").clone();
+        assert!(seen.iter().any(|entry| entry
+            == &format!("PATCH /apis/cilium.io/v2/namespaces/compute/ciliumnetworkpolicies/{CILIUM_S3_POLICY}")));
     }
 
     const POD_START: &str = "2027-01-01T00:00:00Z";

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -288,7 +288,9 @@ impl KubernetesBackend {
         Ok(())
     }
 
-    async fn apply_network(&self) -> Result<(), BackendError> {
+    /// Creates or patches both network policies. Running pods keep the policy
+    /// they were started with, so a node applies them at startup too.
+    pub async fn apply_network(&self) -> Result<(), BackendError> {
         let policies: Api<NetworkPolicy> =
             Api::namespaced(self.client.clone(), &self.config.namespace);
         let params = PatchParams::apply("aruna-compute");
@@ -2729,6 +2731,45 @@ mod tests {
             config,
         };
         assert!(backend.capabilities().session);
+    }
+
+    #[tokio::test]
+    async fn applies_startup_policies() {
+        // A pod keeps the policy it started with, so an upgraded node must
+        // patch both of them before it serves an already running session.
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let client = fake_client(move |method, path| {
+            recorder
+                .lock()
+                .expect("record requests")
+                .push(format!("{method} {path}"));
+            (
+                200,
+                json!({
+                    "apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy",
+                    "metadata":{"name":"aruna-compute-deny","namespace":"compute"}
+                }),
+            )
+        });
+        let mut config = test_config();
+        config.s3_cidrs.push("10.0.0.0/8".to_string());
+        let backend = KubernetesBackend { client, config };
+
+        backend.apply_network().await.expect("the policies apply");
+
+        let seen = seen.lock().expect("read requests").clone();
+        let patched: Vec<&String> = seen
+            .iter()
+            .filter(|entry| entry.starts_with("PATCH"))
+            .collect();
+        assert_eq!(patched.len(), 2);
+        assert!(
+            patched
+                .iter()
+                .all(|entry| entry.contains("networkpolicies"))
+        );
+        assert!(patched[1].contains("aruna-compute-s3"));
     }
 
     const POD_START: &str = "2027-01-01T00:00:00Z";

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -850,7 +850,7 @@ impl ExecutorBackend for KubernetesBackend {
             local_site: false,
             worker_site,
             limits: self.config.envelope,
-            session: true,
+            session: !self.config.s3_cidrs.is_empty(),
         }
     }
 
@@ -2710,6 +2710,25 @@ mod tests {
                 .iter()
                 .any(|path| path.contains("csidrivers"))
         );
+    }
+
+    #[tokio::test]
+    async fn advertises_session_egress() {
+        // Without S3 CIDRs an isolated session is refused at submit, so the
+        // node must not advertise one the planner could still pick.
+        let backend = KubernetesBackend {
+            client: fake_client(|_, _| (200, json!({}))),
+            config: test_config(),
+        };
+        assert!(!backend.capabilities().session);
+
+        let mut config = test_config();
+        config.s3_cidrs.push("10.0.0.0/8".to_string());
+        let backend = KubernetesBackend {
+            client: fake_client(|_, _| (200, json!({}))),
+            config,
+        };
+        assert!(backend.capabilities().session);
     }
 
     const POD_START: &str = "2027-01-01T00:00:00Z";

--- a/compute/src/registry.rs
+++ b/compute/src/registry.rs
@@ -118,6 +118,7 @@ impl ExecutorRegistry {
                 capability.direct_s3 = caps.direct_s3;
                 capability.s3_mount = caps.s3_mount;
                 capability.network_policy = caps.network_policy;
+                capability.session = caps.session;
                 capability.limits = caps.limits;
                 capability.policy_draining = policy_draining;
                 Ok(capability)

--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -86,7 +86,8 @@ pub struct ExecutorCapability {
     /// The backend proves worker placement and enforces network isolation,
     /// which protected data requires before open networking is allowed.
     pub network_policy: bool,
-    /// The backend can open a session channel and reach S3 for one.
+    /// The backend can open a session channel that reaches S3 without the open
+    /// network.
     #[serde(default)]
     pub session: bool,
     /// Execution site this backend runs on, carrying its own generation.

--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -86,6 +86,9 @@ pub struct ExecutorCapability {
     /// The backend proves worker placement and enforces network isolation,
     /// which protected data requires before open networking is allowed.
     pub network_policy: bool,
+    /// The backend can open a session channel and reach S3 for one.
+    #[serde(default)]
+    pub session: bool,
     /// Execution site this backend runs on, carrying its own generation.
     pub subject: PlacementSubject,
     /// Digest of `subject`; a mismatch is drift and never eligible.
@@ -113,6 +116,7 @@ impl ExecutorCapability {
             direct_s3: false,
             s3_mount: false,
             network_policy: false,
+            session: false,
             subject,
             subject_digest,
             policy_draining: false,

--- a/core/src/credential_encryption.rs
+++ b/core/src/credential_encryption.rs
@@ -90,7 +90,7 @@ impl EncryptedS3Secret {
         let ciphertext = key
             .cipher()
             .encrypt(
-                XNonce::from_slice(&nonce),
+                &XNonce::from(nonce),
                 Payload {
                     msg: plaintext.as_bytes(),
                     aad,
@@ -108,7 +108,7 @@ impl EncryptedS3Secret {
         let plaintext = key
             .cipher()
             .decrypt(
-                XNonce::from_slice(&self.nonce),
+                &XNonce::from(self.nonce),
                 Payload {
                     msg: &self.ciphertext,
                     aad,

--- a/core/src/permission_path.rs
+++ b/core/src/permission_path.rs
@@ -91,10 +91,9 @@ fn split_roots<'a>(
     (allowed, denied)
 }
 
-/// The subtrees at or below `root` a caller may reach, taken from its role
-/// patterns and narrowed by a credential's restrictions. Only the subtree is
-/// derived here: whether a concrete path inside it is readable stays with the
-/// ordinary permission check.
+/// The subtrees at or below `root` a caller may reach, from its role patterns
+/// and narrowed by a credential's restrictions. Whether a concrete path inside
+/// one is readable stays with the ordinary permission check.
 pub fn readable_roots(
     granted: &[(String, Permission)],
     restrictions: Option<&[PathRestriction]>,

--- a/core/src/permission_path.rs
+++ b/core/src/permission_path.rs
@@ -1,4 +1,4 @@
-use crate::structs::PathRestriction;
+use crate::structs::{PathRestriction, Permission};
 use globset::GlobMatcher;
 use thiserror::Error;
 
@@ -45,6 +45,99 @@ pub fn role_path_confined(pattern: &str, subtree_root: &str) -> bool {
     pattern == subtree_root || pattern.starts_with(&format!("{subtree_root}/"))
 }
 
+/// Whether a concrete path is a root itself or lies below it.
+pub fn path_within(path: &str, root: &str) -> bool {
+    path == root
+        || path
+            .strip_prefix(root)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+/// The literal subtree a pattern grants on: the pattern itself when it holds no
+/// wildcard, the parent of a trailing `/**`, and nothing otherwise, so an
+/// unsupported wildcard never widens a derived scope.
+fn pattern_root(pattern: &str) -> Option<&str> {
+    if let Some(root) = pattern.strip_suffix("/**") {
+        return (!root.is_empty() && !root.contains(['*', '?', '[', ']', '{', '}']))
+            .then_some(root);
+    }
+    (!pattern.contains(['*', '?', '[', ']', '{', '}'])).then_some(pattern)
+}
+
+/// Splits patterns into the allowed and denied roots at or below `root`. A
+/// pattern that covers `root` itself contributes `root`.
+fn split_roots<'a>(
+    patterns: impl IntoIterator<Item = (&'a str, &'a Permission)>,
+    root: &str,
+) -> (Vec<String>, Vec<String>) {
+    let mut allowed = Vec::new();
+    let mut denied = Vec::new();
+    for (pattern, permission) in patterns {
+        let covered = if permission_pattern_matches(pattern, root) {
+            Some(root.to_string())
+        } else {
+            pattern_root(pattern)
+                .filter(|candidate| path_within(candidate, root))
+                .map(str::to_string)
+        };
+        let Some(covered) = covered else {
+            continue;
+        };
+        match permission {
+            Permission::DENY => denied.push(covered),
+            _ => allowed.push(covered),
+        }
+    }
+    (allowed, denied)
+}
+
+/// The subtrees at or below `root` a caller may reach, taken from its role
+/// patterns and narrowed by a credential's restrictions. Only the subtree is
+/// derived here: whether a concrete path inside it is readable stays with the
+/// ordinary permission check.
+pub fn readable_roots(
+    granted: &[(String, Permission)],
+    restrictions: Option<&[PathRestriction]>,
+    root: &str,
+) -> Vec<String> {
+    let (mut allowed, mut denied) = split_roots(
+        granted
+            .iter()
+            .map(|(pattern, permission)| (pattern.as_str(), permission)),
+        root,
+    );
+    if let Some(restrictions) = restrictions {
+        let (restricted, restricted_denied) = split_roots(
+            restrictions
+                .iter()
+                .map(|restriction| (restriction.pattern.as_str(), &restriction.permission)),
+            root,
+        );
+        allowed = narrow_roots(&allowed, &restricted);
+        denied.extend(restricted_denied);
+    }
+    allowed.retain(|candidate| !denied.iter().any(|deny| path_within(candidate, deny)));
+    allowed.sort();
+    allowed.dedup();
+    allowed
+}
+
+/// Keeps the deeper root of every overlapping pair, so a narrowing set can only
+/// shrink the reachable subtrees.
+fn narrow_roots(granted: &[String], narrowing: &[String]) -> Vec<String> {
+    let mut kept = Vec::new();
+    for candidate in granted {
+        for other in narrowing {
+            if path_within(candidate, other) {
+                kept.push(candidate.clone());
+            } else if path_within(other, candidate) {
+                kept.push(other.clone());
+            }
+        }
+    }
+    kept
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum RestrictionLimitError {
     #[error("too many path restrictions ({count})")]
@@ -84,7 +177,7 @@ pub fn validate_restriction_limits(
 mod tests {
     use super::{
         MAX_RESTRICTION_PATTERN_BYTES, MAX_TOKEN_RESTRICTIONS, RestrictionLimitError,
-        permission_pattern_matches, validate_restriction_limits,
+        permission_pattern_matches, readable_roots, validate_restriction_limits,
     };
     use crate::structs::{PathRestriction, Permission};
 
@@ -174,5 +267,79 @@ mod tests {
                 bytes: MAX_RESTRICTION_PATTERN_BYTES + 1
             })
         );
+    }
+
+    fn granted(patterns: &[(&str, Permission)]) -> Vec<(String, Permission)> {
+        patterns
+            .iter()
+            .map(|(pattern, permission)| (pattern.to_string(), permission.clone()))
+            .collect()
+    }
+
+    const BUCKET: &str = "/realm/g/group/data/node/study";
+
+    #[test]
+    fn pattern_covers_root() {
+        let granted = granted(&[("/realm/g/group/data/**", Permission::READ)]);
+        assert_eq!(readable_roots(&granted, None, BUCKET), vec![BUCKET]);
+    }
+
+    #[test]
+    fn pattern_yields_subpath() {
+        let granted = granted(&[
+            (
+                "/realm/g/group/data/node/study/imaging/**",
+                Permission::READ,
+            ),
+            ("/realm/g/group/meta/**", Permission::WRITE),
+        ]);
+        assert_eq!(
+            readable_roots(&granted, None, BUCKET),
+            vec![format!("{BUCKET}/imaging")]
+        );
+    }
+
+    #[test]
+    fn unrelated_yields_nothing() {
+        let granted = granted(&[("/realm/g/other/data/**", Permission::WRITE)]);
+        assert!(readable_roots(&granted, None, BUCKET).is_empty());
+    }
+
+    #[test]
+    fn deny_removes_root() {
+        let granted = granted(&[
+            (
+                "/realm/g/group/data/node/study/imaging/**",
+                Permission::READ,
+            ),
+            ("/realm/g/group/data/node/study/**", Permission::DENY),
+        ]);
+        assert!(readable_roots(&granted, None, BUCKET).is_empty());
+    }
+
+    #[test]
+    fn restrictions_narrow_roots() {
+        // A credential restricted deeper than the role keeps only its own scope.
+        let granted = granted(&[("/realm/g/group/data/**", Permission::READ)]);
+        let restrictions = vec![PathRestriction {
+            pattern: format!("{BUCKET}/imaging/**"),
+            permission: Permission::READ,
+        }];
+        assert_eq!(
+            readable_roots(&granted, Some(&restrictions), BUCKET),
+            vec![format!("{BUCKET}/imaging")]
+        );
+
+        let elsewhere = vec![PathRestriction {
+            pattern: "/realm/g/group/data/node/other/**".to_string(),
+            permission: Permission::READ,
+        }];
+        assert!(readable_roots(&granted, Some(&elsewhere), BUCKET).is_empty());
+    }
+
+    #[test]
+    fn wildcard_grants_nothing() {
+        let granted = granted(&[("/realm/g/group/data/node/study/*/imaging", Permission::READ)]);
+        assert!(readable_roots(&granted, None, BUCKET).is_empty());
     }
 }

--- a/core/src/scheduling/digest.rs
+++ b/core/src/scheduling/digest.rs
@@ -35,6 +35,7 @@ pub fn plan_digest(
         field(&mut hasher, Some(&label.value));
     }
     hasher.update(&[request.staging as u8, request.network as u8]);
+    flag(&mut hasher, request.session);
 
     count(&mut hasher, request.inputs.len());
     for (input, route) in request.inputs.iter().zip(routes) {
@@ -80,6 +81,7 @@ pub fn plan_digest(
         capability.direct_s3,
         capability.s3_mount,
         capability.network_policy,
+        capability.session,
         capability.policy_draining,
     ] {
         flag(&mut hasher, value);

--- a/core/src/scheduling/eligibility.rs
+++ b/core/src/scheduling/eligibility.rs
@@ -22,7 +22,7 @@ pub enum RejectionVerdict {
     SubjectDrift,
     ExecutorKind,
     Staging,
-    /// The backend runs no interactive session, or cannot reach S3 for one.
+    /// The backend cannot reach S3 for a session kept off the open network.
     Session,
     RequiredLabels,
     Resources,
@@ -78,7 +78,7 @@ impl RejectionVerdict {
             RejectionVerdict::SubjectDrift => "advertisement does not match its digest".to_string(),
             RejectionVerdict::ExecutorKind => "no executor of that kind".to_string(),
             RejectionVerdict::Staging => "staging mode is not supported".to_string(),
-            RejectionVerdict::Session => "sessions do not run here".to_string(),
+            RejectionVerdict::Session => "S3-only sessions do not run here".to_string(),
             RejectionVerdict::RequiredLabels => "a required label is missing".to_string(),
             RejectionVerdict::Resources => "not enough resources".to_string(),
             RejectionVerdict::OpenNetwork => "open network is not allowed here".to_string(),
@@ -119,7 +119,9 @@ pub fn screen(request: &PlanRequest, candidate: &TargetCandidate) -> Option<Reje
     if !candidate.capability.supports(request.staging) {
         return Some(RejectionVerdict::Staging);
     }
-    if request.session && !candidate.capability.session {
+    // An open-network session reaches S3 like any other traffic, so only a
+    // session that must be kept to S3 asks the backend for the capability.
+    if request.session && request.network != NetworkAccess::Open && !candidate.capability.session {
         return Some(RejectionVerdict::Session);
     }
     if !labels_match(request, &candidate.capability.subject) {

--- a/core/src/scheduling/eligibility.rs
+++ b/core/src/scheduling/eligibility.rs
@@ -22,6 +22,8 @@ pub enum RejectionVerdict {
     SubjectDrift,
     ExecutorKind,
     Staging,
+    /// The backend runs no interactive session, or cannot reach S3 for one.
+    Session,
     RequiredLabels,
     Resources,
     /// Protected data with open networking on a site that enforces none.
@@ -76,6 +78,7 @@ impl RejectionVerdict {
             RejectionVerdict::SubjectDrift => "advertisement does not match its digest".to_string(),
             RejectionVerdict::ExecutorKind => "no executor of that kind".to_string(),
             RejectionVerdict::Staging => "staging mode is not supported".to_string(),
+            RejectionVerdict::Session => "sessions do not run here".to_string(),
             RejectionVerdict::RequiredLabels => "a required label is missing".to_string(),
             RejectionVerdict::Resources => "not enough resources".to_string(),
             RejectionVerdict::OpenNetwork => "open network is not allowed here".to_string(),
@@ -115,6 +118,9 @@ pub fn screen(request: &PlanRequest, candidate: &TargetCandidate) -> Option<Reje
     }
     if !candidate.capability.supports(request.staging) {
         return Some(RejectionVerdict::Staging);
+    }
+    if request.session && !candidate.capability.session {
+        return Some(RejectionVerdict::Session);
     }
     if !labels_match(request, &candidate.capability.subject) {
         return Some(RejectionVerdict::RequiredLabels);

--- a/core/src/scheduling/inputs.rs
+++ b/core/src/scheduling/inputs.rs
@@ -107,6 +107,9 @@ pub struct PlanRequest {
     pub required_labels: Vec<LabelMatch>,
     pub staging: StagingMode,
     pub network: NetworkAccess,
+    /// An interactive session, which only a backend that can open a session
+    /// channel to the running attempt may take.
+    pub session: bool,
     pub inputs: Vec<ResolvedInput>,
     /// Refs the outputs and workspace inherit.
     pub output_policies: Vec<PlacementPolicyRef>,

--- a/core/src/scheduling/tests.rs
+++ b/core/src/scheduling/tests.rs
@@ -772,6 +772,18 @@ fn digest_covers_inputs() {
     let compute = config(vec![link("us", "eu", 1_000)]);
     let base = selected(&plan_request, scan.clone(), &compute).plan_digest;
 
+    let mut capable = scan.clone();
+    capable[0].capability.session = true;
+    let capable_digest = selected(&plan_request, capable.clone(), &compute).plan_digest;
+    assert_ne!(capable_digest, base);
+
+    let mut session = plan_request.clone();
+    session.session = true;
+    assert_ne!(
+        selected(&session, capable, &compute).plan_digest,
+        capable_digest
+    );
+
     let mut resized = plan_request.clone();
     resized.inputs[0].bytes += 1;
     assert_ne!(selected(&resized, scan.clone(), &compute).plan_digest, base);

--- a/core/src/scheduling/tests.rs
+++ b/core/src/scheduling/tests.rs
@@ -99,6 +99,7 @@ pub(crate) fn request(inputs: Vec<ResolvedInput>) -> PlanRequest {
         required_labels: Vec::new(),
         staging: StagingMode::Files,
         network: NetworkAccess::Isolated,
+        session: false,
         inputs,
         output_policies: Vec::new(),
         policies: BTreeMap::new(),
@@ -589,6 +590,28 @@ fn filters_request_constraints() {
         verdict(&plan(&labelled, scan, &config(Vec::new())), node(2)),
         RejectionVerdict::RequiredLabels
     );
+}
+
+#[test]
+fn screens_session_support() {
+    // A session needs a backend that can open a channel to the attempt, so a
+    // site without one must leave the scan instead of taking the job.
+    let target = node(2);
+    let mut plan_request = request(Vec::new());
+    plan_request.session = true;
+
+    let outcome = plan(
+        &plan_request,
+        vec![candidate(target, "docker")],
+        &config(Vec::new()),
+    );
+    assert!(outcome.selected.is_none());
+    assert_eq!(verdict(&outcome, target), RejectionVerdict::Session);
+
+    let mut capable = candidate(target, "docker");
+    capable.capability.session = true;
+    let outcome = plan(&plan_request, vec![capable], &config(Vec::new()));
+    assert!(outcome.selected.is_some());
 }
 
 #[test]

--- a/core/src/scheduling/tests.rs
+++ b/core/src/scheduling/tests.rs
@@ -612,6 +612,17 @@ fn screens_session_support() {
     capable.capability.session = true;
     let outcome = plan(&plan_request, vec![capable], &config(Vec::new()));
     assert!(outcome.selected.is_some());
+
+    // An open-network session needs no S3 reachability of its own, so a
+    // backend without the capability may still take it.
+    let mut open = plan_request.clone();
+    open.network = NetworkAccess::Open;
+    let outcome = plan(
+        &open,
+        vec![candidate(target, "docker")],
+        &config(Vec::new()),
+    );
+    assert!(outcome.selected.is_some());
 }
 
 #[test]

--- a/core/src/structs/group.rs
+++ b/core/src/structs/group.rs
@@ -113,6 +113,20 @@ impl GroupAuthorizationDocument {
         }
     }
 
+    /// Permission patterns of every role this user is assigned to, for callers
+    /// that must reason about granted subtrees instead of a single path.
+    pub fn user_permissions(&self, user_id: UserId) -> Vec<(String, Permission)> {
+        self.roles
+            .values()
+            .filter(|role| role.assigned_users.contains(&user_id))
+            .flat_map(|role| {
+                role.permissions
+                    .iter()
+                    .map(|(pattern, permission)| (pattern.clone(), permission.clone()))
+            })
+            .collect()
+    }
+
     pub fn to_bytes(&self, _actor: &Actor) -> Result<Vec<u8>, ConversionError> {
         Ok(postcard::to_allocvec(self)?)
     }

--- a/operations/src/jobs/lifecycle/cancel.rs
+++ b/operations/src/jobs/lifecycle/cancel.rs
@@ -9,9 +9,10 @@
 use aruna_core::effects::JobRecordFrame;
 use aruna_core::jobs::{JobRequest, JobResponse};
 use aruna_core::structs::{
-    AuthContext, CancelAuthority, JobCancelRecord, JobFamilyRecord, JobId, JobRecordEnvelope,
-    LogicalJobSpec, Permission, blob_group_permission_path,
+    AuthContext, CancelAuthority, JobCancelRecord, JobFamilyId, JobFamilyRecord, JobId,
+    JobRecordEnvelope, JobRecordKind, LogicalJobSpec, Permission, blob_group_permission_path,
 };
+use aruna_core::types::NodeId;
 use aruna_core::util::unix_timestamp_millis;
 use tracing::{debug, warn};
 use ulid::Ulid;
@@ -21,7 +22,11 @@ use crate::driver::{DriverContext, drive};
 use crate::jobs::JobRouteError;
 use crate::jobs::protocol::send_job_request;
 use crate::jobs::records::verify::FamilyView;
-use crate::jobs::records::{Admission, AppendRecordConfig, AppendRecordOperation, RecordOrigin};
+use crate::jobs::records::{
+    Admission, AppendRecordConfig, AppendRecordOperation, RecordOrigin, load_kind_complete,
+};
+use crate::jobs::service::kick_drain;
+use crate::jobs::store::{CancelRequestOutcome, JobMutationError, set_cancel_requested};
 use crate::metadata::MetadataAuthToken;
 use crate::metadata::api::load_realm_config;
 use crate::request_authorization::authorize;
@@ -35,11 +40,11 @@ pub async fn cancel_family(
     job_id: JobId,
     auth_token: Option<MetadataAuthToken>,
 ) -> Option<Result<(), JobRouteError>> {
-    match family_of_alias(context, job_id).await {
-        Ok(Some(_)) => {}
+    let family = match family_of_alias(context, job_id).await {
+        Ok(Some(family)) => family,
         Ok(None) => return None,
         Err(error) => return Some(Err(error)),
-    }
+    };
     let (projected, spec) = match family_projection(context, job_id).await {
         Ok(Some(projected)) => projected,
         Ok(None) => return None,
@@ -61,6 +66,7 @@ pub async fn cancel_family(
     if let Err(error) = publish_cancel(context, &spec, auth, authority).await {
         return Some(Err(error));
     }
+    cancel_local_runs(context, family).await;
     // Every known active execution is asked to stop; a partitioned one may
     // still finish and stays visible as a late completion.
     if let Some(auth_token) = auth_token {
@@ -218,6 +224,7 @@ async fn stop_execution(
     job_id: JobId,
     auth_token: &MetadataAuthToken,
 ) {
+    // A local execution has no network cancel: `cancel_local_runs` flagged it.
     if context
         .net_handle
         .as_ref()
@@ -231,5 +238,57 @@ async fn stop_execution(
     };
     if let Err(error) = send_job_request(context, executor, request).await {
         warn!(peer = %executor, error = %error, "Cancel delivery to an executor failed");
+    }
+}
+
+/// Stops every physical execution of one family this node runs. The replicated
+/// record reaches no local attempt by itself, so each local row is flagged here
+/// and the drain is woken once.
+pub(crate) async fn cancel_local_runs(context: &DriverContext, family: JobFamilyId) {
+    let Some(local) = context.net_handle.as_ref().map(|net| net.node_id()) else {
+        return;
+    };
+    let receipts = match load_kind_complete(context, family, JobRecordKind::Receipt).await {
+        Ok(receipts) => receipts,
+        Err(error) => {
+            warn!(error = %error, "Family receipts unreadable for a local cancel");
+            return;
+        }
+    };
+    let mut flagged = false;
+    for physical in local_physical_jobs(&receipts, local) {
+        flagged |= flag_local_run(context, physical).await;
+    }
+    if flagged {
+        kick_drain(context).await;
+    }
+}
+
+/// Physical rows of the executions this node signed a receipt for.
+fn local_physical_jobs(receipts: &[JobRecordEnvelope], local: NodeId) -> Vec<JobId> {
+    receipts
+        .iter()
+        .filter_map(|envelope| match &envelope.record {
+            JobFamilyRecord::Receipt(receipt) if receipt.executor_node_id == local => {
+                Some(receipt.physical_job_id)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Requests cancellation of one local physical row. A settled or pruned row is
+/// a no-op, and a repeated request leaves the stored record untouched.
+async fn flag_local_run(context: &DriverContext, physical: JobId) -> bool {
+    match set_cancel_requested(&context.storage_handle, physical, unix_timestamp_millis()).await {
+        Ok(CancelRequestOutcome::Cancelled(_) | CancelRequestOutcome::Flagged(_)) => {
+            debug!(job_id = %physical, "Local execution cancelled by its family");
+            true
+        }
+        Ok(CancelRequestOutcome::AlreadyTerminal(_)) | Err(JobMutationError::NotFound) => false,
+        Err(error) => {
+            warn!(job_id = %physical, error = %error, "Local execution cancel flag failed");
+            false
+        }
     }
 }

--- a/operations/src/jobs/lifecycle/cancel.rs
+++ b/operations/src/jobs/lifecycle/cancel.rs
@@ -18,6 +18,7 @@ use tracing::{debug, warn};
 use ulid::Ulid;
 
 use super::routing::{family_of_alias, family_projection};
+use super::updates::{SETTLE_RETRY_AFTER, publish_terminal, schedule_terminal_settle};
 use crate::driver::{DriverContext, drive};
 use crate::jobs::JobRouteError;
 use crate::jobs::protocol::send_job_request;
@@ -289,7 +290,18 @@ pub(crate) async fn cancel_local_run(context: &DriverContext, physical: JobId) {
 /// a no-op, and a repeated request leaves the stored record untouched.
 async fn flag_local_run(context: &DriverContext, physical: JobId) -> bool {
     match set_cancel_requested(&context.storage_handle, physical, unix_timestamp_millis()).await {
-        Ok(CancelRequestOutcome::Cancelled(_) | CancelRequestOutcome::Flagged(_)) => {
+        Ok(CancelRequestOutcome::Cancelled(record)) => {
+            if !publish_terminal(context, &record).await
+                && let Some(task) = context.task_handle.as_ref()
+            {
+                use aruna_core::handle::Handle;
+                let _ = task
+                    .send_effect(schedule_terminal_settle(SETTLE_RETRY_AFTER))
+                    .await;
+            }
+            true
+        }
+        Ok(CancelRequestOutcome::Flagged(_)) => {
             debug!(job_id = %physical, "Local execution cancelled by its family");
             true
         }

--- a/operations/src/jobs/lifecycle/cancel.rs
+++ b/operations/src/jobs/lifecycle/cancel.rs
@@ -277,6 +277,14 @@ fn local_physical_jobs(receipts: &[JobRecordEnvelope], local: NodeId) -> Vec<Job
         .collect()
 }
 
+/// Cancels one local row whose launch committed while the family was already
+/// cancelled, waking the drain so the row never starts.
+pub(crate) async fn cancel_local_run(context: &DriverContext, physical: JobId) {
+    if flag_local_run(context, physical).await {
+        kick_drain(context).await;
+    }
+}
+
 /// Requests cancellation of one local physical row. A settled or pruned row is
 /// a no-op, and a repeated request leaves the stored record untouched.
 async fn flag_local_run(context: &DriverContext, physical: JobId) -> bool {

--- a/operations/src/jobs/lifecycle/plan.rs
+++ b/operations/src/jobs/lifecycle/plan.rs
@@ -105,6 +105,7 @@ fn plan_request(
         required_labels: ids::required_labels(&spec.payload)?,
         staging: REALM_STAGING,
         network: network_access(spec),
+        session: ids::session_of(&spec.payload).is_some(),
         inputs,
         output_policies,
         policies,
@@ -681,6 +682,21 @@ mod tests {
             name: None,
             description: None,
         });
+    }
+
+    #[test]
+    fn flags_session_request() {
+        // Only a backend that can open a session channel may take a session, so
+        // the tag must reach the request every advertisement is screened by.
+        let family = Family::new([4u8; 32]);
+        let mut spec = family.spec();
+        assert!(!round_request(&spec).session);
+
+        spec.payload.tags.insert(
+            aruna_core::compute::runtimes::SESSION_TAG.to_string(),
+            aruna_core::compute::runtimes::SESSION_TAG_NOTEBOOK.to_string(),
+        );
+        assert!(round_request(&spec).session);
     }
 
     #[test]

--- a/operations/src/jobs/lifecycle/target.rs
+++ b/operations/src/jobs/lifecycle/target.rs
@@ -21,11 +21,11 @@ use aruna_core::events::{DeclinedPolicy, Event, JobRecordEvent, LaunchDecline, N
 use aruna_core::operation::Operation;
 use aruna_core::scheduling::PlannedInput;
 use aruna_core::structs::{
-    AuthContext, CapturedInput, ExecutionReceipt, InputSource, JobFamilyId, JobFamilyRecord,
-    JobPayload, JobRecord, JobRecordEnvelope, JobRecordKind, LaunchIntent, LogicalJobSpec,
-    Permission, PhysicalExecutionState, PlacementDecision, PlacementPolicyRef, PlacementSubject,
-    PolicyResolution, RealmConfigDocument, WorkspaceMode, blob_group_permission_path,
-    evaluate_placement,
+    AuthContext, CapturedInput, ExecutionReceipt, InputSource, JobFamilyId, JobFamilyRecord, JobId,
+    JobPayload, JobRecord, JobRecordBody, JobRecordEnvelope, JobRecordKind, LaunchIntent,
+    LogicalJobSpec, Permission, PhysicalExecutionState, PlacementDecision, PlacementPolicyRef,
+    PlacementSubject, PolicyResolution, RealmConfigDocument, WorkspaceMode,
+    blob_group_permission_path, evaluate_placement,
 };
 use aruna_core::types::{Effects, NodeId};
 use aruna_core::util::unix_timestamp_millis;
@@ -37,6 +37,7 @@ use tracing::{debug, info, warn};
 use ulid::Ulid;
 
 use super::LifecycleError;
+use super::cancel::cancel_local_run;
 use super::ids::{self, workspace_of};
 use super::plan::{REALM_STAGING, network_access};
 use super::reservation::{ReserveExecutionConfig, ReserveExecutionOperation};
@@ -298,10 +299,27 @@ pub(crate) async fn commit_receipt(
     intent: &LaunchIntent,
 ) -> Option<Result<ReceiptFrame, LaunchDecline>> {
     let ctx: &DriverContext = context.as_ref();
-    commit_with(context, config, intent, move |config| {
+    let job_id = config.job_id;
+    let committed = commit_with(context, config, intent, move |config| {
         drive(ReserveExecutionOperation::new(config), ctx)
     })
-    .await
+    .await;
+    if matches!(committed, Some(Ok(_))) {
+        apply_late_cancel(context, intent, job_id).await;
+    }
+    committed
+}
+
+/// A cancel admitted while this launch was being decided reached the family
+/// before the receipt existed, so the row it just minted is flagged here.
+async fn apply_late_cancel(context: &Arc<DriverContext>, intent: &LaunchIntent, job_id: JobId) {
+    let family = intent.family();
+    let Some(records) = family_records(context, family).await else {
+        return;
+    };
+    if cancelled(family, &records) {
+        cancel_local_run(context.as_ref(), job_id).await;
+    }
 }
 
 /// What one reservation attempt decided, and what it proves about the writes it

--- a/operations/src/jobs/lifecycle/target.rs
+++ b/operations/src/jobs/lifecycle/target.rs
@@ -21,11 +21,11 @@ use aruna_core::events::{DeclinedPolicy, Event, JobRecordEvent, LaunchDecline, N
 use aruna_core::operation::Operation;
 use aruna_core::scheduling::PlannedInput;
 use aruna_core::structs::{
-    AuthContext, CapturedInput, ExecutionReceipt, InputSource, JobFamilyId, JobFamilyRecord, JobId,
-    JobPayload, JobRecord, JobRecordBody, JobRecordEnvelope, JobRecordKind, LaunchIntent,
-    LogicalJobSpec, Permission, PhysicalExecutionState, PlacementDecision, PlacementPolicyRef,
-    PlacementSubject, PolicyResolution, RealmConfigDocument, WorkspaceMode,
-    blob_group_permission_path, evaluate_placement,
+    AuthContext, CapturedInput, ExecutionReceipt, InputSource, JobFamilyId, JobFamilyRecord,
+    JobPayload, JobRecord, JobRecordEnvelope, JobRecordKind, LaunchIntent, LogicalJobSpec,
+    Permission, PhysicalExecutionState, PlacementDecision, PlacementPolicyRef, PlacementSubject,
+    PolicyResolution, RealmConfigDocument, WorkspaceMode, blob_group_permission_path,
+    evaluate_placement,
 };
 use aruna_core::types::{Effects, NodeId};
 use aruna_core::util::unix_timestamp_millis;
@@ -107,7 +107,7 @@ pub async fn admit_launch(
     // A replayed offer re-arms the wakeups the first acceptance may have lost,
     // so the receipt still replicates and the execution still starts.
     if let Some(decision) = existing_receipt(&records, &intent) {
-        return Some(accepted(context.as_ref(), decision).await);
+        return accepted(context, decision).await;
     }
     if cancelled(family, &records) {
         return Some(Err(LaunchDecline::Cancelled));
@@ -299,27 +299,10 @@ pub(crate) async fn commit_receipt(
     intent: &LaunchIntent,
 ) -> Option<Result<ReceiptFrame, LaunchDecline>> {
     let ctx: &DriverContext = context.as_ref();
-    let job_id = config.job_id;
-    let committed = commit_with(context, config, intent, move |config| {
+    commit_with(context, config, intent, move |config| {
         drive(ReserveExecutionOperation::new(config), ctx)
     })
-    .await;
-    if matches!(committed, Some(Ok(_))) {
-        apply_late_cancel(context, intent, job_id).await;
-    }
-    committed
-}
-
-/// A cancel admitted while this launch was being decided reached the family
-/// before the receipt existed, so the row it just minted is flagged here.
-async fn apply_late_cancel(context: &Arc<DriverContext>, intent: &LaunchIntent, job_id: JobId) {
-    let family = intent.family();
-    let Some(records) = family_records(context, family).await else {
-        return;
-    };
-    if cancelled(family, &records) {
-        cancel_local_run(context.as_ref(), job_id).await;
-    }
+    .await
 }
 
 /// What one reservation attempt decided, and what it proves about the writes it
@@ -379,7 +362,7 @@ where
             Ok(_) => {
                 let frame = ReceiptFrame::new(config.receipt.envelope().clone())
                     .map_err(|_| LaunchDecline::Unauthorized);
-                return Some(accepted(context.as_ref(), frame).await);
+                return accepted(context, frame).await;
             }
             Err(error) => error,
         };
@@ -390,7 +373,7 @@ where
             // is searched for before the reservation is attempted again.
             CommitVerdict::Raced => {
                 if let Some(committed) = committed_receipt(context, family, intent).await {
-                    return Some(accepted(context.as_ref(), committed).await);
+                    return accepted(context, committed).await;
                 }
                 debug!(attempt, "Execution reservation lost a race and retries");
                 tokio::task::yield_now().await;
@@ -405,7 +388,7 @@ where
             CommitVerdict::Uncertain => {
                 warn!(error = %error, "Execution commit outcome is unknown; reconciling");
                 let committed = committed_receipt(context, family, intent).await?;
-                return Some(accepted(context.as_ref(), committed).await);
+                return accepted(context, committed).await;
             }
             CommitVerdict::Drained => return Some(Err(LaunchDecline::Draining)),
             CommitVerdict::Faulted => {
@@ -418,17 +401,24 @@ where
 }
 
 /// Answers one decided offer and, when it was admitted, re-arms the runtime the
-/// acceptance owes: the receipt still has to replicate and the execution still
-/// has to start. A decline wakes nothing.
+/// acceptance owes, after applying any cancellation to the committed physical
+/// row. An incomplete cancellation read leaves the offer undecided.
 async fn accepted(
-    context: &DriverContext,
+    context: &Arc<DriverContext>,
     decision: Result<ReceiptFrame, LaunchDecline>,
-) -> Result<ReceiptFrame, LaunchDecline> {
-    if decision.is_ok() {
+) -> Option<Result<ReceiptFrame, LaunchDecline>> {
+    if let Ok(frame) = &decision {
+        let family = frame.envelope().family();
+        let records = family_records(context, family).await?;
+        if cancelled(family, &records)
+            && let JobFamilyRecord::Receipt(receipt) = &frame.envelope().record
+        {
+            cancel_local_run(context.as_ref(), receipt.physical_job_id).await;
+        }
         super::outbox::kick(context).await;
         schedule_local(context).await;
     }
-    decision
+    Some(decision)
 }
 
 /// The receipt already committed for this exact launch, whoever won the race.
@@ -623,6 +613,9 @@ pub(crate) async fn local_capability(
             .as_deref()
             .is_some_and(|kind| kind.trim() != capability.kind.trim())
         || !capability.supports(REALM_STAGING)
+        || (ids::session_of(&spec.payload).is_some()
+            && network_access(spec) != NetworkAccess::Open
+            && !capability.session)
         || !capability.limits.fits(&spec.resources)
     {
         return Err(LaunchDecline::Unauthorized);

--- a/operations/src/jobs/lifecycle/tests/admission_race.rs
+++ b/operations/src/jobs/lifecycle/tests/admission_race.rs
@@ -83,7 +83,8 @@ pub(super) fn config(
     execution: u8,
     envelope: ResourceEnvelope,
 ) -> ReserveExecutionConfig {
-    let receipt = family.receipt(launch, execution);
+    let mut receipt = family.receipt(launch, execution);
+    receipt.physical_job_id = physical(execution);
     let frame = JobRecordFrame::new(family.sign(
         &family.target,
         JobFamilyRecord::Receipt(Box::new(receipt.clone())),

--- a/operations/src/jobs/lifecycle/tests/cancel.rs
+++ b/operations/src/jobs/lifecycle/tests/cancel.rs
@@ -1,14 +1,19 @@
 //! Cancelling a family has to reach the executions this node itself runs: the
 //! replicated record stops further launches, it does not stop a running one.
 
-use aruna_core::structs::{AuthContext, JobState};
+use std::sync::Arc;
+
+use aruna_core::effects::JobRecordFrame;
+use aruna_core::structs::{AuthContext, JobFamilyRecord, JobState};
 use aruna_core::types::UserId;
 
 use super::terminal::{node_context, physical, reserve_execution, seed_family};
 use crate::driver::DriverContext;
 use crate::jobs::lifecycle::cancel::cancel_family;
 use crate::jobs::records::tests::fixture::{Family, REALM, user};
+use crate::jobs::records::transport::serve_job_record;
 use crate::jobs::store::read_job_record;
+use crate::metadata::protocol::MetadataTransportMessage;
 
 fn auth(user_id: UserId) -> AuthContext {
     AuthContext {
@@ -79,6 +84,39 @@ async fn repeated_cancel_is_quiet() {
         .expect("physical row exists");
     assert_eq!(first, second);
     assert!(second.cancel_requested);
+}
+
+#[tokio::test]
+async fn admitted_cancel_stops_local() {
+    // The record arrives after this node already admitted the execution, so
+    // admission itself has to apply it to the row that is already running.
+    let family = Family::new([43u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    assert!(!flagged(&ctx).await);
+    let ctx = Arc::new(ctx);
+    let record = JobRecordFrame::new(family.sign(
+        &family.holder,
+        JobFamilyRecord::Cancel(family.cancel(&family.spec())),
+    ))
+    .expect("bounded record");
+
+    let reply = serve_job_record(
+        &ctx,
+        family.holder.public(),
+        MetadataTransportMessage::ForwardJobRecord {
+            placement: family.placement,
+            record: Box::new(record),
+        },
+    )
+    .await;
+
+    assert!(matches!(
+        reply,
+        MetadataTransportMessage::ForwardedJobRecord { result: Ok(()) }
+    ));
+    assert!(flagged(&ctx).await);
 }
 
 #[tokio::test]

--- a/operations/src/jobs/lifecycle/tests/cancel.rs
+++ b/operations/src/jobs/lifecycle/tests/cancel.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use aruna_core::effects::{JobRecordFrame, LaunchFrame};
+use aruna_core::errors::StorageError;
 use aruna_core::keyspaces::JOB_RESERVATION_KEYSPACE;
 use aruna_core::structs::{
     AuthContext, JobFamilyRecord, JobId, JobRecordKind, JobState, PhysicalExecutionState,
@@ -13,8 +14,9 @@ use aruna_core::types::UserId;
 use super::admission_race::{config, envelope, rows, seed};
 use super::terminal::{node_context, physical, reserve_execution, seed_family};
 use crate::driver::{DriverContext, drive};
+use crate::jobs::lifecycle::LifecycleError;
 use crate::jobs::lifecycle::cancel::cancel_family;
-use crate::jobs::lifecycle::target::{admit_launch, commit_receipt};
+use crate::jobs::lifecycle::target::{admit_launch, commit_receipt, commit_with};
 use crate::jobs::records::tests::fixture::{Family, REALM, user};
 use crate::jobs::records::transport::serve_job_record;
 use crate::jobs::records::{
@@ -265,10 +267,16 @@ async fn winner_cancel_recovers() {
         .unwrap();
     store_cancel(&ctx, &family).await;
 
-    let raced = commit_receipt(&ctx, config(&family, &launch, 2, envelope(4)), &launch)
-        .await
-        .unwrap()
-        .unwrap();
+    // Only a concurrent commit conflicts, so the lost race is injected here.
+    let raced = commit_with(
+        &ctx,
+        config(&family, &launch, 2, envelope(4)),
+        &launch,
+        |_| async { Err(LifecycleError::Storage(StorageError::TransactionConflict)) },
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(accepted, raced);
     let record = read_job_record(&ctx.storage_handle, JobId::from_bytes([1u8; 16]), None)

--- a/operations/src/jobs/lifecycle/tests/cancel.rs
+++ b/operations/src/jobs/lifecycle/tests/cancel.rs
@@ -1,0 +1,105 @@
+//! Cancelling a family has to reach the executions this node itself runs: the
+//! replicated record stops further launches, it does not stop a running one.
+
+use aruna_core::structs::{AuthContext, JobState};
+use aruna_core::types::UserId;
+
+use super::terminal::{node_context, physical, reserve_execution, seed_family};
+use crate::driver::DriverContext;
+use crate::jobs::lifecycle::cancel::cancel_family;
+use crate::jobs::records::tests::fixture::{Family, REALM, user};
+use crate::jobs::store::read_job_record;
+
+fn auth(user_id: UserId) -> AuthContext {
+    AuthContext {
+        user_id,
+        realm_id: REALM,
+        path_restrictions: None,
+        session: None,
+    }
+}
+
+/// Whether the local physical row of the seeded execution is flagged.
+async fn flagged(ctx: &DriverContext) -> bool {
+    read_job_record(&ctx.storage_handle, physical(), None)
+        .await
+        .expect("physical row read")
+        .expect("physical row exists")
+        .cancel_requested
+}
+
+#[tokio::test]
+async fn family_cancel_stops_local() {
+    // The execution runs on the node that publishes the cancellation, so no
+    // network cancel can reach it: its own row has to be flagged here.
+    let family = Family::new([41u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    let spec = family.spec();
+
+    cancel_family(&ctx, &auth(user()), spec.job_id, None)
+        .await
+        .expect("alias names a family")
+        .expect("cancellation publishes");
+
+    let record = read_job_record(&ctx.storage_handle, physical(), None)
+        .await
+        .expect("physical row read")
+        .expect("physical row exists");
+    assert!(record.cancel_requested);
+    assert_eq!(record.state, JobState::Running);
+}
+
+#[tokio::test]
+async fn repeated_cancel_is_quiet() {
+    // A second cancellation must leave the already flagged row untouched.
+    let family = Family::new([42u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    let spec = family.spec();
+
+    cancel_family(&ctx, &auth(user()), spec.job_id, None)
+        .await
+        .expect("alias names a family")
+        .expect("cancellation publishes");
+    let first = read_job_record(&ctx.storage_handle, physical(), None)
+        .await
+        .expect("physical row read")
+        .expect("physical row exists");
+    cancel_family(&ctx, &auth(user()), spec.job_id, None)
+        .await
+        .expect("alias names a family")
+        .expect("cancellation publishes");
+
+    let second = read_job_record(&ctx.storage_handle, physical(), None)
+        .await
+        .expect("physical row read")
+        .expect("physical row exists");
+    assert_eq!(first, second);
+    assert!(second.cancel_requested);
+}
+
+#[tokio::test]
+async fn remote_run_stays_untouched() {
+    // Another node's execution is stopped by the network cancel only: a holder
+    // that runs nothing must not flag a row it does not execute.
+    let family = Family::new([44u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    let spec = family.spec();
+    let (_holder_dir, holder_ctx) = node_context(&family, &family.holder).await;
+    let holder_ctx = DriverContext {
+        storage_handle: ctx.storage_handle.clone(),
+        ..holder_ctx
+    };
+
+    cancel_family(&holder_ctx, &auth(user()), spec.job_id, None)
+        .await
+        .expect("alias names a family")
+        .expect("cancellation publishes");
+
+    assert!(!flagged(&ctx).await);
+}

--- a/operations/src/jobs/lifecycle/tests/cancel.rs
+++ b/operations/src/jobs/lifecycle/tests/cancel.rs
@@ -3,17 +3,23 @@
 
 use std::sync::Arc;
 
-use aruna_core::effects::JobRecordFrame;
-use aruna_core::structs::{AuthContext, JobFamilyRecord, JobId, JobState};
+use aruna_core::effects::{JobRecordFrame, LaunchFrame};
+use aruna_core::keyspaces::JOB_RESERVATION_KEYSPACE;
+use aruna_core::structs::{
+    AuthContext, JobFamilyRecord, JobId, JobRecordKind, JobState, PhysicalExecutionState,
+};
 use aruna_core::types::UserId;
 
-use super::admission_race::{config, envelope, seed};
+use super::admission_race::{config, envelope, rows, seed};
 use super::terminal::{node_context, physical, reserve_execution, seed_family};
-use crate::driver::DriverContext;
+use crate::driver::{DriverContext, drive};
 use crate::jobs::lifecycle::cancel::cancel_family;
-use crate::jobs::lifecycle::target::commit_receipt;
+use crate::jobs::lifecycle::target::{admit_launch, commit_receipt};
 use crate::jobs::records::tests::fixture::{Family, REALM, user};
 use crate::jobs::records::transport::serve_job_record;
+use crate::jobs::records::{
+    Admission, AppendRecordConfig, AppendRecordOperation, RecordOrigin, load_kind_complete,
+};
 use crate::jobs::store::read_job_record;
 use crate::metadata::protocol::MetadataTransportMessage;
 
@@ -123,9 +129,159 @@ async fn admitted_cancel_stops() {
     assert!(!flagged(&ctx).await);
     let ctx = Arc::new(ctx);
 
+    let reply = serve_job_record(
+        &ctx,
+        family.holder.public(),
+        MetadataTransportMessage::ForwardJobRecord {
+            placement: family.placement,
+            record: Box::new(
+                JobRecordFrame::new(family.sign(
+                    &family.holder,
+                    JobFamilyRecord::Spec(Box::new(family.spec())),
+                ))
+                .unwrap(),
+            ),
+        },
+    )
+    .await;
+    assert!(matches!(
+        reply,
+        MetadataTransportMessage::ForwardedJobRecord { result: Ok(()) }
+    ));
+    assert!(!flagged(&ctx).await);
+
     admit_cancel(&ctx, &family).await;
 
     assert!(flagged(&ctx).await);
+}
+
+#[tokio::test]
+async fn promoted_cancel_stops() {
+    let family = Family::new([46u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    let spec = family.spec_for(JobId::from_bytes([47u8; 16]), family.holder.public());
+    let ctx = Arc::new(ctx);
+
+    for (record, accepted) in [
+        (JobFamilyRecord::Cancel(family.cancel(&spec)), false),
+        (JobFamilyRecord::Spec(Box::new(spec)), true),
+    ] {
+        let reply = serve_job_record(
+            &ctx,
+            family.holder.public(),
+            MetadataTransportMessage::ForwardJobRecord {
+                placement: family.placement,
+                record: Box::new(JobRecordFrame::new(family.sign(&family.holder, record)).unwrap()),
+            },
+        )
+        .await;
+        assert_eq!(
+            matches!(
+                reply,
+                MetadataTransportMessage::ForwardedJobRecord { result: Ok(()) }
+            ),
+            accepted
+        );
+        assert_eq!(flagged(&ctx).await, accepted);
+    }
+}
+
+async fn store_cancel(ctx: &DriverContext, family: &Family) {
+    let outcome = drive(
+        AppendRecordOperation::new(AppendRecordConfig {
+            realm_id: REALM,
+            local_node_id: family.target.public(),
+            record: JobRecordFrame::new(family.sign(
+                &family.holder,
+                JobFamilyRecord::Cancel(family.cancel(&family.spec())),
+            ))
+            .unwrap(),
+            local: None,
+            origin: RecordOrigin::Peer(family.holder.public()),
+            now_ms: 5_000,
+        }),
+        ctx,
+    )
+    .await
+    .unwrap();
+    assert_eq!(outcome.admission, Admission::Authentic);
+}
+
+#[tokio::test]
+async fn duplicate_cancel_recovers() {
+    let family = Family::new([48u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    // The record committed, but its physical side effect did not run.
+    store_cancel(&ctx, &family).await;
+    assert!(!flagged(&ctx).await);
+
+    let ctx = Arc::new(ctx);
+    admit_cancel(&ctx, &family).await;
+
+    assert!(flagged(&ctx).await);
+}
+
+#[tokio::test]
+async fn replay_cancel_recovers() {
+    let family = Family::new([49u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    store_cancel(&ctx, &family).await;
+    assert!(!flagged(&ctx).await);
+    let launch = family.launch(&family.spec(), family.holder.public(), 0);
+    let ctx = Arc::new(ctx);
+
+    let accepted = admit_launch(
+        &ctx,
+        LaunchFrame::new(family.sign(&family.holder, JobFamilyRecord::Launch(Box::new(launch))))
+            .unwrap(),
+    )
+    .await
+    .expect("replay decides")
+    .expect("stored receipt answers");
+
+    assert!(flagged(&ctx).await);
+    assert!(
+        matches!(&accepted.envelope().record, JobFamilyRecord::Receipt(stored) if stored.execution_id == receipt.execution_id)
+    );
+}
+
+#[tokio::test]
+async fn winner_cancel_recovers() {
+    let family = Family::new([50u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let (launch, _) = seed(&ctx, &family).await;
+    let ctx = Arc::new(ctx);
+    let mut winner = config(&family, &launch, 1, envelope(4));
+    winner.record.state = JobState::Running;
+    let accepted = commit_receipt(&ctx, winner, &launch)
+        .await
+        .unwrap()
+        .unwrap();
+    store_cancel(&ctx, &family).await;
+
+    let raced = commit_receipt(&ctx, config(&family, &launch, 2, envelope(4)), &launch)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(accepted, raced);
+    let record = read_job_record(&ctx.storage_handle, JobId::from_bytes([1u8; 16]), None)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(record.cancel_requested);
+    assert!(
+        read_job_record(&ctx.storage_handle, JobId::from_bytes([2u8; 16]), None)
+            .await
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[tokio::test]
@@ -148,6 +304,14 @@ async fn late_cancel_flags() {
         .expect("physical row read")
         .expect("physical row exists");
     assert!(record.cancel_requested);
+    assert_eq!(rows(&ctx, JOB_RESERVATION_KEYSPACE, None).await, 0);
+    let updates = load_kind_complete(&ctx, family.family(), JobRecordKind::Update)
+        .await
+        .unwrap();
+    assert!(updates.iter().any(|envelope| matches!(
+        &envelope.record,
+        JobFamilyRecord::Update(update) if update.state == PhysicalExecutionState::Cancelled
+    )));
 }
 
 #[tokio::test]

--- a/operations/src/jobs/lifecycle/tests/cancel.rs
+++ b/operations/src/jobs/lifecycle/tests/cancel.rs
@@ -4,12 +4,14 @@
 use std::sync::Arc;
 
 use aruna_core::effects::JobRecordFrame;
-use aruna_core::structs::{AuthContext, JobFamilyRecord, JobState};
+use aruna_core::structs::{AuthContext, JobFamilyRecord, JobId, JobState};
 use aruna_core::types::UserId;
 
+use super::admission_race::{config, envelope, seed};
 use super::terminal::{node_context, physical, reserve_execution, seed_family};
 use crate::driver::DriverContext;
 use crate::jobs::lifecycle::cancel::cancel_family;
+use crate::jobs::lifecycle::target::commit_receipt;
 use crate::jobs::records::tests::fixture::{Family, REALM, user};
 use crate::jobs::records::transport::serve_job_record;
 use crate::jobs::store::read_job_record;
@@ -86,16 +88,8 @@ async fn repeated_cancel_is_quiet() {
     assert!(second.cancel_requested);
 }
 
-#[tokio::test]
-async fn admitted_cancel_stops_local() {
-    // The record arrives after this node already admitted the execution, so
-    // admission itself has to apply it to the row that is already running.
-    let family = Family::new([43u8; 32]);
-    let (_dir, ctx) = node_context(&family, &family.target).await;
-    let receipt = seed_family(&ctx, &family).await;
-    reserve_execution(&ctx, &family, &receipt).await;
-    assert!(!flagged(&ctx).await);
-    let ctx = Arc::new(ctx);
+/// Delivers a signed cancel record the way replication does.
+async fn admit_cancel(ctx: &Arc<DriverContext>, family: &Family) {
     let record = JobRecordFrame::new(family.sign(
         &family.holder,
         JobFamilyRecord::Cancel(family.cancel(&family.spec())),
@@ -103,7 +97,7 @@ async fn admitted_cancel_stops_local() {
     .expect("bounded record");
 
     let reply = serve_job_record(
-        &ctx,
+        ctx,
         family.holder.public(),
         MetadataTransportMessage::ForwardJobRecord {
             placement: family.placement,
@@ -116,7 +110,44 @@ async fn admitted_cancel_stops_local() {
         reply,
         MetadataTransportMessage::ForwardedJobRecord { result: Ok(()) }
     ));
+}
+
+#[tokio::test]
+async fn admitted_cancel_stops_local() {
+    // The record arrives after this node already admitted the execution, so
+    // admission itself has to apply it to the row that is already running.
+    let family = Family::new([43u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let receipt = seed_family(&ctx, &family).await;
+    reserve_execution(&ctx, &family, &receipt).await;
+    assert!(!flagged(&ctx).await);
+    let ctx = Arc::new(ctx);
+
+    admit_cancel(&ctx, &family).await;
+
     assert!(flagged(&ctx).await);
+}
+
+#[tokio::test]
+async fn late_cancel_flags_launch() {
+    // The cancel is admitted while the launch is still being decided, so it
+    // finds no receipt to stop; the committed launch must flag its own row.
+    let family = Family::new([45u8; 32]);
+    let (_dir, ctx) = node_context(&family, &family.target).await;
+    let (launch, _) = seed(&ctx, &family).await;
+    let ctx = Arc::new(ctx);
+    admit_cancel(&ctx, &family).await;
+
+    commit_receipt(&ctx, config(&family, &launch, 1, envelope(4)), &launch)
+        .await
+        .expect("commit decides")
+        .expect("receipt commits");
+
+    let record = read_job_record(&ctx.storage_handle, JobId::from_bytes([1u8; 16]), None)
+        .await
+        .expect("physical row read")
+        .expect("physical row exists");
+    assert!(record.cancel_requested);
 }
 
 #[tokio::test]

--- a/operations/src/jobs/lifecycle/tests/cancel.rs
+++ b/operations/src/jobs/lifecycle/tests/cancel.rs
@@ -36,7 +36,7 @@ async fn flagged(ctx: &DriverContext) -> bool {
 }
 
 #[tokio::test]
-async fn family_cancel_stops_local() {
+async fn cancel_stops_local() {
     // The execution runs on the node that publishes the cancellation, so no
     // network cancel can reach it: its own row has to be flagged here.
     let family = Family::new([41u8; 32]);
@@ -59,7 +59,7 @@ async fn family_cancel_stops_local() {
 }
 
 #[tokio::test]
-async fn repeated_cancel_is_quiet() {
+async fn repeated_cancel_quiet() {
     // A second cancellation must leave the already flagged row untouched.
     let family = Family::new([42u8; 32]);
     let (_dir, ctx) = node_context(&family, &family.target).await;
@@ -113,7 +113,7 @@ async fn admit_cancel(ctx: &Arc<DriverContext>, family: &Family) {
 }
 
 #[tokio::test]
-async fn admitted_cancel_stops_local() {
+async fn admitted_cancel_stops() {
     // The record arrives after this node already admitted the execution, so
     // admission itself has to apply it to the row that is already running.
     let family = Family::new([43u8; 32]);
@@ -129,7 +129,7 @@ async fn admitted_cancel_stops_local() {
 }
 
 #[tokio::test]
-async fn late_cancel_flags_launch() {
+async fn late_cancel_flags() {
     // The cancel is admitted while the launch is still being decided, so it
     // finds no receipt to stop; the committed launch must flag its own row.
     let family = Family::new([45u8; 32]);
@@ -151,7 +151,7 @@ async fn late_cancel_flags_launch() {
 }
 
 #[tokio::test]
-async fn remote_run_stays_untouched() {
+async fn remote_run_untouched() {
     // Another node's execution is stopped by the network cancel only: a holder
     // that runs nothing must not flag a row it does not execute.
     let family = Family::new([44u8; 32]);

--- a/operations/src/jobs/lifecycle/tests/mod.rs
+++ b/operations/src/jobs/lifecycle/tests/mod.rs
@@ -1,5 +1,6 @@
 mod admission;
 mod admission_race;
+mod cancel;
 mod capacity;
 mod family_reads;
 mod report;

--- a/operations/src/jobs/lifecycle/tests/terminal.rs
+++ b/operations/src/jobs/lifecycle/tests/terminal.rs
@@ -29,7 +29,7 @@ const TOKEN: Ulid = Ulid(0x7E12);
 
 /// The local physical row a target mints for an admitted launch. It is never
 /// the logical job id the family records are keyed by.
-fn physical() -> JobId {
+pub(super) fn physical() -> JobId {
     JobId::from_bytes([31u8; 16])
 }
 
@@ -43,14 +43,17 @@ fn resources() -> EffectiveResources {
     }
 }
 
-/// The execution target itself, with a live net handle so it can sign the
-/// records only the receipted executor may publish.
-async fn target_context(family: &Family) -> (TempDir, DriverContext) {
+/// One node of the family with a live net handle, so it can sign the records
+/// only that node may publish.
+pub(super) async fn node_context(
+    family: &Family,
+    key: &iroh::SecretKey,
+) -> (TempDir, DriverContext) {
     let (dir, ctx) = context(&family.config, family.holder.public()).await;
     let net_handle = NetHandle::new(
         NetConfig {
             bind_addr: "127.0.0.1:0".parse().expect("loopback address"),
-            secret_key: Some(family.target.clone()),
+            secret_key: Some(key.clone()),
             realm_id: REALM,
             discovery_method: DiscoveryMethod::None,
             relay_method: RelayMethod::None,
@@ -71,7 +74,7 @@ async fn target_context(family: &Family) -> (TempDir, DriverContext) {
 
 /// Stores every family record the receipt chains to, exactly as replication
 /// delivers them to the target before it admits the launch.
-async fn seed_family(ctx: &DriverContext, family: &Family) -> ExecutionReceipt {
+pub(super) async fn seed_family(ctx: &DriverContext, family: &Family) -> ExecutionReceipt {
     let spec = family.spec();
     let launch = family.launch(&spec, family.holder.public(), 0);
     for record in [
@@ -101,7 +104,7 @@ async fn seed_family(ctx: &DriverContext, family: &Family) -> ExecutionReceipt {
 
 /// Commits the receipt with the reservation that binds the local physical row
 /// to the logical job the family knows.
-async fn reserve_execution(
+pub(super) async fn reserve_execution(
     ctx: &DriverContext,
     family: &Family,
     receipt: &ExecutionReceipt,
@@ -156,7 +159,7 @@ async fn publishes_terminal_success() {
     // The whole terminal path of one receipted execution: the local physical
     // job id must never be read as the logical alias the family is keyed by.
     let family = Family::new([21u8; 32]);
-    let (_dir, ctx) = target_context(&family).await;
+    let (_dir, ctx) = node_context(&family, &family.target).await;
     let receipt = seed_family(&ctx, &family).await;
     let record = reserve_execution(&ctx, &family, &receipt).await;
     let intent = AttemptIntent {
@@ -243,7 +246,7 @@ async fn publishes_terminal_success() {
 async fn bumps_dashboard_once() {
     // A new state advances the dashboard revision; a replay of it does not.
     let family = Family::new([22u8; 32]);
-    let (_dir, ctx) = target_context(&family).await;
+    let (_dir, ctx) = node_context(&family, &family.target).await;
     let receipt = seed_family(&ctx, &family).await;
     let mut terminal = reserve_execution(&ctx, &family, &receipt).await;
     let chain = execution_chain(&ctx, physical())

--- a/operations/src/jobs/lifecycle/tests/uncertain_commit.rs
+++ b/operations/src/jobs/lifecycle/tests/uncertain_commit.rs
@@ -207,6 +207,44 @@ async fn recovers_durable_commit() {
 }
 
 #[tokio::test]
+async fn cancellation_read_required() {
+    let family = Family::new([20u8; 32]);
+    let (_dir, ctx, _fired) = wired(&family).await;
+    let (launch, _) = seed(&ctx, &family).await;
+    let config = config(&family, &launch, 1, envelope(4));
+    let driver = ctx.as_ref();
+    let cancel = family.sign(
+        &family.holder,
+        JobFamilyRecord::Cancel(family.cancel(&family.spec())),
+    );
+
+    let decided = commit_with(&ctx, config, &launch, |config| {
+        let key = record_key(&cancel.key());
+        async move {
+            let execution = drive(ReserveExecutionOperation::new(config), driver).await?;
+            let event = driver
+                .storage_handle
+                .send_effect(Effect::Storage(StorageEffect::Write {
+                    key_space: JOB_FAMILY_RECORD_KEYSPACE.to_string(),
+                    key,
+                    value: Value::from([0xffu8; 16].as_slice()),
+                    txn_id: None,
+                }))
+                .await;
+            assert!(matches!(
+                event,
+                Event::Storage(StorageEvent::WriteResult { .. })
+            ));
+            Ok(execution)
+        }
+    })
+    .await;
+
+    assert!(decided.is_none());
+    assert_eq!(receipts(&ctx, &family).await, 1);
+}
+
+#[tokio::test]
 async fn undecided_without_receipt() {
     // An unknown commit that left no receipt decides nothing, and the same
     // offer must still be admissible when the scheduler asks again.
@@ -320,6 +358,44 @@ async fn drain_still_drains() {
         local_capability(&open, &family.config, local, &launch, &spec).await,
         Err(LaunchDecline::Draining)
     ));
+}
+
+#[tokio::test]
+async fn session_support_rechecked() {
+    let family = Family::new([19u8; 32]);
+    let local = family.target.public();
+    let (_dir, ctx) = context(&family.config, family.holder.public()).await;
+    let mut document = advertised(local, false);
+    document.executors[0].file_staging = true;
+    advertise(&ctx, &document).await;
+    let mut spec = family.spec();
+    spec.payload.tags.insert(
+        aruna_core::compute::runtimes::SESSION_TAG.to_string(),
+        aruna_core::compute::runtimes::SESSION_TAG_NOTEBOOK.to_string(),
+    );
+    let launch = family.launch(&spec, family.holder.public(), 0);
+
+    assert!(matches!(
+        local_capability(&ctx, &family.config, local, &launch, &spec).await,
+        Err(LaunchDecline::Unauthorized)
+    ));
+    document.executors[0].session = true;
+    advertise(&ctx, &document).await;
+    assert!(
+        local_capability(&ctx, &family.config, local, &launch, &spec)
+            .await
+            .is_ok()
+    );
+    document.executors[0].session = false;
+    advertise(&ctx, &document).await;
+    spec.payload
+        .tags
+        .insert("aruna-engine.org/network".to_string(), "open".to_string());
+    assert!(
+        local_capability(&ctx, &family.config, local, &launch, &spec)
+            .await
+            .is_ok()
+    );
 }
 
 #[tokio::test]

--- a/operations/src/jobs/records/transport.rs
+++ b/operations/src/jobs/records/transport.rs
@@ -15,8 +15,8 @@ use aruna_core::events::{
     JobRecordEvent, JobRecordPage, JobRecordRejection, LaunchDecline, LaunchOfferEvent,
 };
 use aruna_core::structs::{
-    JobFamilyId, JobFamilyRecord, JobRecordEnvelope, JobRecordError, PhysicalExecutionState,
-    PlacementRef, RealmConfigDocument, RealmId, SubmissionId,
+    JobFamilyId, JobFamilyRecord, JobRecordEnvelope, JobRecordError, JobRecordKind,
+    PhysicalExecutionState, PlacementRef, RealmConfigDocument, RealmId, SubmissionId,
 };
 use futures_util::future::join_all;
 use tokio::time::timeout_at;
@@ -25,6 +25,7 @@ use tracing::warn;
 use super::admit::Admission;
 use super::append::{AppendRecordConfig, AppendRecordOperation, RecordOrigin};
 use super::audit::{AuditScope, FamilyAuditConfig, FamilyAuditOperation};
+use super::load_kind_complete;
 use super::rows::PendingNeed;
 use crate::dashboard::notify_dashboard_change;
 use crate::driver::{DriverContext, drive};
@@ -363,7 +364,6 @@ async fn accept_record(
         return Err(ServeError::Refused(JobRecordRejection::Invalid));
     }
     let rearms = rearms_witness(record.envelope());
-    let cancels = matches!(record.envelope().record, JobFamilyRecord::Cancel(_));
     let now_ms = aruna_core::util::unix_timestamp_millis();
     let outcome = drive(
         AppendRecordOperation::new(AppendRecordConfig {
@@ -386,14 +386,18 @@ async fn accept_record(
         if rearms {
             crate::jobs::lifecycle::witness::arm_family(context.as_ref(), family, now_ms).await;
         }
-        // Committed already: a cancel admitted here still has to reach the
-        // local executions this node admitted before it arrived.
-        if cancels {
-            crate::jobs::lifecycle::cancel::cancel_local_runs(context.as_ref(), family).await;
-        }
     }
     match outcome.admission {
-        Admission::Authentic | Admission::Duplicate => Ok(()),
+        Admission::Authentic | Admission::Duplicate => {
+            let cancels = load_kind_complete(context.as_ref(), family, JobRecordKind::Cancel)
+                .await
+                .map_err(|_| ServeError::Unavailable)?;
+            // Admission may promote a pending cancel, and retries must reapply its side effect.
+            if !cancels.is_empty() {
+                crate::jobs::lifecycle::cancel::cancel_local_runs(context.as_ref(), family).await;
+            }
+            Ok(())
+        }
         Admission::Local
         | Admission::Pending(
             PendingNeed::Evidence(_) | PendingNeed::LocalView | PendingNeed::HolderView,

--- a/operations/src/jobs/records/transport.rs
+++ b/operations/src/jobs/records/transport.rs
@@ -363,6 +363,7 @@ async fn accept_record(
         return Err(ServeError::Refused(JobRecordRejection::Invalid));
     }
     let rearms = rearms_witness(record.envelope());
+    let cancels = matches!(record.envelope().record, JobFamilyRecord::Cancel(_));
     let now_ms = aruna_core::util::unix_timestamp_millis();
     let outcome = drive(
         AppendRecordOperation::new(AppendRecordConfig {
@@ -384,6 +385,11 @@ async fn accept_record(
         notify_dashboard_change(context.as_ref());
         if rearms {
             crate::jobs::lifecycle::witness::arm_family(context.as_ref(), family, now_ms).await;
+        }
+        // Committed already: a cancel admitted here still has to reach the
+        // local executions this node admitted before it arrived.
+        if cancels {
+            crate::jobs::lifecycle::cancel::cancel_local_runs(context.as_ref(), family).await;
         }
     }
     match outcome.admission {

--- a/operations/src/jobs/service.rs
+++ b/operations/src/jobs/service.rs
@@ -1317,7 +1317,7 @@ fn artifact_job_matches(artifact: &OwnedArtifact, user_id: UserId, job_id: JobId
     artifact.job_id == job_id && artifact.created_by == user_id
 }
 
-async fn kick_drain(context: &DriverContext) {
+pub(crate) async fn kick_drain(context: &DriverContext) {
     if let Some(task_handle) = context.task_handle.as_ref()
         && let Event::Task(TaskEvent::Error { message, .. }) =
             task_handle.send_effect(schedule_job_drain_effect()).await

--- a/operations/src/permission_rules.rs
+++ b/operations/src/permission_rules.rs
@@ -5,7 +5,9 @@ use aruna_core::errors::AuthorizationError;
 use aruna_core::events::{Event, StorageEvent};
 use aruna_core::keyspaces::AUTH_KEYSPACE;
 use aruna_core::operation::Operation;
-use aruna_core::permission_path::{compile_permission_matcher, validate_restriction_limits};
+use aruna_core::permission_path::{
+    compile_permission_matcher, readable_roots, validate_restriction_limits,
+};
 use aruna_core::structs::{
     AuthContext, GroupAuthorizationDocument, MetadataRegistryRecord, PathRestriction, Permission,
     RealmAuthorizationDocument, RealmId, Role,
@@ -138,6 +140,21 @@ impl PermissionRules {
         allowed && self.restrictions_allow(path, required)
     }
 
+    /// Patterns of the roles the caller holds directly, for callers that derive
+    /// reachable subtrees instead of deciding one concrete path.
+    pub fn direct_patterns(&self) -> Vec<(String, Permission)> {
+        self.rules
+            .iter()
+            .filter(|rule| rule.direct)
+            .map(|rule| {
+                (
+                    rule.matcher.glob().glob().to_string(),
+                    rule.permission.clone(),
+                )
+            })
+            .collect()
+    }
+
     fn restrictions_allow(&self, path: &str, required: &Permission) -> bool {
         let Some(restrictions) = self.restrictions.as_ref() else {
             return true;
@@ -160,6 +177,29 @@ impl PermissionRules {
         }
         allowed
     }
+}
+
+/// The subtrees at or below `root` the caller reaches, decided from the realm
+/// and group roles together so a realm deny also applies, and narrowed by the
+/// credential's own restrictions. `root` selects the authorization documents.
+pub async fn reachable_roots(
+    context: &DriverContext,
+    auth_context: &AuthContext,
+    root: &str,
+) -> Result<Vec<String>, AuthorizationError> {
+    let rules = drive(
+        PermissionRulesOperation::new(PermissionRulesConfig {
+            auth_context: auth_context.clone(),
+            path: root.to_string(),
+        }),
+        context,
+    )
+    .await?;
+    Ok(readable_roots(
+        &rules.direct_patterns(),
+        auth_context.path_restrictions.as_deref(),
+        root,
+    ))
 }
 
 /// The caller's rules for a set of groups, collected once per request: every

--- a/operations/tests/convergence/mod.rs
+++ b/operations/tests/convergence/mod.rs
@@ -72,3 +72,12 @@ where
         Err(_) => panic!("hang cap fired: `{context}` did not finish within {HANG_CAP:?}"),
     }
 }
+
+/// Waits until every clone of `storage` is gone and its worker released the
+/// directory, so a restart on the same path does not find fjall locked. The
+/// deferred metadata persist thread keeps a clone until its flush loop ends.
+pub async fn wait_storage_released(storage: aruna_storage::StorageHandle) -> Result<(), String> {
+    timeout(HANG_CAP, storage.close())
+        .await
+        .map_err(|_| "storage still held after shutdown".to_string())
+}

--- a/operations/tests/metadata_throughput.rs
+++ b/operations/tests/metadata_throughput.rs
@@ -40,7 +40,7 @@ use ulid::Ulid;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 mod convergence;
-use convergence::{NO_PROGRESS_TIMEOUT, wait_for_convergence};
+use convergence::{NO_PROGRESS_TIMEOUT, wait_for_convergence, wait_storage_released};
 
 const PROJECTION_BATCH: usize = 32;
 const TOTAL_CREATES: usize = 2000;
@@ -333,8 +333,10 @@ async fn churn_convergence_body() -> Result<f64, BoxError> {
     node2.net.clear_inbound_handler();
     node2.task_handle.clear_inbound_handler().await;
     node2.net.shutdown().await;
+    let storage = node2.context.storage_handle.clone();
     drop(node2);
     tokio::task::spawn_blocking(move || aux.shutdown_timeout(Duration::from_secs(10))).await?;
+    wait_storage_released(storage).await?;
     println!("node 2 shut down");
 
     let created = run_writer(realm_id, group_id, "churn", 0, 200, targets0).await?;

--- a/operations/tests/restart_traffic.rs
+++ b/operations/tests/restart_traffic.rs
@@ -38,7 +38,7 @@ use ulid::Ulid;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 mod convergence;
-use convergence::{HANG_CAP, NO_PROGRESS_TIMEOUT, wait_for_convergence};
+use convergence::{HANG_CAP, NO_PROGRESS_TIMEOUT, wait_for_convergence, wait_storage_released};
 
 const PROJECTION_BATCH: usize = 32;
 const SEED_DOCUMENTS: usize = 256;
@@ -240,8 +240,10 @@ async fn restart_node(
     node2.net.clear_inbound_handler();
     let _ = node2.task_handle.shutdown(NO_PROGRESS_TIMEOUT).await;
     node2.net.shutdown().await;
+    let storage = node2.context.storage_handle.clone();
     drop(node2);
     aux.shutdown().await?;
+    wait_storage_released(storage).await?;
     println!("node 2 shut down");
 
     let node2 = respawn_with_retry(realm_id, secret, node2_dir.path()).await?;
@@ -1070,8 +1072,12 @@ async fn stop_peers(mut nodes: Vec<TestNode>) -> Result<(TestNode, TempDir, Temp
     offline_two.net.clear_inbound_handler();
     let _ = offline_two.task_handle.shutdown(NO_PROGRESS_TIMEOUT).await;
     offline_two.net.shutdown().await;
+    let storage_one = offline_one.context.storage_handle.clone();
+    let storage_two = offline_two.context.storage_handle.clone();
     drop(offline_one);
     drop(offline_two);
+    wait_storage_released(storage_one).await?;
+    wait_storage_released(storage_two).await?;
     Ok((live, dir_one, dir_two))
 }
 

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -242,7 +242,7 @@ impl Compactor {
         }
     }
 
-    /// Queues a compaction unless one for this keyspace is still pending.
+    /// Keeps at most one queued compaction per keyspace, including while one runs.
     fn submit(&self, key_space: &str, deletes: u64, keyspace: OptimisticTxKeyspace) {
         let Some(sender) = self.sender.as_ref() else {
             return;
@@ -305,6 +305,10 @@ fn run_compaction(job: CompactionJob, active: &Arc<Mutex<HashSet<String>>>) {
         deletes,
         run,
     } = job;
+    active
+        .lock()
+        .expect("storage compaction mutex poisoned")
+        .remove(&key_space);
     let started = Instant::now();
     match run() {
         Ok(()) => debug!(
@@ -322,10 +326,6 @@ fn run_compaction(job: CompactionJob, active: &Arc<Mutex<HashSet<String>>>) {
             "Keyspace compaction failed"
         ),
     }
-    active
-        .lock()
-        .expect("storage compaction mutex poisoned")
-        .remove(&key_space);
 }
 
 pub struct FjallStorage {
@@ -5721,12 +5721,32 @@ mod tests {
         assert_eq!(job.key_space, "dht_meta_v2");
         assert_eq!(job.deletes, super::COMPACT_AFTER_DELETES);
         assert_eq!(storage.deletes.get("dht_meta_v2").copied(), Some(0));
-        (job.run)().expect("keyspace compacts");
-
-        // The keyspace stays active until the compaction thread releases it, so
-        // a second crossing queues nothing.
-        storage.process_effect(delete_batch(super::COMPACT_AFTER_DELETES));
-        assert!(jobs.try_recv().is_err());
+        let active = storage.compactor.active.clone();
+        super::run_compaction(
+            super::CompactionJob {
+                key_space: job.key_space,
+                deletes: job.deletes,
+                run: Box::new(move || {
+                    (job.run)().expect("keyspace compacts");
+                    // Deletes after rotation need a successor before this job returns.
+                    storage.process_effect(delete_batch(super::COMPACT_AFTER_DELETES));
+                    let successor = jobs.try_recv().expect("successor is queued");
+                    storage.process_effect(delete_batch(super::COMPACT_AFTER_DELETES));
+                    assert!(jobs.try_recv().is_err(), "only one successor is queued");
+                    super::run_compaction(successor, &storage.compactor.active);
+                    assert!(
+                        storage
+                            .compactor
+                            .active
+                            .lock()
+                            .expect("compaction mutex")
+                            .is_empty()
+                    );
+                    Ok(())
+                }),
+            },
+            &active,
+        );
     }
 
     #[test]
@@ -5787,7 +5807,9 @@ mod tests {
             .expect("next job is queued");
         drop(sender);
 
-        finished.recv().expect("the thread ran the next job");
+        finished
+            .recv_timeout(std::time::Duration::from_secs(300))
+            .expect("the thread ran the next job");
         compactor.shutdown();
         assert!(
             compactor

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -214,15 +214,23 @@ struct Compactor {
     sender: Option<std::sync::mpsc::Sender<CompactionJob>>,
     thread: Option<thread::JoinHandle<()>>,
     active: Arc<Mutex<HashSet<String>>>,
+    stopping: Arc<AtomicBool>,
 }
 
 impl Compactor {
     fn spawn() -> Self {
         let (sender, receiver) = std::sync::mpsc::channel::<CompactionJob>();
         let active: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let stopping = Arc::new(AtomicBool::new(false));
         let running = active.clone();
+        let stop = stopping.clone();
         let thread = thread::spawn(move || {
+            // A queued job holds a keyspace handle, so the backlog is dropped
+            // on shutdown instead of keeping the database open job by job.
             while let Ok(job) = receiver.recv() {
+                if stop.load(Ordering::Acquire) {
+                    break;
+                }
                 run_compaction(job, &running);
             }
         });
@@ -230,6 +238,7 @@ impl Compactor {
             sender: Some(sender),
             thread: Some(thread),
             active,
+            stopping,
         }
     }
 
@@ -271,6 +280,7 @@ impl Compactor {
 
     /// Waits for a running compaction so no keyspace handle outlives the store.
     fn shutdown(&mut self) {
+        self.stopping.store(true, Ordering::Release);
         self.sender = None;
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
@@ -4083,6 +4093,7 @@ mod tests {
             sender: None,
             thread: None,
             active: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            stopping: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -5664,6 +5675,7 @@ mod tests {
             sender: Some(sender),
             thread: None,
             active: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            stopping: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         receiver
     }
@@ -5774,9 +5786,9 @@ mod tests {
             })
             .expect("next job is queued");
         drop(sender);
-        compactor.shutdown();
 
         finished.recv().expect("the thread ran the next job");
+        compactor.shutdown();
         assert!(
             compactor
                 .active
@@ -5784,6 +5796,41 @@ mod tests {
                 .expect("compaction mutex")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn shutdown_drops_backlog() {
+        // A job queued behind a running one must not keep the database open.
+        let mut compactor = super::Compactor::spawn();
+        let (release, blocked) = std::sync::mpsc::channel::<()>();
+        let (ran, second) = std::sync::mpsc::channel::<()>();
+        let sender = compactor.sender.clone().expect("compactor accepts jobs");
+        sender
+            .send(super::CompactionJob {
+                key_space: "first".to_string(),
+                deletes: 1,
+                run: Box::new(move || {
+                    blocked.recv().expect("test releases the first job");
+                    Ok(())
+                }),
+            })
+            .expect("first job is queued");
+        sender
+            .send(super::CompactionJob {
+                key_space: "second".to_string(),
+                deletes: 1,
+                run: Box::new(move || {
+                    ran.send(()).expect("test observes the second job");
+                    Ok(())
+                }),
+            })
+            .expect("second job is queued");
+        drop(sender);
+
+        compactor.stopping.store(true, Ordering::Release);
+        release.send(()).expect("first job is released");
+        compactor.shutdown();
+        assert!(second.try_recv().is_err(), "the backlog ran after shutdown");
     }
 
     #[test]

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -115,6 +115,9 @@ fn storage_effect_key_space(effect: &StorageEffect) -> Option<&str> {
 // Deletes leave tombstones that every later read walks. Small keyspaces never
 // fill a memtable, so compaction has to be triggered by the delete count.
 const COMPACT_AFTER_DELETES: u64 = 5_000;
+// A major compaction rewrites the whole keyspace and rotates its memtable under
+// the database-wide journal lock, so only a small keyspace is compacted here.
+const COMPACT_MAX_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_GROUP_COMMIT: usize = 256;
 const READ_POOL_THREADS: usize = 4;
 const BULK_READ_POOL_THREADS: usize = 2;
@@ -247,6 +250,8 @@ impl Compactor {
             key_space: key_space.to_string(),
             deletes,
             run: Box::new(move || {
+                // fjall 3.1.10 hides both calls from its docs; a version bump
+                // has to recheck that they still exist and still block here.
                 let keyspace: &fjall::Keyspace = keyspace.as_ref();
                 keyspace.rotate_memtable_and_wait()?;
                 keyspace.major_compact()
@@ -277,6 +282,11 @@ impl Drop for Compactor {
     fn drop(&mut self) {
         self.shutdown();
     }
+}
+
+/// Whether a keyspace is small enough for a delete-triggered major compaction.
+fn compactable(disk_space: u64) -> bool {
+    disk_space <= COMPACT_MAX_BYTES
 }
 
 fn run_compaction(job: CompactionJob, active: &Arc<Mutex<HashSet<String>>>) {
@@ -2380,6 +2390,7 @@ impl FjallStorage {
 
     /// Counts committed deletes and compacts the keyspace once they cross
     /// `COMPACT_AFTER_DELETES`, because its tombstones slow every later read.
+    /// A keyspace past `COMPACT_MAX_BYTES` only resets its counter.
     fn note_deletes(&mut self, key_space: &str, count: u64) {
         let total = match self.deletes.get_mut(key_space) {
             Some(total) => total,
@@ -2391,7 +2402,20 @@ impl FjallStorage {
         }
         let deletes = std::mem::take(total);
         match self.store.resolve_keyspace(key_space) {
-            Ok(keyspace) => self.compactor.submit(key_space, deletes, keyspace),
+            Ok(keyspace) => {
+                let disk_space = AsRef::<fjall::Keyspace>::as_ref(&keyspace).disk_space();
+                if !compactable(disk_space) {
+                    debug!(
+                        event = "storage.keyspace.compact_skipped",
+                        key_space,
+                        disk_space,
+                        deletes,
+                        "Keyspace is too large for a delete-triggered compaction"
+                    );
+                    return;
+                }
+                self.compactor.submit(key_space, deletes, keyspace)
+            }
             Err(error) => warn!(
                 event = "storage.keyspace.compact_failed",
                 key_space, error = %error, "Keyspace compaction could not resolve the keyspace"
@@ -5691,6 +5715,15 @@ mod tests {
         // a second crossing queues nothing.
         storage.process_effect(delete_batch(super::COMPACT_AFTER_DELETES));
         assert!(jobs.try_recv().is_err());
+    }
+
+    #[test]
+    fn gate_limits_compaction() {
+        // Only a keyspace small enough to rewrite quickly is compacted on
+        // deletes; a larger one keeps its tombstones for now.
+        assert!(super::compactable(0));
+        assert!(super::compactable(super::COMPACT_MAX_BYTES));
+        assert!(!super::compactable(super::COMPACT_MAX_BYTES + 1));
     }
 
     #[test]

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, RwLock};
@@ -19,7 +19,7 @@ use fjall::{
     KeyspaceCreateOptions, OptimisticTxDatabase, OptimisticTxKeyspace, PersistMode, Readable,
 };
 use tokio::sync::{Notify, oneshot};
-use tracing::{Span, debug_span, field, warn};
+use tracing::{Span, debug, debug_span, field, warn};
 use ulid::Ulid;
 
 use crate::errors::StorageLibError;
@@ -112,6 +112,9 @@ fn storage_effect_key_space(effect: &StorageEffect) -> Option<&str> {
         | StorageEffect::SyncAll => None,
     }
 }
+// Deletes leave tombstones that every later read walks. Small keyspaces never
+// fill a memtable, so compaction has to be triggered by the delete count.
+const COMPACT_AFTER_DELETES: u64 = 5_000;
 const MAX_GROUP_COMMIT: usize = 256;
 const READ_POOL_THREADS: usize = 4;
 const BULK_READ_POOL_THREADS: usize = 2;
@@ -196,6 +199,115 @@ impl Store {
     }
 }
 
+struct CompactionJob {
+    key_space: String,
+    deletes: u64,
+    run: Box<dyn FnOnce() -> fjall::Result<()> + Send>,
+}
+
+/// Runs keyspace compactions on one background thread, so compaction never
+/// blocks the write worker and never holds a lock the read pool needs.
+struct Compactor {
+    sender: Option<std::sync::mpsc::Sender<CompactionJob>>,
+    thread: Option<thread::JoinHandle<()>>,
+    active: Arc<Mutex<HashSet<String>>>,
+}
+
+impl Compactor {
+    fn spawn() -> Self {
+        let (sender, receiver) = std::sync::mpsc::channel::<CompactionJob>();
+        let active: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let running = active.clone();
+        let thread = thread::spawn(move || {
+            while let Ok(job) = receiver.recv() {
+                run_compaction(job, &running);
+            }
+        });
+        Self {
+            sender: Some(sender),
+            thread: Some(thread),
+            active,
+        }
+    }
+
+    /// Queues a compaction unless one for this keyspace is still pending.
+    fn submit(&self, key_space: &str, deletes: u64, keyspace: OptimisticTxKeyspace) {
+        let Some(sender) = self.sender.as_ref() else {
+            return;
+        };
+        if !self
+            .active
+            .lock()
+            .expect("storage compaction mutex poisoned")
+            .insert(key_space.to_string())
+        {
+            return;
+        }
+        let job = CompactionJob {
+            key_space: key_space.to_string(),
+            deletes,
+            run: Box::new(move || {
+                let keyspace: &fjall::Keyspace = keyspace.as_ref();
+                keyspace.rotate_memtable_and_wait()?;
+                keyspace.major_compact()
+            }),
+        };
+        if sender.send(job).is_err() {
+            self.release(key_space);
+        }
+    }
+
+    fn release(&self, key_space: &str) {
+        self.active
+            .lock()
+            .expect("storage compaction mutex poisoned")
+            .remove(key_space);
+    }
+
+    /// Waits for a running compaction so no keyspace handle outlives the store.
+    fn shutdown(&mut self) {
+        self.sender = None;
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for Compactor {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn run_compaction(job: CompactionJob, active: &Arc<Mutex<HashSet<String>>>) {
+    let CompactionJob {
+        key_space,
+        deletes,
+        run,
+    } = job;
+    let started = Instant::now();
+    match run() {
+        Ok(()) => debug!(
+            event = "storage.keyspace.compacted",
+            key_space = %key_space,
+            deletes,
+            elapsed_ms = duration_ms(started.elapsed()),
+            "Compacted a delete-heavy keyspace"
+        ),
+        Err(error) => warn!(
+            event = "storage.keyspace.compact_failed",
+            key_space = %key_space,
+            deletes,
+            error = %error,
+            "Keyspace compaction failed"
+        ),
+    }
+    active
+        .lock()
+        .expect("storage compaction mutex poisoned")
+        .remove(&key_space);
+}
+
 pub struct FjallStorage {
     store: Store,
     persist_policy: FjallPersistPolicy,
@@ -207,6 +319,10 @@ pub struct FjallStorage {
     bulk_read_pool: Vec<EffectSender>,
     next_bulk_reader: usize,
     pool_threads: Vec<thread::JoinHandle<()>>,
+    compactor: Compactor,
+    /// Committed deletes per keyspace since its last compaction.
+    deletes: HashMap<String, u64>,
+    txn_deletes: HashMap<Ulid, HashMap<String, u64>>,
 }
 
 #[derive(Debug, Default)]
@@ -1398,6 +1514,7 @@ impl FjallStorage {
     /// Joins the read pools so every store clone is gone when this returns;
     /// the fjall lock is released by the final store drop right after.
     fn close(mut self) {
+        self.compactor.shutdown();
         self.read_pool.clear();
         self.bulk_read_pool.clear();
         for reader in std::mem::take(&mut self.pool_threads) {
@@ -1430,6 +1547,9 @@ impl FjallStorage {
             bulk_read_pool,
             next_bulk_reader: 0,
             pool_threads,
+            compactor: Compactor::spawn(),
+            deletes: HashMap::new(),
+            txn_deletes: HashMap::new(),
         }
     }
 
@@ -1459,6 +1579,7 @@ impl FjallStorage {
     /// Rolls a fenced transaction back and retires its cleanup entry through the
     /// terminal `Aborted` state, whether it was open or had a commit queued.
     fn retire_fenced_txn(&mut self, txn_id: Ulid) {
+        self.take_txn_deletes(txn_id, false);
         if let Some(Txn::Write(txn)) = self.txns.remove(&txn_id) {
             txn.rollback();
         }
@@ -1805,6 +1926,14 @@ impl FjallStorage {
             Err(error) => Some(error),
         };
 
+        if group_error.is_none() {
+            for ((effect, ..), outcome) in &prepared {
+                if outcome.is_ok() {
+                    self.note_effect_deletes(effect);
+                }
+            }
+        }
+
         let service_elapsed = service_started.elapsed();
         for ((effect, response_tx, span, enqueued_at, in_flight), outcome) in prepared {
             let _guard = span.enter();
@@ -2021,6 +2150,7 @@ impl FjallStorage {
                 error: StorageError::TransactionConflict,
             };
         }
+        self.take_txn_deletes(txn_id, false);
         match self.txns.remove(&txn_id) {
             Some(Txn::Write(txn)) => {
                 txn.rollback();
@@ -2220,7 +2350,9 @@ impl FjallStorage {
         match self.txns.remove(&txn_id) {
             Some(Txn::Read(_txn)) => StorageEvent::TransactionCommitted { txn_id },
             Some(Txn::Write(txn)) => {
-                match txn.commit() {
+                let committed = txn.commit();
+                self.take_txn_deletes(txn_id, matches!(committed, Ok(Ok(()))));
+                match committed {
                     Ok(Ok(())) => StorageEvent::TransactionCommitted { txn_id },
                     Ok(Err(_)) => StorageEvent::Error {
                         error: StorageError::TransactionConflict,
@@ -2246,6 +2378,61 @@ impl FjallStorage {
         }
     }
 
+    /// Counts committed deletes and compacts the keyspace once they cross
+    /// `COMPACT_AFTER_DELETES`, because its tombstones slow every later read.
+    fn note_deletes(&mut self, key_space: &str, count: u64) {
+        let total = match self.deletes.get_mut(key_space) {
+            Some(total) => total,
+            None => self.deletes.entry(key_space.to_string()).or_default(),
+        };
+        *total += count;
+        if *total < COMPACT_AFTER_DELETES {
+            return;
+        }
+        let deletes = std::mem::take(total);
+        match self.store.resolve_keyspace(key_space) {
+            Ok(keyspace) => self.compactor.submit(key_space, deletes, keyspace),
+            Err(error) => warn!(
+                event = "storage.keyspace.compact_failed",
+                key_space, error = %error, "Keyspace compaction could not resolve the keyspace"
+            ),
+        }
+    }
+
+    fn note_effect_deletes(&mut self, effect: &StorageEffect) {
+        match effect {
+            StorageEffect::Delete { key_space, .. } => self.note_deletes(key_space, 1),
+            StorageEffect::BatchDelete { deletes, .. } => {
+                for (key_space, _) in deletes {
+                    self.note_deletes(key_space, 1);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn hold_txn_delete(&mut self, txn_id: Ulid, key_space: &str) {
+        *self
+            .txn_deletes
+            .entry(txn_id)
+            .or_default()
+            .entry(key_space.to_string())
+            .or_default() += 1;
+    }
+
+    /// Counts the deletes a transaction made durable; other outcomes drop them.
+    fn take_txn_deletes(&mut self, txn_id: Ulid, committed: bool) {
+        let Some(deletes) = self.txn_deletes.remove(&txn_id) else {
+            return;
+        };
+        if !committed {
+            return;
+        }
+        for (key_space, count) in deletes {
+            self.note_deletes(&key_space, count);
+        }
+    }
+
     #[tracing::instrument(
         name = "storage.delete",
         level = "debug",
@@ -2261,6 +2448,7 @@ impl FjallStorage {
         if let Some(txn_id) = txn_id {
             if let Some(Txn::Write(txn)) = self.txns.get_mut(&txn_id) {
                 txn.remove(keyspace, key.clone());
+                self.hold_txn_delete(txn_id, &key_space);
                 StorageEvent::DeleteResult { key }
             } else {
                 StorageEvent::Error {
@@ -2279,6 +2467,7 @@ impl FjallStorage {
             if let Err(error) = self.persist_journal() {
                 return StorageEvent::Error { error };
             }
+            self.note_deletes(&key_space, 1);
             StorageEvent::DeleteResult { key }
         }
     }
@@ -2315,6 +2504,9 @@ impl FjallStorage {
                 txn.remove(keyspace, key.clone());
                 entries.push((key_space, key));
             }
+            for (key_space, _) in &entries {
+                self.hold_txn_delete(txn_id, key_space);
+            }
         } else {
             let mut tx = match self.buffered_write_tx() {
                 Ok(tx) => tx,
@@ -2329,6 +2521,9 @@ impl FjallStorage {
                 .and_then(|()| self.persist_journal())
             {
                 return StorageEvent::Error { error };
+            }
+            for (key_space, _) in &entries {
+                self.note_deletes(key_space, 1);
             }
         }
 
@@ -3513,6 +3708,9 @@ mod tests {
             bulk_read_pool: vec![bulk_sender],
             next_bulk_reader: 0,
             pool_threads: Vec::new(),
+            compactor: idle_compactor(),
+            deletes: std::collections::HashMap::new(),
+            txn_deletes: std::collections::HashMap::new(),
         };
         let metrics = std::sync::Arc::new(super::StorageMetrics::default());
         let read_effect = || StorageEffect::Read {
@@ -3852,6 +4050,16 @@ mod tests {
             read_txn,
             Event::Storage(StorageEvent::TransactionStarted { .. })
         ));
+    }
+
+    /// Compactor that accepts no job, for workers built without a background
+    /// thread.
+    fn idle_compactor() -> super::Compactor {
+        super::Compactor {
+            sender: None,
+            thread: None,
+            active: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        }
     }
 
     /// Worker sharing the handle's channels, cleanup map and fence, driven by
@@ -4425,6 +4633,9 @@ mod tests {
             bulk_read_pool: Vec::new(),
             next_bulk_reader: 0,
             pool_threads: Vec::new(),
+            compactor: idle_compactor(),
+            deletes: std::collections::HashMap::new(),
+            txn_deletes: std::collections::HashMap::new(),
         };
 
         let event = storage.commit_transaction(txn_id);
@@ -4469,6 +4680,9 @@ mod tests {
             bulk_read_pool: Vec::new(),
             next_bulk_reader: 0,
             pool_threads: Vec::new(),
+            compactor: idle_compactor(),
+            deletes: std::collections::HashMap::new(),
+            txn_deletes: std::collections::HashMap::new(),
         };
 
         for _ in 0..=super::MAX_CLEANUP_ATTEMPTS {
@@ -4510,6 +4724,9 @@ mod tests {
             bulk_read_pool: Vec::new(),
             next_bulk_reader: 0,
             pool_threads: Vec::new(),
+            compactor: idle_compactor(),
+            deletes: std::collections::HashMap::new(),
+            txn_deletes: std::collections::HashMap::new(),
         };
 
         storage.retry_cleanup();
@@ -5411,5 +5628,151 @@ mod tests {
             metrics_after_conflict.last_error,
             Some("Transaction conflict".to_string())
         );
+    }
+
+    /// Replaces the worker's compactor with a channel the test owns, so queued
+    /// compactions are observable without running one.
+    fn stub_compactor(
+        storage: &mut FjallStorage,
+    ) -> std::sync::mpsc::Receiver<super::CompactionJob> {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        storage.compactor = super::Compactor {
+            sender: Some(sender),
+            thread: None,
+            active: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        };
+        receiver
+    }
+
+    fn delete_batch(count: u64) -> StorageEffect {
+        StorageEffect::BatchDelete {
+            deletes: (0..count)
+                .map(|index| {
+                    (
+                        "dht_meta_v2".to_string(),
+                        index.to_string().into_bytes().into(),
+                    )
+                })
+                .collect(),
+            txn_id: None,
+        }
+    }
+
+    #[test]
+    fn deletes_below_threshold() {
+        let dir = tempdir().unwrap();
+        let (handle, _receivers) = StorageHandle::new();
+        let mut storage = worker(&dir, &handle);
+        let jobs = stub_compactor(&mut storage);
+
+        let below = super::COMPACT_AFTER_DELETES - 1;
+        storage.process_effect(delete_batch(below));
+
+        assert!(jobs.try_recv().is_err());
+        assert_eq!(storage.deletes.get("dht_meta_v2").copied(), Some(below));
+    }
+
+    #[test]
+    fn deletes_cross_threshold() {
+        let dir = tempdir().unwrap();
+        let (handle, _receivers) = StorageHandle::new();
+        let mut storage = worker(&dir, &handle);
+        let jobs = stub_compactor(&mut storage);
+
+        storage.process_effect(delete_batch(super::COMPACT_AFTER_DELETES));
+
+        let job = jobs.try_recv().expect("compaction is queued");
+        assert_eq!(job.key_space, "dht_meta_v2");
+        assert_eq!(job.deletes, super::COMPACT_AFTER_DELETES);
+        assert_eq!(storage.deletes.get("dht_meta_v2").copied(), Some(0));
+        (job.run)().expect("keyspace compacts");
+
+        // The keyspace stays active until the compaction thread releases it, so
+        // a second crossing queues nothing.
+        storage.process_effect(delete_batch(super::COMPACT_AFTER_DELETES));
+        assert!(jobs.try_recv().is_err());
+    }
+
+    #[test]
+    fn delete_survives_compactor() {
+        let dir = tempdir().unwrap();
+        let (handle, _receivers) = StorageHandle::new();
+        let mut storage = worker(&dir, &handle);
+        drop(stub_compactor(&mut storage));
+
+        let event = storage.process_effect(delete_batch(super::COMPACT_AFTER_DELETES));
+
+        assert!(matches!(event, StorageEvent::BatchDeleteResult { .. }));
+        assert!(
+            storage
+                .compactor
+                .active
+                .lock()
+                .expect("compaction mutex")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn compaction_failure_continues() {
+        let mut compactor = super::Compactor::spawn();
+        let (done, finished) = std::sync::mpsc::channel();
+        let sender = compactor.sender.clone().expect("compactor accepts jobs");
+        compactor
+            .active
+            .lock()
+            .expect("compaction mutex")
+            .insert("failing".to_string());
+        sender
+            .send(super::CompactionJob {
+                key_space: "failing".to_string(),
+                deletes: super::COMPACT_AFTER_DELETES,
+                run: Box::new(|| Err(fjall::Error::Poisoned)),
+            })
+            .expect("failing job is queued");
+        sender
+            .send(super::CompactionJob {
+                key_space: "next".to_string(),
+                deletes: 1,
+                run: Box::new(move || {
+                    done.send(()).expect("test receives the signal");
+                    Ok(())
+                }),
+            })
+            .expect("next job is queued");
+        drop(sender);
+        compactor.shutdown();
+
+        finished.recv().expect("the thread ran the next job");
+        assert!(
+            compactor
+                .active
+                .lock()
+                .expect("compaction mutex")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn commit_counts_deletes() {
+        let dir = tempdir().unwrap();
+        let (handle, _receivers) = StorageHandle::new();
+        let mut storage = worker(&dir, &handle);
+        let _jobs = stub_compactor(&mut storage);
+        let StorageEvent::TransactionStarted { txn_id } =
+            storage.process_effect(StorageEffect::StartTransaction { read: false })
+        else {
+            panic!("transaction starts");
+        };
+
+        storage.process_effect(StorageEffect::Delete {
+            key_space: "dht_meta_v2".to_string(),
+            key: b"deadline".to_vec().into(),
+            txn_id: Some(txn_id),
+        });
+        assert!(!storage.deletes.contains_key("dht_meta_v2"));
+
+        storage.process_effect(StorageEffect::CommitTransaction { txn_id });
+        assert_eq!(storage.deletes.get("dht_meta_v2").copied(), Some(1));
     }
 }


### PR DESCRIPTION
## Description

Notebook sessions on Kubernetes could not reach their workspace bucket, job cancellation did not reach executions on the receiving node, read-only group members were refused S3 sessions and access keys, and every node logged thousands of avoidable warnings. This branch fixes those paths, pulls in the merged irokle and craqle document sync fixes, and upgrades the remaining dependencies.

## Changes

- Session pods get DNS through a port-only egress rule, and operators hand extra cluster policies to the node through `ARUNA_COMPUTE_K8S_POLICY_MANIFESTS`, applied at startup and before each job.
- Session support is advertised only with S3 egress, the planner screens S3-only sessions by that capability, and the S3 policy port follows the endpoint URL with a reachability guard.
- Partial session input staging answers with the items that landed and the ones that failed; the session idle timer resets only after something landed.
- A refused image pull (unknown name, no access) fails the attempt at once instead of after the pull deadline.
- A family cancel now flags executions on the local node, cancel records replicated late flag attempts admitted meanwhile, and a launch admitted during a cancel is flagged after its receipt.
- Read-only members can open S3 sessions and create access keys; members with a subpath permission see exactly that bucket and list only their subtree, with realm deny rules and policies still enforced and listing markers kept inside the scope.
- Delete-heavy small keyspaces are compacted after 5000 deletes, which removes the slow DHT deadline peeks.
- The bucket location probe is admitted for subpath callers.
- craqle and irokle move to the revisions carrying the merged sync fixes with a relaxed smallvec requirement; iroh 1.2, chacha20poly1305 0.11, dirs 7, s3s 0.15, serde-saphyr instead of serde_yaml, and compatible updates.
- Workspace version 3.0.0-alpha.79.
