### PR TITLE
feat: mount the workspace data prefix into session pods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "aruna"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "aruna-api",
  "aruna-blob",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-api"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "ahash 0.8.12",
  "aruna-blob",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-blob"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "aruna-core",
  "aruna-net",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-compute"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "aruna-core",
  "async-trait",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-compute-helper"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "rustix",
  "serde_json",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-core"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-doctor"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "ahash 0.8.12",
  "aruna",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-net"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "aruna-core",
  "aruna-storage",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-operations"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "aruna-blob",
  "aruna-compute",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-storage"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "aruna-core",
  "async-trait",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "aruna-tasks"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 dependencies = [
  "aruna-core",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 
 [workspace.package]
 description = "A federated data orchestration network"
-version = "3.0.0-alpha.79"
+version = "3.0.0-alpha.80"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/arunaengine/aruna"

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -21,6 +21,7 @@ pub const MARKER_PATH: &str = "/aruna-marker/marker";
 pub const SENTINEL_PATH: &str = "/workspace/.aruna-stage";
 pub const TASK_SENTINEL: &str = "/aruna-workspace/.aruna-stage";
 pub const HELPER_PATH: &str = "/aruna-compute-helper";
+pub const DATA_DIR: &str = "data";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageMarker {
@@ -129,6 +130,18 @@ pub fn job_manifest(
             };
             volumes.push(json!({"name":"scratch","emptyDir":empty_dir}));
             mounts.push(json!({"name":"scratch","mountPath":scratch}));
+        }
+        if mounts_data(spec, config) {
+            let volume = data_name(&name);
+            volumes.push(json!({
+                "name":volume,
+                "persistentVolumeClaim":{"claimName":volume}
+            }));
+            mounts.push(json!({
+                "name":volume,
+                "mountPath":scratch.join(DATA_DIR),
+                "readOnly":false
+            }));
         }
     }
     // The credential Secret rides `envFrom`, which any inline entry of the same
@@ -246,9 +259,64 @@ pub fn mount_pv_manifest(
     bucket: &str,
 ) -> Result<PersistentVolume, BackendError> {
     let name = mount_name(&context.attempt.external_name(), index);
+    let options = ["file-mode=0444", "dir-mode=0555"];
+    s3_pv_manifest(context, config, &name, bucket, &options, true)
+}
+
+pub fn mount_pvc_manifest(
+    context: &FenceContext,
+    config: &KubernetesConfig,
+    index: usize,
+) -> Result<PersistentVolumeClaim, BackendError> {
+    s3_pvc_manifest(
+        context,
+        config,
+        &mount_name(&context.attempt.external_name(), index),
+    )
+}
+
+/// The session's writable view of the workspace bucket's `data/` prefix.
+pub fn data_pv_manifest(
+    context: &FenceContext,
+    config: &KubernetesConfig,
+    bucket: &str,
+) -> Result<PersistentVolume, BackendError> {
+    let name = data_name(&context.attempt.external_name());
+    let prefix = format!("prefix={DATA_DIR}/");
+    let options = [
+        prefix.as_str(),
+        "allow-delete",
+        "allow-overwrite",
+        "file-mode=0644",
+        "dir-mode=0755",
+    ];
+    s3_pv_manifest(context, config, &name, bucket, &options, false)
+}
+
+pub fn data_pvc_manifest(
+    context: &FenceContext,
+    config: &KubernetesConfig,
+) -> Result<PersistentVolumeClaim, BackendError> {
+    s3_pvc_manifest(
+        context,
+        config,
+        &data_name(&context.attempt.external_name()),
+    )
+}
+
+fn s3_pv_manifest(
+    context: &FenceContext,
+    config: &KubernetesConfig,
+    name: &str,
+    bucket: &str,
+    options: &[&str],
+    read_only: bool,
+) -> Result<PersistentVolume, BackendError> {
     let driver = config.s3_mount_driver.as_deref().ok_or_else(|| {
         BackendError::InvalidSpec("S3 mounts are disabled on this backend".to_string())
     })?;
+    let mut mount_options = vec!["uid=65534", "gid=65534", "allow-other"];
+    mount_options.extend_from_slice(options);
     serde_json::from_value(json!({
         "apiVersion":"v1",
         "kind":"PersistentVolume",
@@ -263,13 +331,11 @@ pub fn mount_pv_manifest(
             "persistentVolumeReclaimPolicy":"Retain",
             "storageClassName":"",
             "claimRef":{"namespace":config.namespace,"name":name},
-            "mountOptions":[
-                "uid=65534","gid=65534","allow-other","file-mode=0444","dir-mode=0555"
-            ],
+            "mountOptions":mount_options,
             "csi":{
                 "driver":driver,
                 "volumeHandle":name,
-                "readOnly":true,
+                "readOnly":read_only,
                 "volumeAttributes":{
                     "bucketName":bucket,
                     "authenticationSource":"secret"
@@ -284,12 +350,11 @@ pub fn mount_pv_manifest(
     .map_err(manifest_error)
 }
 
-pub fn mount_pvc_manifest(
+fn s3_pvc_manifest(
     context: &FenceContext,
     config: &KubernetesConfig,
-    index: usize,
+    name: &str,
 ) -> Result<PersistentVolumeClaim, BackendError> {
-    let name = mount_name(&context.attempt.external_name(), index);
     serde_json::from_value(json!({
         "apiVersion":"v1",
         "kind":"PersistentVolumeClaim",
@@ -374,11 +439,22 @@ pub fn secret_manifest(
     config: &KubernetesConfig,
     spec: &TaskSpec,
 ) -> Result<Secret, BackendError> {
-    let values = spec
+    let mut values = spec
         .secret_env
         .iter()
         .map(|(key, value)| (key.clone(), value.expose().to_string()))
         .collect::<BTreeMap<_, _>>();
+    // The CSI driver reads the data mount credential under its own key names.
+    if mounts_data(spec, config) {
+        for (env, key) in [
+            ("AWS_ACCESS_KEY_ID", "access_key_id"),
+            ("AWS_SECRET_ACCESS_KEY", "secret_access_key"),
+        ] {
+            if let Some(value) = values.get(env).cloned() {
+                values.entry(key.to_string()).or_insert(value);
+            }
+        }
+    }
     serde_json::from_value(json!({
         "apiVersion":"v1",
         "kind":"Secret",
@@ -522,6 +598,18 @@ pub fn workspace_name(name: &str) -> String {
 
 pub fn mount_name(name: &str, index: usize) -> String {
     format!("{name}-s3-{index}")
+}
+
+pub fn data_name(name: &str) -> String {
+    format!("{name}-data")
+}
+
+/// A session with a workspace sees the bucket's `data/` prefix below its workdir.
+pub fn mounts_data(spec: &TaskSpec, config: &KubernetesConfig) -> bool {
+    spec.session
+        && spec.workspace.is_some()
+        && spec.workdir.is_some()
+        && config.s3_mount_driver.is_some()
 }
 
 pub fn mount_buckets(layout: &StageLayout) -> Vec<String> {
@@ -690,7 +778,7 @@ fn manifest_error(error: serde_json::Error) -> BackendError {
 
 #[cfg(test)]
 mod tests {
-    use aruna_core::compute::{AttemptRef, S3Mount, Secret, TaskInput};
+    use aruna_core::compute::{AttemptRef, S3Mount, Secret, TaskInput, WorkspaceBinding};
 
     use super::*;
 

--- a/compute/src/executor/kubernetes/manifest.rs
+++ b/compute/src/executor/kubernetes/manifest.rs
@@ -1057,6 +1057,115 @@ mod tests {
         assert_eq!(pv["spec"]["csi"]["driver"], "s3.csi.example.org");
     }
 
+    fn session_spec() -> TaskSpec {
+        let mut spec = TaskSpec::new(context().attempt, "registry.example/session:latest");
+        spec.session = true;
+        spec.workdir = Some("/work".to_string());
+        spec.workspace = Some(WorkspaceBinding {
+            s3_endpoint: "https://s3.example".to_string(),
+            bucket_name: "workspace-bucket".to_string(),
+            region: "us-east-1".to_string(),
+        });
+        spec.secret_env.insert(
+            "AWS_ACCESS_KEY_ID".to_string(),
+            Secret::new("session-access"),
+        );
+        spec.secret_env.insert(
+            "AWS_SECRET_ACCESS_KEY".to_string(),
+            Secret::new("session-secret"),
+        );
+        spec
+    }
+
+    #[test]
+    fn mounts_session_data() {
+        // The workspace bucket's data prefix shows up writable below the workdir.
+        let spec = session_spec();
+        let layout = StageLayout::from_spec(&spec).unwrap();
+        let job = job_manifest(&context(), &spec, &config(), &layout).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+        let mounts = pod.containers[0].volume_mounts.clone().unwrap();
+        assert!(mounts.iter().any(|mount| mount.mount_path == "/work"));
+        let data = mounts
+            .iter()
+            .find(|mount| mount.mount_path == "/work/data")
+            .unwrap();
+        assert_eq!(data.name, "aruna-job-a1-data");
+        assert_eq!(data.read_only, Some(false));
+        let volume = pod
+            .volumes
+            .unwrap()
+            .into_iter()
+            .find(|volume| volume.name == "aruna-job-a1-data")
+            .unwrap();
+        assert_eq!(
+            volume.persistent_volume_claim.unwrap().claim_name,
+            "aruna-job-a1-data"
+        );
+
+        let pv = serde_json::to_value(
+            data_pv_manifest(&context(), &config(), "workspace-bucket").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(pv["metadata"]["name"], "aruna-job-a1-data");
+        assert_eq!(pv["metadata"]["labels"][ROLE_LABEL], "s3-mount");
+        assert_eq!(pv["metadata"]["annotations"][EPOCH_ANNOTATION], "7");
+        assert_eq!(
+            pv["spec"]["mountOptions"],
+            json!([
+                "uid=65534",
+                "gid=65534",
+                "allow-other",
+                "prefix=data/",
+                "allow-delete",
+                "allow-overwrite",
+                "file-mode=0644",
+                "dir-mode=0755"
+            ])
+        );
+        assert_eq!(pv["spec"]["csi"]["readOnly"], false);
+        assert_eq!(
+            pv["spec"]["csi"]["volumeAttributes"]["bucketName"],
+            "workspace-bucket"
+        );
+        assert_eq!(
+            pv["spec"]["csi"]["nodePublishSecretRef"]["name"],
+            "aruna-job-a1-env"
+        );
+        let pvc = serde_json::to_value(data_pvc_manifest(&context(), &config()).unwrap()).unwrap();
+        assert_eq!(pvc["metadata"]["labels"][ROLE_LABEL], "s3-mount");
+        assert_eq!(pvc["metadata"]["annotations"][EPOCH_ANNOTATION], "7");
+        assert_eq!(pvc["spec"]["volumeName"], "aruna-job-a1-data");
+
+        let secret = secret_manifest(&context(), &config(), &spec).unwrap();
+        let data = secret.string_data.unwrap();
+        assert_eq!(data["access_key_id"], "session-access");
+        assert_eq!(data["secret_access_key"], "session-secret");
+        assert_eq!(data["AWS_ACCESS_KEY_ID"], "session-access");
+    }
+
+    #[test]
+    fn skips_data_mount() {
+        // Without a CSI driver a session keeps its plain scratch workdir.
+        let spec = session_spec();
+        let mut config = config();
+        config.s3_mount_driver = None;
+        let layout = StageLayout::from_spec(&spec).unwrap();
+        let job = job_manifest(&context(), &spec, &config, &layout).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+        let mounts = pod.containers[0].volume_mounts.clone().unwrap();
+        assert!(mounts.iter().any(|mount| mount.mount_path == "/work"));
+        assert!(mounts.iter().all(|mount| mount.mount_path != "/work/data"));
+        assert!(
+            pod.volumes
+                .unwrap()
+                .iter()
+                .all(|volume| volume.name != "aruna-job-a1-data")
+        );
+        let secret = secret_manifest(&context(), &config, &spec).unwrap();
+        assert!(!secret.string_data.unwrap().contains_key("access_key_id"));
+    }
+
     #[test]
     fn mounts_scratch_dir() {
         // Mounted jobs get a writable working directory instead of a workspace.

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -49,10 +49,10 @@ use super::{BackendCaps, ExecutorBackend, SessionChannel, digest_pinned};
 mod manifest;
 
 use manifest::{
-    HELPER_PATH, PolicyManifest, StageMarker, WORKSPACE_PATH, helper_pod, job_manifest,
-    marker_manifest, marker_name, mount_buckets, mount_name, mount_pv_manifest, mount_pvc_manifest,
-    needs_workspace, network_policies, policy_manifests, pvc_manifest, secret_manifest,
-    secret_name, workspace_name,
+    HELPER_PATH, PolicyManifest, StageMarker, WORKSPACE_PATH, data_pv_manifest, data_pvc_manifest,
+    helper_pod, job_manifest, marker_manifest, marker_name, mount_buckets, mount_pv_manifest,
+    mount_pvc_manifest, mounts_data, needs_workspace, network_policies, policy_manifests,
+    pvc_manifest, secret_manifest, secret_name, workspace_name,
 };
 
 pub const EPOCH_ANNOTATION: &str = "aruna-engine.org/attempt-epoch";
@@ -209,69 +209,95 @@ impl KubernetesBackend {
         context: &FenceContext,
         layout: &StageLayout,
     ) -> Result<(), BackendError> {
+        for (index, bucket) in mount_buckets(layout).iter().enumerate() {
+            let pv = mount_pv_manifest(context, &self.config, index, bucket)?;
+            let pvc = mount_pvc_manifest(context, &self.config, index)?;
+            self.ensure_volume(context, bucket, pv, pvc).await?;
+        }
+        Ok(())
+    }
+
+    async fn ensure_data(
+        &self,
+        context: &FenceContext,
+        spec: &TaskSpec,
+    ) -> Result<(), BackendError> {
+        let Some(workspace) = spec.workspace.as_ref() else {
+            return Ok(());
+        };
+        let pv = data_pv_manifest(context, &self.config, &workspace.bucket_name)?;
+        let pvc = data_pvc_manifest(context, &self.config)?;
+        self.ensure_volume(context, &workspace.bucket_name, pv, pvc)
+            .await
+    }
+
+    async fn ensure_volume(
+        &self,
+        context: &FenceContext,
+        bucket: &str,
+        pv: PersistentVolume,
+        pvc: PersistentVolumeClaim,
+    ) -> Result<(), BackendError> {
         let driver = self.config.s3_mount_driver.as_deref().ok_or_else(|| {
             BackendError::InvalidSpec("S3 mounts are disabled on this backend".to_string())
         })?;
-        for (index, bucket) in mount_buckets(layout).iter().enumerate() {
-            let name = mount_name(&context.attempt.external_name(), index);
-            let pv = mount_pv_manifest(context, &self.config, index, bucket)?;
-            match self.pvs().create(&PostParams::default(), &pv).await {
-                Ok(_) => {}
-                Err(error) if api_code(&error) == Some(409) => {
-                    let existing = self.pvs().get(&name).await.map_err(kube_error)?;
-                    let valid = existing
-                        .metadata
-                        .annotations
+        let name = pv.name_any();
+        match self.pvs().create(&PostParams::default(), &pv).await {
+            Ok(_) => {}
+            Err(error) if api_code(&error) == Some(409) => {
+                let existing = self.pvs().get(&name).await.map_err(kube_error)?;
+                let valid = existing
+                    .metadata
+                    .annotations
+                    .as_ref()
+                    .and_then(|annotations| annotations.get(EPOCH_ANNOTATION))
+                    .and_then(|epoch| epoch.parse::<u64>().ok())
+                    == Some(context.attempt_epoch)
+                    && existing
+                        .spec
                         .as_ref()
-                        .and_then(|annotations| annotations.get(EPOCH_ANNOTATION))
-                        .and_then(|epoch| epoch.parse::<u64>().ok())
-                        == Some(context.attempt_epoch)
-                        && existing
-                            .spec
-                            .as_ref()
-                            .and_then(|spec| spec.csi.as_ref())
-                            .is_some_and(|csi| {
-                                csi.driver == driver
-                                    && csi.volume_handle == name
-                                    && csi
-                                        .volume_attributes
-                                        .as_ref()
-                                        .and_then(|attributes| attributes.get("bucketName"))
-                                        == Some(bucket)
-                            });
-                    if !valid {
-                        return Err(BackendError::Conflict(format!(
-                            "S3 PersistentVolume `{name}` belongs to another attempt"
-                        )));
-                    }
+                        .and_then(|spec| spec.csi.as_ref())
+                        .is_some_and(|csi| {
+                            csi.driver == driver
+                                && csi.volume_handle == name
+                                && csi
+                                    .volume_attributes
+                                    .as_ref()
+                                    .and_then(|attributes| attributes.get("bucketName"))
+                                    .map(String::as_str)
+                                    == Some(bucket)
+                        });
+                if !valid {
+                    return Err(BackendError::Conflict(format!(
+                        "S3 PersistentVolume `{name}` belongs to another attempt"
+                    )));
                 }
-                Err(error) => return Err(kube_error(error)),
             }
-            let pvc = mount_pvc_manifest(context, &self.config, index)?;
-            match self.pvcs().create(&PostParams::default(), &pvc).await {
-                Ok(_) => {}
-                Err(error) if api_code(&error) == Some(409) => {
-                    let existing = self.pvcs().get(&name).await.map_err(kube_error)?;
-                    let valid = existing
-                        .metadata
-                        .annotations
+            Err(error) => return Err(kube_error(error)),
+        }
+        match self.pvcs().create(&PostParams::default(), &pvc).await {
+            Ok(_) => {}
+            Err(error) if api_code(&error) == Some(409) => {
+                let existing = self.pvcs().get(&name).await.map_err(kube_error)?;
+                let valid = existing
+                    .metadata
+                    .annotations
+                    .as_ref()
+                    .and_then(|annotations| annotations.get(EPOCH_ANNOTATION))
+                    .and_then(|epoch| epoch.parse::<u64>().ok())
+                    == Some(context.attempt_epoch)
+                    && existing
+                        .spec
                         .as_ref()
-                        .and_then(|annotations| annotations.get(EPOCH_ANNOTATION))
-                        .and_then(|epoch| epoch.parse::<u64>().ok())
-                        == Some(context.attempt_epoch)
-                        && existing
-                            .spec
-                            .as_ref()
-                            .and_then(|spec| spec.volume_name.as_deref())
-                            == Some(name.as_str());
-                    if !valid {
-                        return Err(BackendError::Conflict(format!(
-                            "S3 PersistentVolumeClaim `{name}` belongs to another attempt"
-                        )));
-                    }
+                        .and_then(|spec| spec.volume_name.as_deref())
+                        == Some(name.as_str());
+                if !valid {
+                    return Err(BackendError::Conflict(format!(
+                        "S3 PersistentVolumeClaim `{name}` belongs to another attempt"
+                    )));
                 }
-                Err(error) => return Err(kube_error(error)),
             }
+            Err(error) => return Err(kube_error(error)),
         }
         Ok(())
     }
@@ -996,6 +1022,9 @@ impl ExecutorBackend for KubernetesBackend {
         self.remove_marker(context).await?;
         if spec.session {
             self.ensure_secret(context, spec).await?;
+            if mounts_data(spec, &self.config) {
+                self.ensure_data(context, spec).await?;
+            }
         }
         match spec.staging_mode {
             StagingMode::Files => {

--- a/compute/src/executor/kubernetes/mod.rs
+++ b/compute/src/executor/kubernetes/mod.rs
@@ -2606,6 +2606,130 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn creates_data_volume() {
+        // A session with a workspace gets its data mount PV and PVC.
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let client = fake_client(move |method, path| {
+            recorder
+                .lock()
+                .expect("record request")
+                .push(format!("{method} {path}"));
+            match (method, path) {
+                ("POST", "/api/v1/persistentvolumes") => {
+                    (201, core_object("PersistentVolume", "aruna-job-a1-data"))
+                }
+                ("POST", "/api/v1/namespaces/compute/persistentvolumeclaims") => (
+                    201,
+                    core_object("PersistentVolumeClaim", "aruna-job-a1-data"),
+                ),
+                _ => (404, status_json(404)),
+            }
+        });
+        let mut config = test_config();
+        config.s3_mount_driver = Some("s3.csi.scality.com".to_string());
+        let backend = KubernetesBackend {
+            client,
+            config,
+            policies: Vec::new(),
+        };
+        let mut spec = TaskSpec::new(context().attempt, "session:latest");
+        spec.session = true;
+        spec.workdir = Some("/work".to_string());
+        backend.ensure_data(&context(), &spec).await.unwrap();
+        assert!(seen.lock().expect("read requests").is_empty());
+
+        spec.workspace = Some(aruna_core::compute::WorkspaceBinding {
+            s3_endpoint: "https://s3.example".to_string(),
+            bucket_name: "workspace-bucket".to_string(),
+            region: String::new(),
+        });
+        backend.ensure_data(&context(), &spec).await.unwrap();
+        assert_eq!(
+            seen.lock().expect("read requests").clone(),
+            [
+                "POST /api/v1/persistentvolumes",
+                "POST /api/v1/namespaces/compute/persistentvolumeclaims",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn removes_data_volume() {
+        // Cleanup finds the data mount through the shared s3-mount role label.
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let client = fake_client(move |method, path| {
+            recorder
+                .lock()
+                .expect("record request")
+                .push(format!("{method} {path}"));
+            match (method, path) {
+                ("GET", "/apis/batch/v1/namespaces/compute/jobs/aruna-job-a1") => {
+                    (200, job_json("tombstone"))
+                }
+                ("GET", "/api/v1/namespaces/compute/pods") => (200, pod_list()),
+                ("GET", "/api/v1/namespaces/compute/persistentvolumeclaims") => (
+                    200,
+                    json!({
+                        "apiVersion":"v1","kind":"PersistentVolumeClaimList",
+                        "items":[core_object("PersistentVolumeClaim", "aruna-job-a1-data")]
+                    }),
+                ),
+                ("GET", "/api/v1/persistentvolumes") => (
+                    200,
+                    json!({
+                        "apiVersion":"v1","kind":"PersistentVolumeList",
+                        "items":[core_object("PersistentVolume", "aruna-job-a1-data")]
+                    }),
+                ),
+                (
+                    "DELETE",
+                    "/api/v1/namespaces/compute/persistentvolumeclaims/aruna-job-a1-data",
+                ) => (
+                    200,
+                    core_object("PersistentVolumeClaim", "aruna-job-a1-data"),
+                ),
+                ("DELETE", "/api/v1/persistentvolumes/aruna-job-a1-data") => {
+                    (200, core_object("PersistentVolume", "aruna-job-a1-data"))
+                }
+                ("DELETE", "/api/v1/namespaces/compute/pods/task-pod") => {
+                    (200, core_object("Pod", "task-pod"))
+                }
+                ("DELETE", "/api/v1/namespaces/compute/persistentvolumeclaims/aruna-job-a1-ws") => {
+                    (200, core_object("PersistentVolumeClaim", "aruna-job-a1-ws"))
+                }
+                ("DELETE", "/api/v1/namespaces/compute/secrets/aruna-job-a1-env") => {
+                    (200, core_object("Secret", "aruna-job-a1-env"))
+                }
+                ("DELETE", "/api/v1/namespaces/compute/configmaps/aruna-job-a1-logs")
+                | ("DELETE", "/api/v1/namespaces/compute/configmaps/aruna-job-a1-staged") => {
+                    (200, core_object("ConfigMap", "marker"))
+                }
+                ("DELETE", "/apis/batch/v1/namespaces/compute/jobs/aruna-job-a1") => {
+                    (200, job_json("tombstone"))
+                }
+                _ => (404, status_json(404)),
+            }
+        });
+        let backend = KubernetesBackend {
+            client,
+            config: test_config(),
+            policies: Vec::new(),
+        };
+
+        backend.cleanup(&context()).await.unwrap();
+
+        let seen = seen.lock().expect("read requests").clone();
+        for volume in [
+            "DELETE /api/v1/namespaces/compute/persistentvolumeclaims/aruna-job-a1-data",
+            "DELETE /api/v1/persistentvolumes/aruna-job-a1-data",
+        ] {
+            assert!(seen.iter().any(|entry| entry == volume), "{volume}");
+        }
+    }
+
+    #[tokio::test]
     async fn cancels_without_logs() {
         // A stuck pod rejects log reads with 400; cancel must still complete.
         let client = fake_client(|method, path| match (method, path) {


### PR DESCRIPTION
## Description

Notebook session staging copies objects into the workspace bucket under `data/`, but on Kubernetes the session pod only had an emptyDir at `/work`, so staged files never appeared in the kernel's file system. When the executor has an S3 mount driver configured, every session pod now gets the workspace bucket prefix `data/` mounted read-write at `<workdir>/data` through the existing S3 CSI machinery. Staged inputs and kernel outputs meet in one folder, the scratch listing shows them, and cleanup removes the volume with the other S3 mounts. Without a mount driver nothing changes.

## Changes

- Add a `<attempt>-data` PersistentVolume and claim for the workspace bucket with writable mountpoint options (`prefix=data/`, `allow-delete`, `allow-overwrite`, task uid and gid) and mount it at `<workdir>/data` in session pods.
- Copy the session S3 credential into the `access_key_id` and `secret_access_key` keys the CSI driver reads from the attempt secret.
- Create the data volume during session preparation and reuse the shared volume creation and epoch checks; cleanup removes it through the existing `s3-mount` role selector.
- Add manifest and executor tests for the data mount, the no-driver case and cleanup.
- Bump the workspace version to 3.0.0-alpha.80.